### PR TITLE
fix(ci): bump trivy-action to v0.36.0 (current latest)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -136,7 +136,7 @@ jobs:
           done
 
       - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: sarif


### PR DESCRIPTION
## Summary

Follow-up to #356. With the hadolint permission fix in, `build-and-push` now starts running, but it fails immediately at job setup:

> Unable to resolve action `aquasecurity/trivy-action@0.28.0`, unable to find version `0.28.0`

(Failing run: https://github.com/lonix/koolbot/actions/runs/25480801700/job/74764305941)

`aquasecurity/trivy-action` migrated all tags to a `v`-prefix during a supply-chain security cleanup, and the bare `0.28.0` tag was removed.

A first attempt to simply re-add the `v` prefix (`@v0.28.0`) tripped the `zizmor (workflow security audit)` job (run https://github.com/lonix/koolbot/actions/runs/25480895069/job/74764541649, exit code 14) — likely an online audit (`stale-action-refs` / `ref-confusion`) that requires a real `GITHUB_TOKEN` to reproduce locally and which I couldn't replicate offline. Rather than chase that for an old release, this PR bumps to **v0.36.0** (current latest stable, released 22 Apr 2026) so we get the broken pin fixed and onto a maintained release in one step.

```diff
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
```

This is the only action in `.github/workflows/` that was pinned without a `v` prefix. Dependabot (`production-minor` / `github-actions` ecosystem) will keep it current going forward.

## Test plan

- [ ] Merge and confirm the next **Docker Build and Push** run on main reaches the Trivy scan step and uploads the SARIF report.
- [ ] Verify the **zizmor (workflow security audit)** check passes on this PR before merging.
- [ ] Verify Trivy results appear under **Security → Code scanning** alongside the hadolint findings.

https://claude.ai/code/session_01W9JmAwsQdN7RWFh55zdCp5