### PR TITLE
feat(voice): button-driven voice channel presets (#364)

### DIFF
--- a/src/handlers/vc-modal-handler.ts
+++ b/src/handlers/vc-modal-handler.ts
@@ -1,13 +1,19 @@
 import { ModalSubmitInteraction, ChannelType } from "discord.js";
 import logger from "../utils/logger.js";
 import { VoiceChannelManager } from "../services/voice-channel-manager.js";
+import { ConfigService } from "../services/config-service.js";
+import { UserVoicePreferences } from "../models/user-voice-preferences.js";
+
+const configService = ConfigService.getInstance();
 
 export async function handleVCModal(
   interaction: ModalSubmitInteraction,
 ): Promise<void> {
   const customId = interaction.customId;
 
-  // Parse custom ID: vc_modal_{action}_{channelId}_{userId}
+  // Forms:
+  //   vc_modal_{action}_{channelId}_{userId}              (5 parts)
+  //   vc_modal_{action}_{presetIndex}_{channelId}_{userId} (6 parts, preset-targeting actions)
   const parts = customId.split("_");
   if (parts.length < 5 || parts[0] !== "vc" || parts[1] !== "modal") {
     await interaction.reply({
@@ -18,8 +24,10 @@ export async function handleVCModal(
   }
 
   const action = parts[2];
-  const channelId = parts[3];
-  const userId = parts[4];
+  const usesPresetIndex = parts.length === 6;
+  const presetIndex = usesPresetIndex ? Number(parts[3]) : null;
+  const channelId = usesPresetIndex ? parts[4] : parts[3];
+  const userId = usesPresetIndex ? parts[5] : parts[4];
 
   // Verify user
   if (userId !== interaction.user.id) {
@@ -45,6 +53,19 @@ export async function handleVCModal(
       case "name":
         await handleNameModal(interaction, channelId);
         break;
+      case "savepreset":
+        await handleSavePresetModal(interaction, channelId, userId);
+        break;
+      case "renamepreset":
+        if (presetIndex === null || !Number.isInteger(presetIndex)) {
+          await interaction.reply({
+            content: "❌ Invalid preset reference.",
+            ephemeral: true,
+          });
+          return;
+        }
+        await handleRenamePresetModal(interaction, presetIndex, userId);
+        break;
       default:
         await interaction.reply({
           content: "❌ Unknown modal action.",
@@ -53,10 +74,12 @@ export async function handleVCModal(
     }
   } catch (error) {
     logger.error("Error handling VC modal:", error);
-    await interaction.reply({
-      content: "❌ An error occurred while processing your request.",
-      ephemeral: true,
-    });
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({
+        content: "❌ An error occurred while processing your request.",
+        ephemeral: true,
+      });
+    }
   }
 }
 
@@ -115,4 +138,150 @@ async function handleNameModal(
       ephemeral: true,
     });
   }
+}
+
+async function handleSavePresetModal(
+  interaction: ModalSubmitInteraction,
+  channelId: string,
+  userId: string,
+): Promise<void> {
+  const enabled = await configService.getBoolean(
+    "voicechannels.presets.enabled",
+    false,
+  );
+  if (!enabled) {
+    await interaction.reply({
+      content: "❌ Presets are disabled on this server.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const presetName = interaction.fields.getTextInputValue("name").trim();
+  if (presetName.length === 0 || presetName.length > 50) {
+    await interaction.reply({
+      content: "❌ Preset name must be 1–50 characters.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const channel = await interaction.guild?.channels.fetch(channelId);
+  if (!channel || channel.type !== ChannelType.GuildVoice) {
+    await interaction.reply({
+      content: "❌ Voice channel not found.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const max = await configService.getNumber(
+    "voicechannels.presets.max_per_user",
+    3,
+  );
+  const prefs =
+    (await UserVoicePreferences.findOne({ userId })) ??
+    (await UserVoicePreferences.create({ userId, presets: [] }));
+
+  const existingIndex = prefs.presets.findIndex(
+    (p) => p.name.toLowerCase() === presetName.toLowerCase(),
+  );
+
+  if (existingIndex === -1 && prefs.presets.length >= max) {
+    await interaction.reply({
+      content: `❌ You already have ${max} presets (the configured maximum). Delete one first or rename an existing preset.`,
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const snapshot = {
+    name: presetName,
+    channelName: channel.name,
+    userLimit: channel.userLimit ?? 0,
+    bitrate: Math.round((channel.bitrate ?? 64000) / 1000),
+    isDefault:
+      existingIndex !== -1
+        ? !!prefs.presets[existingIndex].isDefault
+        : false,
+  };
+
+  if (existingIndex !== -1) {
+    prefs.presets[existingIndex] = snapshot;
+  } else {
+    prefs.presets.push(snapshot);
+  }
+  prefs.markModified("presets");
+  await prefs.save();
+
+  logger.info(
+    `User ${userId} saved preset "${presetName}" from channel ${channelId}`,
+  );
+
+  await interaction.reply({
+    content:
+      existingIndex !== -1
+        ? `✅ Preset **${presetName}** updated from this channel's settings.`
+        : `✅ Preset **${presetName}** saved.`,
+    ephemeral: true,
+  });
+}
+
+async function handleRenamePresetModal(
+  interaction: ModalSubmitInteraction,
+  presetIndex: number,
+  userId: string,
+): Promise<void> {
+  const enabled = await configService.getBoolean(
+    "voicechannels.presets.enabled",
+    false,
+  );
+  if (!enabled) {
+    await interaction.reply({
+      content: "❌ Presets are disabled on this server.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const newName = interaction.fields.getTextInputValue("name").trim();
+  if (newName.length === 0 || newName.length > 50) {
+    await interaction.reply({
+      content: "❌ Preset name must be 1–50 characters.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const prefs = await UserVoicePreferences.findOne({ userId });
+  const preset = prefs?.presets?.[presetIndex];
+  if (!prefs || !preset) {
+    await interaction.reply({
+      content: "❌ Preset no longer exists.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const collision = prefs.presets.findIndex(
+    (p, i) =>
+      i !== presetIndex && p.name.toLowerCase() === newName.toLowerCase(),
+  );
+  if (collision !== -1) {
+    await interaction.reply({
+      content: `❌ You already have a preset named **${newName}**.`,
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const oldName = preset.name;
+  preset.name = newName;
+  prefs.markModified("presets");
+  await prefs.save();
+
+  await interaction.reply({
+    content: `✏️ Preset **${oldName}** renamed to **${newName}**.`,
+    ephemeral: true,
+  });
 }

--- a/src/handlers/vc-modal-handler.ts
+++ b/src/handlers/vc-modal-handler.ts
@@ -201,9 +201,7 @@ async function handleSavePresetModal(
     userLimit: channel.userLimit ?? 0,
     bitrate: Math.round((channel.bitrate ?? 64000) / 1000),
     isDefault:
-      existingIndex !== -1
-        ? !!prefs.presets[existingIndex].isDefault
-        : false,
+      existingIndex !== -1 ? !!prefs.presets[existingIndex].isDefault : false,
   };
 
   if (existingIndex !== -1) {

--- a/src/handlers/vc-preset-handler.ts
+++ b/src/handlers/vc-preset-handler.ts
@@ -1,0 +1,612 @@
+import {
+  ButtonInteraction,
+  StringSelectMenuInteraction,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  StringSelectMenuBuilder,
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  EmbedBuilder,
+  VoiceChannel,
+  ChannelType,
+  MessageFlags,
+} from "discord.js";
+import logger from "../utils/logger.js";
+import { ConfigService } from "../services/config-service.js";
+import {
+  UserVoicePreferences,
+  IChannelPreset,
+  IUserVoicePreferences,
+} from "../models/user-voice-preferences.js";
+
+const configService = ConfigService.getInstance();
+
+type ParsedId = {
+  action: string;
+  presetIndex: number | null;
+  channelId: string;
+  ownerId: string;
+};
+
+function parseCustomId(customId: string): ParsedId | null {
+  // Forms:
+  //   vc_preset_{action}_{channelId}_{ownerId}                    (5 parts)
+  //   vc_preset_{action}_{presetIndex}_{channelId}_{ownerId}      (6 parts)
+  const parts = customId.split("_");
+  if (parts[0] !== "vc" || parts[1] !== "preset") return null;
+
+  const action = parts[2];
+  if (!action) return null;
+
+  if (parts.length === 5) {
+    return {
+      action,
+      presetIndex: null,
+      channelId: parts[3],
+      ownerId: parts[4],
+    };
+  }
+  if (parts.length === 6) {
+    const idx = Number(parts[3]);
+    if (!Number.isInteger(idx) || idx < 0) return null;
+    return {
+      action,
+      presetIndex: idx,
+      channelId: parts[4],
+      ownerId: parts[5],
+    };
+  }
+  return null;
+}
+
+async function presetsEnabled(): Promise<boolean> {
+  return await configService.getBoolean("voicechannels.presets.enabled", false);
+}
+
+async function maxPerUser(): Promise<number> {
+  return await configService.getNumber("voicechannels.presets.max_per_user", 3);
+}
+
+async function loadPrefs(userId: string): Promise<IUserVoicePreferences> {
+  return (
+    (await UserVoicePreferences.findOne({ userId })) ??
+    (await UserVoicePreferences.create({ userId, presets: [] }))
+  );
+}
+
+function presetSummary(p: IChannelPreset): string {
+  const bits: string[] = [];
+  if (p.channelName) bits.push(`name "${p.channelName}"`);
+  if (typeof p.userLimit === "number")
+    bits.push(p.userLimit === 0 ? "no limit" : `limit ${p.userLimit}`);
+  if (typeof p.bitrate === "number") bits.push(`${p.bitrate}kbps`);
+  return bits.length ? bits.join(" · ") : "(empty)";
+}
+
+function buildApplyPanel(
+  presets: IChannelPreset[],
+  channelId: string,
+  ownerId: string,
+): {
+  embed: EmbedBuilder;
+  components: ActionRowBuilder<ButtonBuilder | StringSelectMenuBuilder>[];
+} {
+  const embed = new EmbedBuilder()
+    .setTitle("🎛️ Voice Channel Presets")
+    .setColor(0x5865f2)
+    .setDescription(
+      presets.length === 0
+        ? "You have no saved presets yet. Configure your channel and click **Save current as preset** below."
+        : presets
+            .map(
+              (p, i) =>
+                `**${i + 1}. ${p.name}** ${p.isDefault ? "⭐" : ""}\n  ${presetSummary(p)}`,
+            )
+            .join("\n"),
+    )
+    .setFooter({
+      text: "⭐ default preset auto-applies when you spawn a new channel",
+    });
+
+  const rows: ActionRowBuilder<ButtonBuilder | StringSelectMenuBuilder>[] = [];
+
+  if (presets.length > 0) {
+    const select = new StringSelectMenuBuilder()
+      .setCustomId(`vc_preset_apply_${channelId}_${ownerId}`)
+      .setPlaceholder("Apply a preset to this channel…")
+      .addOptions(
+        presets.slice(0, 25).map((p, i) => ({
+          label: p.isDefault ? `⭐ ${p.name}` : p.name,
+          description: presetSummary(p).slice(0, 100),
+          value: String(i),
+        })),
+      );
+    rows.push(
+      new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select),
+    );
+  }
+
+  const actionRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`vc_preset_save_${channelId}_${ownerId}`)
+      .setLabel("Save current as preset")
+      .setStyle(ButtonStyle.Success)
+      .setEmoji("💾"),
+    new ButtonBuilder()
+      .setCustomId(`vc_preset_manage_${channelId}_${ownerId}`)
+      .setLabel("Manage…")
+      .setStyle(ButtonStyle.Secondary)
+      .setEmoji("🗑️")
+      .setDisabled(presets.length === 0),
+  );
+  rows.push(actionRow);
+
+  return { embed, components: rows };
+}
+
+function buildManagePanel(
+  presets: IChannelPreset[],
+  channelId: string,
+  ownerId: string,
+  selectedIndex: number | null,
+): {
+  embed: EmbedBuilder;
+  components: ActionRowBuilder<ButtonBuilder | StringSelectMenuBuilder>[];
+} {
+  const selected =
+    selectedIndex !== null && selectedIndex >= 0
+      ? presets[selectedIndex]
+      : null;
+
+  const embed = new EmbedBuilder()
+    .setTitle("🎛️ Manage Presets")
+    .setColor(0xed4245)
+    .setDescription(
+      selected
+        ? `Selected: **${selected.name}** ${selected.isDefault ? "⭐" : ""}\n${presetSummary(selected)}`
+        : "Pick a preset below to rename, delete, or set as default.",
+    );
+
+  const select = new StringSelectMenuBuilder()
+    .setCustomId(`vc_preset_pick_${channelId}_${ownerId}`)
+    .setPlaceholder("Choose a preset to manage…")
+    .addOptions(
+      presets.slice(0, 25).map((p, i) => ({
+        label: p.isDefault ? `⭐ ${p.name}` : p.name,
+        description: presetSummary(p).slice(0, 100),
+        value: String(i),
+        default: i === selectedIndex,
+      })),
+    );
+
+  const rows: ActionRowBuilder<ButtonBuilder | StringSelectMenuBuilder>[] = [
+    new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select),
+  ];
+
+  const idx = selectedIndex ?? 0;
+  const disabled = selected === null;
+  rows.push(
+    new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(`vc_preset_default_${idx}_${channelId}_${ownerId}`)
+        .setLabel(selected?.isDefault ? "Unset default" : "Set as default")
+        .setStyle(ButtonStyle.Primary)
+        .setEmoji("⭐")
+        .setDisabled(disabled),
+      new ButtonBuilder()
+        .setCustomId(`vc_preset_rename_${idx}_${channelId}_${ownerId}`)
+        .setLabel("Rename")
+        .setStyle(ButtonStyle.Secondary)
+        .setEmoji("✏️")
+        .setDisabled(disabled),
+      new ButtonBuilder()
+        .setCustomId(`vc_preset_delete_${idx}_${channelId}_${ownerId}`)
+        .setLabel("Delete")
+        .setStyle(ButtonStyle.Danger)
+        .setEmoji("🗑️")
+        .setDisabled(disabled),
+      new ButtonBuilder()
+        .setCustomId(`vc_preset_back_${channelId}_${ownerId}`)
+        .setLabel("Back")
+        .setStyle(ButtonStyle.Secondary)
+        .setEmoji("⬅️"),
+    ),
+  );
+
+  return { embed, components: rows };
+}
+
+async function ensureOwnership(
+  interaction: ButtonInteraction | StringSelectMenuInteraction,
+  parsed: ParsedId,
+): Promise<VoiceChannel | null> {
+  if (interaction.user.id !== parsed.ownerId) {
+    await interaction.reply({
+      content: "❌ Only the channel owner can use these controls.",
+      flags: MessageFlags.Ephemeral,
+    });
+    return null;
+  }
+  const channel = await interaction.guild?.channels.fetch(parsed.channelId);
+  if (!channel || channel.type !== ChannelType.GuildVoice) {
+    await interaction.reply({
+      content: "❌ Voice channel not found.",
+      flags: MessageFlags.Ephemeral,
+    });
+    return null;
+  }
+  return channel as VoiceChannel;
+}
+
+export async function handleVCPresetButton(
+  interaction: ButtonInteraction,
+): Promise<void> {
+  if (!(await presetsEnabled())) {
+    await interaction.reply({
+      content: "❌ Presets are disabled on this server.",
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const parsed = parseCustomId(interaction.customId);
+  if (!parsed) {
+    await interaction.reply({
+      content: "❌ Invalid preset interaction.",
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const channel = await ensureOwnership(interaction, parsed);
+  if (!channel) return;
+
+  try {
+    switch (parsed.action) {
+      case "open":
+        return await openPanel(interaction, parsed);
+      case "save":
+        return await openSaveModal(interaction, parsed, channel);
+      case "manage":
+        return await switchToManage(interaction, parsed, null);
+      case "back":
+        return await switchToApply(interaction, parsed);
+      case "default":
+        return await toggleDefault(interaction, parsed);
+      case "rename":
+        return await openRenameModal(interaction, parsed);
+      case "delete":
+        return await deletePreset(interaction, parsed);
+      default:
+        await interaction.reply({
+          content: "❌ Unknown preset action.",
+          flags: MessageFlags.Ephemeral,
+        });
+    }
+  } catch (error) {
+    logger.error("Error handling VC preset button:", error);
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({
+        content: "❌ An error occurred while processing your request.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
+  }
+}
+
+export async function handleVCPresetSelect(
+  interaction: StringSelectMenuInteraction,
+): Promise<void> {
+  if (!(await presetsEnabled())) {
+    await interaction.reply({
+      content: "❌ Presets are disabled on this server.",
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const parsed = parseCustomId(interaction.customId);
+  if (!parsed) {
+    await interaction.reply({
+      content: "❌ Invalid preset interaction.",
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const channel = await ensureOwnership(interaction, parsed);
+  if (!channel) return;
+
+  try {
+    const idx = Number(interaction.values[0]);
+    if (!Number.isInteger(idx) || idx < 0) {
+      await interaction.reply({
+        content: "❌ Invalid preset selected.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (parsed.action === "apply") {
+      return await applyPreset(interaction, parsed, channel, idx);
+    }
+    if (parsed.action === "pick") {
+      return await switchToManage(interaction, parsed, idx);
+    }
+
+    await interaction.reply({
+      content: "❌ Unknown preset action.",
+      flags: MessageFlags.Ephemeral,
+    });
+  } catch (error) {
+    logger.error("Error handling VC preset select:", error);
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({
+        content: "❌ An error occurred while processing your request.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
+  }
+}
+
+async function openPanel(
+  interaction: ButtonInteraction,
+  parsed: ParsedId,
+): Promise<void> {
+  const prefs = await loadPrefs(parsed.ownerId);
+  const { embed, components } = buildApplyPanel(
+    prefs.presets,
+    parsed.channelId,
+    parsed.ownerId,
+  );
+  await interaction.reply({
+    embeds: [embed],
+    components,
+    flags: MessageFlags.Ephemeral,
+  });
+}
+
+async function switchToApply(
+  interaction: ButtonInteraction,
+  parsed: ParsedId,
+): Promise<void> {
+  const prefs = await loadPrefs(parsed.ownerId);
+  const { embed, components } = buildApplyPanel(
+    prefs.presets,
+    parsed.channelId,
+    parsed.ownerId,
+  );
+  await interaction.update({ embeds: [embed], components });
+}
+
+async function switchToManage(
+  interaction: ButtonInteraction | StringSelectMenuInteraction,
+  parsed: ParsedId,
+  selectedIndex: number | null,
+): Promise<void> {
+  const prefs = await loadPrefs(parsed.ownerId);
+  if (prefs.presets.length === 0) {
+    await interaction.reply({
+      content: "❌ You don't have any presets yet.",
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+  const { embed, components } = buildManagePanel(
+    prefs.presets,
+    parsed.channelId,
+    parsed.ownerId,
+    selectedIndex,
+  );
+  await interaction.update({ embeds: [embed], components });
+}
+
+async function openSaveModal(
+  interaction: ButtonInteraction,
+  parsed: ParsedId,
+  channel: VoiceChannel,
+): Promise<void> {
+  const prefs = await loadPrefs(parsed.ownerId);
+  const max = await maxPerUser();
+  if (prefs.presets.length >= max) {
+    await interaction.reply({
+      content: `❌ You already have ${max} presets (the configured maximum). Delete one first.`,
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const modal = new ModalBuilder()
+    .setCustomId(`vc_modal_savepreset_${parsed.channelId}_${parsed.ownerId}`)
+    .setTitle("Save preset");
+  const nameInput = new TextInputBuilder()
+    .setCustomId("name")
+    .setLabel("Preset name")
+    .setStyle(TextInputStyle.Short)
+    .setPlaceholder("e.g. Squad night")
+    .setRequired(true)
+    .setMaxLength(50)
+    .setValue(channel.name.slice(0, 50));
+
+  modal.addComponents(
+    new ActionRowBuilder<TextInputBuilder>().addComponents(nameInput),
+  );
+  await interaction.showModal(modal);
+}
+
+async function openRenameModal(
+  interaction: ButtonInteraction,
+  parsed: ParsedId,
+): Promise<void> {
+  if (parsed.presetIndex === null) {
+    await interaction.reply({
+      content: "❌ No preset selected.",
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+  const prefs = await loadPrefs(parsed.ownerId);
+  const preset = prefs.presets[parsed.presetIndex];
+  if (!preset) {
+    await interaction.reply({
+      content: "❌ Preset no longer exists.",
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const modal = new ModalBuilder()
+    .setCustomId(
+      `vc_modal_renamepreset_${parsed.presetIndex}_${parsed.channelId}_${parsed.ownerId}`,
+    )
+    .setTitle("Rename preset");
+  const nameInput = new TextInputBuilder()
+    .setCustomId("name")
+    .setLabel("New preset name")
+    .setStyle(TextInputStyle.Short)
+    .setRequired(true)
+    .setMaxLength(50)
+    .setValue(preset.name);
+
+  modal.addComponents(
+    new ActionRowBuilder<TextInputBuilder>().addComponents(nameInput),
+  );
+  await interaction.showModal(modal);
+}
+
+async function toggleDefault(
+  interaction: ButtonInteraction,
+  parsed: ParsedId,
+): Promise<void> {
+  if (parsed.presetIndex === null) return;
+  const prefs = await loadPrefs(parsed.ownerId);
+  const target = prefs.presets[parsed.presetIndex];
+  if (!target) {
+    await interaction.reply({
+      content: "❌ Preset no longer exists.",
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const wasDefault = !!target.isDefault;
+  prefs.presets.forEach((p) => {
+    p.isDefault = false;
+  });
+  if (!wasDefault) target.isDefault = true;
+  prefs.markModified("presets");
+  await prefs.save();
+
+  await switchToManage(interaction, parsed, parsed.presetIndex);
+  await interaction.followUp({
+    content: wasDefault
+      ? `⭐ **${target.name}** is no longer the default.`
+      : `⭐ **${target.name}** will auto-apply on your next channel.`,
+    flags: MessageFlags.Ephemeral,
+  });
+}
+
+async function deletePreset(
+  interaction: ButtonInteraction,
+  parsed: ParsedId,
+): Promise<void> {
+  if (parsed.presetIndex === null) return;
+  const prefs = await loadPrefs(parsed.ownerId);
+  const target = prefs.presets[parsed.presetIndex];
+  if (!target) {
+    await interaction.reply({
+      content: "❌ Preset no longer exists.",
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const removedName = target.name;
+  prefs.presets.splice(parsed.presetIndex, 1);
+  prefs.markModified("presets");
+  await prefs.save();
+
+  if (prefs.presets.length === 0) {
+    await switchToApply(interaction, parsed);
+  } else {
+    await switchToManage(interaction, parsed, null);
+  }
+  await interaction.followUp({
+    content: `🗑️ Deleted preset **${removedName}**.`,
+    flags: MessageFlags.Ephemeral,
+  });
+}
+
+async function applyPreset(
+  interaction: StringSelectMenuInteraction,
+  parsed: ParsedId,
+  channel: VoiceChannel,
+  index: number,
+): Promise<void> {
+  const prefs = await loadPrefs(parsed.ownerId);
+  const preset = prefs.presets[index];
+  if (!preset) {
+    await interaction.reply({
+      content: "❌ Preset no longer exists.",
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  await applyPresetToChannel(channel, preset);
+
+  await interaction.update({
+    embeds: [
+      new EmbedBuilder()
+        .setTitle("✅ Preset applied")
+        .setColor(0x57f287)
+        .setDescription(
+          `**${preset.name}** applied to this channel.\n${presetSummary(preset)}`,
+        ),
+    ],
+    components: [],
+  });
+}
+
+export async function applyPresetToChannel(
+  channel: VoiceChannel,
+  preset: IChannelPreset,
+): Promise<void> {
+  if (preset.channelName && preset.channelName !== channel.name) {
+    try {
+      await channel.setName(preset.channelName.slice(0, 100));
+    } catch (error) {
+      logger.warn(
+        `Failed to set channel name from preset on ${channel.id}:`,
+        error,
+      );
+    }
+  }
+  if (typeof preset.userLimit === "number") {
+    try {
+      await channel.setUserLimit(preset.userLimit);
+    } catch (error) {
+      logger.warn(
+        `Failed to set user limit from preset on ${channel.id}:`,
+        error,
+      );
+    }
+  }
+  if (typeof preset.bitrate === "number") {
+    try {
+      await channel.setBitrate(preset.bitrate * 1000);
+    } catch (error) {
+      logger.warn(`Failed to set bitrate from preset on ${channel.id}:`, error);
+    }
+  }
+}
+
+export async function getDefaultPreset(
+  userId: string,
+): Promise<IChannelPreset | null> {
+  const prefs = await UserVoicePreferences.findOne({ userId }).lean();
+  if (!prefs?.presets) return null;
+  return prefs.presets.find((p) => p.isDefault) ?? null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -601,6 +601,10 @@ client.on(Events.InteractionCreate, async (interaction) => {
         const { handleVCControlButton } =
           await import("./handlers/vc-control-button-handler.js");
         await handleVCControlButton(interaction);
+      } else if (interaction.customId.startsWith("vc_preset_")) {
+        const { handleVCPresetButton } =
+          await import("./handlers/vc-preset-handler.js");
+        await handleVCPresetButton(interaction);
       } else {
         // Handle wizard buttons
         const { handleWizardButton } =
@@ -621,6 +625,10 @@ client.on(Events.InteractionCreate, async (interaction) => {
         const { handleVCTransferSelect } =
           await import("./handlers/vc-transfer-select-handler.js");
         await handleVCTransferSelect(interaction);
+      } else if (interaction.customId.startsWith("vc_preset_")) {
+        const { handleVCPresetSelect } =
+          await import("./handlers/vc-preset-handler.js");
+        await handleVCPresetSelect(interaction);
       } else {
         // Handle wizard select menus
         const { handleWizardSelectMenu } =

--- a/src/models/user-voice-preferences.ts
+++ b/src/models/user-voice-preferences.ts
@@ -1,13 +1,33 @@
 import mongoose, { Schema, Document } from "mongoose";
 
+export interface IChannelPreset {
+  name: string; // Preset label, e.g. "Squad night"
+  channelName?: string; // Channel name to apply when this preset is loaded
+  userLimit?: number; // 0 = unlimited
+  bitrate?: number; // kbps (Discord accepts 8–384)
+  isDefault?: boolean; // Auto-apply on next lobby spawn
+}
+
 export interface IUserVoicePreferences extends Document {
   userId: string;
   namePattern?: string; // Custom channel naming pattern (e.g., "{username}'s Room", "🎮 {username}")
   userLimit?: number; // Channel user limit (0 = unlimited)
   bitrate?: number; // Bitrate in kbps (8-384 for most servers, up to 128 for non-boosted)
+  presets: IChannelPreset[];
   createdAt: Date;
   updatedAt: Date;
 }
+
+const ChannelPresetSchema = new Schema<IChannelPreset>(
+  {
+    name: { type: String, required: true, maxlength: 50 },
+    channelName: { type: String, maxlength: 100 },
+    userLimit: { type: Number, min: 0, max: 99 },
+    bitrate: { type: Number, min: 8, max: 384 },
+    isDefault: { type: Boolean, default: false },
+  },
+  { _id: false },
+);
 
 const UserVoicePreferencesSchema = new Schema(
   {
@@ -15,6 +35,7 @@ const UserVoicePreferencesSchema = new Schema(
     namePattern: { type: String },
     userLimit: { type: Number, min: 0, max: 99 },
     bitrate: { type: Number, min: 8, max: 384 }, // Discord limits: 8kbps min, 384kbps max (with boost)
+    presets: { type: [ChannelPresetSchema], default: [] },
   },
   {
     timestamps: true,

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -8,6 +8,8 @@ export interface ConfigSchema {
   "voicechannels.channel.suffix": string;
   "voicechannels.controlpanel.enabled": boolean;
   "voicechannels.ownership.grace_period_seconds": number;
+  "voicechannels.presets.enabled": boolean;
+  "voicechannels.presets.max_per_user": number;
 
   // Voice Activity Tracking
   "voicetracking.enabled": boolean;
@@ -104,6 +106,8 @@ export const defaultConfig: ConfigSchema = {
   "voicechannels.channel.suffix": "",
   "voicechannels.controlpanel.enabled": true,
   "voicechannels.ownership.grace_period_seconds": 30,
+  "voicechannels.presets.enabled": false,
+  "voicechannels.presets.max_per_user": 3,
 
   // Voice Activity Tracking
   "voicetracking.enabled": false,

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -1007,7 +1007,7 @@ export class VoiceChannelManager {
           .setEmoji("👑"),
       );
 
-      const row2 = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      const row2Buttons = [
         new ButtonBuilder()
           .setCustomId(`vc_control_live_${channel.id}_${ownerId}`)
           .setLabel(isLive ? "Go Offline" : "Go Live")
@@ -1018,6 +1018,24 @@ export class VoiceChannelManager {
           .setLabel(hasWaitingRoom ? "Remove Waiting Room" : "Waiting Room")
           .setStyle(hasWaitingRoom ? ButtonStyle.Danger : ButtonStyle.Secondary)
           .setEmoji(hasWaitingRoom ? "🗑️" : "⏳"),
+      ];
+
+      const presetsEnabled = await configService.getBoolean(
+        "voicechannels.presets.enabled",
+        false,
+      );
+      if (presetsEnabled) {
+        row2Buttons.push(
+          new ButtonBuilder()
+            .setCustomId(`vc_preset_open_${channel.id}_${ownerId}`)
+            .setLabel("Presets")
+            .setStyle(ButtonStyle.Secondary)
+            .setEmoji("🎛️"),
+        );
+      }
+
+      const row2 = new ActionRowBuilder<ButtonBuilder>().addComponents(
+        ...row2Buttons,
       );
 
       // In Discord, voice channels can have built-in text chat enabled
@@ -1283,6 +1301,28 @@ export class VoiceChannelManager {
 
       // Store ownership
       this.userChannels.set(userId, newChannel);
+
+      // Auto-apply the user's default preset (if presets are enabled)
+      const presetsEnabled = await configService.getBoolean(
+        "voicechannels.presets.enabled",
+        false,
+      );
+      if (presetsEnabled) {
+        try {
+          const { getDefaultPreset, applyPresetToChannel } = await import(
+            "../handlers/vc-preset-handler.js"
+          );
+          const defaultPreset = await getDefaultPreset(userId);
+          if (defaultPreset) {
+            await applyPresetToChannel(newChannel, defaultPreset);
+            logger.info(
+              `Auto-applied default preset "${defaultPreset.name}" for user ${userId} on channel ${newChannel.id}`,
+            );
+          }
+        } catch (error) {
+          logger.error("Error auto-applying default preset:", error);
+        }
+      }
 
       // Send control panel
       await this.sendControlPanel(newChannel, userId);
@@ -2076,7 +2116,7 @@ export class VoiceChannelManager {
         .setEmoji("👑"),
     );
 
-    const row2 = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    const row2Buttons = [
       new ButtonBuilder()
         .setCustomId(`vc_control_live_${channel.id}_${ownerId}`)
         .setLabel(isLive ? "Go Offline" : "Go Live")
@@ -2087,6 +2127,24 @@ export class VoiceChannelManager {
         .setLabel(hasWaitingRoom ? "Remove Waiting Room" : "Waiting Room")
         .setStyle(hasWaitingRoom ? ButtonStyle.Danger : ButtonStyle.Secondary)
         .setEmoji(hasWaitingRoom ? "🗑️" : "⏳"),
+    ];
+
+    const presetsEnabled = await configService.getBoolean(
+      "voicechannels.presets.enabled",
+      false,
+    );
+    if (presetsEnabled) {
+      row2Buttons.push(
+        new ButtonBuilder()
+          .setCustomId(`vc_preset_open_${channel.id}_${ownerId}`)
+          .setLabel("Presets")
+          .setStyle(ButtonStyle.Secondary)
+          .setEmoji("🎛️"),
+      );
+    }
+
+    const row2 = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      ...row2Buttons,
     );
 
     await message.edit({

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -1309,9 +1309,8 @@ export class VoiceChannelManager {
       );
       if (presetsEnabled) {
         try {
-          const { getDefaultPreset, applyPresetToChannel } = await import(
-            "../handlers/vc-preset-handler.js"
-          );
+          const { getDefaultPreset, applyPresetToChannel } =
+            await import("../handlers/vc-preset-handler.js");
           const defaultPreset = await getDefaultPreset(userId);
           if (defaultPreset) {
             await applyPresetToChannel(newChannel, defaultPreset);


### PR DESCRIPTION
Closes #364.

Reworks the proposed preset system so the common user-facing flows live inside the **existing voice control panel** instead of a new `/vc preset …` slash command group. No new slash commands.

## What's added

- **`UserVoicePreferences.presets`** — array of `{ name, channelName?, userLimit?, bitrate?, isDefault? }` (max-length capped per config).
- **Config keys** (`config-schema.ts`):
  - `voicechannels.presets.enabled` — default `false` (opt-in)
  - `voicechannels.presets.max_per_user` — default `3`
- **🎛️ Presets** button on the control panel (`sendControlPanel` + `rebuildControlPanel`), only rendered when the feature is enabled.
- **`src/handlers/vc-preset-handler.ts`** — handles all `vc_preset_*` buttons + select menus. Two views in one ephemeral panel:
  - *Apply mode*: select-menu of saved presets + **💾 Save current as preset** + **🗑️ Manage…**
  - *Manage mode*: pick a preset → **⭐ Set as default** / **✏️ Rename** / **🗑️ Delete** / **⬅️ Back**
- **Modal extensions** in `vc-modal-handler.ts` for `savepreset` and `renamepreset` (mirrors the existing rename-channel modal pattern; the preset-rename custom-id format embeds an extra `presetIndex` slot).
- **Lobby auto-apply**: `createDynamicChannel` looks up the user's default preset (when presets are enabled) and applies its `channelName` / `userLimit` / `bitrate` to the new channel — zero clicks for the common case.
- **Dispatcher wiring** in `src/index.ts` for `vc_preset_*` buttons and select menus.

## Why button-driven

Per the discussion on #364: presets are a per-user, frequently-used affordance, so they belong inside the panel users already use rather than behind discoverability-poor slash commands. Save/Apply mirrors the existing **rename modal** and **transfer select menu** patterns, so no new infrastructure is introduced.

## Custom-ID layout

```
vc_preset_open_{channelId}_{ownerId}              (button — open panel)
vc_preset_apply_{channelId}_{ownerId}             (select — value = preset index)
vc_preset_save_{channelId}_{ownerId}              (button — open save modal)
vc_preset_manage_{channelId}_{ownerId}            (button — switch to manage mode)
vc_preset_pick_{channelId}_{ownerId}              (select — pick preset to manage)
vc_preset_back_{channelId}_{ownerId}              (button — back to apply mode)
vc_preset_default_{idx}_{channelId}_{ownerId}     (button — toggle default)
vc_preset_rename_{idx}_{channelId}_{ownerId}      (button — open rename modal)
vc_preset_delete_{idx}_{channelId}_{ownerId}      (button — delete preset)

vc_modal_savepreset_{channelId}_{userId}          (modal submit)
vc_modal_renamepreset_{idx}_{channelId}_{userId}  (modal submit)
```

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` — 0 errors (warnings unchanged)
- [x] `npm test` — all 84 suites / 735 tests pass; existing `vc-modal-handler` and control-panel tests still green.
- [ ] Manual: enable `voicechannels.presets.enabled`, verify Presets button appears on a freshly spawned dynamic channel; save → apply → set default → rename → delete works.
- [ ] Manual: with a default preset set, rejoin lobby and confirm the new channel spawns with that name / limit / bitrate.
- [ ] Manual: with `voicechannels.presets.enabled = false`, verify the Presets button is hidden and the lobby spawn is unchanged.
- [ ] Manual: enforce `max_per_user` — try to save a 4th preset (default 3) and confirm the rejection message.

https://claude.ai/code/session_01UGwbsLLDP8GZHLYieeXSvg

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGwbsLLDP8GZHLYieeXSvg)_