### PR TITLE
feat: add transfer ownership command for voice channels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,31 +8,25 @@ ENABLE_VC_MANAGEMENT=true
 VC_CATEGORY_NAME=Voice Channels
 LOBBY_CHANNEL_NAME=🎮 Lobby
 LOBBY_CHANNEL_NAME_OFFLINE=🎮 Lobby (Offline)
-VC_USER_LIMIT=5
 VC_CHANNEL_PREFIX=🎮
+VC_SUFFIX='s Room
 
-# Voice Channel Tracking (Requires ENABLE_VC_MANAGEMENT=true)
+# Voice Channel Tracking
 ENABLE_VC_TRACKING=true
-ENABLE_VC_STATS=true
-ENABLE_VC_TOP=true
 ENABLE_SEEN=true
 
 # MongoDB Configuration
 MONGODB_URI=mongodb://mongodb:27017/koolbot
 
-# Logging Configuration
-LOG_LEVEL=info
-
 # Bot Features
-ENABLE_PLEX_PRICE=true
+ENABLE_PING=true
 ENABLE_AMIKOOL=true
+ENABLE_PLEX_PRICE=true
 
 # Role Configuration
-# Customize role names and permissions
 COOL_ROLE_NAME=Verifyed Kool Kid
 VC_TRACKING_ADMIN_ROLES=Admin,Moderator
 
 # Debug Configuration
-# Set to false in production
 DEBUG=true
 NODE_ENV=development

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -40,4 +40,4 @@ template: |
 
   ## Contributors
 
-  $CONTRIBUTORS 
+  $CONTRIBUTORS

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@typescript-eslint/eslint-plugin": "^8.29.1",
         "@typescript-eslint/parser": "^8.29.1",
         "eslint": "^9.24.0",
-        "prettier": "^3.2.5",
+        "prettier": "^3.5.3",
         "ts-node": "^10.9.2",
         "typescript": "^5.3.3"
       }
@@ -2125,6 +2125,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "watch": "tsc -w",
     "deploy-commands": "node --import ./src/loader.js src/deploy-commands.ts",
     "unregister-guild-commands": "node --import ./src/loader.js src/unregister-guild-commands.ts",
-    "lint": "eslint . --ext .ts",
-    "lint:fix": "eslint . --ext .ts --fix",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "format": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\"",
     "check": "npm run build && npm run lint && npm run format:check"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@typescript-eslint/eslint-plugin": "^8.29.1",
     "@typescript-eslint/parser": "^8.29.1",
     "eslint": "^9.24.0",
-    "prettier": "^3.2.5",
+    "prettier": "^3.5.3",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3"
   }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -21,7 +21,8 @@ const commands = {
   vctop: process.env.ENABLE_VC_TRACKING === "true" ? vctop : undefined,
   vcstats: process.env.ENABLE_VC_TRACKING === "true" ? vcstats : undefined,
   seen: process.env.ENABLE_SEEN === "true" ? seen : undefined,
-  "transfer-ownership": process.env.ENABLE_VC_MANAGEMENT === "true" ? transferOwnership : undefined,
+  "transfer-ownership":
+    process.env.ENABLE_VC_MANAGEMENT === "true" ? transferOwnership : undefined,
 };
 
 // Create a wrapper for the interaction that makes replies ephemeral by default

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -10,6 +10,7 @@ import { execute as plexprice } from "./plexprice.js";
 import { execute as vctop } from "./vctop.js";
 import { execute as vcstats } from "./vcstats.js";
 import { execute as seen } from "./seen.js";
+import { execute as transferOwnership } from "./transfer-ownership.js";
 
 const logger = Logger.getInstance();
 
@@ -20,6 +21,7 @@ const commands = {
   vctop: process.env.ENABLE_VC_TRACKING === "true" ? vctop : undefined,
   vcstats: process.env.ENABLE_VC_TRACKING === "true" ? vcstats : undefined,
   seen: process.env.ENABLE_SEEN === "true" ? seen : undefined,
+  "transfer-ownership": process.env.ENABLE_VC_MANAGEMENT === "true" ? transferOwnership : undefined,
 };
 
 // Create a wrapper for the interaction that makes replies ephemeral by default

--- a/src/commands/transfer-ownership.ts
+++ b/src/commands/transfer-ownership.ts
@@ -1,7 +1,6 @@
 import {
   CommandInteraction,
   SlashCommandBuilder,
-  VoiceChannel,
   GuildMember,
   SlashCommandUserOption,
 } from "discord.js";

--- a/src/commands/transfer-ownership.ts
+++ b/src/commands/transfer-ownership.ts
@@ -16,7 +16,7 @@ export const data = new SlashCommandBuilder()
     option
       .setName("user")
       .setDescription("The user to transfer ownership to")
-      .setRequired(true)
+      .setRequired(true),
   );
 
 export async function execute(interaction: CommandInteraction): Promise<void> {
@@ -77,13 +77,15 @@ export async function execute(interaction: CommandInteraction): Promise<void> {
     }
 
     // Get the voice channel manager instance
-    const voiceChannelManager = VoiceChannelManager.getInstance(interaction.client);
+    const voiceChannelManager = VoiceChannelManager.getInstance(
+      interaction.client,
+    );
 
     // Transfer ownership
     await voiceChannelManager.transferOwnership(
       voiceChannel.id,
       member.id,
-      targetMember.id
+      targetMember.id,
     );
 
     await interaction.reply({

--- a/src/commands/transfer-ownership.ts
+++ b/src/commands/transfer-ownership.ts
@@ -1,0 +1,101 @@
+import {
+  CommandInteraction,
+  SlashCommandBuilder,
+  VoiceChannel,
+  GuildMember,
+  SlashCommandUserOption,
+} from "discord.js";
+import Logger from "../utils/logger.js";
+import { VoiceChannelManager } from "../services/voice-channel-manager.js";
+
+const logger = Logger.getInstance();
+
+export const data = new SlashCommandBuilder()
+  .setName("transfer-ownership")
+  .setDescription("Transfer ownership of your voice channel to another user")
+  .addUserOption((option: SlashCommandUserOption) =>
+    option
+      .setName("user")
+      .setDescription("The user to transfer ownership to")
+      .setRequired(true)
+  );
+
+export async function execute(interaction: CommandInteraction): Promise<void> {
+  try {
+    if (!interaction.guild) {
+      await interaction.reply({
+        content: "This command can only be used in a server!",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const member = interaction.member as GuildMember;
+    if (!member) {
+      await interaction.reply({
+        content: "Could not find your member information.",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const voiceChannel = member.voice.channel;
+    if (!voiceChannel) {
+      await interaction.reply({
+        content: "You must be in a voice channel to transfer ownership!",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    // Get the target user
+    const targetUser = interaction.options.get("user")?.user;
+    if (!targetUser) {
+      await interaction.reply({
+        content: "Please specify a user to transfer ownership to.",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    // Get the target member
+    const targetMember = await interaction.guild.members.fetch(targetUser.id);
+    if (!targetMember) {
+      await interaction.reply({
+        content: "Could not find the target user in this server.",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    // Check if target user is in the same voice channel
+    if (targetMember.voice.channelId !== voiceChannel.id) {
+      await interaction.reply({
+        content: "The target user must be in the same voice channel!",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    // Get the voice channel manager instance
+    const voiceChannelManager = VoiceChannelManager.getInstance(interaction.client);
+
+    // Transfer ownership
+    await voiceChannelManager.transferOwnership(
+      voiceChannel.id,
+      member.id,
+      targetMember.id
+    );
+
+    await interaction.reply({
+      content: `Ownership transferred to ${targetMember.displayName}!`,
+      ephemeral: true,
+    });
+  } catch (error) {
+    logger.error("Error in transfer-ownership command:", error);
+    await interaction.reply({
+      content: "An error occurred while transferring ownership.",
+      ephemeral: true,
+    });
+  }
+}

--- a/src/services/command-manager.ts
+++ b/src/services/command-manager.ts
@@ -7,6 +7,8 @@ import { data as plexprice } from "../commands/plexprice.js";
 import { data as vctop } from "../commands/vctop.js";
 import { data as vcstats } from "../commands/vcstats.js";
 import { data as seen } from "../commands/seen.js";
+import { data as requestOwnership } from "../commands/request-ownership.js";
+import { data as transferOwnership } from "../commands/transfer-ownership.js";
 
 config();
 const logger = Logger.getInstance();
@@ -59,6 +61,11 @@ export class CommandManager {
 
     if (process.env.ENABLE_SEEN === "true") {
       commands.push(seen.toJSON());
+    }
+
+    if (process.env.ENABLE_VC_MANAGEMENT === "true") {
+      commands.push(requestOwnership.toJSON());
+      commands.push(transferOwnership.toJSON());
     }
 
     return commands;

--- a/src/services/command-manager.ts
+++ b/src/services/command-manager.ts
@@ -7,7 +7,6 @@ import { data as plexprice } from "../commands/plexprice.js";
 import { data as vctop } from "../commands/vctop.js";
 import { data as vcstats } from "../commands/vcstats.js";
 import { data as seen } from "../commands/seen.js";
-import { data as requestOwnership } from "../commands/request-ownership.js";
 import { data as transferOwnership } from "../commands/transfer-ownership.js";
 
 config();
@@ -64,7 +63,6 @@ export class CommandManager {
     }
 
     if (process.env.ENABLE_VC_MANAGEMENT === "true") {
-      commands.push(requestOwnership.toJSON());
       commands.push(transferOwnership.toJSON());
     }
 

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -165,7 +165,7 @@ export class VoiceChannelManager {
             member,
             totalTime: stats?.totalTime || 0,
           };
-        })
+        }),
       );
 
       // Sort members by their voice time in the last 7 days
@@ -176,13 +176,18 @@ export class VoiceChannelManager {
 
       // Update channel ownership
       await this.updateChannelOwnership(channel, newOwner);
-      logger.info(`Channel ${channel.name} ownership transferred to ${newOwner.displayName} based on voice time`);
+      logger.info(
+        `Channel ${channel.name} ownership transferred to ${newOwner.displayName} based on voice time`,
+      );
     } catch (error) {
       logger.error("Error handling channel ownership change:", error);
     }
   }
 
-  public async requestOwnership(channelId: string, userId: string): Promise<void> {
+  public async requestOwnership(
+    channelId: string,
+    userId: string,
+  ): Promise<void> {
     try {
       const queue = this.ownershipQueue.get(channelId) || [];
       if (!queue.includes(userId)) {
@@ -190,17 +195,19 @@ export class VoiceChannelManager {
         this.ownershipQueue.set(channelId, queue);
 
         // Notify the current owner
-        const channel = this.client.channels.cache.get(channelId) as VoiceChannel;
+        const channel = this.client.channels.cache.get(
+          channelId,
+        ) as VoiceChannel;
         if (channel) {
           const currentOwnerId = Array.from(this.userChannels.entries()).find(
-            ([, userChannel]) => userChannel.id === channelId
+            ([, userChannel]) => userChannel.id === channelId,
           )?.[0];
 
           if (currentOwnerId) {
             const currentOwner = channel.members.get(currentOwnerId);
             if (currentOwner) {
               await channel.send(
-                `<@${userId}> has requested ownership of this channel. They will receive ownership when you leave.`
+                `<@${userId}> has requested ownership of this channel. They will receive ownership when you leave.`,
               );
             }
           }
@@ -214,7 +221,7 @@ export class VoiceChannelManager {
   public async transferOwnership(
     channelId: string,
     currentOwnerId: string,
-    newOwnerId: string
+    newOwnerId: string,
   ): Promise<void> {
     try {
       const channel = this.client.channels.cache.get(channelId) as VoiceChannel;
@@ -240,11 +247,11 @@ export class VoiceChannelManager {
 
       // Notify channel members
       await channel.send(
-        `Channel ownership has been transferred to ${newOwner.displayName}`
+        `Channel ownership has been transferred to ${newOwner.displayName}`,
       );
 
       logger.info(
-        `Ownership of channel ${channel.name} manually transferred from ${currentOwnerId} to ${newOwnerId}`
+        `Ownership of channel ${channel.name} manually transferred from ${currentOwnerId} to ${newOwnerId}`,
       );
     } catch (error) {
       logger.error("Error transferring channel ownership:", error);
@@ -551,7 +558,7 @@ export class VoiceChannelManager {
       // Notify channel members about the ownership change
       try {
         await channel.send(
-          `Channel ownership has been transferred to ${newOwner.displayName} based on voice time in the last 7 days`
+          `Channel ownership has been transferred to ${newOwner.displayName} based on voice time in the last 7 days`,
         );
       } catch (error) {
         logger.error("Error sending ownership change notification:", error);

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -6,7 +6,6 @@ import {
   GuildMember,
   Guild,
   Client,
-  TextChannel,
 } from "discord.js";
 import Logger from "../utils/logger.js";
 import { VoiceChannelTracker } from "../services/voice-channel-tracker.js";


### PR DESCRIPTION
- Introduced a new command `/transfer-ownership` to allow users to transfer ownership of their voice channel to another user.
- Updated command manager to include the new command based on environment configuration.
- Enhanced the voice channel manager to handle ownership transfers and notify users accordingly.
- Improved error handling and user feedback for various scenarios during the ownership transfer process.