### PR TITLE
feat(webui): read-only admin views (#381)

### DIFF
--- a/__tests__/services/settings-metadata.test.ts
+++ b/__tests__/services/settings-metadata.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  defaultConfig,
+  settingsMetadata,
+} from "../../src/services/config-schema.js";
+
+describe("settingsMetadata", () => {
+  it("has an entry for every key in defaultConfig", () => {
+    const missing: string[] = [];
+    for (const key of Object.keys(defaultConfig)) {
+      if (
+        !(key in settingsMetadata) ||
+        !settingsMetadata[key as keyof typeof settingsMetadata]
+      ) {
+        missing.push(key);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it("provides a non-empty description and category for every key", () => {
+    const violations: string[] = [];
+    for (const [key, meta] of Object.entries(settingsMetadata)) {
+      if (!meta.description || meta.description.length === 0) {
+        violations.push(`empty description for ${key}`);
+      }
+      if (!meta.category || meta.category.length === 0) {
+        violations.push(`empty category for ${key}`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("uses only known feature categories that match the Mongo Config model enum", () => {
+    // The Mongo Config model's category enum is grouped by feature
+    // (voicechannels, voicetracking, quotes, …). Most settings keys are
+    // dot-prefixed with that same group. Anything that diverges should be
+    // intentional, not accidental.
+    const knownCategories = new Set([
+      "voicechannels",
+      "voicetracking",
+      "ping",
+      "help",
+      "amikool",
+      "quotes",
+      "core",
+      "fun",
+      "ratelimit",
+      "announcements",
+      "achievements",
+      "reactionroles",
+      "wizard",
+      "notices",
+      "polls",
+    ]);
+    const violations: string[] = [];
+    for (const [key, meta] of Object.entries(settingsMetadata)) {
+      if (!knownCategories.has(meta.category)) {
+        violations.push(`unknown category "${meta.category}" for ${key}`);
+      }
+      if (key.includes(".")) {
+        const prefix = key.slice(0, key.indexOf("."));
+        if (knownCategories.has(prefix) && meta.category !== prefix) {
+          violations.push(
+            `${key} category "${meta.category}" disagrees with key prefix "${prefix}"`,
+          );
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/__tests__/web/admin-layout.test.ts
+++ b/__tests__/web/admin-layout.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import {
+  escapeHtml,
+  getDisplayedRemainingMs,
+  NAV_ITEMS,
+  renderAdminPage,
+} from "../../src/web/admin-layout.js";
+
+describe("admin-layout escapeHtml", () => {
+  it("returns empty string for null/undefined", () => {
+    expect(escapeHtml(null)).toBe("");
+    expect(escapeHtml(undefined)).toBe("");
+  });
+
+  it("escapes HTML metacharacters", () => {
+    expect(escapeHtml(`<script>"x'&y"</script>`)).toBe(
+      "&lt;script&gt;&quot;x&#39;&amp;y&quot;&lt;/script&gt;",
+    );
+  });
+
+  it("stringifies non-strings before escaping", () => {
+    expect(escapeHtml(42)).toBe("42");
+    expect(escapeHtml(true)).toBe("true");
+  });
+});
+
+describe("admin-layout NAV_ITEMS", () => {
+  it("includes every page promised by issue #381", () => {
+    const labels = NAV_ITEMS.map((n) => n.label);
+    expect(labels).toEqual(
+      expect.arrayContaining([
+        "Dashboard",
+        "Settings",
+        "Permissions",
+        "Announcements",
+        "Polls",
+        "Reaction Roles",
+        "Notices",
+        "Voice Channels",
+        "Database",
+        "Bootstrap",
+      ]),
+    );
+  });
+});
+
+describe("renderAdminPage", () => {
+  it("renders the session-expires banner with the supplied countdown ms", () => {
+    const html = renderAdminPage({
+      title: "Test",
+      active: "/admin/",
+      body: "<p>hi</p>",
+      csrfToken: "csrftoken",
+      remainingMs: 1234567,
+    });
+    expect(html).toContain('id="session-countdown"');
+    expect(html).toContain('data-remaining-ms="1234567"');
+    expect(html).toContain('action="/admin/finish"');
+    expect(html).toContain('value="csrftoken"');
+    expect(html).toContain("<p>hi</p>");
+  });
+
+  it("escapes the title", () => {
+    const html = renderAdminPage({
+      title: "<bad>",
+      active: "/admin/",
+      body: "",
+      csrfToken: "",
+      remainingMs: 0,
+    });
+    expect(html).toContain("&lt;bad&gt;");
+    expect(html).not.toContain("<title><bad>");
+  });
+
+  it("marks the active nav item", () => {
+    const html = renderAdminPage({
+      title: "Settings",
+      active: "/admin/settings",
+      body: "",
+      csrfToken: "",
+      remainingMs: 0,
+    });
+    expect(html).toContain('href="/admin/settings" class="active"');
+  });
+});
+
+describe("getDisplayedRemainingMs", () => {
+  let saved: string | undefined;
+  beforeEach(() => {
+    saved = process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES;
+    delete process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES;
+  });
+  afterEach(() => {
+    if (saved === undefined) {
+      delete process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES;
+    } else {
+      process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES = saved;
+    }
+  });
+
+  it("defaults to 30 minutes when env var is unset", () => {
+    expect(getDisplayedRemainingMs()).toBe(30 * 60 * 1000);
+  });
+
+  it("uses the env var when valid", () => {
+    process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES = "5";
+    expect(getDisplayedRemainingMs()).toBe(5 * 60 * 1000);
+  });
+
+  it("falls back to default for invalid values", () => {
+    process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES = "abc";
+    expect(getDisplayedRemainingMs()).toBe(30 * 60 * 1000);
+    process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES = "0";
+    expect(getDisplayedRemainingMs()).toBe(30 * 60 * 1000);
+  });
+});

--- a/__tests__/web/admin-layout.test.ts
+++ b/__tests__/web/admin-layout.test.ts
@@ -113,4 +113,23 @@ describe("getDisplayedRemainingMs", () => {
     process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES = "0";
     expect(getDisplayedRemainingMs()).toBe(30 * 60 * 1000);
   });
+
+  it("honours the TTL hard cap when it ends before the inactivity window", () => {
+    // Inactivity window = 30 min, but the session has only 5 min left.
+    const expiresAt = new Date(Date.now() + 5 * 60 * 1000);
+    const remaining = getDisplayedRemainingMs({ expiresAt });
+    expect(remaining).toBeLessThanOrEqual(5 * 60 * 1000);
+    expect(remaining).toBeGreaterThan(4 * 60 * 1000);
+  });
+
+  it("uses the inactivity window when the TTL cap is further out", () => {
+    process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES = "10";
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000); // 1h
+    expect(getDisplayedRemainingMs({ expiresAt })).toBe(10 * 60 * 1000);
+  });
+
+  it("returns 0 when the hard cap has already passed", () => {
+    const expiresAt = new Date(Date.now() - 1000);
+    expect(getDisplayedRemainingMs({ expiresAt })).toBe(0);
+  });
 });

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  renderBootstrapPage,
+  renderDashboardPage,
+  renderPermissionsPage,
+  renderSettingsPage,
+} from "../../src/web/admin-views.js";
+
+const COMMON = { csrfToken: "csrf", remainingMs: 60_000 };
+
+describe("renderDashboardPage", () => {
+  it("renders feature toggles with status tags", () => {
+    const html = renderDashboardPage({
+      ...COMMON,
+      guild: {
+        id: "g1",
+        name: "Test Guild",
+        memberCount: 42,
+        voiceUsers: 3,
+        botTag: "Bot#0001",
+      },
+      mongoState: "connected",
+      counts: {
+        announcements: 1,
+        pollSchedules: 2,
+        pollItems: 3,
+        reactionRoles: 4,
+        notices: 5,
+      },
+      features: [
+        { key: "voicechannels.enabled", label: "Voice Channels", on: true },
+        { key: "polls.enabled", label: "Polls", on: false },
+      ],
+    });
+    expect(html).toContain("Test Guild");
+    expect(html).toContain("Bot#0001");
+    expect(html).toContain("voicechannels.enabled");
+    expect(html).toContain('class="tag tag-on">ON');
+    expect(html).toContain('class="tag tag-off">OFF');
+  });
+});
+
+describe("renderBootstrapPage", () => {
+  it("shows status tags + masked secrets", () => {
+    const html = renderBootstrapPage({
+      ...COMMON,
+      groups: [
+        {
+          category: "WebUI",
+          rows: [
+            {
+              key: "WEBUI_SESSION_SECRET",
+              present: true,
+              isSecret: true,
+              display: "…abcd",
+            },
+            { key: "WEBUI_SESSION_TTL_MINUTES", present: false, isSecret: false },
+          ],
+        },
+      ],
+    });
+    expect(html).toContain("WEBUI_SESSION_SECRET");
+    expect(html).toContain("…abcd");
+    expect(html).toContain("configured");
+    expect(html).toContain("unset");
+  });
+});
+
+describe("renderSettingsPage", () => {
+  it("renders one section per category and one row per setting", () => {
+    const html = renderSettingsPage({
+      ...COMMON,
+      groups: [
+        {
+          category: "voicechannels",
+          rows: [
+            {
+              key: "voicechannels.enabled",
+              current: true,
+              defaultValue: false,
+              type: "boolean",
+              description: "Enable VC mgmt",
+              category: "voicechannels",
+            },
+          ],
+        },
+      ],
+    });
+    expect(html).toContain("voicechannels.enabled");
+    expect(html).toContain("Enable VC mgmt");
+    expect(html).toContain('class="tag tag-info">boolean');
+  });
+});
+
+describe("renderPermissionsPage", () => {
+  it("falls back to an empty state when no roles are configured", () => {
+    const html = renderPermissionsPage({
+      ...COMMON,
+      commands: ["ping"],
+      roleIds: [],
+      roleNames: new Map(),
+      perCommand: new Map(),
+    });
+    expect(html).toContain("No restricted commands");
+    expect(html).toContain("/ping");
+  });
+
+  it("renders a matrix when roles exist", () => {
+    const html = renderPermissionsPage({
+      ...COMMON,
+      commands: ["dbtrunk"],
+      roleIds: ["r1"],
+      roleNames: new Map([["r1", "Admins"]]),
+      perCommand: new Map([["dbtrunk", ["r1"]]]),
+    });
+    expect(html).toContain(">Admins<");
+    expect(html).toContain('class="tag tag-warn">restricted');
+  });
+});

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect } from "@jest/globals";
 import {
+  renderAnnouncementsPage,
   renderBootstrapPage,
   renderDashboardPage,
+  renderDatabasePage,
+  renderNoticesPage,
   renderPermissionsPage,
+  renderPollsPage,
+  renderReactionRolesPage,
   renderSettingsPage,
+  renderVoiceChannelsPage,
 } from "../../src/web/admin-views.js";
 
 const COMMON = { csrfToken: "csrf", remainingMs: 60_000 };
@@ -115,5 +121,274 @@ describe("renderPermissionsPage", () => {
     });
     expect(html).toContain(">Admins<");
     expect(html).toContain('class="tag tag-warn">restricted');
+  });
+});
+
+describe("renderAnnouncementsPage", () => {
+  it("shows the empty state when no schedules exist", () => {
+    const html = renderAnnouncementsPage({
+      ...COMMON,
+      enabled: false,
+      rows: [],
+    });
+    expect(html).toContain("No scheduled announcements");
+    expect(html).toContain("disabled");
+  });
+
+  it("renders a row with cron + escapes the message preview", () => {
+    const html = renderAnnouncementsPage({
+      ...COMMON,
+      enabled: true,
+      rows: [
+        {
+          id: "a1",
+          channelName: "general",
+          cron: "0 9 * * *",
+          enabled: true,
+          messagePreview: "<b>hi</b>",
+          embedTitle: null,
+          placeholders: false,
+          createdAt: "2026-05-08T00:00:00.000Z",
+        },
+      ],
+    });
+    expect(html).toContain("0 9 * * *");
+    expect(html).toContain("&lt;b&gt;hi&lt;/b&gt;");
+    expect(html).toContain("#general");
+  });
+});
+
+describe("renderPollsPage", () => {
+  it("shows empty state for both schedules and items", () => {
+    const html = renderPollsPage({
+      ...COMMON,
+      enabled: true,
+      defaultDurationHours: 24,
+      cooldownDays: 7,
+      schedules: [],
+      items: [],
+    });
+    expect(html).toContain("No poll schedules");
+    expect(html).toContain("No poll questions");
+  });
+
+  it("renders schedules and items with channel + role mentions", () => {
+    const html = renderPollsPage({
+      ...COMMON,
+      enabled: true,
+      defaultDurationHours: 24,
+      cooldownDays: 7,
+      schedules: [
+        {
+          id: "s1",
+          channelName: "polls",
+          cron: "0 12 * * 1",
+          durationHours: 12,
+          pingRoleName: "Members",
+          enabled: true,
+          lastRun: "—",
+        },
+      ],
+      items: [
+        {
+          question: "Pineapple on pizza?",
+          answers: ["Yes", "No"],
+          tags: ["food"],
+          usageCount: 0,
+          lastUsed: "—",
+          enabled: true,
+          source: "manual",
+        },
+      ],
+    });
+    expect(html).toContain("Pineapple on pizza?");
+    expect(html).toContain("@Members");
+    expect(html).toContain("Yes • No");
+  });
+});
+
+describe("renderReactionRolesPage", () => {
+  it("shows the empty state for active and archived", () => {
+    const html = renderReactionRolesPage({
+      ...COMMON,
+      enabled: false,
+      configChannel: null,
+      active: [],
+      archived: [],
+    });
+    expect(html).toContain("No active reaction-role mappings");
+    expect(html).toContain("No archived mappings");
+  });
+
+  it("renders an active row with category/channel resolution", () => {
+    const html = renderReactionRolesPage({
+      ...COMMON,
+      enabled: true,
+      configChannel: { name: "roles", id: "c1" },
+      active: [
+        {
+          emoji: "🎮",
+          roleName: "Gamer",
+          roleId: "r1",
+          categoryName: "Roles",
+          channelName: "roles",
+          messageId: "m1",
+          isArchived: false,
+          archivedAt: null,
+        },
+      ],
+      archived: [],
+    });
+    expect(html).toContain("🎮");
+    expect(html).toContain("Gamer");
+    expect(html).toContain("#roles");
+    expect(html).toContain('class="tag tag-on">active');
+  });
+});
+
+describe("renderNoticesPage", () => {
+  it("renders the empty state when no notices exist", () => {
+    const html = renderNoticesPage({
+      ...COMMON,
+      enabled: false,
+      channel: null,
+      headerEnabled: false,
+      total: 0,
+      groups: [],
+    });
+    expect(html).toContain("No notices stored");
+  });
+
+  it("groups by category and escapes content", () => {
+    const html = renderNoticesPage({
+      ...COMMON,
+      enabled: true,
+      channel: { name: "notices", id: "c1" },
+      headerEnabled: true,
+      total: 1,
+      groups: [
+        {
+          category: "rules",
+          rows: [
+            {
+              order: 1,
+              title: "Be nice",
+              preview: "<3 everyone",
+              messageId: "m1",
+              updatedAt: "2026-05-08T00:00:00.000Z",
+            },
+          ],
+        },
+      ],
+    });
+    expect(html).toContain("rules");
+    expect(html).toContain("Be nice");
+    expect(html).toContain("&lt;3 everyone");
+  });
+});
+
+describe("renderDatabasePage", () => {
+  it("renders connection state and an empty collection list", () => {
+    const html = renderDatabasePage({
+      ...COMMON,
+      connection: {
+        state: "connected",
+        name: "koolbot",
+        host: "mongodb",
+      },
+      trunk: {
+        enabled: false,
+        schedule: "",
+        isScheduled: false,
+        isRunning: false,
+        lastRun: "—",
+        notificationChannel: null,
+        detailedDays: 30,
+        monthlyMonths: 6,
+        yearlyYears: 1,
+      },
+      collections: [],
+    });
+    expect(html).toContain("connected");
+    expect(html).toContain("No collection statistics");
+    expect(html).toContain("30 days");
+  });
+
+  it("lists collections with counts when present", () => {
+    const html = renderDatabasePage({
+      ...COMMON,
+      connection: { state: "connected", name: "koolbot", host: "mongodb" },
+      trunk: {
+        enabled: true,
+        schedule: "0 0 * * *",
+        isScheduled: true,
+        isRunning: false,
+        lastRun: "—",
+        notificationChannel: null,
+        detailedDays: 30,
+        monthlyMonths: 6,
+        yearlyYears: 1,
+      },
+      collections: [{ name: "configs", count: 42 }],
+    });
+    expect(html).toContain("configs");
+    expect(html).toContain("42");
+    expect(html).toContain("0 0 * * *");
+  });
+});
+
+describe("renderVoiceChannelsPage", () => {
+  it("renders the not-found state when category is missing", () => {
+    const html = renderVoiceChannelsPage({
+      ...COMMON,
+      enabled: false,
+      controlPanelEnabled: true,
+      categoryName: "Voice",
+      lobbyName: "Lobby",
+      offlineLobbyName: "Offline Lobby",
+      prefix: "🎮",
+      totalManaged: 0,
+      totalEmpty: 0,
+      channels: [],
+      categoryFound: false,
+    });
+    expect(html).toContain("Voice channel category not found");
+  });
+
+  it("renders managed channels with lobby/dynamic/live tags", () => {
+    const html = renderVoiceChannelsPage({
+      ...COMMON,
+      enabled: true,
+      controlPanelEnabled: true,
+      categoryName: "Voice",
+      lobbyName: "Lobby",
+      offlineLobbyName: "Offline Lobby",
+      prefix: "🎮",
+      totalManaged: 2,
+      totalEmpty: 1,
+      channels: [
+        {
+          name: "Lobby",
+          isLobby: true,
+          isLive: false,
+          memberCount: 0,
+          customName: null,
+          channelId: "c1",
+        },
+        {
+          name: "🎮 Game",
+          isLobby: false,
+          isLive: true,
+          memberCount: 3,
+          customName: "Friday night",
+          channelId: "c2",
+        },
+      ],
+      categoryFound: true,
+    });
+    expect(html).toContain('class="tag tag-info">lobby');
+    expect(html).toContain('class="tag tag-warn">dynamic');
+    expect(html).toContain('class="tag tag-warn">LIVE');
+    expect(html).toContain("Friday night");
   });
 });

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -192,3 +192,341 @@ export const defaultConfig: ConfigSchema = {
   "polls.default_duration_hours": 24, // Default 24 hours
   "polls.cooldown_days": 7, // Minimum 7 days between reusing same poll
 };
+
+/**
+ * Per-key metadata used by the WebUI Settings page and by future
+ * `/config` description surfaces. Single source of truth so every key in
+ * `defaultConfig` has a stable description even when the DB row hasn't
+ * been written yet (e.g. on a fresh install).
+ *
+ * Categories match the existing values used by `migrateFromEnv()` and the
+ * `Config` mongoose model's `category` enum, so a Settings group rendered
+ * from this map looks identical to one rendered from a populated DB.
+ */
+export interface SettingMetadata {
+  description: string;
+  category: string;
+}
+
+export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
+  // Voice Channel Management
+  "voicechannels.enabled": {
+    description: "Enable voice channel management.",
+    category: "voicechannels",
+  },
+  "voicechannels.category.name": {
+    description:
+      "Name of the Discord category that contains managed voice channels.",
+    category: "voicechannels",
+  },
+  "voicechannels.lobby.name": {
+    description:
+      "Name of the lobby channel users join to spawn a personal channel.",
+    category: "voicechannels",
+  },
+  "voicechannels.lobby.offlinename": {
+    description:
+      "Name displayed on the lobby channel while the bot is offline.",
+    category: "voicechannels",
+  },
+  "voicechannels.channel.prefix": {
+    description: "Prefix prepended to dynamically created voice channel names.",
+    category: "voicechannels",
+  },
+  "voicechannels.channel.suffix": {
+    description: "Suffix appended to dynamically created voice channel names.",
+    category: "voicechannels",
+  },
+  "voicechannels.controlpanel.enabled": {
+    description:
+      "Show the in-channel control panel (rename / privacy / live / transfer).",
+    category: "voicechannels",
+  },
+  "voicechannels.ownership.grace_period_seconds": {
+    description:
+      "Seconds to wait before transferring ownership when the channel owner leaves.",
+    category: "voicechannels",
+  },
+  "voicechannels.presets.enabled": {
+    description:
+      "Enable per-user channel presets (saved channel name + privacy).",
+    category: "voicechannels",
+  },
+  "voicechannels.presets.max_per_user": {
+    description: "Maximum number of presets a user can save.",
+    category: "voicechannels",
+  },
+
+  // Voice Activity Tracking
+  "voicetracking.enabled": {
+    description: "Enable voice activity tracking and the /voicestats command.",
+    category: "voicetracking",
+  },
+  "voicetracking.stats.top.enabled": {
+    description: "Enable the /voicestats top leaderboard subcommand.",
+    category: "voicetracking",
+  },
+  "voicetracking.stats.user.enabled": {
+    description: "Enable the /voicestats user personal-stats subcommand.",
+    category: "voicetracking",
+  },
+  "voicetracking.seen.enabled": {
+    description: "Enable last-seen tracking and the /seen command.",
+    category: "voicetracking",
+  },
+  "voicetracking.excluded_channels": {
+    description:
+      "Comma-separated channel IDs to exclude from voice activity tracking.",
+    category: "voicetracking",
+  },
+  "voicetracking.announcements.enabled": {
+    description: "Enable scheduled voice-stats announcements.",
+    category: "voicetracking",
+  },
+  "voicetracking.announcements.schedule": {
+    description: "Cron schedule for the recurring voice-stats announcement.",
+    category: "voicetracking",
+  },
+  "voicetracking.announcements.channel": {
+    description: "Channel name where voice-stats announcements are posted.",
+    category: "voicetracking",
+  },
+  "voicetracking.admin_roles": {
+    description:
+      "Comma-separated role names allowed to run privileged voice tracking commands.",
+    category: "voicetracking",
+  },
+
+  // Voice Channel Cleanup (dbtrunk)
+  "voicetracking.cleanup.enabled": {
+    description: "Enable scheduled database cleanup of voice tracking data.",
+    category: "voicetracking",
+  },
+  "voicetracking.cleanup.schedule": {
+    description: "Cron schedule for the database cleanup job.",
+    category: "voicetracking",
+  },
+  "voicetracking.cleanup.retention.detailed_sessions_days": {
+    description:
+      "Days to keep detailed session rows before they are summarised away.",
+    category: "voicetracking",
+  },
+  "voicetracking.cleanup.retention.monthly_summaries_months": {
+    description: "Months to keep monthly summary rows.",
+    category: "voicetracking",
+  },
+  "voicetracking.cleanup.retention.yearly_summaries_years": {
+    description: "Years to keep yearly summary rows.",
+    category: "voicetracking",
+  },
+
+  // Individual Features
+  "ping.enabled": {
+    description: "Enable the /ping latency check command.",
+    category: "ping",
+  },
+  "help.enabled": {
+    description: "Enable the /help command.",
+    category: "help",
+  },
+  "amikool.enabled": {
+    description: "Enable the /amikool fun role check command.",
+    category: "amikool",
+  },
+  "amikool.role.name": {
+    description: 'Role name required to be considered "kool" by /amikool.',
+    category: "amikool",
+  },
+
+  // Quote System
+  "quotes.enabled": {
+    description: "Enable the quotes system and the /quote command.",
+    category: "quotes",
+  },
+  "quotes.channel_id": {
+    description: "Channel ID where quote messages are posted.",
+    category: "quotes",
+  },
+  "quotes.add_roles": {
+    description:
+      "Comma-separated role IDs allowed to add quotes. Empty means everyone can add.",
+    category: "quotes",
+  },
+  "quotes.delete_roles": {
+    description:
+      "Comma-separated role IDs allowed to delete quotes. Empty means only admins.",
+    category: "quotes",
+  },
+  "quotes.max_length": {
+    description: "Maximum length of a single quote in characters.",
+    category: "quotes",
+  },
+  "quotes.cooldown": {
+    description: "Cooldown in seconds between quote additions per user.",
+    category: "quotes",
+  },
+  "quotes.cleanup_interval": {
+    description:
+      "Interval in minutes between sweeps for unauthorised messages in the quote channel.",
+    category: "quotes",
+  },
+  "quotes.header_enabled": {
+    description:
+      "Post and maintain a pinned informational header in the quote channel.",
+    category: "quotes",
+  },
+  "quotes.header_message_id": {
+    description: "Auto-managed message ID of the quote channel header post.",
+    category: "quotes",
+  },
+  "quotes.header_pin_enabled": {
+    description: "Pin the header post in the quote channel.",
+    category: "quotes",
+  },
+
+  // Core Bot Logging (Discord)
+  "core.startup.enabled": {
+    description: "Send bot startup notifications to a Discord channel.",
+    category: "core",
+  },
+  "core.startup.channel_id": {
+    description: "Channel ID for startup notifications.",
+    category: "core",
+  },
+  "core.errors.enabled": {
+    description: "Send error notifications to a Discord channel.",
+    category: "core",
+  },
+  "core.errors.channel_id": {
+    description: "Channel ID for error notifications.",
+    category: "core",
+  },
+  "core.cleanup.enabled": {
+    description: "Send cleanup-job notifications to a Discord channel.",
+    category: "core",
+  },
+  "core.cleanup.channel_id": {
+    description: "Channel ID for cleanup-job notifications.",
+    category: "core",
+  },
+  "core.config.enabled": {
+    description:
+      "Send configuration-change notifications to a Discord channel.",
+    category: "core",
+  },
+  "core.config.channel_id": {
+    description: "Channel ID for configuration-change notifications.",
+    category: "core",
+  },
+  "core.cron.enabled": {
+    description: "Send cron-job notifications to a Discord channel.",
+    category: "core",
+  },
+  "core.cron.channel_id": {
+    description: "Channel ID for cron-job notifications.",
+    category: "core",
+  },
+
+  // Fun / Easter Eggs
+  "fun.friendship": {
+    description: "Enable the friendship easter-egg trigger phrases.",
+    category: "fun",
+  },
+
+  // Rate Limiting
+  "ratelimit.enabled": {
+    description: "Enable per-user command rate limiting.",
+    category: "ratelimit",
+  },
+  "ratelimit.max_commands": {
+    description: "Maximum number of commands a user can run per time window.",
+    category: "ratelimit",
+  },
+  "ratelimit.window_seconds": {
+    description: "Length of the rate-limit time window in seconds.",
+    category: "ratelimit",
+  },
+  "ratelimit.bypass_admin": {
+    description: "Allow administrators to bypass rate limiting.",
+    category: "ratelimit",
+  },
+
+  // Scheduled Announcements
+  "announcements.enabled": {
+    description: "Enable scheduled announcements and the /announce command.",
+    category: "announcements",
+  },
+
+  // Achievements
+  "achievements.enabled": {
+    description: "Enable the achievements / accolades system.",
+    category: "achievements",
+  },
+  "achievements.announcements.enabled": {
+    description: "Announce newly earned achievements in a Discord channel.",
+    category: "achievements",
+  },
+  "achievements.dm_notifications.enabled": {
+    description: "DM users when they earn a new achievement.",
+    category: "achievements",
+  },
+
+  // Reaction Roles
+  "reactionroles.enabled": {
+    description: "Enable the reaction-role system and the /reactrole command.",
+    category: "reactionroles",
+  },
+  "reactionroles.message_channel_id": {
+    description: "Channel ID where reaction-role messages are posted.",
+    category: "reactionroles",
+  },
+
+  // Setup Wizard
+  "wizard.enabled": {
+    description: "Enable the /setup wizard command.",
+    category: "wizard",
+  },
+
+  // Notices System
+  "notices.enabled": {
+    description: "Enable the notices system and the /notice command.",
+    category: "notices",
+  },
+  "notices.channel_id": {
+    description: "Channel ID where notice messages are posted.",
+    category: "notices",
+  },
+  "notices.cleanup_interval": {
+    description:
+      "Interval in minutes between sweeps for unauthorised messages in the notices channel.",
+    category: "notices",
+  },
+  "notices.header_enabled": {
+    description:
+      "Post and maintain a pinned informational header in the notices channel.",
+    category: "notices",
+  },
+  "notices.header_message_id": {
+    description: "Auto-managed message ID of the notices channel header post.",
+    category: "notices",
+  },
+  "notices.header_pin_enabled": {
+    description: "Pin the header post in the notices channel.",
+    category: "notices",
+  },
+
+  // Poll System
+  "polls.enabled": {
+    description: "Enable the poll system and the /poll command.",
+    category: "polls",
+  },
+  "polls.default_duration_hours": {
+    description: "Default poll duration in hours (1–768).",
+    category: "polls",
+  },
+  "polls.cooldown_days": {
+    description:
+      "Minimum days before a question from the library can be reused.",
+    category: "polls",
+  },
+};

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -1,0 +1,140 @@
+/**
+ * Shared layout for the read-only admin pages added in #381. The scaffold's
+ * `views.ts` keeps tiny static pages for sign-in / sign-out flows; this
+ * module renders the navigated pages with the always-visible "session
+ * expires in X · [Finish]" banner mandated by #367.
+ */
+
+export function escapeHtml(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+interface NavItem {
+  href: string;
+  label: string;
+}
+
+export const NAV_ITEMS: NavItem[] = [
+  { href: "/admin/", label: "Dashboard" },
+  { href: "/admin/settings", label: "Settings" },
+  { href: "/admin/permissions", label: "Permissions" },
+  { href: "/admin/announcements", label: "Announcements" },
+  { href: "/admin/polls", label: "Polls" },
+  { href: "/admin/reaction-roles", label: "Reaction Roles" },
+  { href: "/admin/notices", label: "Notices" },
+  { href: "/admin/voice-channels", label: "Voice Channels" },
+  { href: "/admin/database", label: "Database" },
+  { href: "/admin/bootstrap", label: "Bootstrap" },
+];
+
+export interface AdminPageOptions {
+  title: string;
+  active: string;
+  body: string;
+  csrfToken: string;
+  remainingMs: number;
+}
+
+const STYLE = [
+  "*,*::before,*::after{box-sizing:border-box}",
+  "body{margin:0;font-family:system-ui,-apple-system,Segoe UI,sans-serif;background:#0f1115;color:#e4e6eb}",
+  "a{color:#6ea8fe;text-decoration:none}",
+  "a:hover{text-decoration:underline}",
+  ".banner{background:#1f2937;border-bottom:1px solid #2d3748;padding:.5rem 1rem;display:flex;justify-content:space-between;align-items:center;font-size:.85rem}",
+  ".banner .left{display:flex;gap:.75rem;align-items:center}",
+  ".banner .pill{background:#374151;color:#d1d5db;padding:.15rem .5rem;border-radius:999px;font-size:.75rem}",
+  ".banner form{display:inline;margin:0}",
+  ".banner button{background:#ef4444;color:#fff;border:0;padding:.3rem .7rem;border-radius:4px;cursor:pointer;font-weight:600}",
+  ".banner button:hover{background:#dc2626}",
+  ".shell{display:flex;min-height:calc(100vh - 41px)}",
+  "nav.side{background:#161a22;border-right:1px solid #2d3748;width:220px;padding:1rem .5rem;flex-shrink:0}",
+  "nav.side ul{list-style:none;padding:0;margin:0}",
+  "nav.side a{display:block;padding:.5rem .75rem;border-radius:6px;color:#cbd5e1}",
+  "nav.side a:hover{background:#1f2937;text-decoration:none}",
+  "nav.side a.active{background:#1d2a44;color:#fff}",
+  "main{flex:1;padding:1.5rem 2rem;max-width:1100px}",
+  "h1{margin:0 0 .25rem;font-size:1.5rem}",
+  "h2{margin:1.5rem 0 .5rem;font-size:1.15rem;color:#cbd5e1}",
+  ".subtitle{color:#94a3b8;margin:0 0 1rem}",
+  ".card{background:#161a22;border:1px solid #2d3748;border-radius:8px;padding:1rem 1.25rem;margin:0 0 1rem}",
+  ".card h2{margin-top:0}",
+  "table{width:100%;border-collapse:collapse;font-size:.9rem}",
+  "th,td{text-align:left;padding:.5rem .6rem;border-bottom:1px solid #2d3748;vertical-align:top}",
+  "th{font-weight:600;color:#94a3b8;background:#1a1f2a}",
+  "tr:hover td{background:#1a1f2a}",
+  ".muted{color:#94a3b8}",
+  ".mono{font-family:ui-monospace,SFMono-Regular,SF Mono,Menlo,monospace;font-size:.85rem}",
+  ".tag{display:inline-block;padding:.1rem .45rem;border-radius:4px;font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.04em}",
+  ".tag-on{background:#14532d;color:#bbf7d0}",
+  ".tag-off{background:#4b1e1e;color:#fecaca}",
+  ".tag-info{background:#1e3a8a;color:#bfdbfe}",
+  ".tag-warn{background:#4a3a0d;color:#fde68a}",
+  ".empty{padding:1rem;color:#94a3b8;font-style:italic}",
+  ".kv{display:grid;grid-template-columns:200px 1fr;gap:.4rem 1rem}",
+  ".kv dt{color:#94a3b8}",
+  ".kv dd{margin:0}",
+  ".notice{padding:.6rem .8rem;border-radius:6px;margin:0 0 1rem}",
+  ".notice.info{background:#1d2a44;color:#bfdbfe}",
+].join("");
+
+const SCRIPT =
+  "(function(){var el=document.getElementById('session-countdown');if(!el)return;" +
+  "var deadline=Date.now()+parseInt(el.getAttribute('data-remaining-ms'),10);" +
+  "function tick(){var r=Math.max(0,deadline-Date.now());var s=Math.floor(r/1000);" +
+  "var m=Math.floor(s/60);var ss=s%60;el.textContent=m+':'+(ss<10?'0'+ss:ss);" +
+  "if(r<=0){window.location.href='/admin/finish-redirect'}}tick();setInterval(tick,1000)})();";
+
+function renderNav(active: string): string {
+  return NAV_ITEMS.map((item) => {
+    const isActive =
+      item.href === active || (item.href === "/admin/" && active === "/admin");
+    const cls = isActive ? ' class="active"' : "";
+    return `<li><a href="${escapeHtml(item.href)}"${cls}>${escapeHtml(item.label)}</a></li>`;
+  }).join("");
+}
+
+export function renderAdminPage(opts: AdminPageOptions): string {
+  const remainingMs = Math.max(0, Math.floor(opts.remainingMs));
+  return [
+    "<!doctype html>",
+    '<html lang="en"><head>',
+    '<meta charset="utf-8">',
+    '<meta name="viewport" content="width=device-width,initial-scale=1">',
+    '<meta name="referrer" content="strict-origin-when-cross-origin">',
+    `<title>${escapeHtml(opts.title)} — Koolbot Admin</title>`,
+    `<style>${STYLE}</style>`,
+    "</head><body>",
+    '<div class="banner">',
+    '<div class="left"><strong>Koolbot Admin</strong> <span class="pill">read-only</span></div>',
+    '<div class="right">Session expires in ',
+    `<span id="session-countdown" data-remaining-ms="${remainingMs}" class="mono">--:--</span> · `,
+    '<form method="POST" action="/admin/finish">',
+    `<input type="hidden" name="_csrf" value="${escapeHtml(opts.csrfToken)}">`,
+    '<button type="submit">Finish</button>',
+    "</form></div></div>",
+    '<div class="shell">',
+    `<nav class="side"><ul>${renderNav(opts.active)}</ul></nav>`,
+    `<main>${opts.body}</main></div>`,
+    `<script>${SCRIPT}</script>`,
+    "</body></html>",
+  ].join("");
+}
+
+/**
+ * Remaining session lifetime in milliseconds for the banner countdown.
+ * Reads WEBUI_INACTIVITY_TIMEOUT_MINUTES — the cookie middleware refreshes
+ * lastActivityAt on every request, so this is what would actually time the
+ * user out without further interaction.
+ */
+export function getDisplayedRemainingMs(): number {
+  const raw = process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES;
+  const parsed = raw ? Number(raw) : NaN;
+  const minutes = Number.isFinite(parsed) && parsed > 0 ? parsed : 30;
+  return minutes * 60 * 1000;
+}

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -86,9 +86,13 @@ const STYLE = [
 const SCRIPT =
   "(function(){var el=document.getElementById('session-countdown');if(!el)return;" +
   "var deadline=Date.now()+parseInt(el.getAttribute('data-remaining-ms'),10);" +
+  "var fired=false;" +
   "function tick(){var r=Math.max(0,deadline-Date.now());var s=Math.floor(r/1000);" +
   "var m=Math.floor(s/60);var ss=s%60;el.textContent=m+':'+(ss<10?'0'+ss:ss);" +
-  "if(r<=0){window.location.href='/admin/finish-redirect'}}tick();setInterval(tick,1000)})();";
+  // When the countdown hits 0, navigate to /admin/. The session middleware
+  // will reject the now-expired cookie and render the scaffold's 401 page.
+  "if(r<=0&&!fired){fired=true;window.location.href='/admin/'}}" +
+  "tick();setInterval(tick,1000)})();";
 
 function renderNav(active: string): string {
   return NAV_ITEMS.map((item) => {
@@ -128,13 +132,22 @@ export function renderAdminPage(opts: AdminPageOptions): string {
 
 /**
  * Remaining session lifetime in milliseconds for the banner countdown.
- * Reads WEBUI_INACTIVITY_TIMEOUT_MINUTES — the cookie middleware refreshes
- * lastActivityAt on every request, so this is what would actually time the
- * user out without further interaction.
+ *
+ * Two ceilings apply, and the banner has to honour both:
+ *   - the inactivity sliding window (`WEBUI_INACTIVITY_TIMEOUT_MINUTES`),
+ *     which the cookie middleware just refreshed back to its full length.
+ *   - the server-side hard cap from `dbSession.expiresAt`
+ *     (`WEBUI_SESSION_TTL_MINUTES`), surfaced on `WebSessionContext`.
+ *
+ * We display whichever ends sooner. Without `session`, we conservatively
+ * fall back to inactivity-only (used by tests).
  */
-export function getDisplayedRemainingMs(): number {
+export function getDisplayedRemainingMs(session?: { expiresAt: Date }): number {
   const raw = process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES;
   const parsed = raw ? Number(raw) : NaN;
-  const minutes = Number.isFinite(parsed) && parsed > 0 ? parsed : 30;
-  return minutes * 60 * 1000;
+  const inactivityMinutes = Number.isFinite(parsed) && parsed > 0 ? parsed : 30;
+  const inactivityMs = inactivityMinutes * 60 * 1000;
+  if (!session) return inactivityMs;
+  const hardCapMs = Math.max(0, session.expiresAt.getTime() - Date.now());
+  return Math.min(inactivityMs, hardCapMs);
 }

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -1,0 +1,723 @@
+/**
+ * Read-only page renderers for #381. Each renderer takes already-shaped
+ * data so the route handler stays thin and the renderer is testable
+ * without a Discord client or MongoDB.
+ */
+
+import { escapeHtml, renderAdminPage } from "./admin-layout.js";
+
+interface CommonProps {
+  csrfToken: string;
+  remainingMs: number;
+}
+
+function tagOnOff(on: boolean, onLabel = "ON", offLabel = "OFF"): string {
+  return `<span class="tag ${on ? "tag-on" : "tag-off"}">${on ? onLabel : offLabel}</span>`;
+}
+
+function formatValue(value: unknown): string {
+  if (value === undefined || value === null) {
+    return `<span class="muted">—</span>`;
+  }
+  if (typeof value === "boolean") {
+    return tagOnOff(value, "true", "false");
+  }
+  if (value === "") {
+    return `<span class="muted">(empty)</span>`;
+  }
+  return `<span class="mono">${escapeHtml(value)}</span>`;
+}
+
+// ---------- Dashboard ----------
+
+export interface DashboardProps extends CommonProps {
+  guild: {
+    name: string | null;
+    id: string;
+    memberCount: number | null;
+    voiceUsers: number | null;
+    botTag: string | null;
+  };
+  mongoState: string;
+  counts: {
+    announcements: number;
+    pollSchedules: number;
+    pollItems: number;
+    reactionRoles: number;
+    notices: number;
+  };
+  features: Array<{ key: string; label: string; on: boolean }>;
+}
+
+export function renderDashboardPage(props: DashboardProps): string {
+  const featuresHtml = props.features
+    .map(
+      (f) =>
+        `<tr><td>${escapeHtml(f.label)}</td><td>${tagOnOff(f.on)}</td>` +
+        `<td class="mono muted">${escapeHtml(f.key)}</td></tr>`,
+    )
+    .join("");
+
+  const body = `
+<h1>Dashboard</h1>
+<p class="subtitle">Read-only overview of the bot's current state.</p>
+
+<div class="card">
+  <h2>Discord</h2>
+  <dl class="kv">
+    <dt>Guild</dt><dd>${escapeHtml(props.guild.name ?? "(unknown)")} <span class="muted mono">${escapeHtml(props.guild.id)}</span></dd>
+    <dt>Members</dt><dd>${props.guild.memberCount ?? "—"}</dd>
+    <dt>In voice now</dt><dd>${props.guild.voiceUsers ?? "—"}</dd>
+    <dt>Bot user</dt><dd>${escapeHtml(props.guild.botTag ?? "(not ready)")}</dd>
+  </dl>
+</div>
+
+<div class="card">
+  <h2>Database</h2>
+  <dl class="kv">
+    <dt>Connection</dt><dd>${tagOnOff(props.mongoState === "connected", props.mongoState, props.mongoState)}</dd>
+    <dt>Scheduled announcements</dt><dd>${props.counts.announcements}</dd>
+    <dt>Poll schedules</dt><dd>${props.counts.pollSchedules}</dd>
+    <dt>Poll questions</dt><dd>${props.counts.pollItems}</dd>
+    <dt>Active reaction roles</dt><dd>${props.counts.reactionRoles}</dd>
+    <dt>Notices</dt><dd>${props.counts.notices}</dd>
+  </dl>
+</div>
+
+<div class="card">
+  <h2>Features</h2>
+  <table>
+    <thead><tr><th>Feature</th><th>Status</th><th>Config key</th></tr></thead>
+    <tbody>${featuresHtml}</tbody>
+  </table>
+</div>
+`;
+  return renderAdminPage({
+    title: "Dashboard",
+    active: "/admin/",
+    body,
+    csrfToken: props.csrfToken,
+    remainingMs: props.remainingMs,
+  });
+}
+
+// ---------- Bootstrap ----------
+
+export interface BootstrapProps extends CommonProps {
+  groups: Array<{
+    category: string;
+    rows: Array<{
+      key: string;
+      present: boolean;
+      isSecret: boolean;
+      display?: string;
+    }>;
+  }>;
+}
+
+export function renderBootstrapPage(props: BootstrapProps): string {
+  const sections = props.groups
+    .map((group) => {
+      const rows = group.rows
+        .map((r) => {
+          const status = r.present
+            ? `<span class="tag tag-on">configured</span>`
+            : `<span class="tag tag-off">unset</span>`;
+          const value = r.present
+            ? r.isSecret
+              ? `<span class="muted mono">${escapeHtml(r.display ?? "")}</span>`
+              : `<span class="mono">${escapeHtml(r.display ?? "")}</span>`
+            : "";
+          return `<tr><td class="mono">${escapeHtml(r.key)}</td><td>${status}</td><td>${value}</td></tr>`;
+        })
+        .join("");
+      return `
+<div class="card">
+  <h2>${escapeHtml(group.category)}</h2>
+  <table><thead><tr><th>Variable</th><th>Status</th><th>Value</th></tr></thead><tbody>${rows}</tbody></table>
+</div>`;
+    })
+    .join("");
+
+  const body = `
+<h1>Bootstrap</h1>
+<p class="subtitle">Process startup variables loaded from <code>.env</code>. Read-only — change them by editing <code>.env</code> and restarting the bot.</p>
+<div class="notice info">Secrets are surfaced as presence + last 4 characters only. Never edited from the WebUI, never written to MongoDB.</div>
+${sections}
+`;
+  return renderAdminPage({
+    title: "Bootstrap",
+    active: "/admin/bootstrap",
+    body,
+    csrfToken: props.csrfToken,
+    remainingMs: props.remainingMs,
+  });
+}
+
+// ---------- Settings ----------
+
+export interface SettingRow {
+  key: string;
+  current: unknown;
+  defaultValue: unknown;
+  type: string;
+  description: string;
+  category: string;
+}
+
+export interface SettingsProps extends CommonProps {
+  groups: Array<{ category: string; rows: SettingRow[] }>;
+}
+
+export function renderSettingsPage(props: SettingsProps): string {
+  const sections = props.groups
+    .map((g) => {
+      const rows = g.rows
+        .map(
+          (r) => `<tr>
+<td class="mono">${escapeHtml(r.key)}</td>
+<td>${formatValue(r.current)}</td>
+<td><span class="tag tag-info">${escapeHtml(r.type)}</span></td>
+<td>${formatValue(r.defaultValue)}</td>
+<td class="muted">${escapeHtml(r.description)}</td>
+</tr>`,
+        )
+        .join("");
+      return `
+<div class="card">
+  <h2>${escapeHtml(g.category)}</h2>
+  <table>
+    <thead><tr><th>Key</th><th>Value</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
+    <tbody>${rows}</tbody>
+  </table>
+</div>`;
+    })
+    .join("");
+
+  const body = `
+<h1>Settings</h1>
+<p class="subtitle">All DB-backed configuration, grouped by feature. Mirrors <code>SETTINGS.md</code> and <code>config-service.ts</code>. Read-only.</p>
+${sections}
+`;
+  return renderAdminPage({
+    title: "Settings",
+    active: "/admin/settings",
+    body,
+    csrfToken: props.csrfToken,
+    remainingMs: props.remainingMs,
+  });
+}
+
+// ---------- Permissions ----------
+
+export interface PermissionsProps extends CommonProps {
+  commands: string[];
+  roleIds: string[];
+  roleNames: Map<string, string>;
+  perCommand: Map<string, string[]>;
+}
+
+export function renderPermissionsPage(props: PermissionsProps): string {
+  const headerRoles = props.roleIds
+    .map(
+      (rid) =>
+        `<th title="${escapeHtml(rid)}">${escapeHtml(props.roleNames.get(rid) ?? rid)}</th>`,
+    )
+    .join("");
+
+  const matrixRows = props.commands
+    .map((cmd) => {
+      const allowed = new Set(props.perCommand.get(cmd) ?? []);
+      const cells = props.roleIds
+        .map(
+          (rid) =>
+            `<td>${allowed.has(rid) ? '<span class="tag tag-on">✓</span>' : '<span class="muted">—</span>'}</td>`,
+        )
+        .join("");
+      const status =
+        allowed.size === 0
+          ? `<span class="tag tag-info">open</span>`
+          : `<span class="tag tag-warn">restricted</span>`;
+      return `<tr><td class="mono">/${escapeHtml(cmd)}</td><td>${status}</td>${cells}</tr>`;
+    })
+    .join("");
+
+  const matrixHtml =
+    props.roleIds.length === 0
+      ? `<div class="empty">No restricted commands. All registered commands are open by default.</div>`
+      : `<table><thead><tr><th>Command</th><th>Status</th>${headerRoles}</tr></thead><tbody>${matrixRows}</tbody></table>`;
+
+  const perCommandRows = props.commands
+    .map((cmd) => {
+      const allowed = props.perCommand.get(cmd) ?? [];
+      if (allowed.length === 0) {
+        return `<tr><td class="mono">/${escapeHtml(cmd)}</td><td><span class="tag tag-info">open</span></td><td class="muted">All members</td></tr>`;
+      }
+      const pills = allowed
+        .map(
+          (rid) =>
+            `<span class="tag tag-info" title="${escapeHtml(rid)}">${escapeHtml(props.roleNames.get(rid) ?? rid)}</span>`,
+        )
+        .join(" ");
+      return `<tr><td class="mono">/${escapeHtml(cmd)}</td><td><span class="tag tag-warn">restricted</span></td><td>${pills}</td></tr>`;
+    })
+    .join("");
+
+  const body = `
+<h1>Permissions</h1>
+<p class="subtitle">Discord command access derived from <code>permissions-service.ts</code>. Administrators always bypass these checks.</p>
+
+<div class="card"><h2>Matrix</h2>${matrixHtml}</div>
+
+<div class="card">
+  <h2>Per-command</h2>
+  <table>
+    <thead><tr><th>Command</th><th>Status</th><th>Allowed roles</th></tr></thead>
+    <tbody>${perCommandRows}</tbody>
+  </table>
+</div>
+`;
+  return renderAdminPage({
+    title: "Permissions",
+    active: "/admin/permissions",
+    body,
+    csrfToken: props.csrfToken,
+    remainingMs: props.remainingMs,
+  });
+}
+
+// ---------- Announcements ----------
+
+export interface AnnouncementRow {
+  id: string;
+  channelName: string;
+  cron: string;
+  enabled: boolean;
+  messagePreview: string;
+  embedTitle: string | null;
+  placeholders: boolean;
+  createdAt: string;
+}
+
+export interface AnnouncementsProps extends CommonProps {
+  enabled: boolean;
+  rows: AnnouncementRow[];
+}
+
+export function renderAnnouncementsPage(props: AnnouncementsProps): string {
+  const tableRows = props.rows
+    .map(
+      (a) => `<tr>
+<td class="mono">${escapeHtml(a.id)}</td>
+<td>#${escapeHtml(a.channelName)}</td>
+<td class="mono">${escapeHtml(a.cron)}</td>
+<td>${tagOnOff(a.enabled)}</td>
+<td>${escapeHtml(a.messagePreview)}${a.embedTitle ? `<div class="muted mono">embed: ${escapeHtml(a.embedTitle)}</div>` : ""}</td>
+<td>${a.placeholders ? '<span class="tag tag-info">yes</span>' : '<span class="muted">no</span>'}</td>
+<td class="muted">${escapeHtml(a.createdAt)}</td>
+</tr>`,
+    )
+    .join("");
+
+  const tableHtml =
+    props.rows.length === 0
+      ? `<div class="empty">No scheduled announcements configured.</div>`
+      : `<table><thead><tr><th>ID</th><th>Channel</th><th>Cron</th><th>Status</th><th>Message</th><th>Placeholders</th><th>Created</th></tr></thead><tbody>${tableRows}</tbody></table>`;
+
+  const body = `
+<h1>Announcements</h1>
+<p class="subtitle">Scheduled announcements posted on a cron. Read-only.</p>
+<div class="card">
+  <h2>Status</h2>
+  <dl class="kv">
+    <dt>Feature</dt><dd>${tagOnOff(props.enabled, "enabled", "disabled")}</dd>
+    <dt>Total schedules</dt><dd>${props.rows.length}</dd>
+  </dl>
+</div>
+<div class="card"><h2>Schedules</h2>${tableHtml}</div>
+`;
+  return renderAdminPage({
+    title: "Announcements",
+    active: "/admin/announcements",
+    body,
+    csrfToken: props.csrfToken,
+    remainingMs: props.remainingMs,
+  });
+}
+
+// ---------- Polls ----------
+
+export interface PollScheduleRow {
+  id: string;
+  channelName: string;
+  cron: string;
+  durationHours: number;
+  pingRoleName: string | null;
+  enabled: boolean;
+  lastRun: string;
+}
+
+export interface PollItemRow {
+  question: string;
+  answers: string[];
+  tags: string[];
+  usageCount: number;
+  lastUsed: string;
+  enabled: boolean;
+  source: string;
+}
+
+export interface PollsProps extends CommonProps {
+  enabled: boolean;
+  defaultDurationHours: number;
+  cooldownDays: number;
+  schedules: PollScheduleRow[];
+  items: PollItemRow[];
+}
+
+export function renderPollsPage(props: PollsProps): string {
+  const scheduleRows = props.schedules
+    .map(
+      (s) => `<tr>
+<td class="mono">${escapeHtml(s.id)}</td>
+<td>#${escapeHtml(s.channelName)}</td>
+<td class="mono">${escapeHtml(s.cron)}</td>
+<td>${s.durationHours}h</td>
+<td>${s.pingRoleName ? `@${escapeHtml(s.pingRoleName)}` : '<span class="muted">none</span>'}</td>
+<td>${tagOnOff(s.enabled)}</td>
+<td class="muted">${escapeHtml(s.lastRun)}</td>
+</tr>`,
+    )
+    .join("");
+
+  const itemRows = props.items
+    .map(
+      (it) => `<tr>
+<td>${escapeHtml(it.question)}<div class="muted mono">${escapeHtml(it.answers.join(" • "))}</div></td>
+<td>${it.tags.length === 0 ? '<span class="muted">—</span>' : it.tags.map((t) => `<span class="tag tag-info">${escapeHtml(t)}</span>`).join(" ")}</td>
+<td>${it.usageCount}</td>
+<td class="muted">${escapeHtml(it.lastUsed)}</td>
+<td>${tagOnOff(it.enabled)}</td>
+<td class="muted">${escapeHtml(it.source)}</td>
+</tr>`,
+    )
+    .join("");
+
+  const body = `
+<h1>Polls</h1>
+<p class="subtitle">Poll schedules and question library. Read-only.</p>
+<div class="card">
+  <h2>Status</h2>
+  <dl class="kv">
+    <dt>Feature</dt><dd>${tagOnOff(props.enabled, "enabled", "disabled")}</dd>
+    <dt>Default duration</dt><dd>${props.defaultDurationHours}h</dd>
+    <dt>Cooldown</dt><dd>${props.cooldownDays} days</dd>
+    <dt>Schedules</dt><dd>${props.schedules.length}</dd>
+    <dt>Question library</dt><dd>${props.items.length}</dd>
+  </dl>
+</div>
+<div class="card">
+  <h2>Schedules</h2>
+  ${
+    props.schedules.length === 0
+      ? `<div class="empty">No poll schedules configured.</div>`
+      : `<table><thead><tr><th>ID</th><th>Channel</th><th>Cron</th><th>Duration</th><th>Ping role</th><th>Status</th><th>Last run</th></tr></thead><tbody>${scheduleRows}</tbody></table>`
+  }
+</div>
+<div class="card">
+  <h2>Question library</h2>
+  ${
+    props.items.length === 0
+      ? `<div class="empty">No poll questions stored.</div>`
+      : `<table><thead><tr><th>Question</th><th>Tags</th><th>Used</th><th>Last used</th><th>Status</th><th>Source</th></tr></thead><tbody>${itemRows}</tbody></table>`
+  }
+</div>
+`;
+  return renderAdminPage({
+    title: "Polls",
+    active: "/admin/polls",
+    body,
+    csrfToken: props.csrfToken,
+    remainingMs: props.remainingMs,
+  });
+}
+
+// ---------- Reaction Roles ----------
+
+export interface ReactionRoleRow {
+  emoji: string;
+  roleName: string;
+  roleId: string;
+  categoryName: string;
+  channelName: string;
+  messageId: string;
+  isArchived: boolean;
+  archivedAt: string | null;
+}
+
+export interface ReactionRolesProps extends CommonProps {
+  enabled: boolean;
+  configChannel: { name: string; id: string } | null;
+  active: ReactionRoleRow[];
+  archived: ReactionRoleRow[];
+}
+
+function reactionRoleRow(rr: ReactionRoleRow): string {
+  return `<tr>
+<td class="mono">${escapeHtml(rr.emoji)}</td>
+<td>${escapeHtml(rr.roleName)} <span class="muted mono">${escapeHtml(rr.roleId)}</span></td>
+<td>${escapeHtml(rr.categoryName)}</td>
+<td>#${escapeHtml(rr.channelName)}</td>
+<td class="mono">${escapeHtml(rr.messageId)}</td>
+<td><span class="tag ${rr.isArchived ? "tag-off" : "tag-on"}">${rr.isArchived ? "archived" : "active"}</span></td>
+<td class="muted">${escapeHtml(rr.archivedAt ?? "")}</td>
+</tr>`;
+}
+
+export function renderReactionRolesPage(props: ReactionRolesProps): string {
+  const activeRows = props.active.map(reactionRoleRow).join("");
+  const archivedRows = props.archived.map(reactionRoleRow).join("");
+  const channelLine = props.configChannel
+    ? `<dt>Message channel</dt><dd>#${escapeHtml(props.configChannel.name)} <span class="muted mono">${escapeHtml(props.configChannel.id)}</span></dd>`
+    : `<dt>Message channel</dt><dd class="muted">unset</dd>`;
+
+  const body = `
+<h1>Reaction Roles</h1>
+<p class="subtitle">Per-message reaction-role mappings stored in <code>reaction_role_configs</code>. Read-only.</p>
+<div class="card">
+  <h2>Status</h2>
+  <dl class="kv">
+    <dt>Feature</dt><dd>${tagOnOff(props.enabled, "enabled", "disabled")}</dd>
+    ${channelLine}
+    <dt>Active mappings</dt><dd>${props.active.length}</dd>
+    <dt>Archived mappings</dt><dd>${props.archived.length}</dd>
+  </dl>
+</div>
+<div class="card">
+  <h2>Active</h2>
+  ${
+    props.active.length === 0
+      ? `<div class="empty">No active reaction-role mappings.</div>`
+      : `<table><thead><tr><th>Emoji</th><th>Role</th><th>Category</th><th>Channel</th><th>Message ID</th><th>Status</th><th>Archived</th></tr></thead><tbody>${activeRows}</tbody></table>`
+  }
+</div>
+<div class="card">
+  <h2>Archived (last 50)</h2>
+  ${
+    props.archived.length === 0
+      ? `<div class="empty">No archived mappings.</div>`
+      : `<table><thead><tr><th>Emoji</th><th>Role</th><th>Category</th><th>Channel</th><th>Message ID</th><th>Status</th><th>Archived</th></tr></thead><tbody>${archivedRows}</tbody></table>`
+  }
+</div>
+`;
+  return renderAdminPage({
+    title: "Reaction Roles",
+    active: "/admin/reaction-roles",
+    body,
+    csrfToken: props.csrfToken,
+    remainingMs: props.remainingMs,
+  });
+}
+
+// ---------- Notices ----------
+
+export interface NoticeRow {
+  order: number;
+  title: string;
+  preview: string;
+  messageId: string;
+  updatedAt: string;
+}
+
+export interface NoticesProps extends CommonProps {
+  enabled: boolean;
+  channel: { name: string; id: string } | null;
+  headerEnabled: boolean;
+  total: number;
+  groups: Array<{ category: string; rows: NoticeRow[] }>;
+}
+
+export function renderNoticesPage(props: NoticesProps): string {
+  const groupSections =
+    props.groups.length === 0
+      ? `<div class="empty">No notices stored.</div>`
+      : props.groups
+          .map((g) => {
+            const rows = g.rows
+              .map(
+                (n) => `<tr>
+<td>${n.order}</td>
+<td>${escapeHtml(n.title)}</td>
+<td class="muted">${escapeHtml(n.preview)}</td>
+<td class="mono muted">${escapeHtml(n.messageId)}</td>
+<td class="muted">${escapeHtml(n.updatedAt)}</td>
+</tr>`,
+              )
+              .join("");
+            return `<div class="card">
+  <h2>${escapeHtml(g.category)} <span class="muted">(${g.rows.length})</span></h2>
+  <table><thead><tr><th>#</th><th>Title</th><th>Content</th><th>Message ID</th><th>Updated</th></tr></thead><tbody>${rows}</tbody></table>
+</div>`;
+          })
+          .join("");
+
+  const body = `
+<h1>Notices</h1>
+<p class="subtitle">Notice posts grouped by category. Read-only.</p>
+<div class="card">
+  <h2>Status</h2>
+  <dl class="kv">
+    <dt>Feature</dt><dd>${tagOnOff(props.enabled, "enabled", "disabled")}</dd>
+    <dt>Channel</dt><dd>${props.channel ? `#${escapeHtml(props.channel.name)} <span class="muted mono">${escapeHtml(props.channel.id)}</span>` : '<span class="muted">unset</span>'}</dd>
+    <dt>Header post</dt><dd>${tagOnOff(props.headerEnabled, "enabled", "disabled")}</dd>
+    <dt>Total notices</dt><dd>${props.total}</dd>
+  </dl>
+</div>
+${groupSections}
+`;
+  return renderAdminPage({
+    title: "Notices",
+    active: "/admin/notices",
+    body,
+    csrfToken: props.csrfToken,
+    remainingMs: props.remainingMs,
+  });
+}
+
+// ---------- Database ----------
+
+export interface DatabaseProps extends CommonProps {
+  connection: {
+    state: string;
+    name: string;
+    host: string;
+  };
+  trunk: {
+    enabled: boolean;
+    schedule: string;
+    isScheduled: boolean;
+    isRunning: boolean;
+    lastRun: string;
+    notificationChannel: { name: string; id: string } | null;
+    detailedDays: number;
+    monthlyMonths: number;
+    yearlyYears: number;
+  };
+  collections: Array<{ name: string; count: number }>;
+}
+
+export function renderDatabasePage(props: DatabaseProps): string {
+  const collectionsHtml =
+    props.collections.length === 0
+      ? `<div class="empty">No collection statistics available.</div>`
+      : `<table><thead><tr><th>Collection</th><th>Documents (est.)</th></tr></thead><tbody>${props.collections.map((c) => `<tr><td class="mono">${escapeHtml(c.name)}</td><td>${c.count}</td></tr>`).join("")}</tbody></table>`;
+
+  const body = `
+<h1>Database</h1>
+<p class="subtitle">MongoDB connection state and the voice-channel <code>dbtrunk</code> cleanup status. Read-only.</p>
+<div class="card">
+  <h2>Connection</h2>
+  <dl class="kv">
+    <dt>State</dt><dd>${tagOnOff(props.connection.state === "connected", props.connection.state, props.connection.state)}</dd>
+    <dt>Database</dt><dd class="mono">${escapeHtml(props.connection.name)}</dd>
+    <dt>Host</dt><dd class="mono">${escapeHtml(props.connection.host)}</dd>
+  </dl>
+</div>
+<div class="card">
+  <h2>dbtrunk (voice-tracking cleanup)</h2>
+  <dl class="kv">
+    <dt>Feature</dt><dd>${tagOnOff(props.trunk.enabled, "enabled", "disabled")}</dd>
+    <dt>Schedule</dt><dd class="mono">${escapeHtml(props.trunk.schedule || "(unset)")}</dd>
+    <dt>Scheduled</dt><dd>${props.trunk.isScheduled ? '<span class="tag tag-on">yes</span>' : '<span class="tag tag-off">no</span>'}</dd>
+    <dt>Currently running</dt><dd>${props.trunk.isRunning ? '<span class="tag tag-warn">yes</span>' : '<span class="tag tag-on">idle</span>'}</dd>
+    <dt>Last run</dt><dd class="muted">${escapeHtml(props.trunk.lastRun)}</dd>
+    <dt>Notification channel</dt><dd>${props.trunk.notificationChannel ? `#${escapeHtml(props.trunk.notificationChannel.name)} <span class="muted mono">${escapeHtml(props.trunk.notificationChannel.id)}</span>` : '<span class="muted">unset</span>'}</dd>
+    <dt>Detailed sessions retention</dt><dd>${props.trunk.detailedDays} days</dd>
+    <dt>Monthly summaries retention</dt><dd>${props.trunk.monthlyMonths} months</dd>
+    <dt>Yearly summaries retention</dt><dd>${props.trunk.yearlyYears} years</dd>
+  </dl>
+</div>
+<div class="card"><h2>Collections</h2>${collectionsHtml}</div>
+`;
+  return renderAdminPage({
+    title: "Database",
+    active: "/admin/database",
+    body,
+    csrfToken: props.csrfToken,
+    remainingMs: props.remainingMs,
+  });
+}
+
+// ---------- Voice Channels ----------
+
+export interface VoiceChannelRow {
+  name: string;
+  isLobby: boolean;
+  isLive: boolean;
+  memberCount: number;
+  customName: string | null;
+  channelId: string;
+}
+
+export interface VoiceChannelsProps extends CommonProps {
+  enabled: boolean;
+  controlPanelEnabled: boolean;
+  categoryName: string;
+  lobbyName: string;
+  offlineLobbyName: string;
+  prefix: string;
+  totalManaged: number;
+  totalEmpty: number;
+  channels: VoiceChannelRow[];
+  categoryFound: boolean;
+}
+
+export function renderVoiceChannelsPage(props: VoiceChannelsProps): string {
+  const rows = props.channels
+    .map((ch) => {
+      const tag = ch.isLobby
+        ? `<span class="tag tag-info">lobby</span>`
+        : `<span class="tag tag-warn">dynamic</span>`;
+      const live = ch.isLive ? ' <span class="tag tag-warn">LIVE</span>' : "";
+      return `<tr>
+<td>${escapeHtml(ch.name)}${live}</td>
+<td>${tag}</td>
+<td>${ch.memberCount}</td>
+<td class="muted">${escapeHtml(ch.customName ?? "")}</td>
+<td class="mono muted">${escapeHtml(ch.channelId)}</td>
+</tr>`;
+    })
+    .join("");
+
+  const channelsHtml = !props.categoryFound
+    ? `<div class="empty">Voice channel category not found in this guild.</div>`
+    : props.channels.length === 0
+      ? `<div class="empty">Category exists but contains no voice channels.</div>`
+      : `<table><thead><tr><th>Name</th><th>Type</th><th>Users</th><th>Custom name</th><th>Channel ID</th></tr></thead><tbody>${rows}</tbody></table>`;
+
+  const body = `
+<h1>Voice Channels</h1>
+<p class="subtitle">Voice-channel category contents and live state. Read-only.</p>
+<div class="card">
+  <h2>Status</h2>
+  <dl class="kv">
+    <dt>Feature</dt><dd>${tagOnOff(props.enabled, "enabled", "disabled")}</dd>
+    <dt>Control panel</dt><dd>${tagOnOff(props.controlPanelEnabled, "enabled", "disabled")}</dd>
+    <dt>Category</dt><dd class="mono">${escapeHtml(props.categoryName)}</dd>
+    <dt>Lobby (online)</dt><dd class="mono">${escapeHtml(props.lobbyName)}</dd>
+    <dt>Lobby (offline)</dt><dd class="mono">${escapeHtml(props.offlineLobbyName)}</dd>
+    <dt>Channel prefix</dt><dd class="mono">${escapeHtml(props.prefix)}</dd>
+    <dt>Total in category</dt><dd>${props.totalManaged}</dd>
+    <dt>Empty channels</dt><dd>${props.totalEmpty}</dd>
+  </dl>
+</div>
+<div class="card"><h2>Channels</h2>${channelsHtml}</div>
+`;
+  return renderAdminPage({
+    title: "Voice Channels",
+    active: "/admin/voice-channels",
+    body,
+    csrfToken: props.csrfToken,
+    remainingMs: props.remainingMs,
+  });
+}

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -64,13 +64,6 @@ export function createWebRouter(client: Client): Router {
     },
   );
 
-  // Read-only admin pages (Dashboard, Bootstrap, Settings, Permissions,
-  // Announcements, Polls, Reaction Roles, Notices, Voice Channels, Database)
-  // are registered by the read-only router. It re-registers `requireSession`
-  // internally; safe to mount before the auth/finish endpoints below since
-  // they live at distinct paths.
-  router.use(createReadOnlyRouter(client, requireSession));
-
   router.post(
     "/finish",
     finishLimiter,
@@ -85,6 +78,14 @@ export function createWebRouter(client: Client): Router {
       res.status(200).type("text/html").send(renderSignedOut());
     },
   );
+
+  // Read-only admin pages (Dashboard, Bootstrap, Settings, Permissions,
+  // Announcements, Polls, Reaction Roles, Notices, Voice Channels, Database).
+  // Mounted *after* /finish so a POST to /finish hits requireCsrf first;
+  // otherwise this router's `requireSession` would refresh the session
+  // cookie and re-hit Mongo even on requests that the CSRF check would
+  // ultimately reject.
+  router.use(createReadOnlyRouter(client, requireSession));
 
   router.use(
     (err: unknown, _req: Request, res: Response, next: NextFunction): void => {

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -10,32 +10,8 @@ import {
   createSessionMiddleware,
   writeSessionCookie,
 } from "./session.js";
-import {
-  renderBootstrap,
-  renderDashboard,
-  renderInvalidLink,
-  renderSignedOut,
-} from "./views.js";
-
-const SECRET_KEYS = new Set([
-  "DISCORD_TOKEN",
-  "MONGODB_URI",
-  "WEBUI_SESSION_SECRET",
-]);
-
-const BOOTSTRAP_KEYS = [
-  "DISCORD_TOKEN",
-  "CLIENT_ID",
-  "GUILD_ID",
-  "MONGODB_URI",
-  "NODE_ENV",
-  "DEBUG",
-  "WEBUI_ENABLED",
-  "WEBUI_BASE_URL",
-  "WEBUI_SESSION_SECRET",
-  "WEBUI_SESSION_TTL_MINUTES",
-  "WEBUI_INACTIVITY_TIMEOUT_MINUTES",
-];
+import { renderInvalidLink, renderSignedOut } from "./views.js";
+import { createReadOnlyRouter } from "./read-only-routes.js";
 
 /**
  * Build the WebUI router. Caller mounts this at /admin on the existing
@@ -88,52 +64,12 @@ export function createWebRouter(client: Client): Router {
     },
   );
 
-  router.get(
-    "/",
-    requireSession,
-    (req: AuthenticatedRequest, res: Response): void => {
-      const ctx = req.webSession;
-      if (!ctx) {
-        res.status(401).type("text/plain").send("Unauthorized");
-        return;
-      }
-      const csrfToken =
-        (req as Request & { csrfToken?: string }).csrfToken ?? "";
-      res.type("text/html").send(
-        renderDashboard({
-          discordUserId: ctx.discordUserId,
-          guildId: ctx.guildId,
-          csrfToken,
-        }),
-      );
-    },
-  );
-
-  router.get(
-    "/bootstrap",
-    requireSession,
-    (_req: AuthenticatedRequest, res: Response): void => {
-      const rows = BOOTSTRAP_KEYS.map((key) => {
-        const raw = process.env[key];
-        const present = typeof raw === "string" && raw.length > 0;
-        let display: string | undefined;
-        if (present && raw) {
-          if (SECRET_KEYS.has(key)) {
-            // Only reveal a 4-char tail when the secret is long enough
-            // that the tail isn't the whole value. For shorter values we
-            // omit the tail entirely so we never echo the full secret.
-            display = raw.length >= 8 ? `…${raw.slice(-4)}` : undefined;
-          } else if (raw.length > 32) {
-            display = `${raw.slice(0, 28)}…`;
-          } else {
-            display = raw;
-          }
-        }
-        return { key, present, display };
-      });
-      res.type("text/html").send(renderBootstrap({ rows }));
-    },
-  );
+  // Read-only admin pages (Dashboard, Bootstrap, Settings, Permissions,
+  // Announcements, Polls, Reaction Roles, Notices, Voice Channels, Database)
+  // are registered by the read-only router. It re-registers `requireSession`
+  // internally; safe to mount before the auth/finish endpoints below since
+  // they live at distinct paths.
+  router.use(createReadOnlyRouter(client, requireSession));
 
   router.post(
     "/finish",

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -1,0 +1,752 @@
+/**
+ * Read-only route handlers for #381. These mount onto the WebUI router built
+ * by `createWebRouter` and behind its session middleware. Every page reads
+ * through existing services in `src/services/` — no duplicate data access,
+ * no writes.
+ */
+
+import {
+  Router,
+  type NextFunction,
+  type Request,
+  type RequestHandler,
+  type Response,
+} from "express";
+import {
+  CategoryChannel,
+  ChannelType,
+  Client,
+  type GuildBasedChannel,
+} from "discord.js";
+import mongoose from "mongoose";
+import logger from "../utils/logger.js";
+import { ConfigService } from "../services/config-service.js";
+import { defaultConfig } from "../services/config-schema.js";
+import { PermissionsService } from "../services/permissions-service.js";
+import { ScheduledAnnouncementService } from "../services/scheduled-announcement-service.js";
+import { ScheduledAnnouncement } from "../models/scheduled-announcement.js";
+import { PollService } from "../services/poll-service.js";
+import { PollSchedule } from "../models/poll-schedule.js";
+import { PollItem } from "../models/poll-item.js";
+import { ReactionRoleService } from "../services/reaction-role-service.js";
+import { ReactionRoleConfig } from "../models/reaction-role-config.js";
+import Notice from "../models/notice.js";
+import { VoiceChannelTruncationService } from "../services/voice-channel-truncation.js";
+import { VoiceChannelManager } from "../services/voice-channel-manager.js";
+import type { AuthenticatedRequest } from "./session.js";
+import { getDisplayedRemainingMs } from "./admin-layout.js";
+import {
+  renderAnnouncementsPage,
+  renderBootstrapPage,
+  renderDashboardPage,
+  renderDatabasePage,
+  renderNoticesPage,
+  renderPermissionsPage,
+  renderPollsPage,
+  renderReactionRolesPage,
+  renderSettingsPage,
+  renderVoiceChannelsPage,
+  type SettingRow,
+} from "./admin-views.js";
+
+interface BootstrapEnvVar {
+  key: string;
+  category: "Discord" | "Database" | "Process" | "WebUI";
+  isSecret: boolean;
+}
+
+const BOOTSTRAP_VARS: BootstrapEnvVar[] = [
+  { key: "DISCORD_TOKEN", category: "Discord", isSecret: true },
+  { key: "CLIENT_ID", category: "Discord", isSecret: false },
+  { key: "GUILD_ID", category: "Discord", isSecret: false },
+  { key: "MONGODB_URI", category: "Database", isSecret: true },
+  { key: "NODE_ENV", category: "Process", isSecret: false },
+  { key: "DEBUG", category: "Process", isSecret: false },
+  { key: "WEBUI_ENABLED", category: "WebUI", isSecret: false },
+  { key: "WEBUI_BASE_URL", category: "WebUI", isSecret: false },
+  { key: "WEBUI_SESSION_SECRET", category: "WebUI", isSecret: true },
+  { key: "WEBUI_SESSION_TTL_MINUTES", category: "WebUI", isSecret: false },
+  {
+    key: "WEBUI_INACTIVITY_TIMEOUT_MINUTES",
+    category: "WebUI",
+    isSecret: false,
+  },
+];
+
+function deriveCategory(key: string): string {
+  const dot = key.indexOf(".");
+  return dot === -1 ? "other" : key.slice(0, dot);
+}
+
+function describeType(value: unknown): string {
+  if (typeof value === "boolean") return "boolean";
+  if (typeof value === "number") return "number";
+  if (typeof value === "string") return "string";
+  return typeof value;
+}
+
+function getCsrfToken(req: Request): string {
+  return (req as Request & { csrfToken?: string }).csrfToken ?? "";
+}
+
+function commonFromReq(req: AuthenticatedRequest): {
+  guildId: string;
+  csrfToken: string;
+  remainingMs: number;
+} {
+  const session = req.webSession;
+  if (!session) {
+    // The middleware should always populate this; throw to satisfy the type
+    // narrower without falling through to a partially-initialised page.
+    throw new Error("requireSession middleware must run first");
+  }
+  return {
+    guildId: session.guildId,
+    csrfToken: getCsrfToken(req),
+    remainingMs: getDisplayedRemainingMs(),
+  };
+}
+
+async function fetchChannelNames(
+  client: Client,
+  guildId: string,
+): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  try {
+    const guild = await client.guilds.fetch(guildId);
+    await guild.channels.fetch();
+    for (const ch of guild.channels.cache.values()) {
+      if (ch?.id) out.set(ch.id, ch.name ?? ch.id);
+    }
+  } catch (err) {
+    logger.debug("fetchChannelNames failed", err);
+  }
+  return out;
+}
+
+async function fetchRoleNames(
+  client: Client,
+  guildId: string,
+): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  try {
+    const guild = await client.guilds.fetch(guildId);
+    await guild.roles.fetch();
+    for (const role of guild.roles.cache.values()) {
+      out.set(role.id, role.name);
+    }
+  } catch (err) {
+    logger.debug("fetchRoleNames failed", err);
+  }
+  return out;
+}
+
+/**
+ * Wrap an async handler so any rejected promise propagates to Express'
+ * error pipeline instead of triggering an UnhandledPromiseRejection.
+ */
+function asyncHandler(
+  fn: (req: AuthenticatedRequest, res: Response) => Promise<void>,
+): RequestHandler {
+  return (req, res, next: NextFunction): void => {
+    fn(req as AuthenticatedRequest, res).catch(next);
+  };
+}
+
+export function createReadOnlyRouter(
+  client: Client,
+  requireSession: RequestHandler,
+): Router {
+  const router = Router();
+  router.use(requireSession);
+
+  // ---------- Dashboard ----------
+  router.get(
+    "/",
+    asyncHandler(async (req, res) => {
+      const common = commonFromReq(req);
+      const config = ConfigService.getInstance();
+
+      let guildName: string | null = null;
+      let memberCount: number | null = null;
+      let voiceUsers: number | null = null;
+      try {
+        const guild = await client.guilds.fetch(common.guildId);
+        guildName = guild.name;
+        memberCount = guild.memberCount;
+        voiceUsers = guild.voiceStates.cache.filter(
+          (s) => s.channelId !== null,
+        ).size;
+      } catch (err) {
+        logger.debug("dashboard guild fetch failed", err);
+      }
+
+      const featureKeys: Array<{ key: string; label: string }> = [
+        { key: "voicechannels.enabled", label: "Voice Channels" },
+        { key: "voicetracking.enabled", label: "Voice Tracking" },
+        { key: "quotes.enabled", label: "Quotes" },
+        { key: "achievements.enabled", label: "Achievements" },
+        { key: "announcements.enabled", label: "Announcements" },
+        { key: "polls.enabled", label: "Polls" },
+        { key: "reactionroles.enabled", label: "Reaction Roles" },
+        { key: "notices.enabled", label: "Notices" },
+        { key: "fun.friendship", label: "Friendship" },
+      ];
+      const features = await Promise.all(
+        featureKeys.map(async (f) => ({
+          ...f,
+          on: await config.getBoolean(f.key, false),
+        })),
+      );
+
+      const [announcements, pollSchedules, pollItems, reactionRoles, notices] =
+        await Promise.all([
+          ScheduledAnnouncement.countDocuments({
+            guildId: common.guildId,
+          }).catch(() => 0),
+          PollSchedule.countDocuments({ guildId: common.guildId }).catch(
+            () => 0,
+          ),
+          PollItem.countDocuments({ guildId: common.guildId }).catch(() => 0),
+          ReactionRoleConfig.countDocuments({
+            guildId: common.guildId,
+            isArchived: false,
+          }).catch(() => 0),
+          Notice.countDocuments({}).catch(() => 0),
+        ]);
+
+      const mongoState =
+        ["disconnected", "connected", "connecting", "disconnecting"][
+          mongoose.connection.readyState
+        ] ?? "unknown";
+
+      res.type("text/html").send(
+        renderDashboardPage({
+          ...common,
+          guild: {
+            id: common.guildId,
+            name: guildName,
+            memberCount,
+            voiceUsers,
+            botTag: client.user?.tag ?? null,
+          },
+          mongoState,
+          counts: {
+            announcements,
+            pollSchedules,
+            pollItems,
+            reactionRoles,
+            notices,
+          },
+          features,
+        }),
+      );
+    }),
+  );
+
+  // ---------- Bootstrap ----------
+  router.get(
+    "/bootstrap",
+    asyncHandler(async (req, res) => {
+      const common = commonFromReq(req);
+      const grouped = new Map<
+        string,
+        Array<{
+          key: string;
+          present: boolean;
+          isSecret: boolean;
+          display?: string;
+        }>
+      >();
+      for (const v of BOOTSTRAP_VARS) {
+        const raw = process.env[v.key];
+        const present = typeof raw === "string" && raw.length > 0;
+        let display: string | undefined;
+        if (present && raw) {
+          if (v.isSecret) {
+            // Only reveal a 4-char tail when long enough that the tail
+            // isn't the whole value. Mirrors the scaffold's behaviour.
+            display = raw.length >= 8 ? `…${raw.slice(-4)}` : undefined;
+          } else if (raw.length > 32) {
+            display = `${raw.slice(0, 28)}…`;
+          } else {
+            display = raw;
+          }
+        }
+        const arr = grouped.get(v.category) ?? [];
+        arr.push({ key: v.key, present, isSecret: v.isSecret, display });
+        grouped.set(v.category, arr);
+      }
+      const groups = Array.from(grouped.entries()).map(([category, rows]) => ({
+        category,
+        rows,
+      }));
+      res.type("text/html").send(renderBootstrapPage({ ...common, groups }));
+    }),
+  );
+
+  // ---------- Settings ----------
+  router.get(
+    "/settings",
+    asyncHandler(async (req, res) => {
+      const common = commonFromReq(req);
+      const config = ConfigService.getInstance();
+      const stored = await config.getAll().catch(() => []);
+      const storedByKey = new Map(stored.map((s) => [s.key, s]));
+
+      const rows: SettingRow[] = Object.entries(defaultConfig).map(
+        ([key, defaultValue]) => {
+          const dbEntry = storedByKey.get(key);
+          return {
+            key,
+            current: dbEntry ? dbEntry.value : defaultValue,
+            defaultValue,
+            type: describeType(defaultValue),
+            description: dbEntry?.description ?? "(no description on disk yet)",
+            category: dbEntry?.category ?? deriveCategory(key),
+          };
+        },
+      );
+      for (const entry of stored) {
+        if (!(entry.key in defaultConfig)) {
+          rows.push({
+            key: entry.key,
+            current: entry.value,
+            defaultValue: undefined,
+            type: describeType(entry.value),
+            description: entry.description ?? "",
+            category: entry.category ?? "other",
+          });
+        }
+      }
+      rows.sort((a, b) =>
+        a.category === b.category
+          ? a.key.localeCompare(b.key)
+          : a.category.localeCompare(b.category),
+      );
+
+      const grouped = new Map<string, SettingRow[]>();
+      for (const row of rows) {
+        const arr = grouped.get(row.category) ?? [];
+        arr.push(row);
+        grouped.set(row.category, arr);
+      }
+      const groups = Array.from(grouped.entries()).map(([category, rs]) => ({
+        category,
+        rows: rs,
+      }));
+
+      res.type("text/html").send(renderSettingsPage({ ...common, groups }));
+    }),
+  );
+
+  // ---------- Permissions ----------
+  router.get(
+    "/permissions",
+    asyncHandler(async (req, res) => {
+      const common = commonFromReq(req);
+      const permissions = PermissionsService.getInstance(client);
+      const all = await permissions.listAllPermissions(common.guildId);
+      const commands = Array.from(client.commands.keys()).sort();
+      const roleNames = await fetchRoleNames(client, common.guildId);
+
+      const perCommand = new Map<string, string[]>();
+      const allRoleIds = new Set<string>();
+      for (const entry of all) {
+        perCommand.set(entry.commandName, entry.roleIds);
+        for (const r of entry.roleIds) allRoleIds.add(r);
+      }
+      const roleIds = Array.from(allRoleIds).sort((a, b) =>
+        (roleNames.get(a) ?? a).localeCompare(roleNames.get(b) ?? b),
+      );
+
+      res.type("text/html").send(
+        renderPermissionsPage({
+          ...common,
+          commands,
+          roleIds,
+          roleNames,
+          perCommand,
+        }),
+      );
+    }),
+  );
+
+  // ---------- Announcements ----------
+  router.get(
+    "/announcements",
+    asyncHandler(async (req, res) => {
+      const common = commonFromReq(req);
+      const service = ScheduledAnnouncementService.getInstance(client);
+      const config = ConfigService.getInstance();
+      const [enabled, announcements, channelNames] = await Promise.all([
+        config.getBoolean("announcements.enabled", false),
+        service.listAnnouncements(common.guildId),
+        fetchChannelNames(client, common.guildId),
+      ]);
+
+      const rows = announcements.map((a) => ({
+        id: String(a._id),
+        channelName: channelNames.get(a.channelId) ?? a.channelId,
+        cron: a.cronSchedule,
+        enabled: a.enabled,
+        messagePreview:
+          a.message.length > 80 ? `${a.message.slice(0, 80)}…` : a.message,
+        embedTitle: a.embedData?.title ?? null,
+        placeholders: a.placeholders,
+        createdAt: new Date(a.createdAt).toISOString(),
+      }));
+
+      res
+        .type("text/html")
+        .send(renderAnnouncementsPage({ ...common, enabled, rows }));
+    }),
+  );
+
+  // ---------- Polls ----------
+  router.get(
+    "/polls",
+    asyncHandler(async (req, res) => {
+      const common = commonFromReq(req);
+      const service = PollService.getInstance(client);
+      const config = ConfigService.getInstance();
+      const [
+        enabled,
+        schedules,
+        items,
+        defaultDurationHours,
+        cooldownDays,
+        channelNames,
+        roleNames,
+      ] = await Promise.all([
+        config.getBoolean("polls.enabled", false),
+        service.listSchedules(common.guildId),
+        service.listPollItems(common.guildId),
+        config.getNumber("polls.default_duration_hours", 24),
+        config.getNumber("polls.cooldown_days", 7),
+        fetchChannelNames(client, common.guildId),
+        fetchRoleNames(client, common.guildId),
+      ]);
+
+      res.type("text/html").send(
+        renderPollsPage({
+          ...common,
+          enabled,
+          defaultDurationHours,
+          cooldownDays,
+          schedules: schedules.map((s) => ({
+            id: String(s._id),
+            channelName: channelNames.get(s.channelId) ?? s.channelId,
+            cron: s.cronSchedule,
+            durationHours: s.pollDuration,
+            pingRoleName: s.roleIdToPing
+              ? (roleNames.get(s.roleIdToPing) ?? s.roleIdToPing)
+              : null,
+            enabled: s.enabled,
+            lastRun: s.lastRun ? new Date(s.lastRun).toISOString() : "—",
+          })),
+          items: items.map((it) => ({
+            question: it.question,
+            answers: it.answers ?? [],
+            tags: it.tags ?? [],
+            usageCount: it.usageCount,
+            lastUsed: it.lastUsed ? new Date(it.lastUsed).toISOString() : "—",
+            enabled: it.enabled,
+            source: it.source,
+          })),
+        }),
+      );
+    }),
+  );
+
+  // ---------- Reaction Roles ----------
+  router.get(
+    "/reaction-roles",
+    asyncHandler(async (req, res) => {
+      const common = commonFromReq(req);
+      const config = ConfigService.getInstance();
+      const service = ReactionRoleService.getInstance(client);
+      const [enabled, configChannelId, all, archived, channelNames] =
+        await Promise.all([
+          config.getBoolean("reactionroles.enabled", false),
+          config.getString("reactionroles.message_channel_id", ""),
+          service.listReactionRoles(common.guildId),
+          ReactionRoleConfig.find({ guildId: common.guildId, isArchived: true })
+            .sort({ archivedAt: -1 })
+            .limit(50)
+            .lean(),
+          fetchChannelNames(client, common.guildId),
+        ]);
+
+      const active = all.filter((rr) => !rr.isArchived);
+      const shape = (rr: {
+        emoji: string;
+        roleName: string;
+        roleId: string;
+        categoryId: string;
+        channelId: string;
+        messageId: string;
+        isArchived: boolean;
+        archivedAt?: Date | null;
+      }): ReturnType<typeof Object> => ({
+        emoji: rr.emoji,
+        roleName: rr.roleName,
+        roleId: rr.roleId,
+        categoryName: channelNames.get(rr.categoryId) ?? rr.categoryId,
+        channelName: channelNames.get(rr.channelId) ?? rr.channelId,
+        messageId: rr.messageId,
+        isArchived: rr.isArchived,
+        archivedAt: rr.archivedAt
+          ? new Date(rr.archivedAt).toISOString()
+          : null,
+      });
+
+      res.type("text/html").send(
+        renderReactionRolesPage({
+          ...common,
+          enabled,
+          configChannel: configChannelId
+            ? {
+                name: channelNames.get(configChannelId) ?? configChannelId,
+                id: configChannelId,
+              }
+            : null,
+          active: active.map(shape),
+          archived: archived.map(shape),
+        }),
+      );
+    }),
+  );
+
+  // ---------- Notices ----------
+  router.get(
+    "/notices",
+    asyncHandler(async (req, res) => {
+      const common = commonFromReq(req);
+      const config = ConfigService.getInstance();
+      const [enabled, channelId, headerEnabled, notices, channelNames] =
+        await Promise.all([
+          config.getBoolean("notices.enabled", false),
+          config.getString("notices.channel_id", ""),
+          config.getBoolean("notices.header_enabled", true),
+          Notice.find({}).sort({ category: 1, order: 1 }).lean(),
+          fetchChannelNames(client, common.guildId),
+        ]);
+
+      const grouped = new Map<string, typeof notices>();
+      for (const n of notices) {
+        const arr = grouped.get(n.category) ?? [];
+        arr.push(n);
+        grouped.set(n.category, arr);
+      }
+      const groups = Array.from(grouped.entries()).map(([category, list]) => ({
+        category,
+        rows: list.map((n) => ({
+          order: n.order,
+          title: n.title,
+          preview:
+            n.content.length > 120 ? `${n.content.slice(0, 120)}…` : n.content,
+          messageId: n.messageId ?? "",
+          updatedAt: new Date(n.updatedAt).toISOString(),
+        })),
+      }));
+
+      res.type("text/html").send(
+        renderNoticesPage({
+          ...common,
+          enabled,
+          channel: channelId
+            ? { name: channelNames.get(channelId) ?? channelId, id: channelId }
+            : null,
+          headerEnabled,
+          total: notices.length,
+          groups,
+        }),
+      );
+    }),
+  );
+
+  // ---------- Database ----------
+  router.get(
+    "/database",
+    asyncHandler(async (req, res) => {
+      const common = commonFromReq(req);
+      const truncation = VoiceChannelTruncationService.getInstance(client);
+      const config = ConfigService.getInstance();
+      const status = truncation.getStatus();
+
+      const [
+        enabled,
+        schedule,
+        notificationChannelId,
+        detailedDays,
+        monthlyMonths,
+        yearlyYears,
+        channelNames,
+      ] = await Promise.all([
+        truncation.isEnabled(),
+        truncation.getSchedule(),
+        truncation.getNotificationChannel(),
+        config.getNumber(
+          "voicetracking.cleanup.retention.detailed_sessions_days",
+          30,
+        ),
+        config.getNumber(
+          "voicetracking.cleanup.retention.monthly_summaries_months",
+          6,
+        ),
+        config.getNumber(
+          "voicetracking.cleanup.retention.yearly_summaries_years",
+          1,
+        ),
+        fetchChannelNames(client, common.guildId),
+      ]);
+
+      const collections: Array<{ name: string; count: number }> = [];
+      if (mongoose.connection.readyState === 1 && mongoose.connection.db) {
+        try {
+          const list = await mongoose.connection.db.listCollections().toArray();
+          for (const c of list) {
+            try {
+              const count = await mongoose.connection.db
+                .collection(c.name)
+                .estimatedDocumentCount();
+              collections.push({ name: c.name, count });
+            } catch (err) {
+              logger.debug(`collection count failed for ${c.name}`, err);
+            }
+          }
+          collections.sort((a, b) => a.name.localeCompare(b.name));
+        } catch (err) {
+          logger.debug("listCollections failed", err);
+        }
+      }
+
+      const stateLabel =
+        ["disconnected", "connected", "connecting", "disconnecting"][
+          mongoose.connection.readyState
+        ] ?? "unknown";
+
+      res.type("text/html").send(
+        renderDatabasePage({
+          ...common,
+          connection: {
+            state: stateLabel,
+            name: mongoose.connection.name ?? "(unknown)",
+            host: mongoose.connection.host ?? "(unknown)",
+          },
+          trunk: {
+            enabled,
+            schedule: schedule ?? "",
+            isScheduled: status.isScheduled,
+            isRunning: status.isRunning,
+            lastRun: status.lastCleanupDate
+              ? status.lastCleanupDate.toISOString()
+              : "—",
+            notificationChannel: notificationChannelId
+              ? {
+                  name:
+                    channelNames.get(notificationChannelId) ??
+                    notificationChannelId,
+                  id: notificationChannelId,
+                }
+              : null,
+            detailedDays,
+            monthlyMonths,
+            yearlyYears,
+          },
+          collections,
+        }),
+      );
+    }),
+  );
+
+  // ---------- Voice Channels ----------
+  router.get(
+    "/voice-channels",
+    asyncHandler(async (req, res) => {
+      const common = commonFromReq(req);
+      const config = ConfigService.getInstance();
+      const manager = VoiceChannelManager.getInstance(client);
+
+      const [
+        enabled,
+        controlPanelEnabled,
+        categoryName,
+        lobbyName,
+        offlineLobbyName,
+        prefix,
+      ] = await Promise.all([
+        config.getBoolean("voicechannels.enabled", false),
+        config.getBoolean("voicechannels.controlpanel.enabled", true),
+        config.getString("voicechannels.category.name", "Voice Channels"),
+        config.getString("voicechannels.lobby.name", "Lobby"),
+        config.getString("voicechannels.lobby.offlinename", "Offline Lobby"),
+        config.getString("voicechannels.channel.prefix", "🎮"),
+      ]);
+
+      let categoryFound = false;
+      let totalManaged = 0;
+      let totalEmpty = 0;
+      const channels: Array<{
+        name: string;
+        isLobby: boolean;
+        isLive: boolean;
+        memberCount: number;
+        customName: string | null;
+        channelId: string;
+      }> = [];
+
+      try {
+        const guild = await client.guilds.fetch(common.guildId);
+        await guild.channels.fetch();
+        const category = guild.channels.cache.find(
+          (c: GuildBasedChannel) =>
+            c.type === ChannelType.GuildCategory &&
+            (c as CategoryChannel).name === categoryName,
+        ) as CategoryChannel | undefined;
+
+        if (category) {
+          categoryFound = true;
+          const voice = Array.from(category.children.cache.values())
+            .filter((c) => c.type === ChannelType.GuildVoice)
+            .sort((a, b) => a.name.localeCompare(b.name));
+          totalManaged = voice.length;
+          for (const ch of voice) {
+            const memberCount =
+              "members" in ch && ch.members ? ch.members.size : 0;
+            if (memberCount === 0) totalEmpty += 1;
+            channels.push({
+              name: ch.name,
+              isLobby: ch.name === lobbyName || ch.name === offlineLobbyName,
+              isLive: manager.isLive(ch.id),
+              memberCount,
+              customName: manager.getCustomChannelName(ch.id) ?? null,
+              channelId: ch.id,
+            });
+          }
+        }
+      } catch (err) {
+        logger.debug("voice channels guild fetch failed", err);
+      }
+
+      res.type("text/html").send(
+        renderVoiceChannelsPage({
+          ...common,
+          enabled,
+          controlPanelEnabled,
+          categoryName,
+          lobbyName,
+          offlineLobbyName,
+          prefix,
+          totalManaged,
+          totalEmpty,
+          channels,
+          categoryFound,
+        }),
+      );
+    }),
+  );
+
+  return router;
+}

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -21,7 +21,7 @@ import {
 import mongoose from "mongoose";
 import logger from "../utils/logger.js";
 import { ConfigService } from "../services/config-service.js";
-import { defaultConfig } from "../services/config-schema.js";
+import { defaultConfig, settingsMetadata } from "../services/config-schema.js";
 import { PermissionsService } from "../services/permissions-service.js";
 import { ScheduledAnnouncementService } from "../services/scheduled-announcement-service.js";
 import { ScheduledAnnouncement } from "../models/scheduled-announcement.js";
@@ -295,16 +295,23 @@ export function createReadOnlyRouter(
       const stored = await config.getAll().catch(() => []);
       const storedByKey = new Map(stored.map((s) => [s.key, s]));
 
+      // Description and category come from the static settingsMetadata
+      // map (one entry per key in `defaultConfig`); when a DB row exists
+      // and overrides them, prefer the DB value. This way every key has a
+      // stable description on a fresh install — even before /config set
+      // ever runs — without losing operator-customised descriptions.
       const rows: SettingRow[] = Object.entries(defaultConfig).map(
         ([key, defaultValue]) => {
           const dbEntry = storedByKey.get(key);
+          const meta = settingsMetadata[key as keyof typeof settingsMetadata];
           return {
             key,
             current: dbEntry ? dbEntry.value : defaultValue,
             defaultValue,
             type: describeType(defaultValue),
-            description: dbEntry?.description ?? "(no description on disk yet)",
-            category: dbEntry?.category ?? deriveCategory(key),
+            description: dbEntry?.description ?? meta?.description ?? "",
+            category:
+              dbEntry?.category ?? meta?.category ?? deriveCategory(key),
           };
         },
       );

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -46,6 +46,7 @@ import {
   renderReactionRolesPage,
   renderSettingsPage,
   renderVoiceChannelsPage,
+  type ReactionRoleRow,
   type SettingRow,
 } from "./admin-views.js";
 
@@ -103,7 +104,7 @@ function commonFromReq(req: AuthenticatedRequest): {
   return {
     guildId: session.guildId,
     csrfToken: getCsrfToken(req),
-    remainingMs: getDisplayedRemainingMs(),
+    remainingMs: getDisplayedRemainingMs(session),
   };
 }
 
@@ -488,7 +489,7 @@ export function createReadOnlyRouter(
         messageId: string;
         isArchived: boolean;
         archivedAt?: Date | null;
-      }): ReturnType<typeof Object> => ({
+      }): ReactionRoleRow => ({
         emoji: rr.emoji,
         roleName: rr.roleName,
         roleId: rr.roleId,

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -24,6 +24,12 @@ export interface WebSessionContext {
   guildId: string;
   scopes: string[];
   lastActivityAt: number;
+  /**
+   * Server-side hard cap for the session, mirrored from
+   * `WebSession.expiresAt`. Used by the banner countdown so the rendered
+   * remaining time respects the TTL ceiling, not just the inactivity window.
+   */
+  expiresAt: Date;
 }
 
 export type AuthenticatedRequest = Request & { webSession?: WebSessionContext };
@@ -176,6 +182,7 @@ export function createSessionMiddleware(
       guildId: payload.gid,
       scopes: dbSession.scopes,
       lastActivityAt: now,
+      expiresAt: dbSession.expiresAt,
     };
     next();
   };


### PR DESCRIPTION
Closes #381. Rebased onto `main` after #388 (the #380 scaffold) merged, so this PR now contains *only* the read-only views.

## Summary

Adds the read-only admin pages on top of the WebUI scaffold from #388:

- **Dashboard** (`/admin/`) — guild summary, DB connection state, feature toggles, content counts. Replaces the placeholder dashboard the scaffold shipped.
- **Bootstrap** (`/admin/bootstrap`) — env presence + last-4 of secrets, grouped by category. Replaces the scaffold's placeholder.
- **Settings** (`/admin/settings`) — every key from `defaultConfig`, grouped by feature, with current value, type, default, and description sourced from `config-service.ts` / `SETTINGS.md`.
- **Permissions** (`/admin/permissions`) — matrix view of commands × roles plus a per-command listing, populated from `permissions-service.ts`.
- **Announcements** (`/admin/announcements`) — scheduled announcements with channel, cron, status, and embed summary.
- **Polls** (`/admin/polls`) — schedule list and the question library, including tags / usage / last-used / source.
- **Reaction Roles** (`/admin/reaction-roles`) — active and archived mappings with channel/category resolution.
- **Notices** (`/admin/notices`) — notices grouped by category with content previews.
- **Database** (`/admin/database`) — `dbtrunk` status, retention windows, per-collection counts.
- **Voice Channels** (`/admin/voice-channels`) — live category contents, lobby vs. dynamic, custom names, live flag.
- "Session expires in X · [Finish]" banner with a live countdown on every page.

## Wiring

- New `src/web/admin-layout.ts` — page shell with banner, nav, and countdown JS. Pure HTML/CSS, no SPA.
- New `src/web/admin-views.ts` — per-page renderers that accept already-shaped data, so they're testable without a Discord client or MongoDB.
- New `src/web/read-only-routes.ts` — route handlers that shape data from existing services into renderer props. Only `GET`s; mounted behind the scaffold's `requireSession` middleware.
- `src/web/index.ts` — swaps the scaffold's placeholder `/` and `/bootstrap` handlers for `createReadOnlyRouter(client, requireSession)`. Magic-link redeem, `/finish`, CSRF, rate limit, and error sink are unchanged from #388.

## Acceptance

- ✅ Every page reads through existing services in `src/services/` — no duplicate data access.
- ✅ Permissions enforced per page via the scaffold's `requireSession` middleware (re-checks `permissions-service.ts` every request); restricted views land on the scaffold's 401 page cleanly.
- ✅ Live-guild data (channels, categories, roles) fetched fresh per request via `client.guilds.fetch(...).channels.fetch()` / `.roles.fetch()`.
- ✅ No write/edit/delete actions; no YAML import/export; no command-reload button.
- ✅ Banner is on every navigated page.

## Test plan

- [x] `npm run check:all` — build, lint, format, tests (89 suites / 775 tests pass; 15 new for `escapeHtml`, `NAV_ITEMS`, `renderAdminPage` banner/active-nav behaviour, `getDisplayedRemainingMs`, and Dashboard/Bootstrap/Settings/Permissions renderers including the matrix + open fallback)
- [ ] Manual smoke: with `WEBUI_ENABLED=true`, run `/config web` in Discord, redeem the DM link, click through every nav entry, confirm the banner countdown ticks down, click Finish, confirm the session is revoked

https://claude.ai/code/session_018HNCpyDZrj31wyvba895jD