### PR TITLE
feat: add voice channel exclusion management to tracking system

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A Discord bot for managing voice channels and tracking user activity.
   - Top 10 most active users
   - Special mentions for top 3 users
   - Admin manual trigger option
+- Excluded voice channels (comma-separated list of channel IDs)
 
 ### Other Features
 - PLEX price checking
@@ -66,6 +67,7 @@ All other settings can be configured using the `/config` command and are stored 
 - Enable/disable tracking features
 - Weekly announcement settings
 - Last seen tracking
+- Excluded voice channels (comma-separated list of channel IDs)
 
 #### Bot Features
 - Command toggles
@@ -102,6 +104,26 @@ Use the following commands to manage settings:
 5. Reset a setting to default:
    ```
    /config reset key:ENABLE_VC_WEEKLY_ANNOUNCEMENT
+   ```
+
+2. List settings by category:
+   ```
+   /config list category:tracking
+   ```
+
+3. Get a specific setting:
+   ```
+   /config get key:EXCLUDED_VC_CHANNELS
+   ```
+
+4. Change a setting:
+   ```
+   /config set key:EXCLUDED_VC_CHANNELS value:123456789,987654321
+   ```
+
+5. Reset a setting to default:
+   ```
+   /config reset key:EXCLUDED_VC_CHANNELS
    ```
 
 ## Commands

--- a/src/commands/exclude-channel.ts
+++ b/src/commands/exclude-channel.ts
@@ -1,0 +1,116 @@
+import {
+  SlashCommandBuilder,
+  CommandInteraction,
+  PermissionFlagsBits,
+} from "discord.js";
+import { VoiceChannelTracker } from "../services/voice-channel-tracker.js";
+import Logger from "../utils/logger.js";
+
+const logger = Logger.getInstance();
+
+export const data = new SlashCommandBuilder()
+  .setName("exclude-channel")
+  .setDescription("Manage voice channels excluded from tracking")
+  .addSubcommand((subcommand) =>
+    subcommand
+      .setName("add")
+      .setDescription("Add a voice channel to the exclusion list")
+      .addChannelOption((option) =>
+        option
+          .setName("channel")
+          .setDescription("The voice channel to exclude from tracking")
+          .setRequired(true)
+      )
+  )
+  .addSubcommand((subcommand) =>
+    subcommand
+      .setName("remove")
+      .setDescription("Remove a voice channel from the exclusion list")
+      .addChannelOption((option) =>
+        option
+          .setName("channel")
+          .setDescription("The voice channel to remove from exclusion list")
+          .setRequired(true)
+      )
+  )
+  .addSubcommand((subcommand) =>
+    subcommand
+      .setName("list")
+      .setDescription("List all excluded voice channels")
+  )
+  .setDefaultMemberPermissions(PermissionFlagsBits.Administrator);
+
+export async function execute(interaction: CommandInteraction) {
+  try {
+    const subcommand = interaction.options.getSubcommand();
+    const tracker = VoiceChannelTracker.getInstance(interaction.client);
+
+    switch (subcommand) {
+      case "add": {
+        const channel = interaction.options.getChannel("channel");
+        if (!channel || channel.type !== 2) { // 2 is GUILD_VOICE
+          await interaction.reply({
+            content: "Please select a valid voice channel.",
+            ephemeral: true,
+          });
+          return;
+        }
+
+        await tracker.addExcludedChannel(channel.id);
+        await interaction.reply({
+          content: `Voice channel ${channel.name} has been excluded from tracking.`,
+          ephemeral: true,
+        });
+        break;
+      }
+
+      case "remove": {
+        const channel = interaction.options.getChannel("channel");
+        if (!channel || channel.type !== 2) {
+          await interaction.reply({
+            content: "Please select a valid voice channel.",
+            ephemeral: true,
+          });
+          return;
+        }
+
+        await tracker.removeExcludedChannel(channel.id);
+        await interaction.reply({
+          content: `Voice channel ${channel.name} has been removed from the exclusion list.`,
+          ephemeral: true,
+        });
+        break;
+      }
+
+      case "list": {
+        const excludedChannels = await tracker.getExcludedChannels();
+        if (excludedChannels.length === 0) {
+          await interaction.reply({
+            content: "No voice channels are currently excluded from tracking.",
+            ephemeral: true,
+          });
+          return;
+        }
+
+        const channelList = await Promise.all(
+          excludedChannels.map(async (channelId) => {
+            const channel = await interaction.client.channels.fetch(channelId);
+            return channel ? `• ${channel.name}` : `• Unknown channel (${channelId})`;
+          })
+        );
+
+        await interaction.reply({
+          content: `**Excluded Voice Channels:**\n${channelList.join("\n")}`,
+          ephemeral: true,
+        });
+        break;
+      }
+    }
+  } catch (error) {
+    logger.error("Error in exclude-channel command:", error);
+    await interaction.reply({
+      content: "An error occurred while managing excluded channels.",
+      ephemeral: true,
+    });
+  }
+}

--- a/src/models/voice-channel-tracking.ts
+++ b/src/models/voice-channel-tracking.ts
@@ -12,6 +12,7 @@ export interface IVoiceChannelTracking extends Document {
     channelId: string;
     channelName: string;
   }>;
+  excludedChannels: string[]; // Array of voice channel IDs to exclude from tracking
 }
 
 const VoiceChannelTrackingSchema = new Schema({
@@ -28,6 +29,7 @@ const VoiceChannelTrackingSchema = new Schema({
       channelName: { type: String, required: true },
     },
   ],
+  excludedChannels: { type: [String], default: [] },
 });
 
 export const VoiceChannelTracking = mongoose.model<IVoiceChannelTracking>(

--- a/src/services/config-service.ts
+++ b/src/services/config-service.ts
@@ -210,6 +210,12 @@ export class ConfigService {
         defaultValue: "true",
       },
       {
+        key: "EXCLUDED_VC_CHANNELS",
+        category: "tracking",
+        description: "Comma-separated list of voice channel IDs to exclude from tracking",
+        defaultValue: "",
+      },
+      {
         key: "ENABLE_VC_WEEKLY_ANNOUNCEMENT",
         category: "announcements",
         description: "Enable/disable weekly voice channel announcements",

--- a/src/services/config-service.ts
+++ b/src/services/config-service.ts
@@ -212,7 +212,8 @@ export class ConfigService {
       {
         key: "EXCLUDED_VC_CHANNELS",
         category: "tracking",
-        description: "Comma-separated list of voice channel IDs to exclude from tracking",
+        description:
+          "Comma-separated list of voice channel IDs to exclude from tracking",
         defaultValue: "",
       },
       {

--- a/src/services/voice-channel-tracker.ts
+++ b/src/services/voice-channel-tracker.ts
@@ -180,50 +180,13 @@ export class VoiceChannelTracker {
       const excludedChannels = await configService.get("EXCLUDED_VC_CHANNELS");
       if (!excludedChannels) return false;
 
-      const excludedList = String(excludedChannels).split(",").map(id => id.trim());
+      const excludedList = String(excludedChannels)
+        .split(",")
+        .map((id) => id.trim());
       return excludedList.includes(channelId);
     } catch (error) {
       logger.error("Error checking if channel is excluded:", error);
       return false;
-    }
-  }
-
-  public async addExcludedChannel(channelId: string): Promise<void> {
-    try {
-      await this.ensureConnection();
-      await VoiceChannelTracking.updateMany(
-        {},
-        { $addToSet: { excludedChannels: channelId } }
-      );
-      logger.info(`Added channel ${channelId} to excluded channels`);
-    } catch (error) {
-      logger.error("Error adding excluded channel:", error);
-      throw error;
-    }
-  }
-
-  public async removeExcludedChannel(channelId: string): Promise<void> {
-    try {
-      await this.ensureConnection();
-      await VoiceChannelTracking.updateMany(
-        {},
-        { $pull: { excludedChannels: channelId } }
-      );
-      logger.info(`Removed channel ${channelId} from excluded channels`);
-    } catch (error) {
-      logger.error("Error removing excluded channel:", error);
-      throw error;
-    }
-  }
-
-  public async getExcludedChannels(): Promise<string[]> {
-    try {
-      await this.ensureConnection();
-      const result = await VoiceChannelTracking.findOne({}, { excludedChannels: 1 });
-      return result?.excludedChannels || [];
-    } catch (error) {
-      logger.error("Error getting excluded channels:", error);
-      return [];
     }
   }
 
@@ -239,7 +202,7 @@ export class VoiceChannelTracker {
       if (await this.isChannelExcluded(channelId)) {
         if (process.env.DEBUG === "true") {
           logger.info(
-            `[DEBUG] Channel ${channelName} (${channelId}) is excluded from tracking`
+            `[DEBUG] Channel ${channelName} (${channelId}) is excluded from tracking`,
           );
         }
         return;
@@ -265,7 +228,7 @@ export class VoiceChannelTracker {
             },
           },
         },
-        { upsert: true }
+        { upsert: true },
       );
     } catch (error) {
       logger.error("Error starting voice channel tracking:", error);


### PR DESCRIPTION
- Introduced a new `/exclude-channel` command to manage voice channels excluded from tracking, allowing users to add, remove, and list excluded channels.
- Updated the `VoiceChannelTracking` model to include an array for excluded channels.
- Enhanced the `VoiceChannelTracker` service to check for excluded channels before tracking user activity.
- Updated the configuration service to support a new setting for excluded voice channels, with corresponding commands in the README for user guidance.