### PR TITLE
fix(command-manager): replace blind error cast with DiscordAPIError type guards

### DIFF
--- a/src/services/command-manager.ts
+++ b/src/services/command-manager.ts
@@ -5,9 +5,12 @@ import {
   Collection,
   SlashCommandBuilder,
   ChatInputCommandInteraction,
+  DiscordAPIError,
+  HTTPError,
 } from "discord.js";
 import { config as dotenvConfig } from "dotenv";
 import logger from "../utils/logger.js";
+import { getErrorMessage } from "../utils/error-guards.js";
 import { ConfigService } from "./config-service.js";
 import { MonitoringService } from "./monitoring-service.js";
 import { CooldownManager } from "./cooldown-manager.js";
@@ -178,17 +181,28 @@ export class CommandManager {
         }
         return result;
       } catch (error: unknown) {
-        const err = error as {
-          code?: number;
-          message?: string;
-          retry_after?: number;
-        };
+        const message = getErrorMessage(error);
+
+        // HTTP 429 surfaces as DiscordAPIError or HTTPError with status 429.
+        // The retry delay is in `rawError.retry_after` (seconds) on
+        // DiscordAPIError; HTTPError doesn't expose it, so fall back to a
+        // conservative default.
+        const httpStatus =
+          error instanceof DiscordAPIError || error instanceof HTTPError
+            ? error.status
+            : undefined;
         const isRateLimit =
-          err.code === 429 || err.message?.includes("rate limit");
-        const isTimeout = err.message?.includes("timeout");
+          httpStatus === 429 || message.toLowerCase().includes("rate limit");
+        const isTimeout = message.toLowerCase().includes("timeout");
 
         if (isRateLimit) {
-          const retryAfter = err.retry_after || 5;
+          let retryAfter = 5;
+          if (error instanceof DiscordAPIError) {
+            const raw = error.rawError as { retry_after?: number } | undefined;
+            if (typeof raw?.retry_after === "number") {
+              retryAfter = raw.retry_after;
+            }
+          }
           logger.warn(
             `⚠️ Discord rate limited for ${operationName}, retrying in ${retryAfter}s (attempt ${attempt}/${maxRetries})`,
           );
@@ -203,8 +217,8 @@ export class CommandManager {
             await new Promise((resolve) => setTimeout(resolve, 2000 * attempt)); // Exponential backoff
           }
         } else {
-          logger.error(`❌ Discord API error for ${operationName}:`, err);
-          throw err;
+          logger.error(`❌ Discord API error for ${operationName}:`, error);
+          throw error;
         }
 
         if (attempt === maxRetries) {

--- a/src/utils/error-guards.ts
+++ b/src/utils/error-guards.ts
@@ -6,9 +6,7 @@
  * and silently break logic that depends on them (e.g. rate-limit retry).
  */
 
-export function isErrorWithCode(
-  e: unknown,
-): e is { code: number; message?: string } {
+export function isErrorWithCode(e: unknown): e is { code: number } {
   return (
     typeof e === "object" &&
     e !== null &&

--- a/src/utils/error-guards.ts
+++ b/src/utils/error-guards.ts
@@ -1,0 +1,33 @@
+/**
+ * Runtime type guards for narrowing `unknown` errors caught from external APIs.
+ *
+ * Prefer these over blind `as { ... }` casts: a cast trusts the compiler shape
+ * but does no runtime validation, so missing properties read as `undefined`
+ * and silently break logic that depends on them (e.g. rate-limit retry).
+ */
+
+export function isErrorWithCode(
+  e: unknown,
+): e is { code: number; message?: string } {
+  return (
+    typeof e === "object" &&
+    e !== null &&
+    "code" in e &&
+    typeof (e as { code: unknown }).code === "number"
+  );
+}
+
+export function isErrorWithMessage(e: unknown): e is { message: string } {
+  return (
+    typeof e === "object" &&
+    e !== null &&
+    "message" in e &&
+    typeof (e as { message: unknown }).message === "string"
+  );
+}
+
+export function getErrorMessage(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  if (isErrorWithMessage(e)) return e.message;
+  return String(e);
+}


### PR DESCRIPTION
## Summary

Fixes #363.

`CommandManager.makeDiscordApiCall` cast caught errors to
`{ code?: number; message?: string; retry_after?: number }` with no
runtime check. Two practical bugs:

1. For `DiscordAPIError`, `code` is the **Discord error code**, not HTTP
   status — so `err.code === 429` was effectively never true and the
   rate-limit branch was dead.
2. `retry_after` lives on `rawError`, not the top-level error — `err.retry_after`
   was always `undefined`, so retries used the fallback `5s` even when Discord
   gave a specific value.

### Changes

- `src/services/command-manager.ts`: use `instanceof DiscordAPIError` /
  `instanceof HTTPError` and read HTTP status from `error.status`; pull
  `retry_after` from `error.rawError` for `DiscordAPIError`.
- `src/utils/error-guards.ts` (new): small `getErrorMessage`,
  `isErrorWithCode`, `isErrorWithMessage` helpers for narrowing `unknown`
  errors at other catch sites.

The broader cleanup in the issue (ESLint `no-unsafe-type-assertion`,
auditing the ~68 `any` usages, CI regression check) is left as
follow-up — this PR scopes to the primary unsafe-cast bug.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` — 0 errors (only pre-existing warnings)
- [x] `npm test -- --testPathPatterns=command-manager` — 12 tests pass

https://claude.ai/code/session_01BFoF554uHoEHmjkHSVBtoV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFoF554uHoEHmjkHSVBtoV)_