### PR TITLE
fix(services): clear long-lived timers during graceful shutdown

### DIFF
--- a/__tests__/services/monitoring-service.test.ts
+++ b/__tests__/services/monitoring-service.test.ts
@@ -165,37 +165,39 @@ describe('MonitoringService', () => {
   });
 
   describe('destroy', () => {
-    afterEach(() => {
-      jest.useRealTimers();
-      // Reset the singleton so the next test starts with a fresh interval.
+    let fresh: MonitoringService;
+
+    beforeEach(() => {
+      // The outer beforeEach instantiated the singleton with real timers.
+      // Destroy it (now that destroy() exists) and reset the singleton
+      // before switching to fake timers, so we don't leak the original
+      // real interval and don't mix real+fake timer state.
+      service.destroy();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (MonitoringService as any).instance = undefined;
+
+      jest.useFakeTimers();
+      fresh = MonitoringService.getInstance();
+    });
+
+    afterEach(() => {
+      // Make sure each test leaves no live interval before resetting the
+      // singleton, even when the test itself didn't call destroy().
+      fresh.destroy();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (MonitoringService as any).instance = undefined;
+      jest.useRealTimers();
     });
 
     it('captures the periodic logging interval handle on construction', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (MonitoringService as any).instance = undefined;
-      jest.useFakeTimers();
-      const setIntervalSpy = jest.spyOn(globalThis, 'setInterval');
-
-      const fresh = MonitoringService.getInstance();
-
-      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const handle = (fresh as any).periodicLoggingInterval;
       expect(handle).not.toBeNull();
       expect(handle).toBeDefined();
-
-      setIntervalSpy.mockRestore();
     });
 
     it('clears the periodic logging interval and nulls the handle', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (MonitoringService as any).instance = undefined;
-      jest.useFakeTimers();
       const clearIntervalSpy = jest.spyOn(globalThis, 'clearInterval');
-
-      const fresh = MonitoringService.getInstance();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const handle = (fresh as any).periodicLoggingInterval;
 
@@ -209,11 +211,6 @@ describe('MonitoringService', () => {
     });
 
     it('does not fire the periodic logger after destroy()', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (MonitoringService as any).instance = undefined;
-      jest.useFakeTimers();
-
-      const fresh = MonitoringService.getInstance();
       const getPerfSpy = jest.spyOn(fresh, 'getPerformanceMetrics');
 
       fresh.destroy();
@@ -226,12 +223,7 @@ describe('MonitoringService', () => {
     });
 
     it('is idempotent — repeated calls are safe', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (MonitoringService as any).instance = undefined;
-      jest.useFakeTimers();
       const clearIntervalSpy = jest.spyOn(globalThis, 'clearInterval');
-
-      const fresh = MonitoringService.getInstance();
 
       expect(() => {
         fresh.destroy();

--- a/__tests__/services/monitoring-service.test.ts
+++ b/__tests__/services/monitoring-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import { MonitoringService } from '../../src/services/monitoring-service.js';
 
 // Mock logger
@@ -159,10 +159,93 @@ describe('MonitoringService', () => {
 
     it('should format uptime as string', () => {
       const uptime = service.formatUptime();
-      
+
       expect(typeof uptime).toBe('string');
     });
   });
 
+  describe('destroy', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+      // Reset the singleton so the next test starts with a fresh interval.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (MonitoringService as any).instance = undefined;
+    });
+
+    it('captures the periodic logging interval handle on construction', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (MonitoringService as any).instance = undefined;
+      jest.useFakeTimers();
+      const setIntervalSpy = jest.spyOn(globalThis, 'setInterval');
+
+      const fresh = MonitoringService.getInstance();
+
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handle = (fresh as any).periodicLoggingInterval;
+      expect(handle).not.toBeNull();
+      expect(handle).toBeDefined();
+
+      setIntervalSpy.mockRestore();
+    });
+
+    it('clears the periodic logging interval and nulls the handle', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (MonitoringService as any).instance = undefined;
+      jest.useFakeTimers();
+      const clearIntervalSpy = jest.spyOn(globalThis, 'clearInterval');
+
+      const fresh = MonitoringService.getInstance();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handle = (fresh as any).periodicLoggingInterval;
+
+      fresh.destroy();
+
+      expect(clearIntervalSpy).toHaveBeenCalledWith(handle);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((fresh as any).periodicLoggingInterval).toBeNull();
+
+      clearIntervalSpy.mockRestore();
+    });
+
+    it('does not fire the periodic logger after destroy()', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (MonitoringService as any).instance = undefined;
+      jest.useFakeTimers();
+
+      const fresh = MonitoringService.getInstance();
+      const getPerfSpy = jest.spyOn(fresh, 'getPerformanceMetrics');
+
+      fresh.destroy();
+      // Advance well past the 1-hour interval.
+      jest.advanceTimersByTime(2 * 60 * 60 * 1000);
+
+      expect(getPerfSpy).not.toHaveBeenCalled();
+
+      getPerfSpy.mockRestore();
+    });
+
+    it('is idempotent — repeated calls are safe', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (MonitoringService as any).instance = undefined;
+      jest.useFakeTimers();
+      const clearIntervalSpy = jest.spyOn(globalThis, 'clearInterval');
+
+      const fresh = MonitoringService.getInstance();
+
+      expect(() => {
+        fresh.destroy();
+        fresh.destroy();
+        fresh.destroy();
+      }).not.toThrow();
+
+      // Only the first call should have anything to clear.
+      expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((fresh as any).periodicLoggingInterval).toBeNull();
+
+      clearIntervalSpy.mockRestore();
+    });
+  });
 
 });

--- a/__tests__/services/voice-channel-manager-destroy.test.ts
+++ b/__tests__/services/voice-channel-manager-destroy.test.ts
@@ -1,0 +1,109 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import type { Client } from "discord.js";
+
+// Mock dependencies before importing
+jest.mock("../../src/utils/logger.js");
+jest.mock("../../src/services/voice-channel-tracker.js");
+jest.mock("../../src/services/config-service.js");
+
+// Import after mocks
+import { VoiceChannelManager } from "../../src/services/voice-channel-manager.js";
+
+describe("VoiceChannelManager - destroy()", () => {
+  let manager: VoiceChannelManager;
+  let mockClient: Partial<Client>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (VoiceChannelManager as any).instance = undefined;
+
+    mockClient = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      channels: { cache: { get: jest.fn() } } as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    manager = VoiceChannelManager.getInstance(mockClient as Client);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (VoiceChannelManager as any).instance = undefined;
+  });
+
+  it("clears the periodic cleanup and health-check intervals", () => {
+    const clearIntervalSpy = jest.spyOn(globalThis, "clearInterval");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cleanupHandle = (manager as any).cleanupInterval;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const healthHandle = (manager as any).healthCheckInterval;
+    expect(cleanupHandle).not.toBeNull();
+    expect(healthHandle).not.toBeNull();
+
+    manager.destroy();
+
+    expect(clearIntervalSpy).toHaveBeenCalledWith(cleanupHandle);
+    expect(clearIntervalSpy).toHaveBeenCalledWith(healthHandle);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((manager as any).cleanupInterval).toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((manager as any).healthCheckInterval).toBeNull();
+
+    clearIntervalSpy.mockRestore();
+  });
+
+  it("clears all pending ownership-transfer timeouts and prevents their callbacks from running", () => {
+    const transferCallback = jest.fn();
+
+    // Simulate a pending ownership transfer for two channels by populating the
+    // private map directly. This mirrors what handleChannelOwnerLeave() does
+    // when an owner leaves their channel.
+    const timer1 = setTimeout(transferCallback, 30_000);
+    const timer2 = setTimeout(transferCallback, 30_000);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const timers = (manager as any).ownershipTransferTimers as Map<
+      string,
+      { timer: ReturnType<typeof setTimeout>; originalOwnerId: string }
+    >;
+    timers.set("channel-a", { timer: timer1, originalOwnerId: "owner-a" });
+    timers.set("channel-b", { timer: timer2, originalOwnerId: "owner-b" });
+    expect(timers.size).toBe(2);
+
+    manager.destroy();
+
+    // Map is emptied.
+    expect(timers.size).toBe(0);
+
+    // Advancing past the grace period must NOT fire the callbacks — they were
+    // cleared by destroy().
+    jest.advanceTimersByTime(60_000);
+    expect(transferCallback).not.toHaveBeenCalled();
+  });
+
+  it("clears the in-memory state maps", () => {
+    manager.setCustomChannelName("channel-id", "Custom Name");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (manager as any).liveChannels.add("channel-id");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (manager as any).waitingRooms.set("main", "waiting");
+
+    manager.destroy();
+
+    expect(manager.hasCustomName("channel-id")).toBe(false);
+    expect(manager.isLive("channel-id")).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((manager as any).waitingRooms.size).toBe(0);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -378,9 +378,9 @@ async function gracefulShutdown(signal: string): Promise<void> {
       "Scheduled announcements cleanup",
     );
 
-    // 6a. Stop remaining timer-owning services so their intervals/timeouts
-    //     don't fire against a half-closed Discord client or MongoDB
-    //     connection during the rest of the shutdown sequence.
+    // 7. Stop remaining timer-owning services so their intervals/timeouts
+    //    don't fire against a half-closed Discord client or MongoDB
+    //    connection during the rest of the shutdown sequence.
     await runWithTimeout(
       async () => {
         voiceChannelManager.destroy();
@@ -396,7 +396,7 @@ async function gracefulShutdown(signal: string): Promise<void> {
       "Service timer cleanup",
     );
 
-    // 7. Close database connections - 3 second timeout
+    // 8. Close database connections - 3 second timeout
     await runWithTimeout(
       async () => {
         const { default: mongoose } = await import("mongoose");
@@ -409,7 +409,7 @@ async function gracefulShutdown(signal: string): Promise<void> {
       "Database connection closure",
     );
 
-    // 7. Destroy Discord client - 5 second timeout
+    // 9. Destroy Discord client - 5 second timeout
     await runWithTimeout(
       async () => {
         await client.destroy();

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,8 @@ import { PermissionsService } from "./services/permissions-service.js";
 import FriendshipListener from "./services/friendship-listener.js";
 import { ReactionRoleService } from "./services/reaction-role-service.js";
 import { PollService } from "./services/poll-service.js";
+import { WizardService } from "./services/wizard-service.js";
+import { MonitoringService } from "./services/monitoring-service.js";
 import mongoose from "mongoose";
 
 dotenvConfig();
@@ -374,6 +376,24 @@ async function gracefulShutdown(signal: string): Promise<void> {
       },
       1000,
       "Scheduled announcements cleanup",
+    );
+
+    // 6a. Stop remaining timer-owning services so their intervals/timeouts
+    //     don't fire against a half-closed Discord client or MongoDB
+    //     connection during the rest of the shutdown sequence.
+    await runWithTimeout(
+      async () => {
+        voiceChannelManager.destroy();
+        voiceChannelAnnouncer.destroy();
+        voiceChannelTruncation.destroy();
+        await noticesChannelManager.stop();
+        pollService.destroy();
+        WizardService.getInstance().shutdown();
+        MonitoringService.getInstance().destroy();
+        await botStatusService.shutdown();
+      },
+      2000,
+      "Service timer cleanup",
     );
 
     // 7. Close database connections - 3 second timeout

--- a/src/services/monitoring-service.ts
+++ b/src/services/monitoring-service.ts
@@ -30,6 +30,7 @@ export class MonitoringService {
   private startTime: Date = new Date();
   private totalCommands: number = 0;
   private totalErrors: number = 0;
+  private periodicLoggingInterval: ReturnType<typeof setInterval> | null = null;
 
   private constructor() {
     // Start periodic memory usage logging
@@ -195,7 +196,7 @@ export class MonitoringService {
    */
   private startPeriodicLogging(): void {
     // Log performance metrics every hour
-    setInterval(
+    this.periodicLoggingInterval = setInterval(
       () => {
         const metrics = this.getPerformanceMetrics();
         const memoryMB = Math.round(metrics.memoryUsage.heapUsed / 1024 / 1024);
@@ -234,6 +235,16 @@ export class MonitoringService {
       return `${hours}h ${minutes}m`;
     } else {
       return `${minutes}m`;
+    }
+  }
+
+  /**
+   * Stop periodic logging and clear the interval handle.
+   */
+  public destroy(): void {
+    if (this.periodicLoggingInterval) {
+      clearInterval(this.periodicLoggingInterval);
+      this.periodicLoggingInterval = null;
     }
   }
 }

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -2202,6 +2202,10 @@ export class VoiceChannelManager {
       clearInterval(this.healthCheckInterval);
       this.healthCheckInterval = null;
     }
+    for (const { timer } of this.ownershipTransferTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.ownershipTransferTimers.clear();
     this.userChannels.clear();
     this.customChannelNames.clear();
     this.ownershipQueue.clear();


### PR DESCRIPTION
## Summary

Closes #359.

`VoiceChannelManager` already exposed a `destroy()` method but it was never invoked from `gracefulShutdown` in `src/index.ts`, so its 5-minute cleanup and 15-minute health-check intervals continued firing while the Discord client and MongoDB connection were being torn down. Several other services owned timers but were similarly unhooked from the shutdown sequence, and `MonitoringService` started an hourly `setInterval` whose handle was never captured at all (so it could not be cleared even in principle).

## Changes

- **`src/services/monitoring-service.ts`** — Capture the periodic logging interval in `periodicLoggingInterval` and add a `destroy()` method that clears it.
- **`src/services/voice-channel-manager.ts`** — Extend `destroy()` to also clear every pending ownership-transfer `setTimeout` in `ownershipTransferTimers` before clearing the map. Without this, grace-period timers (default 30s) could fire against a closed Discord client.
- **`src/index.ts`** — Add a "Service timer cleanup" step (6a) to `gracefulShutdown` that calls `destroy()` / `stop()` / `shutdown()` on the timer-owning services (VoiceChannelManager, VoiceChannelAnnouncer, VoiceChannelTruncationService, NoticesChannelManager, PollService, WizardService, MonitoringService, BotStatusService) before the database and Discord client are closed.

The new step is wrapped in the existing `runWithTimeout` helper with a 2-second budget, matching the style of the surrounding shutdown phases.

## Test plan

- [x] `npm run build` (TypeScript compile) — clean
- [x] `npm run lint` — 0 errors (warnings unchanged from main)
- [x] `npm run format:check` — passes
- [x] `npm test` — 735 tests pass, 1 skipped (unchanged)
- [ ] Manual: send SIGTERM to a running bot and confirm no `setInterval`-driven Discord/Mongo errors appear in the post-shutdown window


---
_Generated by [Claude Code](https://claude.ai/code/session_019UDTdLhEvbKTLGEF3SJ1mL)_