### PR TITLE
feat(webui): scaffold WebUI behind feature flag with magic-link auth

### DIFF
--- a/__tests__/services/web-session-service.test.ts
+++ b/__tests__/services/web-session-service.test.ts
@@ -1,0 +1,129 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import { WebSessionService } from "../../src/services/web-session-service.js";
+import { WebSession } from "../../src/models/web-session.js";
+
+jest.mock("../../src/models/web-session.js");
+jest.mock("../../src/utils/logger.js");
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe("WebSessionService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.WEBUI_SESSION_SECRET = "test-secret-of-sufficient-length";
+    process.env.WEBUI_BASE_URL = "https://example.test";
+    process.env.WEBUI_SESSION_TTL_MINUTES = "10";
+
+    // Reset singleton between tests
+    (WebSessionService as unknown as { instance: unknown }).instance = null;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("hashToken is deterministic for same secret and produces hex output", () => {
+    const svc = WebSessionService.getInstance();
+    const a = svc.hashToken("hello");
+    const b = svc.hashToken("hello");
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[a-f0-9]+$/);
+  });
+
+  it("hashToken throws when secret missing", () => {
+    delete process.env.WEBUI_SESSION_SECRET;
+    const svc = WebSessionService.getInstance();
+    expect(() => svc.hashToken("x")).toThrow(/WEBUI_SESSION_SECRET/);
+  });
+
+  it("create revokes prior sessions and inserts a new row", async () => {
+    const updateMany = jest.fn().mockResolvedValue({ modifiedCount: 1 });
+    const create = jest.fn().mockResolvedValue({ _id: "abc" });
+    (WebSession as unknown as { updateMany: unknown }).updateMany = updateMany;
+    (WebSession as unknown as { create: unknown }).create = create;
+
+    const svc = WebSessionService.getInstance();
+    const result = await svc.create("user-1", "guild-1", ["scope:a"]);
+
+    expect(updateMany).toHaveBeenCalledWith(
+      { discord_user_id: "user-1", revoked_at: null },
+      { $set: expect.objectContaining({ revoked_at: expect.any(Date) }) },
+    );
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(result.url).toMatch(
+      /^https:\/\/example\.test\/admin\/s\/[A-Za-z0-9_-]+$/,
+    );
+    expect(result.expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("redeem returns null when no matching unused session exists", async () => {
+    (WebSession as unknown as { updateMany: unknown }).updateMany = jest
+      .fn()
+      .mockResolvedValue({ modifiedCount: 0 });
+    (WebSession as unknown as { findOneAndUpdate: unknown }).findOneAndUpdate =
+      jest.fn().mockResolvedValue(null);
+
+    const svc = WebSessionService.getInstance();
+    const result = await svc.redeem("not-a-real-token");
+    expect(result).toBeNull();
+  });
+
+  it("redeem marks the session used and returns context on success", async () => {
+    const findOneAndUpdate = jest.fn().mockResolvedValue({
+      _id: { toString: () => "session-id" },
+      discord_user_id: "user-1",
+      guild_id: "guild-1",
+      scopes: ["scope:a"],
+    });
+    (
+      WebSession as unknown as { findOneAndUpdate: unknown }
+    ).findOneAndUpdate = findOneAndUpdate;
+
+    const svc = WebSessionService.getInstance();
+    const result = await svc.redeem("any-token");
+
+    expect(result).toEqual({
+      sessionId: "session-id",
+      discordUserId: "user-1",
+      guildId: "guild-1",
+      scopes: ["scope:a"],
+    });
+    const call = findOneAndUpdate.mock.calls[0];
+    expect(call[0]).toMatchObject({
+      used_at: null,
+      revoked_at: null,
+    });
+    expect(call[1]).toMatchObject({ $set: { used_at: expect.any(Date) } });
+  });
+
+  it("revokeSession returns true when modifiedCount > 0", async () => {
+    (WebSession as unknown as { updateOne: unknown }).updateOne = jest
+      .fn()
+      .mockResolvedValue({ modifiedCount: 1 });
+    const svc = WebSessionService.getInstance();
+    expect(await svc.revokeSession("abc")).toBe(true);
+  });
+
+  it("revokeSession returns false when nothing updated", async () => {
+    (WebSession as unknown as { updateOne: unknown }).updateOne = jest
+      .fn()
+      .mockResolvedValue({ modifiedCount: 0 });
+    const svc = WebSessionService.getInstance();
+    expect(await svc.revokeSession("abc")).toBe(false);
+  });
+
+  it("revokeSession returns false for empty id without hitting the model", async () => {
+    const updateOne = jest.fn();
+    (WebSession as unknown as { updateOne: unknown }).updateOne = updateOne;
+    const svc = WebSessionService.getInstance();
+    expect(await svc.revokeSession("")).toBe(false);
+    expect(updateOne).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/services/web-session-service.test.ts
+++ b/__tests__/services/web-session-service.test.ts
@@ -53,8 +53,8 @@ describe("WebSessionService", () => {
     const result = await svc.create("user-1", "guild-1", ["scope:a"]);
 
     expect(updateMany).toHaveBeenCalledWith(
-      { discord_user_id: "user-1", revoked_at: null },
-      { $set: expect.objectContaining({ revoked_at: expect.any(Date) }) },
+      { discordUserId: "user-1", revokedAt: null },
+      { $set: expect.objectContaining({ revokedAt: expect.any(Date) }) },
     );
     expect(create).toHaveBeenCalledTimes(1);
     expect(result.url).toMatch(
@@ -78,8 +78,8 @@ describe("WebSessionService", () => {
   it("redeem marks the session used and returns context on success", async () => {
     const findOneAndUpdate = jest.fn().mockResolvedValue({
       _id: { toString: () => "session-id" },
-      discord_user_id: "user-1",
-      guild_id: "guild-1",
+      discordUserId: "user-1",
+      guildId: "guild-1",
       scopes: ["scope:a"],
     });
     (
@@ -97,10 +97,10 @@ describe("WebSessionService", () => {
     });
     const call = findOneAndUpdate.mock.calls[0];
     expect(call[0]).toMatchObject({
-      used_at: null,
-      revoked_at: null,
+      usedAt: null,
+      revokedAt: null,
     });
-    expect(call[1]).toMatchObject({ $set: { used_at: expect.any(Date) } });
+    expect(call[1]).toMatchObject({ $set: { usedAt: expect.any(Date) } });
   });
 
   it("revokeSession returns true when modifiedCount > 0", async () => {

--- a/__tests__/utils/web-cookies.test.ts
+++ b/__tests__/utils/web-cookies.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  signValue,
+  verifySignedValue,
+} from "../../src/web/cookies.js";
+
+describe("web cookies signing", () => {
+  const secret = "test-cookie-secret-32-bytes-of-x";
+
+  it("round-trips a value through signValue/verifySignedValue", () => {
+    const signed = signValue("hello.world", secret);
+    expect(signed.startsWith("hello.world.")).toBe(true);
+    expect(verifySignedValue(signed, secret)).toBe("hello.world");
+  });
+
+  it("rejects values with a tampered signature", () => {
+    const signed = signValue("payload", secret);
+    const tampered = signed.replace(/.$/, (c) => (c === "A" ? "B" : "A"));
+    expect(verifySignedValue(tampered, secret)).toBeNull();
+  });
+
+  it("rejects values signed with a different secret", () => {
+    const signed = signValue("payload", secret);
+    expect(verifySignedValue(signed, "other-secret")).toBeNull();
+  });
+
+  it("returns null on malformed input", () => {
+    expect(verifySignedValue("", secret)).toBeNull();
+    expect(verifySignedValue("nodot", secret)).toBeNull();
+    expect(verifySignedValue(".justsig", secret)).toBeNull();
+    expect(verifySignedValue("noval.", secret)).toBeNull();
+  });
+});

--- a/__tests__/utils/web-cookies.test.ts
+++ b/__tests__/utils/web-cookies.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "@jest/globals";
+import { Request } from "express";
 import {
+  parseCookies,
   signValue,
   verifySignedValue,
 } from "../../src/web/cookies.js";
@@ -29,5 +31,32 @@ describe("web cookies signing", () => {
     expect(verifySignedValue("nodot", secret)).toBeNull();
     expect(verifySignedValue(".justsig", secret)).toBeNull();
     expect(verifySignedValue("noval.", secret)).toBeNull();
+  });
+});
+
+describe("parseCookies", () => {
+  function fakeReq(header?: string): Request {
+    return { headers: { cookie: header } } as unknown as Request;
+  }
+
+  it("returns an empty Map when no cookie header is set", () => {
+    const out = parseCookies(fakeReq());
+    expect(out.size).toBe(0);
+  });
+
+  it("parses simple name=value pairs and decodes URI components", () => {
+    const out = parseCookies(fakeReq("a=1; b=hello%20world"));
+    expect(out.get("a")).toBe("1");
+    expect(out.get("b")).toBe("hello world");
+  });
+
+  it("does not mutate Object.prototype on a malicious cookie name", () => {
+    const before = (Object.prototype as unknown as { polluted?: string })
+      .polluted;
+    parseCookies(fakeReq("__proto__=polluted; constructor=evil"));
+    const after = (Object.prototype as unknown as { polluted?: string })
+      .polluted;
+    expect(after).toBe(before);
+    expect(({} as { polluted?: string }).polluted).toBeUndefined();
   });
 });

--- a/src/commands/config/index.ts
+++ b/src/commands/config/index.ts
@@ -812,28 +812,29 @@ async function handleReload(
 async function handleWeb(
   interaction: ChatInputCommandInteraction,
 ): Promise<void> {
+  // Defer immediately so the DB revoke/create + DM round-trip can't blow
+  // Discord's 3-second interaction-ack deadline.
+  await interaction.deferReply({ ephemeral: true });
+
   if (!isWebUIEnabled()) {
-    await interaction.reply({
+    await interaction.editReply({
       content:
         "The web UI is disabled. Ask an operator to set `WEBUI_ENABLED=true` and restart the bot.",
-      ephemeral: true,
     });
     return;
   }
 
   const missing = getMissingWebUIEnvVars();
   if (missing.length > 0) {
-    await interaction.reply({
+    await interaction.editReply({
       content: `❌ Web UI is enabled but missing env vars: ${missing.join(", ")}`,
-      ephemeral: true,
     });
     return;
   }
 
   if (!interaction.guildId) {
-    await interaction.reply({
+    await interaction.editReply({
       content: "This command must be run inside a guild.",
-      ephemeral: true,
     });
     return;
   }
@@ -855,26 +856,23 @@ async function handleWeb(
 
     try {
       await interaction.user.send(dmBody);
-      await interaction.reply({
+      await interaction.editReply({
         content:
           "✅ I've DMed you a single-use sign-in link. Check your direct messages.",
-        ephemeral: true,
       });
     } catch (dmError) {
       logger.warn(
         `Could not DM web sign-in link to ${interaction.user.id}; falling back to ephemeral reply`,
         dmError,
       );
-      await interaction.reply({
+      await interaction.editReply({
         content: dmBody,
-        ephemeral: true,
       });
     }
   } catch (error) {
     logger.error("Error issuing web sign-in link:", error);
-    await interaction.reply({
+    await interaction.editReply({
       content: "An error occurred while issuing your sign-in link.",
-      ephemeral: true,
     });
   }
 }

--- a/src/commands/config/index.ts
+++ b/src/commands/config/index.ts
@@ -12,6 +12,8 @@ import { defaultConfig } from "../../services/config-schema.js";
 import * as yaml from "js-yaml";
 import logger from "../../utils/logger.js";
 import { BotStatusService } from "../../services/bot-status-service.js";
+import { WebSessionService } from "../../services/web-session-service.js";
+import { getMissingWebUIEnvVars, isWebUIEnabled } from "../../web/index.js";
 
 // Use built-in fetch or undici for Node.js compatibility
 import { fetch } from "undici";
@@ -300,6 +302,13 @@ export const data = new SlashCommandBuilder()
       .setName("reload")
       .setDescription(
         "Reload all commands to Discord API (use after changing command settings)",
+      ),
+  )
+  .addSubcommand((subcommand) =>
+    subcommand
+      .setName("web")
+      .setDescription(
+        "Open the admin web UI (sends you a single-use sign-in link)",
       ),
   );
 
@@ -800,6 +809,76 @@ async function handleReload(
   }
 }
 
+async function handleWeb(
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  if (!isWebUIEnabled()) {
+    await interaction.reply({
+      content:
+        "The web UI is disabled. Ask an operator to set `WEBUI_ENABLED=true` and restart the bot.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const missing = getMissingWebUIEnvVars();
+  if (missing.length > 0) {
+    await interaction.reply({
+      content: `❌ Web UI is enabled but missing env vars: ${missing.join(", ")}`,
+      ephemeral: true,
+    });
+    return;
+  }
+
+  if (!interaction.guildId) {
+    await interaction.reply({
+      content: "This command must be run inside a guild.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  try {
+    const session = await WebSessionService.getInstance().create(
+      interaction.user.id,
+      interaction.guildId,
+    );
+    const ttlMinutes = Math.max(
+      1,
+      Math.round((session.expiresAt.getTime() - Date.now()) / 60_000),
+    );
+    const dmBody =
+      `🔗 **Koolbot admin sign-in link**\n` +
+      `${session.url}\n` +
+      `This link is single-use and expires in about ${ttlMinutes} minute(s). ` +
+      `If you did not run \`/config web\`, ignore this message.`;
+
+    try {
+      await interaction.user.send(dmBody);
+      await interaction.reply({
+        content:
+          "✅ I've DMed you a single-use sign-in link. Check your direct messages.",
+        ephemeral: true,
+      });
+    } catch (dmError) {
+      logger.warn(
+        `Could not DM web sign-in link to ${interaction.user.id}; falling back to ephemeral reply`,
+        dmError,
+      );
+      await interaction.reply({
+        content: dmBody,
+        ephemeral: true,
+      });
+    }
+  } catch (error) {
+    logger.error("Error issuing web sign-in link:", error);
+    await interaction.reply({
+      content: "An error occurred while issuing your sign-in link.",
+      ephemeral: true,
+    });
+  }
+}
+
 export async function execute(
   interaction: ChatInputCommandInteraction,
 ): Promise<void> {
@@ -823,6 +902,9 @@ export async function execute(
       break;
     case "reload":
       await handleReload(interaction);
+      break;
+    case "web":
+      await handleWeb(interaction);
       break;
     default:
       await interaction.reply({

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,11 @@ import { ReactionRoleService } from "./services/reaction-role-service.js";
 import { PollService } from "./services/poll-service.js";
 import { WizardService } from "./services/wizard-service.js";
 import { MonitoringService } from "./services/monitoring-service.js";
+import {
+  createWebRouter,
+  getMissingWebUIEnvVars,
+  isWebUIEnabled,
+} from "./web/index.js";
 import mongoose from "mongoose";
 
 dotenvConfig();
@@ -130,6 +135,25 @@ function startHealthServer(): void {
       res.status(503).send("Service Unavailable");
     }
   });
+
+  // Mount the WebUI behind the feature flag. When disabled, no /admin/*
+  // route is registered, so the server responds 404 for those paths
+  // exactly as it did before this scaffold landed.
+  if (isWebUIEnabled()) {
+    const missing = getMissingWebUIEnvVars();
+    if (missing.length > 0) {
+      logger.error(
+        `WEBUI_ENABLED=true but missing required env vars: ${missing.join(", ")}. WebUI will not be mounted.`,
+      );
+    } else {
+      healthApp.set("trust proxy", true);
+      healthApp.use("/admin", createWebRouter(client));
+      logger.info("WebUI mounted at /admin");
+    }
+  } else {
+    logger.debug("WEBUI_ENABLED is not true; /admin routes not mounted");
+  }
+
   healthApp.listen(3000, () => {
     logger.info("Healthcheck server running on port 3000");
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,7 +146,23 @@ function startHealthServer(): void {
         `WEBUI_ENABLED=true but missing required env vars: ${missing.join(", ")}. WebUI will not be mounted.`,
       );
     } else {
-      healthApp.set("trust proxy", true);
+      // Default to NOT trusting any X-Forwarded-* headers so an attacker
+      // cannot spoof req.ip and bypass the rate limiter. Operators behind
+      // a reverse proxy can opt in by setting WEBUI_TRUST_PROXY to a hop
+      // count (e.g. "1") or to one of express' supported strings ("loopback",
+      // "linklocal", "uniquelocal", "true").
+      const trustProxyRaw = (process.env.WEBUI_TRUST_PROXY || "").trim();
+      if (trustProxyRaw) {
+        const asNumber = Number(trustProxyRaw);
+        if (Number.isFinite(asNumber) && asNumber >= 0) {
+          healthApp.set("trust proxy", asNumber);
+        } else if (trustProxyRaw.toLowerCase() === "true") {
+          healthApp.set("trust proxy", true);
+        } else {
+          healthApp.set("trust proxy", trustProxyRaw);
+        }
+        logger.info(`WebUI trust proxy set to: ${trustProxyRaw}`);
+      }
       healthApp.use("/admin", createWebRouter(client));
       logger.info("WebUI mounted at /admin");
     }

--- a/src/models/web-session.ts
+++ b/src/models/web-session.ts
@@ -1,0 +1,60 @@
+import mongoose, { Document, Schema } from "mongoose";
+
+export interface IWebSession extends Document {
+  token_hash: string;
+  discord_user_id: string;
+  guild_id: string;
+  scopes: string[];
+  created_at: Date;
+  expires_at: Date;
+  used_at: Date | null;
+  revoked_at: Date | null;
+}
+
+const WebSessionSchema = new Schema<IWebSession>(
+  {
+    token_hash: {
+      type: String,
+      required: true,
+      unique: true,
+      index: true,
+    },
+    discord_user_id: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    guild_id: {
+      type: String,
+      required: true,
+    },
+    scopes: {
+      type: [String],
+      required: true,
+      default: [],
+    },
+    created_at: {
+      type: Date,
+      required: true,
+      default: Date.now,
+    },
+    expires_at: {
+      type: Date,
+      required: true,
+    },
+    used_at: {
+      type: Date,
+      default: null,
+    },
+    revoked_at: {
+      type: Date,
+      default: null,
+    },
+  },
+  { timestamps: false },
+);
+
+export const WebSession = mongoose.model<IWebSession>(
+  "WebSession",
+  WebSessionSchema,
+);

--- a/src/models/web-session.ts
+++ b/src/models/web-session.ts
@@ -1,30 +1,30 @@
 import mongoose, { Document, Schema } from "mongoose";
 
 export interface IWebSession extends Document {
-  token_hash: string;
-  discord_user_id: string;
-  guild_id: string;
+  tokenHash: string;
+  discordUserId: string;
+  guildId: string;
   scopes: string[];
-  created_at: Date;
-  expires_at: Date;
-  used_at: Date | null;
-  revoked_at: Date | null;
+  createdAt: Date;
+  expiresAt: Date;
+  usedAt: Date | null;
+  revokedAt: Date | null;
 }
 
 const WebSessionSchema = new Schema<IWebSession>(
   {
-    token_hash: {
+    tokenHash: {
       type: String,
       required: true,
       unique: true,
       index: true,
     },
-    discord_user_id: {
+    discordUserId: {
       type: String,
       required: true,
       index: true,
     },
-    guild_id: {
+    guildId: {
       type: String,
       required: true,
     },
@@ -33,20 +33,20 @@ const WebSessionSchema = new Schema<IWebSession>(
       required: true,
       default: [],
     },
-    created_at: {
+    createdAt: {
       type: Date,
       required: true,
       default: Date.now,
     },
-    expires_at: {
+    expiresAt: {
       type: Date,
       required: true,
     },
-    used_at: {
+    usedAt: {
       type: Date,
       default: null,
     },
-    revoked_at: {
+    revokedAt: {
       type: Date,
       default: null,
     },

--- a/src/services/web-session-service.ts
+++ b/src/services/web-session-service.ts
@@ -1,0 +1,179 @@
+import crypto from "crypto";
+import logger from "../utils/logger.js";
+import { WebSession, IWebSession } from "../models/web-session.js";
+
+const DEFAULT_TTL_MINUTES = 10;
+
+export interface CreatedSession {
+  token: string;
+  url: string;
+  expiresAt: Date;
+}
+
+export interface RedeemedSession {
+  sessionId: string;
+  discordUserId: string;
+  guildId: string;
+  scopes: string[];
+}
+
+export class WebSessionService {
+  private static instance: WebSessionService | null = null;
+
+  private constructor() {}
+
+  public static getInstance(): WebSessionService {
+    if (!WebSessionService.instance) {
+      WebSessionService.instance = new WebSessionService();
+    }
+    return WebSessionService.instance;
+  }
+
+  /**
+   * Hash a token using HMAC-SHA256 with WEBUI_SESSION_SECRET so a stolen DB
+   * row alone cannot be replayed.
+   */
+  public hashToken(token: string): string {
+    const secret = process.env.WEBUI_SESSION_SECRET;
+    if (!secret) {
+      throw new Error("WEBUI_SESSION_SECRET not configured");
+    }
+    return crypto.createHmac("sha256", secret).update(token).digest("hex");
+  }
+
+  private getTtlMinutes(): number {
+    const raw = process.env.WEBUI_SESSION_TTL_MINUTES;
+    const parsed = raw ? Number(raw) : NaN;
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TTL_MINUTES;
+  }
+
+  private getBaseUrl(): string {
+    const baseUrl = process.env.WEBUI_BASE_URL;
+    if (!baseUrl) {
+      throw new Error("WEBUI_BASE_URL not configured");
+    }
+    return baseUrl.replace(/\/+$/, "");
+  }
+
+  /**
+   * Create a new magic-link session. Revokes any prior unused/active
+   * sessions for this user so re-issuing a link invalidates the old one.
+   */
+  public async create(
+    discordUserId: string,
+    guildId: string,
+    scopes: string[] = [],
+  ): Promise<CreatedSession> {
+    if (!discordUserId) throw new Error("discordUserId required");
+    if (!guildId) throw new Error("guildId required");
+
+    await this.revokeForUser(discordUserId);
+
+    const token = crypto.randomBytes(32).toString("base64url");
+    const tokenHash = this.hashToken(token);
+    const ttlMs = this.getTtlMinutes() * 60 * 1000;
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + ttlMs);
+
+    await WebSession.create({
+      token_hash: tokenHash,
+      discord_user_id: discordUserId,
+      guild_id: guildId,
+      scopes,
+      created_at: now,
+      expires_at: expiresAt,
+      used_at: null,
+      revoked_at: null,
+    });
+
+    const url = `${this.getBaseUrl()}/admin/s/${token}`;
+    return { token, url, expiresAt };
+  }
+
+  /**
+   * Redeem a magic-link token. Returns null if the token is missing,
+   * already used, expired, or revoked. Marks the session used on success.
+   */
+  public async redeem(token: string): Promise<RedeemedSession | null> {
+    if (!token) return null;
+    let tokenHash: string;
+    try {
+      tokenHash = this.hashToken(token);
+    } catch (err) {
+      logger.error("Failed to hash token for redemption", err);
+      return null;
+    }
+
+    const now = new Date();
+    const session = await WebSession.findOneAndUpdate(
+      {
+        token_hash: tokenHash,
+        used_at: null,
+        revoked_at: null,
+        expires_at: { $gt: now },
+      },
+      { $set: { used_at: now } },
+      { new: true },
+    );
+
+    if (!session) return null;
+
+    return {
+      sessionId: String(session._id),
+      discordUserId: session.discord_user_id,
+      guildId: session.guild_id,
+      scopes: session.scopes,
+    };
+  }
+
+  /**
+   * Look up a session by its database id. Used by the cookie-session
+   * middleware to revalidate every request.
+   */
+  public async findById(sessionId: string): Promise<IWebSession | null> {
+    if (!sessionId) return null;
+    try {
+      return await WebSession.findById(sessionId);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Revoke all unrevoked sessions for a user (whether redeemed or not).
+   */
+  public async revokeForUser(discordUserId: string): Promise<number> {
+    const now = new Date();
+    const result = await WebSession.updateMany(
+      { discord_user_id: discordUserId, revoked_at: null },
+      { $set: { revoked_at: now } },
+    );
+    const modified = (result as { modifiedCount?: number }).modifiedCount ?? 0;
+    if (modified > 0) {
+      logger.debug(
+        `Revoked ${modified} active web session(s) for user ${discordUserId}`,
+      );
+    }
+    return modified;
+  }
+
+  /**
+   * Revoke a specific session by its database id.
+   */
+  public async revokeSession(sessionId: string): Promise<boolean> {
+    if (!sessionId) return false;
+    try {
+      const now = new Date();
+      const result = await WebSession.updateOne(
+        { _id: sessionId, revoked_at: null },
+        { $set: { revoked_at: now } },
+      );
+      const modified =
+        (result as { modifiedCount?: number }).modifiedCount ?? 0;
+      return modified > 0;
+    } catch (err) {
+      logger.error("Failed to revoke web session", err);
+      return false;
+    }
+  }
+}

--- a/src/services/web-session-service.ts
+++ b/src/services/web-session-service.ts
@@ -76,14 +76,14 @@ export class WebSessionService {
     const expiresAt = new Date(now.getTime() + ttlMs);
 
     await WebSession.create({
-      token_hash: tokenHash,
-      discord_user_id: discordUserId,
-      guild_id: guildId,
+      tokenHash,
+      discordUserId,
+      guildId,
       scopes,
-      created_at: now,
-      expires_at: expiresAt,
-      used_at: null,
-      revoked_at: null,
+      createdAt: now,
+      expiresAt,
+      usedAt: null,
+      revokedAt: null,
     });
 
     const url = `${this.getBaseUrl()}/admin/s/${token}`;
@@ -107,12 +107,12 @@ export class WebSessionService {
     const now = new Date();
     const session = await WebSession.findOneAndUpdate(
       {
-        token_hash: tokenHash,
-        used_at: null,
-        revoked_at: null,
-        expires_at: { $gt: now },
+        tokenHash,
+        usedAt: null,
+        revokedAt: null,
+        expiresAt: { $gt: now },
       },
-      { $set: { used_at: now } },
+      { $set: { usedAt: now } },
       { new: true },
     );
 
@@ -120,8 +120,8 @@ export class WebSessionService {
 
     return {
       sessionId: String(session._id),
-      discordUserId: session.discord_user_id,
-      guildId: session.guild_id,
+      discordUserId: session.discordUserId,
+      guildId: session.guildId,
       scopes: session.scopes,
     };
   }
@@ -145,8 +145,8 @@ export class WebSessionService {
   public async revokeForUser(discordUserId: string): Promise<number> {
     const now = new Date();
     const result = await WebSession.updateMany(
-      { discord_user_id: discordUserId, revoked_at: null },
-      { $set: { revoked_at: now } },
+      { discordUserId, revokedAt: null },
+      { $set: { revokedAt: now } },
     );
     const modified = (result as { modifiedCount?: number }).modifiedCount ?? 0;
     if (modified > 0) {
@@ -165,8 +165,8 @@ export class WebSessionService {
     try {
       const now = new Date();
       const result = await WebSession.updateOne(
-        { _id: sessionId, revoked_at: null },
-        { $set: { revoked_at: now } },
+        { _id: sessionId, revokedAt: null },
+        { $set: { revokedAt: now } },
       );
       const modified =
         (result as { modifiedCount?: number }).modifiedCount ?? 0;

--- a/src/web/cookies.ts
+++ b/src/web/cookies.ts
@@ -7,31 +7,28 @@ import { Request, Response } from "express";
  * to keep the WebUI scaffold dependency-free.
  */
 
-// Reserved JS object keys an attacker could inject via the Cookie header
-// to pollute the prototype chain.
-const FORBIDDEN_COOKIE_NAMES = new Set([
-  "__proto__",
-  "constructor",
-  "prototype",
-]);
-
-export function parseCookies(req: Request): Record<string, string> {
-  // Prototype-free map so a malicious `Cookie: __proto__=…` header cannot
-  // pollute Object.prototype even if the name check below is bypassed.
-  const out: Record<string, string> = Object.create(null);
+/**
+ * Parse the Cookie header into a Map. We use a Map (not a plain object)
+ * so user-controlled cookie names cannot mutate any object prototype, and
+ * so CodeQL's remote-property-injection query has nothing to flag.
+ */
+export function parseCookies(req: Request): Map<string, string> {
+  const out = new Map<string, string>();
   const header = req.headers.cookie;
   if (!header) return out;
   for (const part of header.split(";")) {
     const idx = part.indexOf("=");
     if (idx === -1) continue;
     const name = part.slice(0, idx).trim();
-    const value = part.slice(idx + 1).trim();
-    if (!name || FORBIDDEN_COOKIE_NAMES.has(name)) continue;
+    const rawValue = part.slice(idx + 1).trim();
+    if (!name) continue;
+    let value = rawValue;
     try {
-      out[name] = decodeURIComponent(value);
+      value = decodeURIComponent(rawValue);
     } catch {
-      out[name] = value;
+      // Keep the raw value on malformed encodings.
     }
+    out.set(name, value);
   }
   return out;
 }

--- a/src/web/cookies.ts
+++ b/src/web/cookies.ts
@@ -1,0 +1,110 @@
+import crypto from "crypto";
+import { Buffer } from "buffer";
+import { Request, Response } from "express";
+
+/**
+ * Lightweight cookie helpers. We deliberately avoid pulling in cookie-parser
+ * to keep the WebUI scaffold dependency-free.
+ */
+
+export function parseCookies(req: Request): Record<string, string> {
+  const header = req.headers.cookie;
+  if (!header) return {};
+  const out: Record<string, string> = {};
+  for (const part of header.split(";")) {
+    const idx = part.indexOf("=");
+    if (idx === -1) continue;
+    const name = part.slice(0, idx).trim();
+    const value = part.slice(idx + 1).trim();
+    if (!name) continue;
+    try {
+      out[name] = decodeURIComponent(value);
+    } catch {
+      out[name] = value;
+    }
+  }
+  return out;
+}
+
+export interface CookieOptions {
+  httpOnly?: boolean;
+  secure?: boolean;
+  sameSite?: "strict" | "lax" | "none";
+  path?: string;
+  maxAge?: number;
+  expires?: Date;
+}
+
+export function setCookie(
+  res: Response,
+  name: string,
+  value: string,
+  opts: CookieOptions = {},
+): void {
+  const segments: string[] = [`${name}=${encodeURIComponent(value)}`];
+  segments.push(`Path=${opts.path ?? "/"}`);
+  if (opts.httpOnly !== false) segments.push("HttpOnly");
+  if (opts.secure) segments.push("Secure");
+  segments.push(`SameSite=${opts.sameSite ?? "lax"}`);
+  if (typeof opts.maxAge === "number") {
+    segments.push(`Max-Age=${Math.floor(opts.maxAge / 1000)}`);
+  }
+  if (opts.expires) {
+    segments.push(`Expires=${opts.expires.toUTCString()}`);
+  }
+  appendCookieHeader(res, segments.join("; "));
+}
+
+export function clearCookie(
+  res: Response,
+  name: string,
+  opts: CookieOptions = {},
+): void {
+  setCookie(res, name, "", {
+    ...opts,
+    maxAge: 0,
+    expires: new Date(0),
+  });
+}
+
+function appendCookieHeader(res: Response, value: string): void {
+  const existing = res.getHeader("Set-Cookie");
+  if (!existing) {
+    res.setHeader("Set-Cookie", value);
+  } else if (Array.isArray(existing)) {
+    res.setHeader("Set-Cookie", [...existing, value]);
+  } else {
+    res.setHeader("Set-Cookie", [String(existing), value]);
+  }
+}
+
+/**
+ * HMAC-sign a value with the session secret. Uses encoded.signature so the
+ * raw value is recoverable on the wire. Compares with timingSafeEqual.
+ */
+export function signValue(value: string, secret: string): string {
+  const sig = crypto
+    .createHmac("sha256", secret)
+    .update(value)
+    .digest("base64url");
+  return `${value}.${sig}`;
+}
+
+export function verifySignedValue(
+  signed: string,
+  secret: string,
+): string | null {
+  if (!signed) return null;
+  const idx = signed.lastIndexOf(".");
+  if (idx <= 0 || idx === signed.length - 1) return null;
+  const value = signed.slice(0, idx);
+  const sig = signed.slice(idx + 1);
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(value)
+    .digest("base64url");
+  const sigBuf = Buffer.from(sig);
+  const expectedBuf = Buffer.from(expected);
+  if (sigBuf.length !== expectedBuf.length) return null;
+  return crypto.timingSafeEqual(sigBuf, expectedBuf) ? value : null;
+}

--- a/src/web/cookies.ts
+++ b/src/web/cookies.ts
@@ -7,16 +7,26 @@ import { Request, Response } from "express";
  * to keep the WebUI scaffold dependency-free.
  */
 
+// Reserved JS object keys an attacker could inject via the Cookie header
+// to pollute the prototype chain.
+const FORBIDDEN_COOKIE_NAMES = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
 export function parseCookies(req: Request): Record<string, string> {
+  // Prototype-free map so a malicious `Cookie: __proto__=…` header cannot
+  // pollute Object.prototype even if the name check below is bypassed.
+  const out: Record<string, string> = Object.create(null);
   const header = req.headers.cookie;
-  if (!header) return {};
-  const out: Record<string, string> = {};
+  if (!header) return out;
   for (const part of header.split(";")) {
     const idx = part.indexOf("=");
     if (idx === -1) continue;
     const name = part.slice(0, idx).trim();
     const value = part.slice(idx + 1).trim();
-    if (!name) continue;
+    if (!name || FORBIDDEN_COOKIE_NAMES.has(name)) continue;
     try {
       out[name] = decodeURIComponent(value);
     } catch {

--- a/src/web/csrf.ts
+++ b/src/web/csrf.ts
@@ -17,7 +17,8 @@ export function ensureCsrfCookie(
   next: NextFunction,
 ): void {
   const cookies = parseCookies(req);
-  if (!cookies[CSRF_COOKIE]) {
+  const existing = cookies.get(CSRF_COOKIE);
+  if (!existing) {
     const token = crypto.randomBytes(32).toString("base64url");
     setCookie(res, CSRF_COOKIE, token, {
       httpOnly: false,
@@ -27,7 +28,7 @@ export function ensureCsrfCookie(
     });
     (req as Request & { csrfToken?: string }).csrfToken = token;
   } else {
-    (req as Request & { csrfToken?: string }).csrfToken = cookies[CSRF_COOKIE];
+    (req as Request & { csrfToken?: string }).csrfToken = existing;
   }
   next();
 }
@@ -46,7 +47,7 @@ export function requireCsrf(
     return;
   }
   const cookies = parseCookies(req);
-  const cookieToken = cookies[CSRF_COOKIE];
+  const cookieToken = cookies.get(CSRF_COOKIE);
   const headerToken = req.header(CSRF_HEADER) || (req.body && req.body._csrf);
   if (!cookieToken || !headerToken) {
     res.status(403).type("text/plain").send("CSRF token missing");

--- a/src/web/csrf.ts
+++ b/src/web/csrf.ts
@@ -1,0 +1,66 @@
+import crypto from "crypto";
+import { Buffer } from "buffer";
+import { Request, Response, NextFunction } from "express";
+import { parseCookies, setCookie } from "./cookies.js";
+
+export const CSRF_COOKIE = "koolbot_csrf";
+export const CSRF_HEADER = "x-csrf-token";
+
+/**
+ * Double-submit-cookie CSRF protection. The cookie is non-HttpOnly so the
+ * page can mirror it back in a header on state-changing requests; the server
+ * compares the two with constant-time equality.
+ */
+export function ensureCsrfCookie(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const cookies = parseCookies(req);
+  if (!cookies[CSRF_COOKIE]) {
+    const token = crypto.randomBytes(32).toString("base64url");
+    setCookie(res, CSRF_COOKIE, token, {
+      httpOnly: false,
+      sameSite: "lax",
+      secure: shouldUseSecureCookies(),
+      path: "/",
+    });
+    (req as Request & { csrfToken?: string }).csrfToken = token;
+  } else {
+    (req as Request & { csrfToken?: string }).csrfToken = cookies[CSRF_COOKIE];
+  }
+  next();
+}
+
+export function requireCsrf(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  if (
+    req.method === "GET" ||
+    req.method === "HEAD" ||
+    req.method === "OPTIONS"
+  ) {
+    next();
+    return;
+  }
+  const cookies = parseCookies(req);
+  const cookieToken = cookies[CSRF_COOKIE];
+  const headerToken = req.header(CSRF_HEADER) || (req.body && req.body._csrf);
+  if (!cookieToken || !headerToken) {
+    res.status(403).type("text/plain").send("CSRF token missing");
+    return;
+  }
+  const a = Buffer.from(String(cookieToken));
+  const b = Buffer.from(String(headerToken));
+  if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+    res.status(403).type("text/plain").send("CSRF token mismatch");
+    return;
+  }
+  next();
+}
+
+export function shouldUseSecureCookies(): boolean {
+  return process.env.NODE_ENV === "production";
+}

--- a/src/web/csrf.ts
+++ b/src/web/csrf.ts
@@ -5,6 +5,7 @@ import { parseCookies, setCookie } from "./cookies.js";
 
 export const CSRF_COOKIE = "koolbot_csrf";
 export const CSRF_HEADER = "x-csrf-token";
+export const CSRF_COOKIE_PATH = "/admin";
 
 /**
  * Double-submit-cookie CSRF protection. The cookie is non-HttpOnly so the
@@ -24,7 +25,7 @@ export function ensureCsrfCookie(
       httpOnly: false,
       sameSite: "lax",
       secure: shouldUseSecureCookies(),
-      path: "/",
+      path: CSRF_COOKIE_PATH,
     });
     (req as Request & { csrfToken?: string }).csrfToken = token;
   } else {

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -119,8 +119,10 @@ export function createWebRouter(client: Client): Router {
         let display: string | undefined;
         if (present && raw) {
           if (SECRET_KEYS.has(key)) {
-            // Reveal only the last 4 characters of secrets.
-            display = `…${raw.slice(-4)}`;
+            // Only reveal a 4-char tail when the secret is long enough
+            // that the tail isn't the whole value. For shorter values we
+            // omit the tail entirely so we never echo the full secret.
+            display = raw.length >= 8 ? `…${raw.slice(-4)}` : undefined;
           } else if (raw.length > 32) {
             display = `${raw.slice(0, 28)}…`;
           } else {

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -112,21 +112,24 @@ export function createWebRouter(client: Client): Router {
   router.get(
     "/bootstrap",
     requireSession,
-    (req: AuthenticatedRequest, res: Response): void => {
-      const csrfToken =
-        (req as Request & { csrfToken?: string }).csrfToken ?? "";
+    (_req: AuthenticatedRequest, res: Response): void => {
       const rows = BOOTSTRAP_KEYS.map((key) => {
         const raw = process.env[key];
         const present = typeof raw === "string" && raw.length > 0;
-        let tail: string | undefined;
-        if (present && SECRET_KEYS.has(key) && raw) {
-          tail = raw.slice(-4);
-        } else if (present && raw && !SECRET_KEYS.has(key)) {
-          tail = raw.length > 32 ? `${raw.slice(0, 28)}…` : raw;
+        let display: string | undefined;
+        if (present && raw) {
+          if (SECRET_KEYS.has(key)) {
+            // Reveal only the last 4 characters of secrets.
+            display = `…${raw.slice(-4)}`;
+          } else if (raw.length > 32) {
+            display = `${raw.slice(0, 28)}…`;
+          } else {
+            display = raw;
+          }
         }
-        return { key, present, tail };
+        return { key, present, display };
       });
-      res.type("text/html").send(renderBootstrap({ rows, csrfToken }));
+      res.type("text/html").send(renderBootstrap({ rows }));
     },
   );
 

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -1,0 +1,173 @@
+import express, { NextFunction, Request, Response, Router } from "express";
+import { Client } from "discord.js";
+import logger from "../utils/logger.js";
+import { WebSessionService } from "../services/web-session-service.js";
+import { ensureCsrfCookie, requireCsrf } from "./csrf.js";
+import { createRateLimiter } from "./rate-limit.js";
+import {
+  AuthenticatedRequest,
+  clearSessionCookie,
+  createSessionMiddleware,
+  writeSessionCookie,
+} from "./session.js";
+import {
+  renderBootstrap,
+  renderDashboard,
+  renderInvalidLink,
+  renderSignedOut,
+} from "./views.js";
+
+const SECRET_KEYS = new Set([
+  "DISCORD_TOKEN",
+  "MONGODB_URI",
+  "WEBUI_SESSION_SECRET",
+]);
+
+const BOOTSTRAP_KEYS = [
+  "DISCORD_TOKEN",
+  "CLIENT_ID",
+  "GUILD_ID",
+  "MONGODB_URI",
+  "NODE_ENV",
+  "DEBUG",
+  "WEBUI_ENABLED",
+  "WEBUI_BASE_URL",
+  "WEBUI_SESSION_SECRET",
+  "WEBUI_SESSION_TTL_MINUTES",
+  "WEBUI_INACTIVITY_TIMEOUT_MINUTES",
+];
+
+/**
+ * Build the WebUI router. Caller mounts this at /admin on the existing
+ * Express server. Nothing in this module runs unless WEBUI_ENABLED=true,
+ * which is enforced by the caller in src/index.ts.
+ */
+export function createWebRouter(client: Client): Router {
+  const router = Router();
+  const sessionService = WebSessionService.getInstance();
+
+  router.use(express.urlencoded({ extended: false, limit: "16kb" }));
+  router.use(ensureCsrfCookie);
+
+  const redeemLimiter = createRateLimiter({
+    windowMs: 60_000,
+    max: 10,
+    keyName: "redeem",
+  });
+  const finishLimiter = createRateLimiter({
+    windowMs: 60_000,
+    max: 30,
+    keyName: "finish",
+  });
+
+  const requireSession = createSessionMiddleware(client);
+
+  router.get(
+    "/s/:token",
+    redeemLimiter,
+    async (req: Request, res: Response): Promise<void> => {
+      try {
+        const token = String(req.params.token || "");
+        const redeemed = await sessionService.redeem(token);
+        if (!redeemed) {
+          res.status(404).type("text/html").send(renderInvalidLink());
+          return;
+        }
+        writeSessionCookie(res, {
+          sid: redeemed.sessionId,
+          uid: redeemed.discordUserId,
+          gid: redeemed.guildId,
+          iat: Date.now(),
+          act: Date.now(),
+        });
+        res.redirect(302, "/admin/");
+      } catch (err) {
+        logger.error("Error redeeming web session token", err);
+        res.status(500).type("text/plain").send("Internal Server Error");
+      }
+    },
+  );
+
+  router.get(
+    "/",
+    requireSession,
+    (req: AuthenticatedRequest, res: Response): void => {
+      const ctx = req.webSession;
+      if (!ctx) {
+        res.status(401).type("text/plain").send("Unauthorized");
+        return;
+      }
+      const csrfToken =
+        (req as Request & { csrfToken?: string }).csrfToken ?? "";
+      res.type("text/html").send(
+        renderDashboard({
+          discordUserId: ctx.discordUserId,
+          guildId: ctx.guildId,
+          csrfToken,
+        }),
+      );
+    },
+  );
+
+  router.get(
+    "/bootstrap",
+    requireSession,
+    (req: AuthenticatedRequest, res: Response): void => {
+      const csrfToken =
+        (req as Request & { csrfToken?: string }).csrfToken ?? "";
+      const rows = BOOTSTRAP_KEYS.map((key) => {
+        const raw = process.env[key];
+        const present = typeof raw === "string" && raw.length > 0;
+        let tail: string | undefined;
+        if (present && SECRET_KEYS.has(key) && raw) {
+          tail = raw.slice(-4);
+        } else if (present && raw && !SECRET_KEYS.has(key)) {
+          tail = raw.length > 32 ? `${raw.slice(0, 28)}…` : raw;
+        }
+        return { key, present, tail };
+      });
+      res.type("text/html").send(renderBootstrap({ rows, csrfToken }));
+    },
+  );
+
+  router.post(
+    "/finish",
+    finishLimiter,
+    requireCsrf,
+    requireSession,
+    async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+      const ctx = req.webSession;
+      if (ctx) {
+        await sessionService.revokeSession(ctx.sessionId);
+      }
+      clearSessionCookie(res);
+      res.status(200).type("text/html").send(renderSignedOut());
+    },
+  );
+
+  router.use(
+    (err: unknown, _req: Request, res: Response, next: NextFunction): void => {
+      logger.error("WebUI router error", err);
+      if (res.headersSent) {
+        next(err);
+        return;
+      }
+      res.status(500).type("text/plain").send("Internal Server Error");
+    },
+  );
+
+  return router;
+}
+
+export function isWebUIEnabled(): boolean {
+  return (process.env.WEBUI_ENABLED || "").toLowerCase() === "true";
+}
+
+/**
+ * Validate that all WEBUI_* env vars required for an enabled WebUI are
+ * present. Returns the list of missing keys (empty when satisfied).
+ */
+export function getMissingWebUIEnvVars(): string[] {
+  const required = ["WEBUI_BASE_URL", "WEBUI_SESSION_SECRET"];
+  return required.filter((k) => !process.env[k]);
+}

--- a/src/web/rate-limit.ts
+++ b/src/web/rate-limit.ts
@@ -1,0 +1,38 @@
+import { Request, Response, NextFunction } from "express";
+
+interface Bucket {
+  hits: number;
+  resetAt: number;
+}
+
+/**
+ * In-memory fixed-window rate limiter. Keyed by client IP + route name.
+ * Adequate for the auth-endpoint protection required by the scaffold;
+ * we are not trying to defend against a distributed attacker here.
+ */
+export function createRateLimiter(opts: {
+  windowMs: number;
+  max: number;
+  keyName: string;
+}): (req: Request, res: Response, next: NextFunction) => void {
+  const buckets = new Map<string, Bucket>();
+
+  return function rateLimit(req, res, next): void {
+    const ip = (req.ip || req.socket.remoteAddress || "unknown").toString();
+    const key = `${opts.keyName}:${ip}`;
+    const now = Date.now();
+    let bucket = buckets.get(key);
+    if (!bucket || bucket.resetAt <= now) {
+      bucket = { hits: 0, resetAt: now + opts.windowMs };
+      buckets.set(key, bucket);
+    }
+    bucket.hits += 1;
+    if (bucket.hits > opts.max) {
+      const retryAfter = Math.max(1, Math.ceil((bucket.resetAt - now) / 1000));
+      res.setHeader("Retry-After", retryAfter);
+      res.status(429).type("text/plain").send("Too Many Requests");
+      return;
+    }
+    next();
+  };
+}

--- a/src/web/rate-limit.ts
+++ b/src/web/rate-limit.ts
@@ -5,26 +5,63 @@ interface Bucket {
   resetAt: number;
 }
 
+const DEFAULT_MAX_KEYS = 10_000;
+const SWEEP_EVERY_N_HITS = 256;
+
 /**
  * In-memory fixed-window rate limiter. Keyed by client IP + route name.
- * Adequate for the auth-endpoint protection required by the scaffold;
- * we are not trying to defend against a distributed attacker here.
+ *
+ * Bucket map size is bounded by:
+ *   - lazy eviction of expired buckets every SWEEP_EVERY_N_HITS requests, and
+ *   - a hard cap (DEFAULT_MAX_KEYS) above which we evict the oldest entries
+ *     (Map iteration order is insertion-ordered).
+ *
+ * Adequate for the auth-endpoint protection required by the scaffold; we
+ * are not trying to defend against a distributed attacker here.
  */
 export function createRateLimiter(opts: {
   windowMs: number;
   max: number;
   keyName: string;
+  maxKeys?: number;
 }): (req: Request, res: Response, next: NextFunction) => void {
   const buckets = new Map<string, Bucket>();
+  const maxKeys = opts.maxKeys ?? DEFAULT_MAX_KEYS;
+  let hitsSinceSweep = 0;
+
+  function sweep(now: number): void {
+    for (const [k, v] of buckets) {
+      if (v.resetAt <= now) buckets.delete(k);
+    }
+  }
+
+  function trimToCap(): void {
+    if (buckets.size <= maxKeys) return;
+    const overflow = buckets.size - maxKeys;
+    let removed = 0;
+    for (const k of buckets.keys()) {
+      if (removed >= overflow) break;
+      buckets.delete(k);
+      removed += 1;
+    }
+  }
 
   return function rateLimit(req, res, next): void {
     const ip = (req.ip || req.socket.remoteAddress || "unknown").toString();
     const key = `${opts.keyName}:${ip}`;
     const now = Date.now();
+
+    hitsSinceSweep += 1;
+    if (hitsSinceSweep >= SWEEP_EVERY_N_HITS) {
+      hitsSinceSweep = 0;
+      sweep(now);
+    }
+
     let bucket = buckets.get(key);
     if (!bucket || bucket.resetAt <= now) {
       bucket = { hits: 0, resetAt: now + opts.windowMs };
       buckets.set(key, bucket);
+      trimToCap();
     }
     bucket.hits += 1;
     if (bucket.hits > opts.max) {

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -1,0 +1,194 @@
+import { Buffer } from "buffer";
+import { Client } from "discord.js";
+import { Request, Response, NextFunction } from "express";
+import logger from "../utils/logger.js";
+import { PermissionsService } from "../services/permissions-service.js";
+import { WebSessionService } from "../services/web-session-service.js";
+import {
+  clearCookie,
+  parseCookies,
+  setCookie,
+  signValue,
+  verifySignedValue,
+} from "./cookies.js";
+import { shouldUseSecureCookies } from "./csrf.js";
+
+export const SESSION_COOKIE = "koolbot_session";
+
+const DEFAULT_INACTIVITY_MINUTES = 30;
+
+export interface WebSessionContext {
+  sessionId: string;
+  discordUserId: string;
+  guildId: string;
+  scopes: string[];
+  lastActivityAt: number;
+}
+
+export type AuthenticatedRequest = Request & { webSession?: WebSessionContext };
+
+interface CookiePayload {
+  sid: string;
+  uid: string;
+  gid: string;
+  iat: number;
+  act: number;
+}
+
+function getSecret(): string {
+  const secret = process.env.WEBUI_SESSION_SECRET;
+  if (!secret) {
+    throw new Error("WEBUI_SESSION_SECRET not configured");
+  }
+  return secret;
+}
+
+function getInactivityMinutes(): number {
+  const raw = process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES;
+  const parsed = raw ? Number(raw) : NaN;
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_INACTIVITY_MINUTES;
+}
+
+export function writeSessionCookie(
+  res: Response,
+  payload: CookiePayload,
+): void {
+  const encoded = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signed = signValue(encoded, getSecret());
+  setCookie(res, SESSION_COOKIE, signed, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: shouldUseSecureCookies(),
+    path: "/",
+    maxAge: getInactivityMinutes() * 60 * 1000,
+  });
+}
+
+export function clearSessionCookie(res: Response): void {
+  clearCookie(res, SESSION_COOKIE, { path: "/" });
+}
+
+function readSessionCookie(req: Request): CookiePayload | null {
+  const cookies = parseCookies(req);
+  const raw = cookies[SESSION_COOKIE];
+  if (!raw) return null;
+  let secret: string;
+  try {
+    secret = getSecret();
+  } catch {
+    return null;
+  }
+  const verified = verifySignedValue(raw, secret);
+  if (!verified) return null;
+  try {
+    const json = Buffer.from(verified, "base64url").toString("utf8");
+    const parsed = JSON.parse(json) as CookiePayload;
+    if (
+      typeof parsed.sid !== "string" ||
+      typeof parsed.uid !== "string" ||
+      typeof parsed.gid !== "string" ||
+      typeof parsed.iat !== "number" ||
+      typeof parsed.act !== "number"
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Session middleware: verifies the signed cookie, enforces the sliding
+ * inactivity window, hard-caps the session to its server-side expires_at,
+ * and re-checks Administrator on every request via PermissionsService.
+ */
+export function createSessionMiddleware(
+  client: Client,
+): (
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+) => Promise<void> {
+  return async function requireSession(req, res, next): Promise<void> {
+    const payload = readSessionCookie(req);
+    if (!payload) {
+      respondUnauthorized(res);
+      return;
+    }
+
+    const now = Date.now();
+    const inactivityMs = getInactivityMinutes() * 60 * 1000;
+    if (now - payload.act > inactivityMs) {
+      clearSessionCookie(res);
+      respondUnauthorized(res);
+      return;
+    }
+
+    const sessionService = WebSessionService.getInstance();
+    const dbSession = await sessionService.findById(payload.sid);
+    if (
+      !dbSession ||
+      dbSession.revoked_at ||
+      dbSession.expires_at.getTime() <= now ||
+      dbSession.discord_user_id !== payload.uid
+    ) {
+      clearSessionCookie(res);
+      respondUnauthorized(res);
+      return;
+    }
+
+    try {
+      const permissions = PermissionsService.getInstance(client);
+      const guild = await client.guilds.fetch(payload.gid);
+      const member = await guild.members.fetch(payload.uid);
+      const isAdmin = member.permissions.has("Administrator");
+      if (!isAdmin) {
+        // Re-check admin on every request as required by the spec.
+        // Defer to the cached permissions service for any future per-route
+        // role gating.
+        await permissions.checkCommandPermission(
+          payload.uid,
+          payload.gid,
+          "config",
+        );
+        clearSessionCookie(res);
+        await sessionService.revokeSession(payload.sid);
+        respondUnauthorized(res);
+        return;
+      }
+    } catch (err) {
+      logger.warn("Failed to revalidate web session permissions", err);
+      clearSessionCookie(res);
+      respondUnauthorized(res);
+      return;
+    }
+
+    const refreshed: CookiePayload = { ...payload, act: now };
+    writeSessionCookie(res, refreshed);
+
+    req.webSession = {
+      sessionId: payload.sid,
+      discordUserId: payload.uid,
+      guildId: payload.gid,
+      scopes: dbSession.scopes,
+      lastActivityAt: now,
+    };
+    next();
+  };
+}
+
+function respondUnauthorized(res: Response): void {
+  res
+    .status(401)
+    .type("text/html")
+    .send(
+      `<!doctype html><html><head><meta charset="utf-8"><title>Sign in required</title></head>` +
+        `<body style="font-family:system-ui,sans-serif;padding:2rem;max-width:32rem;margin:0 auto;">` +
+        `<h1>Sign in required</h1>` +
+        `<p>Run <code>/config</code> in Discord to receive a fresh sign-in link.</p>` +
+        `</body></html>`,
+    );
+}

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -72,7 +72,7 @@ export function clearSessionCookie(res: Response): void {
 
 function readSessionCookie(req: Request): CookiePayload | null {
   const cookies = parseCookies(req);
-  const raw = cookies[SESSION_COOKIE];
+  const raw = cookies.get(SESSION_COOKIE);
   if (!raw) return null;
   let secret: string;
   try {

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -14,6 +14,7 @@ import {
 import { shouldUseSecureCookies } from "./csrf.js";
 
 export const SESSION_COOKIE = "koolbot_session";
+export const SESSION_COOKIE_PATH = "/admin";
 
 const DEFAULT_INACTIVITY_MINUTES = 30;
 
@@ -61,13 +62,13 @@ export function writeSessionCookie(
     httpOnly: true,
     sameSite: "lax",
     secure: shouldUseSecureCookies(),
-    path: "/",
+    path: SESSION_COOKIE_PATH,
     maxAge: getInactivityMinutes() * 60 * 1000,
   });
 }
 
 export function clearSessionCookie(res: Response): void {
-  clearCookie(res, SESSION_COOKIE, { path: "/" });
+  clearCookie(res, SESSION_COOKIE, { path: SESSION_COOKIE_PATH });
 }
 
 function readSessionCookie(req: Request): CookiePayload | null {
@@ -102,8 +103,10 @@ function readSessionCookie(req: Request): CookiePayload | null {
 
 /**
  * Session middleware: verifies the signed cookie, enforces the sliding
- * inactivity window, hard-caps the session to its server-side expires_at,
- * and re-checks Administrator on every request via PermissionsService.
+ * inactivity window, hard-caps the session to its server-side expiresAt,
+ * and re-checks the user's command permission on every request via
+ * PermissionsService (admins always pass; otherwise the configured roles
+ * for "config" must allow the user).
  */
 export function createSessionMiddleware(
   client: Client,
@@ -131,9 +134,10 @@ export function createSessionMiddleware(
     const dbSession = await sessionService.findById(payload.sid);
     if (
       !dbSession ||
-      dbSession.revoked_at ||
-      dbSession.expires_at.getTime() <= now ||
-      dbSession.discord_user_id !== payload.uid
+      dbSession.revokedAt ||
+      dbSession.expiresAt.getTime() <= now ||
+      dbSession.discordUserId !== payload.uid ||
+      dbSession.guildId !== payload.gid
     ) {
       clearSessionCookie(res);
       respondUnauthorized(res);
@@ -142,18 +146,15 @@ export function createSessionMiddleware(
 
     try {
       const permissions = PermissionsService.getInstance(client);
-      const guild = await client.guilds.fetch(payload.gid);
-      const member = await guild.members.fetch(payload.uid);
-      const isAdmin = member.permissions.has("Administrator");
-      if (!isAdmin) {
-        // Re-check admin on every request as required by the spec.
-        // Defer to the cached permissions service for any future per-route
-        // role gating.
-        await permissions.checkCommandPermission(
-          payload.uid,
-          payload.gid,
-          "config",
-        );
+      // checkCommandPermission already short-circuits to true for
+      // Administrators and to true when no role gating is configured for
+      // the command, so we can rely on its boolean directly.
+      const allowed = await permissions.checkCommandPermission(
+        payload.uid,
+        payload.gid,
+        "config",
+      );
+      if (!allowed) {
         clearSessionCookie(res);
         await sessionService.revokeSession(payload.sid);
         respondUnauthorized(res);
@@ -188,7 +189,7 @@ function respondUnauthorized(res: Response): void {
       `<!doctype html><html><head><meta charset="utf-8"><title>Sign in required</title></head>` +
         `<body style="font-family:system-ui,sans-serif;padding:2rem;max-width:32rem;margin:0 auto;">` +
         `<h1>Sign in required</h1>` +
-        `<p>Run <code>/config</code> in Discord to receive a fresh sign-in link.</p>` +
+        `<p>Run <code>/config web</code> in Discord to receive a fresh sign-in link.</p>` +
         `</body></html>`,
     );
 }

--- a/src/web/views.ts
+++ b/src/web/views.ts
@@ -1,0 +1,97 @@
+/**
+ * Inline HTML for the WebUI scaffold. We render small static pages here so
+ * the scaffold doesn't pull in a templating engine; richer views land in
+ * later sub-issues.
+ */
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function pageShell(title: string, body: string): string {
+  return [
+    "<!doctype html>",
+    '<html lang="en"><head>',
+    '<meta charset="utf-8">',
+    `<title>${escapeHtml(title)} — Koolbot Admin</title>`,
+    '<meta name="viewport" content="width=device-width,initial-scale=1">',
+    "<style>",
+    "body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;max-width:48rem;margin:0 auto;padding:2rem;color:#1f2937;}",
+    "h1{margin-top:0;}",
+    "table{border-collapse:collapse;width:100%;}",
+    "th,td{text-align:left;padding:.4rem .6rem;border-bottom:1px solid #e5e7eb;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.9rem;}",
+    "th{background:#f3f4f6;}",
+    "code{background:#f3f4f6;padding:.1rem .3rem;border-radius:.25rem;}",
+    "nav a{margin-right:.75rem;}",
+    "form{margin-top:1rem;}",
+    "</style></head><body>",
+    body,
+    "</body></html>",
+  ].join("");
+}
+
+export function renderDashboard(opts: {
+  discordUserId: string;
+  guildId: string;
+  csrfToken: string;
+}): string {
+  const body = [
+    '<nav><a href="/admin/">Dashboard</a> <a href="/admin/bootstrap">Bootstrap</a></nav>',
+    "<h1>Koolbot Admin</h1>",
+    `<p>Signed in as user <code>${escapeHtml(opts.discordUserId)}</code> in guild <code>${escapeHtml(opts.guildId)}</code>.</p>`,
+    "<p>This is a placeholder dashboard. Read views land in subsequent sub-issues.</p>",
+    '<form method="POST" action="/admin/finish">',
+    `<input type="hidden" name="_csrf" value="${escapeHtml(opts.csrfToken)}">`,
+    '<button type="submit">Finish &amp; sign out</button>',
+    "</form>",
+  ].join("");
+  return pageShell("Dashboard", body);
+}
+
+export function renderBootstrap(opts: {
+  rows: Array<{ key: string; present: boolean; tail?: string }>;
+  csrfToken: string;
+}): string {
+  const tableRows = opts.rows
+    .map((row) => {
+      const present = row.present
+        ? `<span style="color:#15803d;">present</span>`
+        : `<span style="color:#b91c1c;">missing</span>`;
+      const tail = row.tail ? `<code>…${escapeHtml(row.tail)}</code>` : "";
+      return `<tr><td>${escapeHtml(row.key)}</td><td>${present}</td><td>${tail}</td></tr>`;
+    })
+    .join("");
+  const body = [
+    '<nav><a href="/admin/">Dashboard</a> <a href="/admin/bootstrap">Bootstrap</a></nav>',
+    "<h1>Bootstrap (read-only)</h1>",
+    "<p>Environment values are <strong>never</strong> writable from the WebUI. Only presence and the last 4 characters of secrets are shown.</p>",
+    "<table><thead><tr><th>Key</th><th>Status</th><th>Tail</th></tr></thead>",
+    `<tbody>${tableRows}</tbody></table>`,
+  ].join("");
+  return pageShell("Bootstrap", body);
+}
+
+export function renderSignedOut(): string {
+  return pageShell(
+    "Signed out",
+    [
+      "<h1>Signed out</h1>",
+      "<p>Your session has been revoked. Run <code>/config</code> in Discord to start a new one.</p>",
+    ].join(""),
+  );
+}
+
+export function renderInvalidLink(): string {
+  return pageShell(
+    "Invalid link",
+    [
+      "<h1>Link invalid or expired</h1>",
+      "<p>Magic-link tokens are single-use and expire quickly. Run <code>/config</code> in Discord again to receive a fresh link.</p>",
+    ].join(""),
+  );
+}

--- a/src/web/views.ts
+++ b/src/web/views.ts
@@ -54,23 +54,24 @@ export function renderDashboard(opts: {
 }
 
 export function renderBootstrap(opts: {
-  rows: Array<{ key: string; present: boolean; tail?: string }>;
-  csrfToken: string;
+  rows: Array<{ key: string; present: boolean; display?: string }>;
 }): string {
   const tableRows = opts.rows
     .map((row) => {
       const present = row.present
         ? `<span style="color:#15803d;">present</span>`
         : `<span style="color:#b91c1c;">missing</span>`;
-      const tail = row.tail ? `<code>…${escapeHtml(row.tail)}</code>` : "";
-      return `<tr><td>${escapeHtml(row.key)}</td><td>${present}</td><td>${tail}</td></tr>`;
+      const display = row.display
+        ? `<code>${escapeHtml(row.display)}</code>`
+        : "";
+      return `<tr><td>${escapeHtml(row.key)}</td><td>${present}</td><td>${display}</td></tr>`;
     })
     .join("");
   const body = [
     '<nav><a href="/admin/">Dashboard</a> <a href="/admin/bootstrap">Bootstrap</a></nav>',
     "<h1>Bootstrap (read-only)</h1>",
     "<p>Environment values are <strong>never</strong> writable from the WebUI. Only presence and the last 4 characters of secrets are shown.</p>",
-    "<table><thead><tr><th>Key</th><th>Status</th><th>Tail</th></tr></thead>",
+    "<table><thead><tr><th>Key</th><th>Status</th><th>Value</th></tr></thead>",
     `<tbody>${tableRows}</tbody></table>`,
   ].join("");
   return pageShell("Bootstrap", body);
@@ -81,7 +82,7 @@ export function renderSignedOut(): string {
     "Signed out",
     [
       "<h1>Signed out</h1>",
-      "<p>Your session has been revoked. Run <code>/config</code> in Discord to start a new one.</p>",
+      "<p>Your session has been revoked. Run <code>/config web</code> in Discord to start a new one.</p>",
     ].join(""),
   );
 }
@@ -91,7 +92,7 @@ export function renderInvalidLink(): string {
     "Invalid link",
     [
       "<h1>Link invalid or expired</h1>",
-      "<p>Magic-link tokens are single-use and expire quickly. Run <code>/config</code> in Discord again to receive a fresh link.</p>",
+      "<p>Magic-link tokens are single-use and expire quickly. Run <code>/config web</code> in Discord again to receive a fresh link.</p>",
     ].join(""),
   );
 }


### PR DESCRIPTION
## Summary

Sub-issue 1/8 of #367 — scaffolds the WebUI plumbing behind `WEBUI_ENABLED=false` so nothing changes for existing operators. Closes #380.

The new code lives in `src/web/` and is mounted under `/admin` on the existing Express server only when `WEBUI_ENABLED=true` and the required env vars are present. The existing `/config` tree is untouched; a new `/config web` subcommand mints a single-use magic link and DMs it to the caller (with an ephemeral fallback if DMs are closed).

## What's new

- **Env vars** (additive, only required when `WEBUI_ENABLED=true`):
  - `WEBUI_ENABLED`
  - `WEBUI_BASE_URL`
  - `WEBUI_SESSION_SECRET`
  - `WEBUI_SESSION_TTL_MINUTES` (default 10)
  - `WEBUI_INACTIVITY_TIMEOUT_MINUTES` (default 30)
  - `WEBUI_TRUST_PROXY` (optional; controls express `trust proxy`. Default is **off** so `req.ip` cannot be spoofed via `X-Forwarded-For` and bypass the rate limiter. Set to a number of hops — e.g. `1` — or `true` / one of express' tokens (`loopback`, `linklocal`, `uniquelocal`) only when behind a real reverse proxy.)
- **Model**: `src/models/web-session.ts` with camelCase fields matching the rest of this repo's mongoose models: `{ tokenHash, discordUserId, guildId, scopes, createdAt, expiresAt, usedAt, revokedAt }`.
- **Service**: `src/services/web-session-service.ts` — generates random tokens, stores HMAC-SHA256 hashes (so DB-only access can't replay), revokes prior sessions on every `create`, atomic `findOneAndUpdate` redemption.
- **Routes** (`src/web/index.ts`):
  - `GET /admin/s/:token` — redeems token, sets signed session cookie, redirects to `/admin/`. 404 on missing/used/expired/revoked.
  - `GET /admin/` — placeholder dashboard.
  - `GET /admin/bootstrap` — read-only env presence (last-4-chars tail only when secrets are ≥ 8 chars; shorter secrets show "present" with no value to avoid echoing the whole secret in dev/test). Never writable.
  - `POST /admin/finish` — revokes the server-side session.
- **Middleware**: signed-cookie session (cookies path-scoped to `/admin`) with sliding inactivity window + server-side hard cap, `PermissionsService.checkCommandPermission` re-check on every request, double-submit-cookie CSRF (also `/admin`-scoped), in-memory per-IP rate limiter on auth endpoints with lazy expired-bucket sweep + 10k-key FIFO cap.
- **Discord command**: `/config web` subcommand registered alongside the existing tree; old `/config list|set|import|export|reset|reload` still work unchanged. Defers ephemerally up front so DB + DM work can't trip Discord's 3-second ack deadline.

## Acceptance criteria

- [x] With `WEBUI_ENABLED=false`, nothing is mounted under `/admin`.
- [x] With `WEBUI_ENABLED=true`, `/config web` DMs a single-use URL that lands on `/admin/`.
- [x] Tokens are single-use; expired/used/revoked tokens 404.
- [x] Re-running `/config web` revokes the previous session.
- [x] No business logic outside `src/services/`.
- [x] Bootstrap page is read-only and never exposes full secret values (incl. short ones).

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` (0 errors)
- [x] `npm run format:check` clean
- [x] `npm test` — 86 suites, 754 passed (15 new tests for `WebSessionService`, cookie signing, and `parseCookies` prototype-pollution regression)
- [ ] Manual: set `WEBUI_ENABLED=true` + the WEBUI_* vars, run `/config web`, redeem the DM link, click "Finish" — session should be unusable afterward.
