### PR TITLE
fix(test): use ESM-compatible mocks in config-service-methods test

### DIFF
--- a/__tests__/services/config-service-methods.test.ts
+++ b/__tests__/services/config-service-methods.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import type { ConfigService as ConfigServiceType } from '../../src/services/config-service.js';
 
 const mockFindOne = jest.fn();
 const mockFind = jest.fn();
@@ -41,7 +42,7 @@ jest.unstable_mockModule('mongoose', () => ({
 const { ConfigService } = await import('../../src/services/config-service.js');
 
 describe('ConfigService - Methods', () => {
-  let service: ConfigService;
+  let service: ConfigServiceType;
   const originalEnv = process.env;
 
   beforeEach(() => {

--- a/__tests__/services/config-service-methods.test.ts
+++ b/__tests__/services/config-service-methods.test.ts
@@ -1,23 +1,22 @@
 import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 
-// Create mock functions for Config model
 const mockFindOne = jest.fn();
 const mockFind = jest.fn();
 const mockFindOneAndUpdate = jest.fn();
 const mockDeleteOne = jest.fn();
+const mockUpdateOne = jest.fn();
 
-// Mock the Config model
-jest.mock('../../src/models/config.js', () => ({
+jest.unstable_mockModule('../../src/models/config.js', () => ({
   Config: {
     findOne: mockFindOne,
     find: mockFind,
     findOneAndUpdate: mockFindOneAndUpdate,
     deleteOne: mockDeleteOne,
+    updateOne: mockUpdateOne,
   },
 }));
 
-// Mock logger
-jest.mock('../../src/utils/logger.js', () => ({
+jest.unstable_mockModule('../../src/utils/logger.js', () => ({
   default: {
     info: jest.fn(),
     error: jest.fn(),
@@ -26,16 +25,20 @@ jest.mock('../../src/utils/logger.js', () => ({
   },
 }));
 
-// Mock mongoose with readyState: 1 (connected)
-jest.mock('mongoose', () => ({
+const mongooseMock = {
   connection: {
     readyState: 1,
     on: jest.fn(),
   },
   connect: jest.fn(),
+};
+
+jest.unstable_mockModule('mongoose', () => ({
+  ...mongooseMock,
+  default: mongooseMock,
 }));
 
-import { ConfigService } from '../../src/services/config-service.js';
+const { ConfigService } = await import('../../src/services/config-service.js');
 
 describe('ConfigService - Methods', () => {
   let service: ConfigService;
@@ -401,15 +404,15 @@ describe('ConfigService - Methods', () => {
     });
 
     it('should load configs from database on initialization', async () => {
+      // Use a key that exists in defaultConfig so cleanupUnknownSettings doesn't evict it
       mockFind.mockResolvedValue([
-        { key: 'loaded.key', value: 'loaded-value' },
+        { key: 'voicechannels.enabled', value: true, category: 'voicechannels' },
       ]);
 
       await service.initialize();
 
-      // The config should now be in cache
-      const result = await service.get('loaded.key');
-      expect(result).toBe('loaded-value');
+      const result = await service.get('voicechannels.enabled');
+      expect(result).toBe(true);
     });
 
     it('should prioritize critical env settings over database', async () => {


### PR DESCRIPTION
## Summary

Fixes the 16 failing tests in `__tests__/services/config-service-methods.test.ts` that were introduced in #336 and have been red on every PR since. CI on `main` is currently broken — every open PR (including #347) inherits this failure.

## Root cause

The new test file uses `jest.mock(path, factory)` with module factories. Under this repo's ESM Jest setup (`preset: ts-jest/presets/default-esm` + `extensionsToTreatAsEsm: ['.ts']`), factory mocks don't hoist before the static `import` of `ConfigService`. The result: `Config.deleteOne`, `Config.find().sort()`, etc. call through to the real Mongoose model, which has none of those methods on the static class in this test environment.

Symptoms reproduced on a clean `origin/main`:

```
Test Suites: 1 failed, 82 passed, 83 total
Tests:       16 failed, 1 skipped, 717 passed, 734 total
```

## Fix

1. **Switch to `jest.unstable_mockModule` + dynamic `import`.** This is the supported pattern for ESM mocks in Jest. Mocks are registered before the dynamic import resolves `config-service.js`.
2. **Mongoose mock exposes both named and default exports** (`config-service.ts` uses `import mongoose from "mongoose"`).
3. **Add `updateOne` to the `Config` mock** — `cleanupUnknownSettings()` calls it during `initialize()` tests; without the mock the call would throw.
4. **Fix the "load configs on initialization" test case.** It seeded the mock with `{ key: 'loaded.key', ... }`, but `loaded.key` is not in `defaultConfig`, so `cleanupUnknownSettings()` evicted it from the cache before the assertion ran. Use `voicechannels.enabled` (a real schema key) instead.

## Verification

```
$ npm run test:ci
Test Suites: 83 passed, 83 total
Tests:       1 skipped, 733 passed, 734 total
```

Coverage thresholds (raised to 15/25/20/20% in #336) are met.

## Test plan

- [ ] CI on this PR shows `Test (Node 22)` and `Test (Node 24)` green.
- [ ] After merge, rebase #347 (release-please swap) and confirm its CI also goes green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HDeXPYM4MiXucQm5NqJnsz)_