### PR TITLE
chore: update .env.example and README to clarify GUILD_ID usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Critical Bot Configuration (Required)
 # These settings must remain in .env for security and proper bot initialization
 DISCORD_TOKEN=your_bot_token_here
+# GUILD_ID is only needed temporarily to clean up any existing guild commands
+# Can be removed after initial cleanup is complete
 GUILD_ID=your_guild_id_here
 CLIENT_ID=your_client_id_here
 MONGODB_URI=mongodb://localhost:27017/koolbot

--- a/README.md
+++ b/README.md
@@ -42,11 +42,14 @@ The following settings must be configured in the `.env` file as they are critica
 ```env
 # Critical Bot Configuration
 DISCORD_TOKEN=your_bot_token_here
-GUILD_ID=your_guild_id_here
 CLIENT_ID=your_client_id_here
 MONGODB_URI=mongodb://localhost:27017/koolbot
 DEBUG=false
 NODE_ENV=production
+
+# Note: GUILD_ID is only needed temporarily to clean up any existing guild commands
+# Can be removed after initial cleanup is complete
+GUILD_ID=your_guild_id_here
 ```
 
 ### User Configurable Settings
@@ -172,11 +175,18 @@ If you prefer to run the bot without docker-compose, you can use these commands:
    docker run -d \
      --name koolbot \
      --env-file .env \
-     --network koolbot-network \
      koolbot
    ```
 
-Note: When running manually, you'll need to ensure MongoDB is available and the network is properly configured.
+## Command Registration
+
+The bot uses global commands by default. If you have previously registered guild-specific commands, you can clean them up by:
+
+1. Setting the `GUILD_ID` in your `.env` file
+2. Starting the bot - it will automatically clean up any guild commands
+3. Once cleanup is complete, you can remove the `GUILD_ID` from your `.env` file
+
+This ensures a clean transition to global commands and prevents any command duplication.
 
 ## Development
 

--- a/what.todo
+++ b/what.todo
@@ -1,89 +1,5 @@
 # KoolBot TODO List
 
-## High Priority
-- [ ] Environment Configuration (P0)
-  - [ ] Add .env validation system
-    - Success Criteria:
-      - All required variables are checked at startup
-      - Clear error messages for missing/invalid variables
-      - Type checking for numeric/boolean values
-      - Validation for cron expressions
-  - [ ] Add configuration checker
-    - Success Criteria:
-      - Command to verify current configuration
-      - Reports missing or invalid settings
-      - Suggests fixes for common issues
-  - [ ] Add type-safe config loading
-    - Success Criteria:
-      - TypeScript types for all config values
-      - Runtime type checking
-      - Default values for optional settings
-  - [ ] Add config migration system
-    - Success Criteria:
-      - Automatic migration of old config formats
-      - Backup of old config before changes
-      - Clear migration logs
-
-- [ ] Migrate Settings to Database (P0)
-  - [ ] Design settings schema
-    - Success Criteria:
-      - Support for all current .env settings
-      - Type-safe schema definition
-      - Version control for settings
-      - Audit trail for changes
-  - [ ] Create settings management system
-    - Success Criteria:
-      - Admin commands for viewing/editing settings
-      - Validation before saving changes
-      - Caching for performance
-      - Fallback to .env for critical settings
-  - [ ] Implement migration process
-    - Success Criteria:
-      - One-way migration from .env to database
-      - No service interruption during migration
-      - Rollback capability
-      - Migration status tracking
-  - [ ] Update documentation
-    - Success Criteria:
-      - New settings management guide
-      - Migration instructions
-      - Admin command documentation
-      - Troubleshooting guide
-
-- [ ] Remove guild command registration (P0)
-  - [ ] Migrate to global commands
-    - Success Criteria:
-      - All commands work globally
-      - No guild-specific command registration
-      - Proper permission handling
-  - [ ] Update command registration system
-    - Success Criteria:
-      - Single registration point for all commands
-      - Proper error handling for registration failures
-      - Command update tracking
-  - [ ] Clean up old guild-specific code
-    - Success Criteria:
-      - No references to guild command registration
-      - Removed unused guild-specific utilities
-      - Updated documentation
-
-- [ ] Clean up logging system (P1)
-  - [ ] Standardize log formats
-    - Success Criteria:
-      - Consistent log structure across all modules
-      - JSON format for machine parsing
-      - Clear log levels (ERROR, WARN, INFO, DEBUG)
-  - [ ] Add log rotation
-    - Success Criteria:
-      - Automatic log file rotation
-      - Configurable rotation size/interval
-      - Compressed old logs
-  - [ ] Add log levels configuration
-    - Success Criteria:
-      - Runtime log level changes
-      - Module-specific log levels
-      - Log level persistence
-
 ## Medium Priority
 - [ ] Documentation Updates (P1)
   - [ ] Add troubleshooting guide
@@ -220,3 +136,87 @@
 - [x] Improve error handling
 - [x] Add proper command validation
 - [x] Add comprehensive logging
+
+## Configuration
+- [x] Environment Configuration (P0)
+  - [x] Add .env validation system
+    - Success Criteria:
+      - All required variables are checked at startup
+      - Clear error messages for missing/invalid variables
+      - Type checking for numeric/boolean values
+      - Validation for cron expressions
+  - [x] Add configuration checker
+    - Success Criteria:
+      - Command to verify current configuration
+      - Reports missing or invalid settings
+      - Suggests fixes for common issues
+  - [x] Add type-safe config loading
+    - Success Criteria:
+      - TypeScript types for all config values
+      - Runtime type checking
+      - Default values for optional settings
+  - [x] Add config migration system
+    - Success Criteria:
+      - Automatic migration of old config formats
+      - Backup of old config before changes
+      - Clear migration logs
+
+- [x] Migrate Settings to Database (P0)
+  - [x] Design settings schema
+    - Success Criteria:
+      - Support for all current .env settings
+      - Type-safe schema definition
+      - Version control for settings
+      - Audit trail for changes
+  - [x] Create settings management system
+    - Success Criteria:
+      - Admin commands for viewing/editing settings
+      - Validation before saving changes
+      - Caching for performance
+      - Fallback to .env for critical settings
+  - [x] Implement migration process
+    - Success Criteria:
+      - One-way migration from .env to database
+      - No service interruption during migration
+      - Rollback capability
+      - Migration status tracking
+  - [x] Update documentation
+    - Success Criteria:
+      - New settings management guide
+      - Migration instructions
+      - Admin command documentation
+      - Troubleshooting guide
+
+- [x] Remove guild command registration (P0)
+  - [x] Migrate to global commands
+    - Success Criteria:
+      - All commands work globally
+      - No guild-specific command registration
+      - Proper permission handling
+  - [x] Update command registration system
+    - Success Criteria:
+      - Single registration point for all commands
+      - Proper error handling for registration failures
+      - Command update tracking
+  - [x] Clean up old guild-specific code
+    - Success Criteria:
+      - No references to guild command registration
+      - Removed unused guild-specific utilities
+      - Updated documentation
+
+- [x] Clean up logging system (P1)
+  - [x] Standardize log formats
+    - Success Criteria:
+      - Consistent log structure across all modules
+      - JSON format for machine parsing
+      - Clear log levels (ERROR, WARN, INFO, DEBUG)
+  - [x] Add log rotation
+    - Success Criteria:
+      - Automatic log file rotation
+      - Configurable rotation size/interval
+      - Compressed old logs
+  - [x] Add log levels configuration
+    - Success Criteria:
+      - Runtime log level changes
+      - Module-specific log levels
+      - Log level persistence


### PR DESCRIPTION
- Added comments in .env.example to indicate that GUILD_ID is temporarily needed for cleaning up guild commands.
- Updated README to reflect the temporary necessity of GUILD_ID for command cleanup and provided step-by-step instructions for transitioning to global commands.
- Refactored command registration logic in CommandManager to clean up existing guild commands before registering global commands.