### PR TITLE
refactor: extract hardcoded content arrays into src/content/

### DIFF
--- a/src/commands/amikool.ts
+++ b/src/commands/amikool.ts
@@ -5,34 +5,12 @@ import {
 } from "discord.js";
 import logger from "../utils/logger.js";
 import { ConfigService } from "../services/config-service.js";
+import {
+  koolResponses,
+  notKoolResponses,
+} from "../content/amikool-responses.js";
 
 const configService = ConfigService.getInstance();
-
-const koolResponses = [
-  "Yes, you are kool! 😎",
-  "Absolutely kool! 🌟",
-  "You're the koolest! 🎸",
-  "Kool status: Confirmed! ✅",
-  "100% kool certified! 🏆",
-  "Kool as ice! ❄️",
-  "Much kool, Such wow! 👑",
-  "Kool vibes detected! 🎵",
-  "Maximum koolness achieved! 🚀",
-  "Kool level: Legendary! 🏅",
-];
-
-const notKoolResponses = [
-  "No, you are not kool... yet! 😢",
-  "Kool status: Pending... ⏳",
-  "Not quite kool enough... 🥺",
-  "Koolness level: Needs improvement 📈",
-  "Almost kool, but not quite! 🎯",
-  "Kool potential detected! 💫",
-  "Koolness in progress... 🔄",
-  "Future kool kid! 🌱",
-  "Kool training required! 🎓",
-  "Koolness upgrade available! 💎",
-];
 
 export const data = new SlashCommandBuilder()
   .setName("amikool")

--- a/src/content/README.md
+++ b/src/content/README.md
@@ -8,7 +8,7 @@ contributors edit copy without touching unrelated code.
 ## What lives here
 
 | File | Used by | What it is |
-|---|---|---|
+| --- | --- | --- |
 | `statuses.ts` | `services/bot-status-service.ts` | Random-rotation Discord presence pools (lonely / single-user / multi-user) |
 | `amikool-responses.ts` | `commands/amikool.ts` | Reply pools for the `/amikool` command |
 | `friendship-triggers.ts` | `services/friendship-listener.ts` | Phrase triggers for the passive "best ship is friendship" reply |

--- a/src/content/README.md
+++ b/src/content/README.md
@@ -1,0 +1,79 @@
+# `src/content/` — static developer-maintained content
+
+This folder holds arrays and lookup tables of **content** — strings, emojis,
+embed colors, badge metadata — that ship with the bot but aren't really
+"logic". The goal is to keep service files focused on behavior and let
+contributors edit copy without touching unrelated code.
+
+## What lives here
+
+| File | Used by | What it is |
+|---|---|---|
+| `statuses.ts` | `services/bot-status-service.ts` | Random-rotation Discord presence pools (lonely / single-user / multi-user) |
+| `amikool-responses.ts` | `commands/amikool.ts` | Reply pools for the `/amikool` command |
+| `friendship-triggers.ts` | `services/friendship-listener.ts` | Phrase triggers for the passive "best ship is friendship" reply |
+| `notice-categories.ts` | `services/notices-channel-manager.ts` | Per-category emoji + embed color + label |
+| `accolades.ts` | `services/achievements-service.ts` | Display metadata (emoji / name / description) for every accolade |
+| `achievements.ts` | `services/achievements-service.ts` | Display metadata for time-based achievements |
+
+## What does **not** belong here
+
+- **Logic.** `checkFunction`/`metadataFunction` for accolades stay in
+  `achievements-service.ts` next to the rest of the awarding code.
+- **Anything user-configurable at runtime.** Server admins set those via
+  `ConfigService` and the `/config` wizard, not by editing source files.
+- **Per-deploy secrets / IDs.** Channel IDs, role IDs, tokens, etc. belong in
+  environment variables or `ConfigService`.
+
+## Adding entries
+
+### Status / response / trigger pools
+
+Just add a string to the array. The exported arrays are `as const`, so the
+literal types narrow automatically — there's nothing else to wire up.
+
+`multipleUsersStatuses` entries must contain the literal `{count}`
+placeholder. The `satisfies readonly` `${string}{count}${string}` `[]`
+constraint will give you a compile error if you forget it.
+
+### A new accolade
+
+Two-step change, both verified by the type checker:
+
+1. Add an entry to `ACCOLADE_METADATA` in `accolades.ts`:
+
+   ```ts
+   my_new_accolade: {
+     emoji: "✨",
+     name: "Display Name",
+     description: "What you did to earn it",
+   },
+   ```
+
+2. Add a matching entry to `accoladeLogic` in
+   `services/achievements-service.ts`:
+
+   ```ts
+   my_new_accolade: {
+     checkFunction: async (userId, userData) => { /* ... */ },
+     metadataFunction: async (userId, userData) => { /* ... */ },
+   },
+   ```
+
+The `Record<AccoladeType, BadgeLogic>` typing means TypeScript fails the
+build if you add metadata without logic, or if a typo in the id stops them
+from matching.
+
+### A new achievement
+
+Same pattern. `ACHIEVEMENT_METADATA` plus `achievementLogic` in the service.
+The achievement logic record is `Partial<>` because some `AchievementType`
+ids are reserved for future use.
+
+## Conventions
+
+- Use `as const` on every exported array/object — it preserves literal
+  types and prevents accidental mutation.
+- Keep one concern per file. If you find yourself adding a second array to
+  a file for an unrelated feature, make a new file instead.
+- Re-export new files from `index.ts` so they're easy to import.

--- a/src/content/accolades.ts
+++ b/src/content/accolades.ts
@@ -1,0 +1,130 @@
+/**
+ * Display metadata for every accolade (persistent badge).
+ *
+ * Logic for awarding each accolade lives in
+ * `src/services/achievements-service.ts` keyed by the same id. Adding a
+ * new accolade is a two-step change: add the entry here, then add a
+ * matching `checkFunction` in the service. Forgetting the second step
+ * is a TypeScript error — the service's logic record is keyed by the
+ * union derived from this object.
+ */
+
+export const ACCOLADE_METADATA = {
+  first_hour: {
+    emoji: "🎉",
+    name: "First Steps",
+    description: "Spent your first hour in voice chat",
+  },
+  voice_veteran_100: {
+    emoji: "🎖️",
+    name: "Voice Veteran",
+    description: "Reached 100 hours in voice chat",
+  },
+  voice_veteran_500: {
+    emoji: "🏅",
+    name: "Voice Elite",
+    description: "Reached 500 hours in voice chat",
+  },
+  voice_veteran_1000: {
+    emoji: "🏆",
+    name: "Voice Master",
+    description: "Reached 1000 hours in voice chat",
+  },
+  voice_legend_8765: {
+    emoji: "👑",
+    name: "Voice Legend",
+    description: "Reached 8765 hours (1 year) in voice chat",
+  },
+  marathon_runner: {
+    emoji: "🏃",
+    name: "Marathon Runner",
+    description: "Completed a 4+ hour voice session",
+  },
+  ultra_marathoner: {
+    emoji: "🦸",
+    name: "Ultra Marathoner",
+    description: "Completed an 8+ hour voice session",
+  },
+  social_butterfly: {
+    emoji: "🦋",
+    name: "Social Butterfly",
+    description: "Voiced with 10+ unique users",
+  },
+  connector: {
+    emoji: "🤝",
+    name: "Connector",
+    description: "Voiced with 25+ unique users",
+  },
+  night_owl: {
+    emoji: "🦉",
+    name: "Night Owl",
+    description: "Accumulated 50+ hours during late night (10 PM - 6 AM)",
+  },
+  early_bird: {
+    emoji: "🐦",
+    name: "Early Bird",
+    description: "Accumulated 50+ hours during early morning (6 AM - 10 AM)",
+  },
+  weekend_warrior: {
+    emoji: "🎮",
+    name: "Weekend Warrior",
+    description: "Accumulated 100+ hours during weekends",
+  },
+  weekday_warrior: {
+    emoji: "💼",
+    name: "Weekday Warrior",
+    description: "Accumulated 100+ hours during weekdays",
+  },
+  consistent_week: {
+    emoji: "🔥",
+    name: "On a Roll",
+    description: "Connected for 7 consecutive days (5+ min/day)",
+  },
+  consistent_fortnight: {
+    emoji: "⚡",
+    name: "Dedicated AF",
+    description: "Connected for 14 consecutive days (5+ min/day)",
+  },
+  consistent_month: {
+    emoji: "💀",
+    name: "No-Lifer",
+    description: "Connected for 30 consecutive days (5+ min/day)",
+  },
+  quotable: {
+    emoji: "🗣️",
+    name: "Quotable",
+    description: "Been quoted for the first time",
+  },
+  quote_master: {
+    emoji: "📝",
+    name: "Quote Master",
+    description: "Added 10 quotes to the collection",
+  },
+  quote_collector: {
+    emoji: "📚",
+    name: "Quote Collector",
+    description: "Added 50 quotes to the collection",
+  },
+  quote_legend: {
+    emoji: "🏆",
+    name: "Quote Legend",
+    description: "Added 100 quotes to the collection",
+  },
+  widely_quoted: {
+    emoji: "⭐",
+    name: "Widely Quoted",
+    description: "Been quoted 25 times",
+  },
+  quote_icon: {
+    emoji: "💫",
+    name: "Quote Icon",
+    description: "Been quoted 50 times",
+  },
+  viral_quote: {
+    emoji: "🔥",
+    name: "Viral Quote",
+    description: "Have a quote with 10+ likes",
+  },
+} as const;
+
+export type AccoladeType = keyof typeof ACCOLADE_METADATA;

--- a/src/content/achievements.ts
+++ b/src/content/achievements.ts
@@ -1,0 +1,26 @@
+/**
+ * Display metadata for time-based achievements.
+ *
+ * Logic for awarding each achievement lives in
+ * `src/services/achievements-service.ts` keyed by the same id.
+ *
+ * `AchievementType` includes ids that are reserved for future use (no
+ * metadata yet, no logic yet) — those entries simply aren't present
+ * in this object. The service's logic record is `Partial<>` to match.
+ */
+
+export const ACHIEVEMENT_METADATA = {
+  weekly_active: {
+    emoji: "⚡",
+    name: "Active",
+    description: "Reached 10 hours in voice chat this week",
+  },
+} as const;
+
+export type AchievementType =
+  | "weekly_champion"
+  | "weekly_night_owl"
+  | "weekly_marathon"
+  | "weekly_social_butterfly"
+  | "weekly_active"
+  | "weekly_consistent";

--- a/src/content/amikool-responses.ts
+++ b/src/content/amikool-responses.ts
@@ -1,0 +1,31 @@
+/**
+ * Reply pools for the `/amikool` slash command.
+ * One is picked at random depending on whether the caller has the
+ * configured "kool" role.
+ */
+
+export const koolResponses = [
+  "Yes, you are kool! 😎",
+  "Absolutely kool! 🌟",
+  "You're the koolest! 🎸",
+  "Kool status: Confirmed! ✅",
+  "100% kool certified! 🏆",
+  "Kool as ice! ❄️",
+  "Much kool, Such wow! 👑",
+  "Kool vibes detected! 🎵",
+  "Maximum koolness achieved! 🚀",
+  "Kool level: Legendary! 🏅",
+] as const;
+
+export const notKoolResponses = [
+  "No, you are not kool... yet! 😢",
+  "Kool status: Pending... ⏳",
+  "Not quite kool enough... 🥺",
+  "Koolness level: Needs improvement 📈",
+  "Almost kool, but not quite! 🎯",
+  "Kool potential detected! 💫",
+  "Koolness in progress... 🔄",
+  "Future kool kid! 🌱",
+  "Kool training required! 🎓",
+  "Koolness upgrade available! 💎",
+] as const;

--- a/src/content/friendship-triggers.ts
+++ b/src/content/friendship-triggers.ts
@@ -1,0 +1,23 @@
+/**
+ * Phrase triggers for the passive FriendshipListener.
+ *
+ * Matched as case-insensitive substrings against incoming messages
+ * (the listener lowercases the message before checking). Keep all
+ * entries lowercase.
+ */
+
+export const bestTriggers = [
+  "best ship",
+  "best eve ship",
+  "best eve online ship",
+  "what is the best ship",
+  "what's the best ship",
+] as const;
+
+export const worstTriggers = [
+  "worst ship",
+  "worst eve ship",
+  "worst eve online ship",
+  "what is the worst ship",
+  "what's the worst ship",
+] as const;

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,0 +1,6 @@
+export * from "./statuses.js";
+export * from "./amikool-responses.js";
+export * from "./friendship-triggers.js";
+export * from "./notice-categories.js";
+export * from "./accolades.js";
+export * from "./achievements.js";

--- a/src/content/notice-categories.ts
+++ b/src/content/notice-categories.ts
@@ -1,0 +1,35 @@
+import { ColorResolvable } from "discord.js";
+
+/**
+ * Display config (emoji, embed color, label) for each notice category.
+ * Keyed by the `Notice.category` field — keep keys in sync with the
+ * Notice model's allowed category values.
+ */
+
+export interface NoticeCategoryInfo {
+  emoji: string;
+  color: ColorResolvable;
+  label: string;
+}
+
+export const NOTICE_CATEGORIES = {
+  general: {
+    emoji: "📋",
+    color: 0x5865f2 as ColorResolvable,
+    label: "General",
+  },
+  rules: { emoji: "📜", color: 0xe74c3c as ColorResolvable, label: "Rules" },
+  info: {
+    emoji: "ℹ️",
+    color: 0x3498db as ColorResolvable,
+    label: "Information",
+  },
+  help: { emoji: "❓", color: 0x9b59b6 as ColorResolvable, label: "Help" },
+  "game-servers": {
+    emoji: "🎮",
+    color: 0x2ecc71 as ColorResolvable,
+    label: "Game Servers",
+  },
+} as const satisfies Record<string, NoticeCategoryInfo>;
+
+export type NoticeCategoryKey = keyof typeof NOTICE_CATEGORIES;

--- a/src/content/statuses.ts
+++ b/src/content/statuses.ts
@@ -1,0 +1,42 @@
+/**
+ * Bot presence status pools used by BotStatusService.
+ *
+ * Picked at random based on how many users are in voice chat.
+ * `multipleUsersStatuses` entries must contain the literal `{count}`
+ * placeholder — it is replaced with the current user count at runtime.
+ */
+
+export const lonelyStatuses = [
+  "nobody, I hate it here",
+  "paint dry, I'm so bored",
+  "the void, I'm contemplating existence",
+  "pixels, I'm counting them",
+  "solitaire, I'm playing alone",
+  "nothing, I'm staring at the void",
+  "the meaning of life, I'm contemplating it",
+  "Rick Astley on repeat, I'm so lonely", // cspell:ignore Astley
+  "Lo-fi girl, kinda goes with the vibe",
+  "the whole universe was in a hot dense state",
+  "Some russian kid, screaming about fucking my mom",
+  "The matrix, blue or red pill, guys ?",
+] as const;
+
+export const singleUserStatuses = [
+  "a lone wanderer",
+  "one solitary soul",
+  "a single user existing",
+  "one person contemplating life",
+  "a lone voice in the void",
+  "just one user vibing",
+] as const;
+
+export const multipleUsersStatuses = [
+  "{count} nerds",
+  "{count} souls",
+  "{count} humans",
+  "{count} chatters",
+  "{count} people",
+  "{count} gamers that suck",
+  "{count} conversing about nothing",
+  "{count} people that need to get a life",
+] as const satisfies readonly `${string}{count}${string}`[];

--- a/src/services/achievements-service.ts
+++ b/src/services/achievements-service.ts
@@ -12,45 +12,15 @@ import { ConfigService } from "./config-service.js";
 import logger from "../utils/logger.js";
 import mongoose from "mongoose";
 import { quoteService } from "./quote-service.js";
+import { ACCOLADE_METADATA, type AccoladeType } from "../content/accolades.js";
+import {
+  ACHIEVEMENT_METADATA,
+  type AchievementType,
+} from "../content/achievements.js";
 
-// Badge type definitions
-export type AccoladeType =
-  | "first_hour"
-  | "voice_veteran_100"
-  | "voice_veteran_500"
-  | "voice_veteran_1000"
-  | "voice_legend_8765"
-  | "marathon_runner"
-  | "ultra_marathoner"
-  | "social_butterfly"
-  | "connector"
-  | "night_owl"
-  | "early_bird"
-  | "weekend_warrior"
-  | "weekday_warrior"
-  | "consistent_week"
-  | "consistent_fortnight"
-  | "consistent_month"
-  | "quotable"
-  | "quote_master"
-  | "quote_collector"
-  | "quote_legend"
-  | "widely_quoted"
-  | "quote_icon"
-  | "viral_quote";
+export type { AccoladeType, AchievementType };
 
-export type AchievementType =
-  | "weekly_champion"
-  | "weekly_night_owl"
-  | "weekly_marathon"
-  | "weekly_social_butterfly"
-  | "weekly_active"
-  | "weekly_consistent";
-
-interface BadgeDefinition {
-  emoji: string;
-  name: string;
-  description: string;
+interface BadgeLogic {
   checkFunction: (
     userId: string,
     userData: IVoiceChannelTracking | null,
@@ -59,6 +29,12 @@ interface BadgeDefinition {
     userId: string,
     userData: IVoiceChannelTracking | null,
   ) => Promise<{ value?: number; description?: string; unit?: string }>;
+}
+
+interface BadgeDefinition extends BadgeLogic {
+  emoji: string;
+  name: string;
+  description: string;
 }
 
 export class AchievementsService {
@@ -70,12 +46,10 @@ export class AchievementsService {
   // Minimum duration threshold for consecutive days (5 minutes in seconds)
   private static readonly MIN_DAILY_DURATION_SECONDS = 300;
 
-  // Accolade definitions (persistent badges)
-  private accoladeDefinitions: Record<AccoladeType, BadgeDefinition> = {
+  // Awarding logic per accolade (display metadata lives in
+  // src/content/accolades.ts). Keys must match ACCOLADE_METADATA exactly.
+  private accoladeLogic: Record<AccoladeType, BadgeLogic> = {
     first_hour: {
-      emoji: "🎉",
-      name: "First Steps",
-      description: "Spent your first hour in voice chat",
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
@@ -98,9 +72,6 @@ export class AchievementsService {
       },
     },
     voice_veteran_100: {
-      emoji: "🎖️",
-      name: "Voice Veteran",
-      description: "Reached 100 hours in voice chat",
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
@@ -123,9 +94,6 @@ export class AchievementsService {
       },
     },
     voice_veteran_500: {
-      emoji: "🏅",
-      name: "Voice Elite",
-      description: "Reached 500 hours in voice chat",
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
@@ -148,9 +116,6 @@ export class AchievementsService {
       },
     },
     voice_veteran_1000: {
-      emoji: "🏆",
-      name: "Voice Master",
-      description: "Reached 1000 hours in voice chat",
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
@@ -173,9 +138,6 @@ export class AchievementsService {
       },
     },
     voice_legend_8765: {
-      emoji: "👑",
-      name: "Voice Legend",
-      description: "Reached 8765 hours (1 year) in voice chat",
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
@@ -198,9 +160,6 @@ export class AchievementsService {
       },
     },
     marathon_runner: {
-      emoji: "🏃",
-      name: "Marathon Runner",
-      description: "Completed a 4+ hour voice session",
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
@@ -227,9 +186,6 @@ export class AchievementsService {
       },
     },
     ultra_marathoner: {
-      emoji: "🦸",
-      name: "Ultra Marathoner",
-      description: "Completed an 8+ hour voice session",
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
@@ -256,9 +212,6 @@ export class AchievementsService {
       },
     },
     social_butterfly: {
-      emoji: "🦋",
-      name: "Social Butterfly",
-      description: "Voiced with 10+ unique users",
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
@@ -288,9 +241,6 @@ export class AchievementsService {
       },
     },
     connector: {
-      emoji: "🤝",
-      name: "Connector",
-      description: "Voiced with 25+ unique users",
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
@@ -320,9 +270,6 @@ export class AchievementsService {
       },
     },
     night_owl: {
-      emoji: "🦉",
-      name: "Night Owl",
-      description: "Accumulated 50+ hours during late night (10 PM - 6 AM)",
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
@@ -366,9 +313,6 @@ export class AchievementsService {
       },
     },
     early_bird: {
-      emoji: "🐦",
-      name: "Early Bird",
-      description: "Accumulated 50+ hours during early morning (6 AM - 10 AM)",
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
@@ -412,9 +356,6 @@ export class AchievementsService {
       },
     },
     weekend_warrior: {
-      emoji: "🎮",
-      name: "Weekend Warrior",
-      description: "Accumulated 100+ hours during weekends",
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
@@ -458,9 +399,6 @@ export class AchievementsService {
       },
     },
     weekday_warrior: {
-      emoji: "💼",
-      name: "Weekday Warrior",
-      description: "Accumulated 100+ hours during weekdays",
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
@@ -504,9 +442,6 @@ export class AchievementsService {
       },
     },
     consistent_week: {
-      emoji: "🔥",
-      name: "On a Roll",
-      description: "Connected for 7 consecutive days (5+ min/day)",
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
@@ -545,9 +480,6 @@ export class AchievementsService {
       },
     },
     consistent_fortnight: {
-      emoji: "⚡",
-      name: "Dedicated AF",
-      description: "Connected for 14 consecutive days (5+ min/day)",
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
@@ -586,9 +518,6 @@ export class AchievementsService {
       },
     },
     consistent_month: {
-      emoji: "💀",
-      name: "No-Lifer",
-      description: "Connected for 30 consecutive days (5+ min/day)",
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
@@ -627,17 +556,8 @@ export class AchievementsService {
       },
     },
     quotable: {
-      emoji: "🗣️",
-      name: "Quotable",
-      description: "Been quoted for the first time",
       checkFunction: async (userId: string) => {
-        const quoteStats = {
-          authoredCount: await quoteService.getQuotesAuthoredByUser(userId),
-          addedCount: await quoteService.getQuotesAddedByUser(userId),
-          mostLikedLikes:
-            (await quoteService.getMostLikedQuoteByAuthor(userId))?.likes || 0,
-        };
-        return quoteStats.authoredCount >= 1;
+        return (await quoteService.getQuotesAuthoredByUser(userId)) >= 1;
       },
       metadataFunction: async (userId: string) => {
         const count = await quoteService.getQuotesAuthoredByUser(userId);
@@ -649,17 +569,8 @@ export class AchievementsService {
       },
     },
     quote_master: {
-      emoji: "📝",
-      name: "Quote Master",
-      description: "Added 10 quotes to the collection",
       checkFunction: async (userId: string) => {
-        const quoteStats = {
-          authoredCount: await quoteService.getQuotesAuthoredByUser(userId),
-          addedCount: await quoteService.getQuotesAddedByUser(userId),
-          mostLikedLikes:
-            (await quoteService.getMostLikedQuoteByAuthor(userId))?.likes || 0,
-        };
-        return quoteStats.addedCount >= 10;
+        return (await quoteService.getQuotesAddedByUser(userId)) >= 10;
       },
       metadataFunction: async (userId: string) => {
         const count = await quoteService.getQuotesAddedByUser(userId);
@@ -671,17 +582,8 @@ export class AchievementsService {
       },
     },
     quote_collector: {
-      emoji: "📚",
-      name: "Quote Collector",
-      description: "Added 50 quotes to the collection",
       checkFunction: async (userId: string) => {
-        const quoteStats = {
-          authoredCount: await quoteService.getQuotesAuthoredByUser(userId),
-          addedCount: await quoteService.getQuotesAddedByUser(userId),
-          mostLikedLikes:
-            (await quoteService.getMostLikedQuoteByAuthor(userId))?.likes || 0,
-        };
-        return quoteStats.addedCount >= 50;
+        return (await quoteService.getQuotesAddedByUser(userId)) >= 50;
       },
       metadataFunction: async (userId: string) => {
         const count = await quoteService.getQuotesAddedByUser(userId);
@@ -693,17 +595,8 @@ export class AchievementsService {
       },
     },
     quote_legend: {
-      emoji: "🏆",
-      name: "Quote Legend",
-      description: "Added 100 quotes to the collection",
       checkFunction: async (userId: string) => {
-        const quoteStats = {
-          authoredCount: await quoteService.getQuotesAuthoredByUser(userId),
-          addedCount: await quoteService.getQuotesAddedByUser(userId),
-          mostLikedLikes:
-            (await quoteService.getMostLikedQuoteByAuthor(userId))?.likes || 0,
-        };
-        return quoteStats.addedCount >= 100;
+        return (await quoteService.getQuotesAddedByUser(userId)) >= 100;
       },
       metadataFunction: async (userId: string) => {
         const count = await quoteService.getQuotesAddedByUser(userId);
@@ -715,17 +608,8 @@ export class AchievementsService {
       },
     },
     widely_quoted: {
-      emoji: "⭐",
-      name: "Widely Quoted",
-      description: "Been quoted 25 times",
       checkFunction: async (userId: string) => {
-        const quoteStats = {
-          authoredCount: await quoteService.getQuotesAuthoredByUser(userId),
-          addedCount: await quoteService.getQuotesAddedByUser(userId),
-          mostLikedLikes:
-            (await quoteService.getMostLikedQuoteByAuthor(userId))?.likes || 0,
-        };
-        return quoteStats.authoredCount >= 25;
+        return (await quoteService.getQuotesAuthoredByUser(userId)) >= 25;
       },
       metadataFunction: async (userId: string) => {
         const count = await quoteService.getQuotesAuthoredByUser(userId);
@@ -737,17 +621,8 @@ export class AchievementsService {
       },
     },
     quote_icon: {
-      emoji: "💫",
-      name: "Quote Icon",
-      description: "Been quoted 50 times",
       checkFunction: async (userId: string) => {
-        const quoteStats = {
-          authoredCount: await quoteService.getQuotesAuthoredByUser(userId),
-          addedCount: await quoteService.getQuotesAddedByUser(userId),
-          mostLikedLikes:
-            (await quoteService.getMostLikedQuoteByAuthor(userId))?.likes || 0,
-        };
-        return quoteStats.authoredCount >= 50;
+        return (await quoteService.getQuotesAuthoredByUser(userId)) >= 50;
       },
       metadataFunction: async (userId: string) => {
         const count = await quoteService.getQuotesAuthoredByUser(userId);
@@ -759,17 +634,10 @@ export class AchievementsService {
       },
     },
     viral_quote: {
-      emoji: "🔥",
-      name: "Viral Quote",
-      description: "Have a quote with 10+ likes",
       checkFunction: async (userId: string) => {
-        const quoteStats = {
-          authoredCount: await quoteService.getQuotesAuthoredByUser(userId),
-          addedCount: await quoteService.getQuotesAddedByUser(userId),
-          mostLikedLikes:
-            (await quoteService.getMostLikedQuoteByAuthor(userId))?.likes || 0,
-        };
-        return quoteStats.mostLikedLikes >= 10;
+        const mostLikedLikes =
+          (await quoteService.getMostLikedQuoteByAuthor(userId))?.likes || 0;
+        return mostLikedLikes >= 10;
       },
       metadataFunction: async (userId: string) => {
         const mostLikedLikes =
@@ -783,14 +651,11 @@ export class AchievementsService {
     },
   };
 
-  // Achievement definitions (time-based, not announced)
-  private achievementDefinitions: Partial<
-    Record<AchievementType, BadgeDefinition>
-  > = {
+  // Awarding logic per achievement (display metadata lives in
+  // src/content/achievements.ts). Only ids present in ACHIEVEMENT_METADATA
+  // need an entry here; reserved-but-unimplemented types stay absent.
+  private achievementLogic: Partial<Record<AchievementType, BadgeLogic>> = {
     weekly_active: {
-      emoji: "⚡",
-      name: "Active",
-      description: "Reached 10 hours in voice chat this week",
       checkFunction: async (userId: string) => {
         const weeklyTime = await this.getWeeklyTimeForUser(userId);
         return weeklyTime >= 36000; // 10 hours = 36000 seconds
@@ -1106,17 +971,16 @@ export class AchievementsService {
       const userTrackingData = await VoiceChannelTracking.findOne({ userId });
 
       // Check each accolade type
-      for (const [type, definition] of Object.entries(
-        this.accoladeDefinitions,
-      )) {
+      for (const type of Object.keys(ACCOLADE_METADATA) as AccoladeType[]) {
         if (existingAccoladeTypes.has(type)) {
           continue; // Already earned
         }
 
-        const earned = await definition.checkFunction(userId, userTrackingData);
+        const logic = this.accoladeLogic[type];
+        const earned = await logic.checkFunction(userId, userTrackingData);
         if (earned) {
-          const metadata = definition.metadataFunction
-            ? await definition.metadataFunction(userId, userTrackingData)
+          const metadata = logic.metadataFunction
+            ? await logic.metadataFunction(userId, userTrackingData)
             : {};
 
           const accolade: IAccolade = {
@@ -1130,7 +994,7 @@ export class AchievementsService {
           userAchievements.statistics.totalAccolades += 1;
 
           logger.info(
-            `User ${username} (${userId}) earned accolade: ${definition.name}`,
+            `User ${username} (${userId}) earned accolade: ${ACCOLADE_METADATA[type].name}`,
           );
         }
       }
@@ -1192,17 +1056,20 @@ export class AchievementsService {
       const newAchievements: IAchievement[] = [];
 
       // Check each achievement type
-      for (const [type, definition] of Object.entries(
-        this.achievementDefinitions,
-      )) {
-        if (!definition || existingAchievementTypes.includes(type)) {
+      for (const type of Object.keys(
+        ACHIEVEMENT_METADATA,
+      ) as AchievementType[]) {
+        if (existingAchievementTypes.includes(type)) {
           continue;
         }
 
-        const earned = await definition.checkFunction(userId, null);
+        const logic = this.achievementLogic[type];
+        if (!logic) continue;
+
+        const earned = await logic.checkFunction(userId, null);
         if (earned) {
-          const metadata = definition.metadataFunction
-            ? await definition.metadataFunction(userId, null)
+          const metadata = logic.metadataFunction
+            ? await logic.metadataFunction(userId, null)
             : undefined;
 
           const achievement: IAchievement = {
@@ -1217,7 +1084,7 @@ export class AchievementsService {
           userAchievements.statistics.totalAchievements += 1;
 
           logger.info(
-            `User ${username} (${userId}) earned achievement: ${definition.name} for ${currentPeriod}`,
+            `User ${username} (${userId}) earned achievement: ${ACHIEVEMENT_METADATA[type as keyof typeof ACHIEVEMENT_METADATA].name} for ${currentPeriod}`,
           );
         }
       }
@@ -1277,11 +1144,18 @@ export class AchievementsService {
    * Get badge definition for an accolade type
    */
   public getAccoladeDefinition(type: string): BadgeDefinition | undefined {
-    return this.accoladeDefinitions[type as AccoladeType];
+    const meta = ACCOLADE_METADATA[type as AccoladeType];
+    const logic = this.accoladeLogic[type as AccoladeType];
+    if (!meta || !logic) return undefined;
+    return { ...meta, ...logic };
   }
 
   public getAchievementDefinition(type: string): BadgeDefinition | undefined {
-    return this.achievementDefinitions[type as AchievementType];
+    const meta =
+      ACHIEVEMENT_METADATA[type as keyof typeof ACHIEVEMENT_METADATA];
+    const logic = this.achievementLogic[type as AchievementType];
+    if (!meta || !logic) return undefined;
+    return { ...meta, ...logic };
   }
 
   /**

--- a/src/services/bot-status-service.ts
+++ b/src/services/bot-status-service.ts
@@ -1,6 +1,11 @@
 import { Client, ActivityType } from "discord.js";
 import { ConfigService } from "./config-service.js";
 import logger from "../utils/logger.js";
+import {
+  lonelyStatuses,
+  singleUserStatuses,
+  multipleUsersStatuses,
+} from "../content/statuses.js";
 
 export class BotStatusService {
   private static instance: BotStatusService;
@@ -10,43 +15,6 @@ export class BotStatusService {
   private currentVcUserCount = 0;
   // Username tracking removed for simplified status logic (field deleted)
   private statusUpdateInterval: ReturnType<typeof setInterval> | null = null;
-
-  // Fun status messages for different scenarios
-  private readonly lonelyStatuses = [
-    "nobody, I hate it here",
-    "paint dry, I'm so bored",
-    "the void, I'm contemplating existence",
-    "pixels, I'm counting them",
-    "solitaire, I'm playing alone",
-    "nothing, I'm staring at the void",
-    "the meaning of life, I'm contemplating it",
-    "Rick Astley on repeat, I'm so lonely", // cspell:ignore Astley
-    "Lo-fi girl, kinda goes with the vibe",
-    "the whole universe was in a hot dense state",
-    "Some russian kid, screaming about fucking my mom",
-    "The matrix, blue or red pill, guys ?",
-  ];
-
-  // Simplified single-user statuses (no username personalization)
-  private readonly singleUserStatuses = [
-    "a lone wanderer",
-    "one solitary soul",
-    "a single user existing",
-    "one person contemplating life",
-    "a lone voice in the void",
-    "just one user vibing",
-  ];
-
-  private readonly multipleUsersStatuses = [
-    "{count} nerds",
-    "{count} souls",
-    "{count} humans",
-    "{count} chatters",
-    "{count} people",
-    "{count} gamers that suck",
-    "{count} conversing about nothing",
-    "{count} people that need to get a life",
-  ];
 
   private constructor(client: Client) {
     this.client = client;
@@ -59,18 +27,16 @@ export class BotStatusService {
   private getRandomStatusMessage(): string {
     // Simplified: only differentiate between 0, 1, and many users; no name interpolation
     if (this.currentVcUserCount <= 0) {
-      return this.lonelyStatuses[
-        Math.floor(Math.random() * this.lonelyStatuses.length)
-      ];
+      return lonelyStatuses[Math.floor(Math.random() * lonelyStatuses.length)];
     }
     if (this.currentVcUserCount === 1) {
-      return this.singleUserStatuses[
-        Math.floor(Math.random() * this.singleUserStatuses.length)
+      return singleUserStatuses[
+        Math.floor(Math.random() * singleUserStatuses.length)
       ];
     }
     const template =
-      this.multipleUsersStatuses[
-        Math.floor(Math.random() * this.multipleUsersStatuses.length)
+      multipleUsersStatuses[
+        Math.floor(Math.random() * multipleUsersStatuses.length)
       ];
     return template.replace("{count}", this.currentVcUserCount.toString());
   }

--- a/src/services/friendship-listener.ts
+++ b/src/services/friendship-listener.ts
@@ -1,5 +1,6 @@
 import { Client, Message } from "discord.js";
 import logger from "../utils/logger.js";
+import { bestTriggers, worstTriggers } from "../content/friendship-triggers.js";
 
 /**
  * Passive friendship listener.
@@ -33,21 +34,6 @@ export class FriendshipListener {
     if (!message.guild) return; // guild text only
 
     const content = message.content.toLowerCase();
-
-    const bestTriggers = [
-      "best ship",
-      "best eve ship",
-      "best eve online ship",
-      "what is the best ship",
-      "what's the best ship",
-    ];
-    const worstTriggers = [
-      "worst ship",
-      "worst eve ship",
-      "worst eve online ship",
-      "what is the worst ship",
-      "what's the worst ship",
-    ];
 
     const isBest = bestTriggers.some((t) => content.includes(t));
     const isWorst = worstTriggers.some((t) => content.includes(t));

--- a/src/services/notices-channel-manager.ts
+++ b/src/services/notices-channel-manager.ts
@@ -1,29 +1,9 @@
-import { Client, TextChannel, EmbedBuilder, ColorResolvable } from "discord.js";
+import { Client, TextChannel, EmbedBuilder } from "discord.js";
 import { CronJob } from "cron";
 import { ConfigService } from "./config-service.js";
 import logger from "../utils/logger.js";
 import Notice, { INotice } from "../models/notice.js";
-
-// Category colors and emojis
-const CATEGORY_CONFIG = {
-  general: {
-    emoji: "📋",
-    color: 0x5865f2 as ColorResolvable,
-    label: "General",
-  },
-  rules: { emoji: "📜", color: 0xe74c3c as ColorResolvable, label: "Rules" },
-  info: {
-    emoji: "ℹ️",
-    color: 0x3498db as ColorResolvable,
-    label: "Information",
-  },
-  help: { emoji: "❓", color: 0x9b59b6 as ColorResolvable, label: "Help" },
-  "game-servers": {
-    emoji: "🎮",
-    color: 0x2ecc71 as ColorResolvable,
-    label: "Game Servers",
-  },
-} as const;
+import { NOTICE_CATEGORIES } from "../content/notice-categories.js";
 
 export class NoticesChannelManager {
   private static instance: NoticesChannelManager;
@@ -531,7 +511,7 @@ export class NoticesChannelManager {
       }
 
       const categoryInfo =
-        CATEGORY_CONFIG[notice.category as keyof typeof CATEGORY_CONFIG];
+        NOTICE_CATEGORIES[notice.category as keyof typeof NOTICE_CATEGORIES];
       const embed = new EmbedBuilder()
         .setColor(categoryInfo.color)
         .setTitle(`${categoryInfo.emoji} ${notice.title}`)


### PR DESCRIPTION
Closes #365.

## Summary

Move "content" arrays (bot status pools, amikool replies, friendship triggers, notice category styling, accolade/achievement metadata) out of the services that consume them and into a new `src/content/` folder. Pure relocation — no behavior change.

For the mixed cases (accolades and achievements) the **display metadata** moves to `src/content/`; the **awarding logic** (`checkFunction`/`metadataFunction`) stays in `achievements-service.ts`, joined to the metadata by id.

## What moved

| Old location | New file |
|---|---|
| `services/bot-status-service.ts` (3 status arrays) | `content/statuses.ts` |
| `commands/amikool.ts` (kool/notKool replies) | `content/amikool-responses.ts` |
| `services/friendship-listener.ts` (best/worst triggers) | `content/friendship-triggers.ts` |
| `services/notices-channel-manager.ts` (`CATEGORY_CONFIG`) | `content/notice-categories.ts` |
| `services/achievements-service.ts` (accolade emoji/name/description × 23) | `content/accolades.ts` |
| `services/achievements-service.ts` (achievement emoji/name/description) | `content/achievements.ts` |

`AccoladeType`/`AchievementType` are still re-exported from `achievements-service.ts` so external callers (`commands/achievements.ts`, `services/voice-channel-announcer.ts`, the test file) don't need to change imports.

## Type-safety wins from the move

- `multipleUsersStatuses` is `satisfies readonly `${string}{count}{string}`[]` — forgetting the `{count}` placeholder is now a compile error.
- `accoladeLogic: Record<AccoladeType, BadgeLogic>` is keyed by the union derived from `ACCOLADE_METADATA`. Adding metadata without matching logic (or a typo'd id) fails the build.
- `NOTICE_CATEGORIES` uses `as const satisfies Record<string, NoticeCategoryInfo>` to enforce the shape while keeping literal narrowing on keys.

## Docs

`src/content/README.md` covers what belongs here, what doesn't (runtime-configurable values still belong in `ConfigService`), and the two-step pattern for adding a new accolade or achievement.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (existing warnings unchanged)
- [x] `npm run format:check` — clean
- [x] `npm test` — 84 suites, 735 passed, 1 skipped (no new tests; pure relocation)
- [x] `npm run build` — clean, `dist/content/*.js` emitted as expected
- [ ] Smoke-test in a dev guild after merge: status messages still rotate, `/amikool` still replies from both pools, "best ship" trigger still fires, notice embeds still get the right color/emoji, accolade names still show "First Steps" / "Voice Veteran" / etc.


---
_Generated by [Claude Code](https://claude.ai/code/session_0145Z3Vp4EzW1mF3TYXk8xKA)_