### PR TITLE
fix(voice-channels): unify lobby name lookup and recover from setChannel failure

### DIFF
--- a/__tests__/services/voice-channel-manager-create-failure.test.ts
+++ b/__tests__/services/voice-channel-manager-create-failure.test.ts
@@ -1,0 +1,163 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import {
+  ChannelType,
+  type Client,
+  type Guild,
+  type VoiceChannel,
+  type CategoryChannel,
+  type GuildMember,
+} from "discord.js";
+
+// Mock dependencies before importing
+jest.mock("../../src/utils/logger.js");
+jest.mock("../../src/services/voice-channel-tracker.js");
+jest.mock("../../src/services/config-service.js");
+
+// Import after mocks
+import { VoiceChannelManager } from "../../src/services/voice-channel-manager.js";
+import { ConfigService } from "../../src/services/config-service.js";
+
+const mockConfigService =
+  ConfigService.getInstance() as jest.Mocked<ConfigService>;
+
+/**
+ * Regression coverage for issue #339: an AFK→lobby transition could leave a
+ * stale entry in `userChannels` when `member.voice.setChannel` failed mid-flight,
+ * locking the user out of all future lobby joins until the bot restarted.
+ */
+describe("VoiceChannelManager.createUserChannel - setChannel failure", () => {
+  let manager: VoiceChannelManager;
+  let mockClient: Partial<Client>;
+  let mockMember: Partial<GuildMember>;
+  let mockGuild: Partial<Guild>;
+  let mockCategory: Partial<CategoryChannel>;
+  let createdChannel: Partial<VoiceChannel>;
+  let setChannelMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (VoiceChannelManager as any).instance = undefined;
+
+    mockConfigService.getBoolean = jest
+      .fn()
+      .mockImplementation((_key: string, defaultValue: boolean) =>
+        Promise.resolve(defaultValue),
+      );
+    mockConfigService.getString = jest
+      .fn()
+      .mockImplementation((key: string, defaultValue?: string) => {
+        if (key === "voicechannels.category.name")
+          return Promise.resolve("Dynamic Voice Channels");
+        if (key === "voicechannels.channel.suffix")
+          return Promise.resolve("'s Room");
+        if (key === "voicechannels.channel.prefix") return Promise.resolve("🎮");
+        return Promise.resolve(defaultValue ?? "");
+      });
+
+    createdChannel = {
+      id: "new-channel-id",
+      name: "🎮 Tester's Room",
+      type: ChannelType.GuildVoice,
+      delete: jest.fn().mockResolvedValue(undefined),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    mockCategory = {
+      id: "category-id",
+      name: "Dynamic Voice Channels",
+      type: ChannelType.GuildCategory,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    mockGuild = {
+      channels: {
+        cache: {
+          find: jest.fn().mockReturnValue(mockCategory),
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+        create: jest.fn().mockResolvedValue(createdChannel),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    setChannelMock = jest.fn();
+    mockMember = {
+      id: "member-id",
+      displayName: "Tester",
+      guild: mockGuild as Guild,
+      voice: {
+        setChannel: setChannelMock,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    mockClient = {} as Partial<Client>;
+    manager = VoiceChannelManager.getInstance(mockClient as Client);
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (VoiceChannelManager as any).instance = undefined;
+  });
+
+  it("does not record a userChannels entry when setChannel fails, and deletes the orphan channel", async () => {
+    setChannelMock.mockRejectedValueOnce(new Error("Stale voice state"));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (manager as any).createUserChannel(mockMember as GuildMember);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const userChannels = (manager as any).userChannels as Map<
+      string,
+      VoiceChannel
+    >;
+
+    expect(userChannels.has("member-id")).toBe(false);
+    expect(createdChannel.delete).toHaveBeenCalled();
+  });
+
+  it("allows a subsequent createUserChannel to succeed after a prior setChannel failure", async () => {
+    setChannelMock
+      .mockRejectedValueOnce(new Error("Stale voice state"))
+      .mockResolvedValueOnce(undefined);
+
+    // First attempt fails — must not lock the user out.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (manager as any).createUserChannel(mockMember as GuildMember);
+
+    // Second attempt: guild.channels.create returns a fresh channel.
+    const secondChannel: Partial<VoiceChannel> = {
+      id: "second-channel-id",
+      name: "🎮 Tester's Room",
+      type: ChannelType.GuildVoice,
+      delete: jest.fn().mockResolvedValue(undefined),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    (
+      mockGuild.channels!.create as jest.Mock
+    ).mockResolvedValueOnce(secondChannel);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (manager as any).createUserChannel(mockMember as GuildMember);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const userChannels = (manager as any).userChannels as Map<
+      string,
+      VoiceChannel
+    >;
+
+    expect(userChannels.get("member-id")).toBe(secondChannel);
+    expect(setChannelMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -82,6 +82,19 @@ export class VoiceChannelManager {
   }
 
   /**
+   * Resolve the lobby channel name, checking the current and legacy config keys
+   * in priority order. Used everywhere the lobby is identified by name so the
+   * different code paths agree on what counts as the lobby.
+   */
+  private async getLobbyChannelName(): Promise<string> {
+    return (
+      (await configService.getString("voicechannels.lobby.name")) ||
+      (await configService.getString("voice_channel.lobby_channel_name")) ||
+      (await configService.getString("LOBBY_CHANNEL_NAME", "Lobby"))
+    );
+  }
+
+  /**
    * Set the live status of a channel
    */
   public setLiveStatus(channelId: string, isLive: boolean): void {
@@ -322,10 +335,7 @@ export class VoiceChannelManager {
           "Dynamic Voice Channels",
         ));
 
-      const lobbyChannelName =
-        (await configService.getString("voicechannels.lobby.name")) ||
-        (await configService.getString("voice_channel.lobby_channel_name")) ||
-        (await configService.getString("LOBBY_CHANNEL_NAME", "Lobby"));
+      const lobbyChannelName = await this.getLobbyChannelName();
 
       const offlineLobbyName =
         (await configService.getString("voicechannels.lobby.offlinename")) ||
@@ -686,10 +696,7 @@ export class VoiceChannelManager {
           await this.sendLiveDisclaimer(newChannel as VoiceChannel, member);
         }
 
-        const lobbyChannelName =
-          (await configService.getString("voicechannels.lobby.name")) ||
-          (await configService.getString("voice_channel.lobby_channel_name")) ||
-          (await configService.getString("LOBBY_CHANNEL_NAME", "Lobby"));
+        const lobbyChannelName = await this.getLobbyChannelName();
         logger.info(
           `User joined channel. Lobby name: "${lobbyChannelName}", Channel name: "${newChannel.name}"`,
         );
@@ -737,10 +744,7 @@ export class VoiceChannelManager {
           await this.sendLiveDisclaimer(newChannel as VoiceChannel, member);
         }
 
-        const lobbyChannelName = await configService.getString(
-          "voicechannels.lobby.name",
-          "Lobby",
-        );
+        const lobbyChannelName = await this.getLobbyChannelName();
         // If user is moving to the Lobby, create a new channel
         if (newChannel.name === lobbyChannelName) {
           // Clean up the old channel if it was a personal channel
@@ -910,8 +914,31 @@ export class VoiceChannelManager {
         userLimit: 0, // 0 = unlimited by default
       });
 
+      // Move the user before recording ownership: if the move fails (which can
+      // happen when the gateway voice state is stale, e.g. AFK→lobby), we don't
+      // want a permanent userChannels entry that locks the user out of future
+      // lobby joins until the bot restarts.
+      try {
+        await member.voice.setChannel(channel);
+      } catch (moveError) {
+        logger.error(
+          `Failed to move ${member.displayName} into newly created channel; cleaning up:`,
+          moveError,
+        );
+        try {
+          await channel.delete(
+            "Failed to move user into newly created channel",
+          );
+        } catch (deleteError) {
+          logger.error(
+            "Error deleting orphaned channel after setChannel failure:",
+            deleteError,
+          );
+        }
+        return;
+      }
+
       this.userChannels.set(member.id, channel);
-      await member.voice.setChannel(channel);
       logger.info(
         `Created voice channel ${channelName} for ${member.displayName}`,
       );
@@ -1612,10 +1639,7 @@ export class VoiceChannelManager {
           "Dynamic Voice Channels",
         ));
 
-      const lobbyChannelName =
-        (await configService.getString("voicechannels.lobby.name")) ||
-        (await configService.getString("voice_channel.lobby_channel_name")) ||
-        (await configService.getString("LOBBY_CHANNEL_NAME", "Lobby"));
+      const lobbyChannelName = await this.getLobbyChannelName();
 
       const offlineLobbyName =
         (await configService.getString("voicechannels.lobby.offlinename")) ||


### PR DESCRIPTION
Fixes #339.

## Summary

Two compounding bugs in `voice-channel-manager.ts` could cause an AFK→lobby transition to silently fail and then permanently lock the user out of personal-channel creation until the bot restarted.

### 1. Lobby name lookup disagreed across branches

- The "user joined" branch, init-cleanup, and periodic-cleanup all tried three config keys: `voicechannels.lobby.name`, `voice_channel.lobby_channel_name`, `LOBBY_CHANNEL_NAME` (default `"Lobby"`).
- The "user switched channels" branch only tried `voicechannels.lobby.name` with a `"Lobby"` default. Deployments using a legacy key with a non-default lobby name made the switch branch silently miss.

Extracted a `getLobbyChannelName()` helper and use it in all four call sites (init cleanup, join, switch, periodic cleanup) so they can't drift apart again.

### 2. Stale `userChannels` entry when `member.voice.setChannel` failed

`createUserChannel` recorded ownership before moving the user:

```ts
this.userChannels.set(member.id, channel);
await member.voice.setChannel(channel);  // could throw on a stale voice state
```

If `setChannel` threw — plausible during AFK→lobby because the gateway voice state is in flux — the catch only logged. The orphan channel stayed in Discord and the map entry stuck around, so every subsequent lobby join hit the `"user already has a channel"` early-return at the top of `createUserChannel`. The only fix was a bot restart.

Now we move first; on failure we delete the orphan channel and return without recording ownership, so the next attempt is clean.

## Test plan

- [x] New regression test (`voice-channel-manager-create-failure.test.ts`) covers both: no `userChannels` entry on `setChannel` failure, and a subsequent `createUserChannel` succeeds.
- [x] Full suite: `npm test` — 735 passed, 1 skipped, 84 suites.
- [x] `npm run build`, `npm run lint` (0 errors), `npm run format:check` clean.

https://claude.ai/code/session_0136vnLBTL268nobejC3h8C7

---
_Generated by [Claude Code](https://claude.ai/code/session_0136vnLBTL268nobejC3h8C7)_