### PR TITLE
feat(leaderboard-roles): auto-assign Discord roles from voice leaderboard

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -42,3 +42,4 @@ jobs:
             !dist
             !coverage
             !.github/prompts
+            !CHANGELOG.md

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -720,7 +720,9 @@ See [Commands Documentation](COMMANDS.md#reactrole) for detailed usage.
 
 ## 🏅 Leaderboard Role Rewards
 
-Auto-assign Discord roles based on each user's position on the voice-channel leaderboard. A cron job recalculates assignments on a schedule; users who fall out of a tier lose the role automatically.
+Auto-assign Discord roles based on each user's position on the voice-channel leaderboard.
+A cron job recalculates assignments on a schedule; users who fall out of a tier lose
+the role automatically.
 
 | Setting | Default | Description |
 | --- | --- | --- |
@@ -732,15 +734,20 @@ Auto-assign Discord roles based on each user's position on the voice-channel lea
 
 ### Tier Configuration
 
-Tiers are admin-defined — there is no built-in "top 1 / top 3 / top 10". You pick any positions you want to reward and which role each one grants. The format is a comma-separated list of `topN:roleId` pairs:
+Tiers are admin-defined — there is no built-in "top 1 / top 3 / top 10". You pick any
+positions you want to reward and which role each one grants. The format is a
+comma-separated list of `topN:roleId` pairs:
 
-```
+```text
 leaderboard_roles.tiers = "1:111111111111111111,3:222222222222222222,10:333333333333333333"
 ```
 
-In this example a user at rank #1 receives all three roles, a user at rank #2 or #3 receives the latter two, and a user at rank #4–#10 receives only the third. Each tier is independent.
+In this example a user at rank #1 receives all three roles, a user at rank #2 or #3
+receives the latter two, and a user at rank #4–#10 receives only the third. Each tier
+is independent.
 
-Invalid entries (non-numeric `topN`, non-snowflake role ID, malformed syntax) are logged and skipped — they don't stop the rest of the configuration from applying.
+Invalid entries (non-numeric `topN`, non-snowflake role ID, malformed syntax) are
+logged and skipped — they don't stop the rest of the configuration from applying.
 
 ### Example
 
@@ -1178,7 +1185,7 @@ The config system automatically converts values:
 
 - `leaderboard_roles.enabled` (bool, default: false)
 - `leaderboard_roles.period` (string, default: "alltime") — `week` / `month` / `alltime`
-- `leaderboard_roles.update_cron` (string, default: "0 0 * * 1")
+- `leaderboard_roles.update_cron` (string, default: `"0 0 * * 1"`)
 - `leaderboard_roles.tiers` (string, default: "") — comma-separated `topN:roleId`
 - `leaderboard_roles.announcement_channel_id` (string, default: "")
 

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -20,6 +20,7 @@ Complete configuration reference for all KoolBot settings. All settings can be m
 - [Announcements](#-announcements) - Automated stats posting
 - [Achievements System](#-achievements-system) - Badges and achievements
 - [Reaction Roles](#-reaction-roles) - Self-assignable roles via reactions
+- [Leaderboard Role Rewards](#-leaderboard-role-rewards) - Auto-assign roles from voice leaderboard
 - [Discord Logging](#-discord-logging) - Event logging to channels
 - [Fun Features](#-fun-features) - Easter eggs and extras
 - [Rate Limiting](#-rate-limiting) - Command spam protection
@@ -717,6 +718,50 @@ See [Commands Documentation](COMMANDS.md#reactrole) for detailed usage.
 
 ---
 
+## 🏅 Leaderboard Role Rewards
+
+Auto-assign Discord roles based on each user's position on the voice-channel leaderboard. A cron job recalculates assignments on a schedule; users who fall out of a tier lose the role automatically.
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `leaderboard_roles.enabled` | `false` | Enable/disable auto-assignment |
+| `leaderboard_roles.period` | `alltime` | Leaderboard period: `week`, `month`, or `alltime` |
+| `leaderboard_roles.update_cron` | `0 0 * * 1` | Cron schedule for recalculation (default: Mondays 00:00) |
+| `leaderboard_roles.tiers` | `""` | Comma-separated `topN:roleId` pairs (e.g. `1:111,3:222,10:333`) |
+| `leaderboard_roles.announcement_channel_id` | `""` | Optional channel ID for role-change announcements (empty disables) |
+
+### Tier Configuration
+
+Tiers are admin-defined — there is no built-in "top 1 / top 3 / top 10". You pick any positions you want to reward and which role each one grants. The format is a comma-separated list of `topN:roleId` pairs:
+
+```
+leaderboard_roles.tiers = "1:111111111111111111,3:222222222222222222,10:333333333333333333"
+```
+
+In this example a user at rank #1 receives all three roles, a user at rank #2 or #3 receives the latter two, and a user at rank #4–#10 receives only the third. Each tier is independent.
+
+Invalid entries (non-numeric `topN`, non-snowflake role ID, malformed syntax) are logged and skipped — they don't stop the rest of the configuration from applying.
+
+### Example
+
+```bash
+# Enable and configure
+/config set key:leaderboard_roles.enabled value:true
+/config set key:leaderboard_roles.period value:week
+/config set key:leaderboard_roles.update_cron value:"0 0 * * 1"
+/config set key:leaderboard_roles.tiers value:"1:111111111111111111,3:222222222222222222"
+/config set key:leaderboard_roles.announcement_channel_id value:"123456789012345678"
+/config reload
+```
+
+**Notes:**
+
+- The bot must have the **Manage Roles** permission and its highest role must sit above the reward roles in the role hierarchy, otherwise role add/remove will fail.
+- Role assignments are tracked in MongoDB so the bot can revoke a role from a user even after a restart, without requiring the privileged `GuildMembers` intent.
+- The announcement embed is only posted when there is at least one add/remove in a run.
+
+---
+
 ## 🧹 Voice Channel Cleanup
 
 Automatic cleanup of old tracking data with data aggregation.
@@ -1128,6 +1173,14 @@ The config system automatically converts values:
 
 - `reactionroles.enabled` (bool, default: false)
 - `reactionroles.message_channel_id` (string, default: "")
+
+#### Leaderboard Role Rewards
+
+- `leaderboard_roles.enabled` (bool, default: false)
+- `leaderboard_roles.period` (string, default: "alltime") — `week` / `month` / `alltime`
+- `leaderboard_roles.update_cron` (string, default: "0 0 * * 1")
+- `leaderboard_roles.tiers` (string, default: "") — comma-separated `topN:roleId`
+- `leaderboard_roles.announcement_channel_id` (string, default: "")
 
 #### Quote System
 

--- a/__tests__/services/leaderboard-role-service.test.ts
+++ b/__tests__/services/leaderboard-role-service.test.ts
@@ -17,6 +17,9 @@ const mockGuildRolesFetch = jest.fn();
 const mockGuildChannelsFetch = jest.fn();
 const mockClientGuildsFetch = jest.fn();
 
+const mockAssignmentFindOne = jest.fn();
+const mockAssignmentFindOneAndUpdate = jest.fn();
+
 jest.unstable_mockModule("../../src/services/config-service.js", () => ({
   ConfigService: {
     getInstance: jest.fn(() => ({
@@ -33,6 +36,16 @@ jest.unstable_mockModule("../../src/services/voice-channel-tracker.js", () => ({
   },
 }));
 
+jest.unstable_mockModule(
+  "../../src/models/leaderboard-role-assignment.js",
+  () => ({
+    LeaderboardRoleAssignment: {
+      findOne: mockAssignmentFindOne,
+      findOneAndUpdate: mockAssignmentFindOneAndUpdate,
+    },
+  }),
+);
+
 jest.unstable_mockModule("../../src/utils/logger.js", () => ({
   default: {
     info: jest.fn(),
@@ -42,9 +55,8 @@ jest.unstable_mockModule("../../src/utils/logger.js", () => ({
   },
 }));
 
-const { LeaderboardRoleService } = await import(
-  "../../src/services/leaderboard-role-service.js"
-);
+const { LeaderboardRoleService } =
+  await import("../../src/services/leaderboard-role-service.js");
 
 type ServiceInstance = InstanceType<typeof LeaderboardRoleService>;
 
@@ -65,20 +77,16 @@ interface MockGuild {
   members: { fetch: typeof mockGuildMembersFetch };
   roles: { fetch: typeof mockGuildRolesFetch };
   channels: { fetch: typeof mockGuildChannelsFetch };
-  role: { id: string; name: string; members: Map<string, { id: string }> };
+  role: { id: string; name: string };
 }
 
 function makeGuildWithRole(opts: {
   roleId: string;
   roleName: string;
-  currentHolders: string[];
 }): MockGuild {
   const role = {
     id: opts.roleId,
     name: opts.roleName,
-    members: new Map(
-      opts.currentHolders.map((id) => [id, { id }]),
-    ),
   };
 
   mockGuildRolesFetch.mockResolvedValue(role);
@@ -91,7 +99,6 @@ function makeGuildWithRole(opts: {
         roles: { add: mockRolesAdd, remove: mockRolesRemove },
       };
     }
-    // No-arg call: prime the cache; returns the full collection (unused here).
     return new Map();
   });
 
@@ -126,6 +133,8 @@ describe("LeaderboardRoleService", () => {
           return "";
       }
     });
+    mockAssignmentFindOne.mockResolvedValue(null);
+    mockAssignmentFindOneAndUpdate.mockResolvedValue({});
   });
 
   describe("singleton", () => {
@@ -144,18 +153,16 @@ describe("LeaderboardRoleService", () => {
   describe("runNow guards", () => {
     it("returns null when the feature is disabled", async () => {
       mockConfigGetBoolean.mockResolvedValue(false);
-      const svc: ServiceInstance = LeaderboardRoleService.getInstance(
-        makeClient(),
-      );
+      const svc: ServiceInstance =
+        LeaderboardRoleService.getInstance(makeClient());
       const result = await svc.runNow();
       expect(result).toBeNull();
       expect(mockGetTopUsers).not.toHaveBeenCalled();
     });
 
     it("returns null when no tiers are configured", async () => {
-      const svc: ServiceInstance = LeaderboardRoleService.getInstance(
-        makeClient(),
-      );
+      const svc: ServiceInstance =
+        LeaderboardRoleService.getInstance(makeClient());
       const result = await svc.runNow();
       expect(result).toBeNull();
       expect(mockGetTopUsers).not.toHaveBeenCalled();
@@ -167,11 +174,36 @@ describe("LeaderboardRoleService", () => {
         if (key === "leaderboard_roles.period") return "alltime";
         return "";
       });
-      const svc: ServiceInstance = LeaderboardRoleService.getInstance(
-        makeClient(),
-      );
+      const svc: ServiceInstance =
+        LeaderboardRoleService.getInstance(makeClient());
       const result = await svc.runNow();
       expect(result).toBeNull();
+    });
+
+    it("coalesces concurrent invocations", async () => {
+      mockConfigGetString.mockImplementation(async (key: unknown) => {
+        const k = key as string;
+        if (k === "GUILD_ID") return "guild-1";
+        if (k === "leaderboard_roles.tiers") return "1:99999001";
+        if (k === "leaderboard_roles.period") return "alltime";
+        return "";
+      });
+      mockGetTopUsers.mockResolvedValue([
+        { userId: "u1", username: "u1", totalTime: 100 },
+      ]);
+      mockClientGuildsFetch.mockResolvedValue(
+        makeGuildWithRole({ roleId: "99999001", roleName: "Top 1" }),
+      );
+
+      const svc: ServiceInstance =
+        LeaderboardRoleService.getInstance(makeClient());
+      const [first, second] = await Promise.all([svc.runNow(), svc.runNow()]);
+
+      // One of them ran, the other was coalesced and returned null.
+      const succeeded = [first, second].filter((r) => r !== null);
+      const skipped = [first, second].filter((r) => r === null);
+      expect(succeeded).toHaveLength(1);
+      expect(skipped).toHaveLength(1);
     });
   });
 
@@ -198,13 +230,11 @@ describe("LeaderboardRoleService", () => {
       const guild = makeGuildWithRole({
         roleId: "111",
         roleName: "Top 1",
-        currentHolders: [],
       });
       mockClientGuildsFetch.mockResolvedValue(guild);
 
-      const svc: ServiceInstance = LeaderboardRoleService.getInstance(
-        makeClient(),
-      );
+      const svc: ServiceInstance =
+        LeaderboardRoleService.getInstance(makeClient());
       const result = await svc.runNow();
 
       expect(result).not.toBeNull();
@@ -216,7 +246,7 @@ describe("LeaderboardRoleService", () => {
   });
 
   describe("role reconciliation", () => {
-    it("adds the role to qualifying users who don't have it", async () => {
+    it("adds the role to qualifying users with no previous assignment", async () => {
       mockConfigGetString.mockImplementation(async (key: unknown) => {
         const k = key as string;
         if (k === "GUILD_ID") return "guild-1";
@@ -229,16 +259,13 @@ describe("LeaderboardRoleService", () => {
         { userId: "u2", username: "u2", totalTime: 90 },
         { userId: "u3", username: "u3", totalTime: 80 },
       ]);
-      const guild = makeGuildWithRole({
-        roleId: "99999003",
-        roleName: "Top 3",
-        currentHolders: [], // nobody has it yet
-      });
-      mockClientGuildsFetch.mockResolvedValue(guild);
-
-      const svc: ServiceInstance = LeaderboardRoleService.getInstance(
-        makeClient(),
+      mockAssignmentFindOne.mockResolvedValue(null); // first-ever run
+      mockClientGuildsFetch.mockResolvedValue(
+        makeGuildWithRole({ roleId: "99999003", roleName: "Top 3" }),
       );
+
+      const svc: ServiceInstance =
+        LeaderboardRoleService.getInstance(makeClient());
       const result = await svc.runNow();
 
       expect(result).not.toBeNull();
@@ -248,6 +275,17 @@ describe("LeaderboardRoleService", () => {
       expect(result!.tiers[0].removed).toEqual([]);
       expect(mockRolesAdd).toHaveBeenCalledTimes(3);
       expect(mockRolesRemove).not.toHaveBeenCalled();
+      // Persists the new holder set
+      expect(mockAssignmentFindOneAndUpdate).toHaveBeenCalledWith(
+        { guildId: "guild-1", roleId: "99999003" },
+        expect.objectContaining({
+          guildId: "guild-1",
+          roleId: "99999003",
+          topN: 3,
+          userIds: expect.arrayContaining(["u1", "u2", "u3"]),
+        }),
+        { upsert: true },
+      );
     });
 
     it("removes the role from users who no longer qualify", async () => {
@@ -262,24 +300,78 @@ describe("LeaderboardRoleService", () => {
         { userId: "u1", username: "u1", totalTime: 100 },
         { userId: "u2", username: "u2", totalTime: 90 },
       ]);
-      const guild = makeGuildWithRole({
+      // Previous run: u1 + u-old had the role. u-old should now lose it.
+      mockAssignmentFindOne.mockResolvedValue({
+        guildId: "guild-1",
         roleId: "99999002",
-        roleName: "Top 2",
-        // u1 is still top, u2 is new top, u-old should lose the role
-        currentHolders: ["u1", "u-old"],
+        topN: 2,
+        userIds: ["u1", "u-old"],
       });
-      mockClientGuildsFetch.mockResolvedValue(guild);
-
-      const svc: ServiceInstance = LeaderboardRoleService.getInstance(
-        makeClient(),
+      mockClientGuildsFetch.mockResolvedValue(
+        makeGuildWithRole({ roleId: "99999002", roleName: "Top 2" }),
       );
+
+      const svc: ServiceInstance =
+        LeaderboardRoleService.getInstance(makeClient());
       const result = await svc.runNow();
 
       expect(result).not.toBeNull();
-      expect(result!.tiers[0].added).toEqual(["u2"]);
+      expect(result!.tiers[0].added).toEqual(["u2"]); // u1 already had it
       expect(result!.tiers[0].removed).toEqual(["u-old"]);
       expect(mockRolesAdd).toHaveBeenCalledTimes(1);
       expect(mockRolesRemove).toHaveBeenCalledTimes(1);
+      // Final holder set should be u1 + u2
+      expect(mockAssignmentFindOneAndUpdate).toHaveBeenCalledWith(
+        { guildId: "guild-1", roleId: "99999002" },
+        expect.objectContaining({
+          userIds: expect.arrayContaining(["u1", "u2"]),
+        }),
+        { upsert: true },
+      );
+    });
+
+    it("counts a member who left the guild as removed without erroring", async () => {
+      mockConfigGetString.mockImplementation(async (key: unknown) => {
+        const k = key as string;
+        if (k === "GUILD_ID") return "guild-1";
+        if (k === "leaderboard_roles.tiers") return "2:99999002";
+        if (k === "leaderboard_roles.period") return "alltime";
+        return "";
+      });
+      mockGetTopUsers.mockResolvedValue([
+        { userId: "u1", username: "u1", totalTime: 100 },
+        { userId: "u2", username: "u2", totalTime: 90 },
+      ]);
+      mockAssignmentFindOne.mockResolvedValue({
+        guildId: "guild-1",
+        roleId: "99999002",
+        topN: 2,
+        userIds: ["u-left"],
+      });
+      mockClientGuildsFetch.mockResolvedValue(
+        makeGuildWithRole({ roleId: "99999002", roleName: "Top 2" }),
+      );
+      // Override member fetch: "u-left" rejects (user is gone)
+      mockGuildMembersFetch.mockImplementation(async (...args: unknown[]) => {
+        const arg = args[0];
+        if (arg === "u-left") throw new Error("Unknown member");
+        if (typeof arg === "string") {
+          return {
+            id: arg,
+            user: { tag: `user-${arg}` },
+            roles: { add: mockRolesAdd, remove: mockRolesRemove },
+          };
+        }
+        return new Map();
+      });
+
+      const svc: ServiceInstance =
+        LeaderboardRoleService.getInstance(makeClient());
+      const result = await svc.runNow();
+
+      expect(result).not.toBeNull();
+      expect(result!.tiers[0].removed).toEqual(["u-left"]);
+      expect(mockRolesRemove).not.toHaveBeenCalled();
     });
 
     it("marks a tier as skipped when the role is not found", async () => {
@@ -299,14 +391,14 @@ describe("LeaderboardRoleService", () => {
         channels: { fetch: mockGuildChannelsFetch },
       });
 
-      const svc: ServiceInstance = LeaderboardRoleService.getInstance(
-        makeClient(),
-      );
+      const svc: ServiceInstance =
+        LeaderboardRoleService.getInstance(makeClient());
       const result = await svc.runNow();
 
       expect(result).not.toBeNull();
       expect(result!.tiers[0].skippedReason).toBe("role-not-found");
       expect(mockRolesAdd).not.toHaveBeenCalled();
+      expect(mockAssignmentFindOneAndUpdate).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/services/leaderboard-role-service.test.ts
+++ b/__tests__/services/leaderboard-role-service.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import type { Client } from "discord.js";
+
+const mockRegisterReloadCallback = jest.fn();
+const mockConfigGetBoolean = jest.fn();
+const mockConfigGetString = jest.fn();
+
+const mockGetTopUsers = jest.fn();
+const mockTrackerGetInstance = jest.fn(() => ({
+  getTopUsers: mockGetTopUsers,
+}));
+
+const mockRolesAdd = jest.fn();
+const mockRolesRemove = jest.fn();
+const mockGuildMembersFetch = jest.fn();
+const mockGuildRolesFetch = jest.fn();
+const mockGuildChannelsFetch = jest.fn();
+const mockClientGuildsFetch = jest.fn();
+
+jest.unstable_mockModule("../../src/services/config-service.js", () => ({
+  ConfigService: {
+    getInstance: jest.fn(() => ({
+      registerReloadCallback: mockRegisterReloadCallback,
+      getBoolean: mockConfigGetBoolean,
+      getString: mockConfigGetString,
+    })),
+  },
+}));
+
+jest.unstable_mockModule("../../src/services/voice-channel-tracker.js", () => ({
+  VoiceChannelTracker: {
+    getInstance: mockTrackerGetInstance,
+  },
+}));
+
+jest.unstable_mockModule("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const { LeaderboardRoleService } = await import(
+  "../../src/services/leaderboard-role-service.js"
+);
+
+type ServiceInstance = InstanceType<typeof LeaderboardRoleService>;
+
+function resetSingleton(): void {
+  (LeaderboardRoleService as unknown as { instance: unknown }).instance =
+    undefined;
+}
+
+function makeClient(): Client {
+  return {
+    isReady: () => true,
+    guilds: { fetch: mockClientGuildsFetch },
+  } as unknown as Client;
+}
+
+interface MockGuild {
+  id: string;
+  members: { fetch: typeof mockGuildMembersFetch };
+  roles: { fetch: typeof mockGuildRolesFetch };
+  channels: { fetch: typeof mockGuildChannelsFetch };
+  role: { id: string; name: string; members: Map<string, { id: string }> };
+}
+
+function makeGuildWithRole(opts: {
+  roleId: string;
+  roleName: string;
+  currentHolders: string[];
+}): MockGuild {
+  const role = {
+    id: opts.roleId,
+    name: opts.roleName,
+    members: new Map(
+      opts.currentHolders.map((id) => [id, { id }]),
+    ),
+  };
+
+  mockGuildRolesFetch.mockResolvedValue(role);
+  mockGuildMembersFetch.mockImplementation(async (...args: unknown[]) => {
+    const arg = args[0];
+    if (typeof arg === "string") {
+      return {
+        id: arg,
+        user: { tag: `user-${arg}` },
+        roles: { add: mockRolesAdd, remove: mockRolesRemove },
+      };
+    }
+    // No-arg call: prime the cache; returns the full collection (unused here).
+    return new Map();
+  });
+
+  return {
+    id: "guild-1",
+    members: { fetch: mockGuildMembersFetch },
+    roles: { fetch: mockGuildRolesFetch },
+    channels: { fetch: mockGuildChannelsFetch },
+    role,
+  };
+}
+
+describe("LeaderboardRoleService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetSingleton();
+    mockConfigGetBoolean.mockResolvedValue(true);
+    mockConfigGetString.mockImplementation(async (key: unknown) => {
+      const k = key as string;
+      switch (k) {
+        case "GUILD_ID":
+          return "guild-1";
+        case "leaderboard_roles.period":
+          return "alltime";
+        case "leaderboard_roles.update_cron":
+          return "0 0 * * 1";
+        case "leaderboard_roles.tiers":
+          return "";
+        case "leaderboard_roles.announcement_channel_id":
+          return "";
+        default:
+          return "";
+      }
+    });
+  });
+
+  describe("singleton", () => {
+    it("returns the same instance", () => {
+      const a = LeaderboardRoleService.getInstance(makeClient());
+      const b = LeaderboardRoleService.getInstance(makeClient());
+      expect(a).toBe(b);
+    });
+
+    it("registers a config reload callback on construction", () => {
+      LeaderboardRoleService.getInstance(makeClient());
+      expect(mockRegisterReloadCallback).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("runNow guards", () => {
+    it("returns null when the feature is disabled", async () => {
+      mockConfigGetBoolean.mockResolvedValue(false);
+      const svc: ServiceInstance = LeaderboardRoleService.getInstance(
+        makeClient(),
+      );
+      const result = await svc.runNow();
+      expect(result).toBeNull();
+      expect(mockGetTopUsers).not.toHaveBeenCalled();
+    });
+
+    it("returns null when no tiers are configured", async () => {
+      const svc: ServiceInstance = LeaderboardRoleService.getInstance(
+        makeClient(),
+      );
+      const result = await svc.runNow();
+      expect(result).toBeNull();
+      expect(mockGetTopUsers).not.toHaveBeenCalled();
+    });
+
+    it("returns null when GUILD_ID is missing", async () => {
+      mockConfigGetString.mockImplementation(async (key: unknown) => {
+        if (key === "leaderboard_roles.tiers") return "1:role-a";
+        if (key === "leaderboard_roles.period") return "alltime";
+        return "";
+      });
+      const svc: ServiceInstance = LeaderboardRoleService.getInstance(
+        makeClient(),
+      );
+      const result = await svc.runNow();
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("tier parsing", () => {
+    it("skips malformed entries and runs the surviving ones", async () => {
+      mockConfigGetString.mockImplementation(async (key: unknown) => {
+        const k = key as string;
+        if (k === "GUILD_ID") return "guild-1";
+        if (k === "leaderboard_roles.tiers")
+          return "1:111,foo,3:not-a-snowflake,5:222,,:333,7:,abc:444";
+        if (k === "leaderboard_roles.period") return "alltime";
+        return "";
+      });
+
+      // Largest tier (5) drives how many top users to fetch
+      mockGetTopUsers.mockResolvedValue([
+        { userId: "u1", username: "u1", totalTime: 100 },
+        { userId: "u2", username: "u2", totalTime: 90 },
+        { userId: "u3", username: "u3", totalTime: 80 },
+        { userId: "u4", username: "u4", totalTime: 70 },
+        { userId: "u5", username: "u5", totalTime: 60 },
+      ]);
+
+      const guild = makeGuildWithRole({
+        roleId: "111",
+        roleName: "Top 1",
+        currentHolders: [],
+      });
+      mockClientGuildsFetch.mockResolvedValue(guild);
+
+      const svc: ServiceInstance = LeaderboardRoleService.getInstance(
+        makeClient(),
+      );
+      const result = await svc.runNow();
+
+      expect(result).not.toBeNull();
+      // Only "1:111" and "5:222" parse successfully → 2 tiers reconciled
+      expect(result!.tiers.map((t) => t.topN).sort()).toEqual([1, 5]);
+      // getTopUsers should be called with the widest tier (5)
+      expect(mockGetTopUsers).toHaveBeenCalledWith(5, "alltime");
+    });
+  });
+
+  describe("role reconciliation", () => {
+    it("adds the role to qualifying users who don't have it", async () => {
+      mockConfigGetString.mockImplementation(async (key: unknown) => {
+        const k = key as string;
+        if (k === "GUILD_ID") return "guild-1";
+        if (k === "leaderboard_roles.tiers") return "3:99999003";
+        if (k === "leaderboard_roles.period") return "week";
+        return "";
+      });
+      mockGetTopUsers.mockResolvedValue([
+        { userId: "u1", username: "u1", totalTime: 100 },
+        { userId: "u2", username: "u2", totalTime: 90 },
+        { userId: "u3", username: "u3", totalTime: 80 },
+      ]);
+      const guild = makeGuildWithRole({
+        roleId: "99999003",
+        roleName: "Top 3",
+        currentHolders: [], // nobody has it yet
+      });
+      mockClientGuildsFetch.mockResolvedValue(guild);
+
+      const svc: ServiceInstance = LeaderboardRoleService.getInstance(
+        makeClient(),
+      );
+      const result = await svc.runNow();
+
+      expect(result).not.toBeNull();
+      expect(result!.period).toBe("week");
+      expect(result!.tiers).toHaveLength(1);
+      expect(result!.tiers[0].added.sort()).toEqual(["u1", "u2", "u3"]);
+      expect(result!.tiers[0].removed).toEqual([]);
+      expect(mockRolesAdd).toHaveBeenCalledTimes(3);
+      expect(mockRolesRemove).not.toHaveBeenCalled();
+    });
+
+    it("removes the role from users who no longer qualify", async () => {
+      mockConfigGetString.mockImplementation(async (key: unknown) => {
+        const k = key as string;
+        if (k === "GUILD_ID") return "guild-1";
+        if (k === "leaderboard_roles.tiers") return "2:99999002";
+        if (k === "leaderboard_roles.period") return "alltime";
+        return "";
+      });
+      mockGetTopUsers.mockResolvedValue([
+        { userId: "u1", username: "u1", totalTime: 100 },
+        { userId: "u2", username: "u2", totalTime: 90 },
+      ]);
+      const guild = makeGuildWithRole({
+        roleId: "99999002",
+        roleName: "Top 2",
+        // u1 is still top, u2 is new top, u-old should lose the role
+        currentHolders: ["u1", "u-old"],
+      });
+      mockClientGuildsFetch.mockResolvedValue(guild);
+
+      const svc: ServiceInstance = LeaderboardRoleService.getInstance(
+        makeClient(),
+      );
+      const result = await svc.runNow();
+
+      expect(result).not.toBeNull();
+      expect(result!.tiers[0].added).toEqual(["u2"]);
+      expect(result!.tiers[0].removed).toEqual(["u-old"]);
+      expect(mockRolesAdd).toHaveBeenCalledTimes(1);
+      expect(mockRolesRemove).toHaveBeenCalledTimes(1);
+    });
+
+    it("marks a tier as skipped when the role is not found", async () => {
+      mockConfigGetString.mockImplementation(async (key: unknown) => {
+        const k = key as string;
+        if (k === "GUILD_ID") return "guild-1";
+        if (k === "leaderboard_roles.tiers") return "1:99999998";
+        return k === "leaderboard_roles.period" ? "alltime" : "";
+      });
+      mockGetTopUsers.mockResolvedValue([
+        { userId: "u1", username: "u1", totalTime: 100 },
+      ]);
+      mockClientGuildsFetch.mockResolvedValue({
+        id: "guild-1",
+        members: { fetch: mockGuildMembersFetch },
+        roles: { fetch: jest.fn().mockResolvedValue(null) },
+        channels: { fetch: mockGuildChannelsFetch },
+      });
+
+      const svc: ServiceInstance = LeaderboardRoleService.getInstance(
+        makeClient(),
+      );
+      const result = await svc.runNow();
+
+      expect(result).not.toBeNull();
+      expect(result!.tiers[0].skippedReason).toBe("role-not-found");
+      expect(mockRolesAdd).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/services/settings-metadata.test.ts
+++ b/__tests__/services/settings-metadata.test.ts
@@ -52,6 +52,7 @@ describe("settingsMetadata", () => {
       "wizard",
       "notices",
       "polls",
+      "leaderboard_roles",
     ]);
     const violations: string[] = [];
     for (const [key, meta] of Object.entries(settingsMetadata)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import { PermissionsService } from "./services/permissions-service.js";
 import FriendshipListener from "./services/friendship-listener.js";
 import { ReactionRoleService } from "./services/reaction-role-service.js";
 import { PollService } from "./services/poll-service.js";
+import { LeaderboardRoleService } from "./services/leaderboard-role-service.js";
 import { WizardService } from "./services/wizard-service.js";
 import { MonitoringService } from "./services/monitoring-service.js";
 import {
@@ -428,6 +429,7 @@ async function gracefulShutdown(signal: string): Promise<void> {
         voiceChannelTruncation.destroy();
         await noticesChannelManager.stop();
         pollService.destroy();
+        leaderboardRoleService.destroy();
         WizardService.getInstance().shutdown();
         MonitoringService.getInstance().destroy();
         await botStatusService.shutdown();
@@ -487,6 +489,7 @@ let quoteChannelManager: QuoteChannelManager;
 let noticesChannelManager: NoticesChannelManager;
 let reactionRoleService: ReactionRoleService;
 let pollService: PollService;
+let leaderboardRoleService: LeaderboardRoleService;
 
 // Wrap service instantiation in try-catch to ensure errors are caught
 try {
@@ -504,6 +507,7 @@ try {
   noticesChannelManager = NoticesChannelManager.getInstance(client);
   reactionRoleService = ReactionRoleService.getInstance(client);
   pollService = PollService.getInstance(client);
+  leaderboardRoleService = LeaderboardRoleService.getInstance(client);
 } catch (error) {
   logger.error("❌ Fatal error during service instantiation:", error);
   process.exit(1);
@@ -582,6 +586,9 @@ async function initializeServices(): Promise<void> {
 
     // Initialize poll service
     await pollService.start();
+
+    // Initialize leaderboard role rewards service
+    await leaderboardRoleService.start();
 
     // Initialize permissions service and set up default permissions
     const permissionsService = PermissionsService.getInstance(client);

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -35,8 +35,10 @@ const ConfigSchema = new Schema<IConfig>(
         "fun",
         "gamification", // Kept for backward compatibility during migration
         "help",
+        "leaderboard_roles",
         "notices",
         "ping",
+        "polls",
         "quotes",
         "ratelimit",
         "reactionroles",

--- a/src/models/leaderboard-role-assignment.ts
+++ b/src/models/leaderboard-role-assignment.ts
@@ -1,0 +1,39 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+/**
+ * Tracks which users currently hold a leaderboard reward role for a given
+ * tier. The service maintains this so it can compute who to add and who to
+ * remove on the next run, without needing the privileged GuildMembers intent
+ * or a full-guild member fetch.
+ *
+ * Identity: (guildId, roleId). `topN` is denormalised on the row for logs.
+ */
+export interface ILeaderboardRoleAssignment extends Document {
+  guildId: string;
+  roleId: string;
+  topN: number;
+  userIds: string[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const LeaderboardRoleAssignmentSchema = new Schema<ILeaderboardRoleAssignment>(
+  {
+    guildId: { type: String, required: true, index: true },
+    roleId: { type: String, required: true },
+    topN: { type: Number, required: true },
+    userIds: { type: [String], default: [] },
+  },
+  { timestamps: true },
+);
+
+LeaderboardRoleAssignmentSchema.index(
+  { guildId: 1, roleId: 1 },
+  { unique: true },
+);
+
+export const LeaderboardRoleAssignment =
+  mongoose.model<ILeaderboardRoleAssignment>(
+    "LeaderboardRoleAssignment",
+    LeaderboardRoleAssignmentSchema,
+  );

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -94,6 +94,13 @@ export interface ConfigSchema {
   "polls.enabled": boolean;
   "polls.default_duration_hours": number; // Default poll duration in hours (1-768)
   "polls.cooldown_days": number; // Minimum days between reusing same poll
+
+  // Leaderboard Role Rewards
+  "leaderboard_roles.enabled": boolean;
+  "leaderboard_roles.period": string; // "week" | "month" | "alltime"
+  "leaderboard_roles.update_cron": string; // Cron schedule for recalculation
+  "leaderboard_roles.tiers": string; // Comma-separated "topN:roleId" pairs, e.g. "1:111,3:222,10:333"
+  "leaderboard_roles.announcement_channel_id": string; // Optional channel ID for role-change announcements
 }
 
 export const defaultConfig: ConfigSchema = {
@@ -191,6 +198,13 @@ export const defaultConfig: ConfigSchema = {
   "polls.enabled": false,
   "polls.default_duration_hours": 24, // Default 24 hours
   "polls.cooldown_days": 7, // Minimum 7 days between reusing same poll
+
+  // Leaderboard Role Rewards defaults
+  "leaderboard_roles.enabled": false,
+  "leaderboard_roles.period": "alltime",
+  "leaderboard_roles.update_cron": "0 0 * * 1", // Every Monday at 00:00
+  "leaderboard_roles.tiers": "",
+  "leaderboard_roles.announcement_channel_id": "",
 };
 
 /**
@@ -528,5 +542,32 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
     description:
       "Minimum days before a question from the library can be reused.",
     category: "polls",
+  },
+
+  // Leaderboard Role Rewards
+  "leaderboard_roles.enabled": {
+    description:
+      "Auto-assign Discord roles to users based on their voice-leaderboard position.",
+    category: "leaderboard_roles",
+  },
+  "leaderboard_roles.period": {
+    description:
+      'Leaderboard period to evaluate: "week", "month", or "alltime".',
+    category: "leaderboard_roles",
+  },
+  "leaderboard_roles.update_cron": {
+    description:
+      "Cron schedule for recalculating leaderboard role assignments.",
+    category: "leaderboard_roles",
+  },
+  "leaderboard_roles.tiers": {
+    description:
+      'Comma-separated "topN:roleId" pairs (e.g. "1:111,3:222,10:333"). Each tier independently assigns the role to users whose rank is ≤ N. Admins pick any positions; nothing is hardcoded.',
+    category: "leaderboard_roles",
+  },
+  "leaderboard_roles.announcement_channel_id": {
+    description:
+      "Optional channel ID where role-change announcements are posted. Leave empty to disable announcements.",
+    category: "leaderboard_roles",
   },
 };

--- a/src/services/leaderboard-role-service.ts
+++ b/src/services/leaderboard-role-service.ts
@@ -3,12 +3,13 @@ import {
   Guild,
   GuildMember,
   Role,
-  TextChannel,
   EmbedBuilder,
+  GuildTextBasedChannel,
 } from "discord.js";
 import { CronJob, CronTime } from "cron";
 import { ConfigService } from "./config-service.js";
 import { VoiceChannelTracker, TimePeriod } from "./voice-channel-tracker.js";
+import { LeaderboardRoleAssignment } from "../models/leaderboard-role-assignment.js";
 import logger from "../utils/logger.js";
 
 interface ParsedTier {
@@ -29,12 +30,17 @@ export interface LeaderboardRoleRunSummary {
   }>;
 }
 
+function sanitizeCronExpression(expression: string): string {
+  return expression.trim().replace(/^["']|["']$/g, "");
+}
+
 export class LeaderboardRoleService {
   private static instance: LeaderboardRoleService;
   private client: Client;
   private configService: ConfigService;
   private job: CronJob | null = null;
   private isInitialized: boolean = false;
+  private isRunning: boolean = false;
 
   private constructor(client: Client) {
     this.client = client;
@@ -77,8 +83,7 @@ export class LeaderboardRoleService {
 
   private validateCronExpression(expression: string): boolean {
     try {
-      const cleanExpression = expression.replace(/^["']|["']$/g, "");
-      new CronTime(cleanExpression);
+      new CronTime(expression);
       return true;
     } catch (error) {
       logger.error(
@@ -183,9 +188,17 @@ export class LeaderboardRoleService {
   /**
    * Recalculate role assignments now. Safe to call manually (e.g. from a
    * future WebUI "Run now" button) — does not depend on the cron job state.
-   * Returns a per-tier summary of which users gained and lost each role.
+   * Concurrent invocations (cron + manual) are coalesced: the second call
+   * returns null immediately without doing work.
    */
   public async runNow(): Promise<LeaderboardRoleRunSummary | null> {
+    if (this.isRunning) {
+      logger.info(
+        "Leaderboard role reconciliation already in progress, skipping concurrent run.",
+      );
+      return null;
+    }
+    this.isRunning = true;
     try {
       await this.waitForClientReady();
 
@@ -236,10 +249,6 @@ export class LeaderboardRoleService {
       const topUsers = await tracker.getTopUsers(maxTopN, period);
       const rankedUserIds: string[] = topUsers.map((u) => u.userId);
 
-      // Ensure the member cache is populated so we can find current role holders.
-      // For very large guilds this is unavoidable; we accept the one-time fetch.
-      await guild.members.fetch();
-
       const summary: LeaderboardRoleRunSummary = {
         ranAt: new Date(),
         period,
@@ -266,6 +275,8 @@ export class LeaderboardRoleService {
     } catch (error) {
       logger.error("Error during leaderboard role reconciliation:", error);
       return null;
+    } finally {
+      this.isRunning = false;
     }
   }
 
@@ -290,32 +301,49 @@ export class LeaderboardRoleService {
     }
 
     const qualifyingIds = new Set(rankedUserIds.slice(0, tier.topN));
-    const currentHolders = new Set<string>(
-      Array.from(role.members.values()).map((m) => m.id),
-    );
+
+    // Source of truth for "who already has this role per our last run" is
+    // our own persisted state — we cannot rely on `role.members` because
+    // the bot does not request the privileged GuildMembers intent.
+    const previousAssignment = await LeaderboardRoleAssignment.findOne({
+      guildId: guild.id,
+      roleId: tier.roleId,
+    });
+    const previousHolders = new Set<string>(previousAssignment?.userIds ?? []);
 
     const added: string[] = [];
     const removed: string[] = [];
+    const finalHolders = new Set<string>();
 
     for (const userId of qualifyingIds) {
-      if (currentHolders.has(userId)) continue;
       const member = await this.safeFetchMember(guild, userId);
-      if (!member) continue;
-      try {
-        await member.roles.add(role, "Leaderboard role reward (auto-assign)");
-        added.push(userId);
-      } catch (error) {
-        logger.warn(
-          `Failed to add role ${role.name} to ${member.user.tag} (${userId}):`,
-          error,
-        );
+      if (!member) {
+        // Couldn't reach the member (left the guild, etc.); skip.
+        continue;
       }
+      if (!previousHolders.has(userId)) {
+        try {
+          await member.roles.add(role, "Leaderboard role reward (auto-assign)");
+          added.push(userId);
+        } catch (error) {
+          logger.warn(
+            `Failed to add role ${role.name} to ${member.user.tag} (${userId}):`,
+            error,
+          );
+          continue;
+        }
+      }
+      finalHolders.add(userId);
     }
 
-    for (const userId of currentHolders) {
+    for (const userId of previousHolders) {
       if (qualifyingIds.has(userId)) continue;
       const member = await this.safeFetchMember(guild, userId);
-      if (!member) continue;
+      if (!member) {
+        // User left the guild; nothing to revoke. Treat as removed.
+        removed.push(userId);
+        continue;
+      }
       try {
         await member.roles.remove(
           role,
@@ -327,8 +355,21 @@ export class LeaderboardRoleService {
           `Failed to remove role ${role.name} from ${member.user.tag} (${userId}):`,
           error,
         );
+        // If we couldn't remove, keep them in the set so we try again next run.
+        finalHolders.add(userId);
       }
     }
+
+    await LeaderboardRoleAssignment.findOneAndUpdate(
+      { guildId: guild.id, roleId: tier.roleId },
+      {
+        guildId: guild.id,
+        roleId: tier.roleId,
+        topN: tier.topN,
+        userIds: Array.from(finalHolders),
+      },
+      { upsert: true },
+    );
 
     return {
       topN: tier.topN,
@@ -368,9 +409,9 @@ export class LeaderboardRoleService {
 
     try {
       const channel = await guild.channels.fetch(channelId);
-      if (!channel || !(channel instanceof TextChannel)) {
+      if (!channel || !channel.isTextBased() || !("send" in channel)) {
         logger.warn(
-          `Leaderboard announcement channel ${channelId} not found or not a text channel`,
+          `Leaderboard announcement channel ${channelId} not found or not a sendable text channel`,
         );
         return;
       }
@@ -402,7 +443,7 @@ export class LeaderboardRoleService {
         });
       }
 
-      await channel.send({ embeds: [embed] });
+      await (channel as GuildTextBasedChannel).send({ embeds: [embed] });
     } catch (error) {
       logger.error("Failed to post leaderboard role announcement:", error);
     }
@@ -428,14 +469,15 @@ export class LeaderboardRoleService {
         return;
       }
 
-      const cronExpression = await this.configService.getString(
+      const rawCron = await this.configService.getString(
         "leaderboard_roles.update_cron",
         "0 0 * * 1",
       );
+      const cronExpression = sanitizeCronExpression(rawCron);
 
       if (!this.validateCronExpression(cronExpression)) {
         logger.error(
-          `Leaderboard role service not started: invalid cron "${cronExpression}"`,
+          `Leaderboard role service not started: invalid cron "${rawCron}"`,
         );
         this.isInitialized = true;
         return;

--- a/src/services/leaderboard-role-service.ts
+++ b/src/services/leaderboard-role-service.ts
@@ -1,0 +1,479 @@
+import {
+  Client,
+  Guild,
+  GuildMember,
+  Role,
+  TextChannel,
+  EmbedBuilder,
+} from "discord.js";
+import { CronJob, CronTime } from "cron";
+import { ConfigService } from "./config-service.js";
+import { VoiceChannelTracker, TimePeriod } from "./voice-channel-tracker.js";
+import logger from "../utils/logger.js";
+
+interface ParsedTier {
+  topN: number;
+  roleId: string;
+}
+
+export interface LeaderboardRoleRunSummary {
+  ranAt: Date;
+  period: TimePeriod;
+  tiers: Array<{
+    topN: number;
+    roleId: string;
+    roleName: string;
+    added: string[]; // user IDs that gained the role
+    removed: string[]; // user IDs that lost the role
+    skippedReason?: string;
+  }>;
+}
+
+export class LeaderboardRoleService {
+  private static instance: LeaderboardRoleService;
+  private client: Client;
+  private configService: ConfigService;
+  private job: CronJob | null = null;
+  private isInitialized: boolean = false;
+
+  private constructor(client: Client) {
+    this.client = client;
+    this.configService = ConfigService.getInstance();
+
+    this.configService.registerReloadCallback(async () => {
+      try {
+        logger.info(
+          "Leaderboard role rewards configuration changed, reloading...",
+        );
+
+        const enabled = await this.configService.getBoolean(
+          "leaderboard_roles.enabled",
+          false,
+        );
+
+        if (!enabled && this.isInitialized) {
+          logger.info(
+            "Leaderboard role rewards disabled, stopping cron job...",
+          );
+          this.destroy();
+        } else if (enabled) {
+          await this.reload();
+        }
+      } catch (error) {
+        logger.error(
+          "Error reloading leaderboard role rewards after configuration change:",
+          error,
+        );
+      }
+    });
+  }
+
+  public static getInstance(client: Client): LeaderboardRoleService {
+    if (!LeaderboardRoleService.instance) {
+      LeaderboardRoleService.instance = new LeaderboardRoleService(client);
+    }
+    return LeaderboardRoleService.instance;
+  }
+
+  private validateCronExpression(expression: string): boolean {
+    try {
+      const cleanExpression = expression.replace(/^["']|["']$/g, "");
+      new CronTime(cleanExpression);
+      return true;
+    } catch (error) {
+      logger.error(
+        `Invalid cron expression for leaderboard roles: ${expression}`,
+        error,
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Parse the tiers config string into [{ topN, roleId }] sorted ascending by topN.
+   * Format: "1:roleId1,3:roleId2,10:roleId3"
+   * Invalid entries are skipped with a warning. Duplicate topNs: last one wins.
+   */
+  private parseTiers(raw: string): ParsedTier[] {
+    if (!raw || raw.trim().length === 0) return [];
+
+    const tiers: Map<number, string> = new Map();
+    const entries = raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s);
+
+    for (const entry of entries) {
+      const parts = entry.split(":").map((p) => p.trim());
+      if (parts.length !== 2) {
+        logger.warn(`Skipping malformed leaderboard tier entry: "${entry}"`);
+        continue;
+      }
+      const topN = Number(parts[0]);
+      const roleId = parts[1];
+      if (!Number.isInteger(topN) || topN <= 0) {
+        logger.warn(
+          `Skipping tier with invalid topN (must be positive integer): "${entry}"`,
+        );
+        continue;
+      }
+      if (!roleId || !/^\d+$/.test(roleId)) {
+        logger.warn(`Skipping tier with invalid Discord role ID: "${entry}"`);
+        continue;
+      }
+      tiers.set(topN, roleId);
+    }
+
+    return Array.from(tiers.entries())
+      .map(([topN, roleId]) => ({ topN, roleId }))
+      .sort((a, b) => a.topN - b.topN);
+  }
+
+  private normalizePeriod(value: string): TimePeriod {
+    if (value === "week" || value === "month" || value === "alltime") {
+      return value;
+    }
+    logger.warn(
+      `Invalid leaderboard_roles.period "${value}", falling back to "alltime"`,
+    );
+    return "alltime";
+  }
+
+  private async waitForClientReady(): Promise<void> {
+    if (this.client.isReady()) return;
+
+    return new Promise((resolve) => {
+      const maxWaitMs = 30000;
+      const pollIntervalMs = 500;
+      let resolved = false;
+      let elapsed = 0;
+
+      const cleanup = (): void => {
+        if (resolved) return;
+        resolved = true;
+        this.client.off("ready", onReady);
+        clearInterval(intervalId);
+      };
+
+      const onReady = (): void => {
+        cleanup();
+        resolve();
+      };
+
+      const intervalId = setInterval((): void => {
+        if (this.client.isReady()) {
+          cleanup();
+          resolve();
+          return;
+        }
+        elapsed += pollIntervalMs;
+        if (elapsed >= maxWaitMs) {
+          logger.warn(
+            "LeaderboardRoleService: client did not become ready in time; continuing anyway.",
+          );
+          cleanup();
+          resolve();
+        }
+      }, pollIntervalMs);
+
+      this.client.once("ready", onReady);
+    });
+  }
+
+  /**
+   * Recalculate role assignments now. Safe to call manually (e.g. from a
+   * future WebUI "Run now" button) — does not depend on the cron job state.
+   * Returns a per-tier summary of which users gained and lost each role.
+   */
+  public async runNow(): Promise<LeaderboardRoleRunSummary | null> {
+    try {
+      await this.waitForClientReady();
+
+      const enabled = await this.configService.getBoolean(
+        "leaderboard_roles.enabled",
+        false,
+      );
+      if (!enabled) {
+        logger.info("Leaderboard role rewards are disabled, skipping run.");
+        return null;
+      }
+
+      const guildId = await this.configService.getString("GUILD_ID", "");
+      if (!guildId) {
+        logger.error("GUILD_ID not configured");
+        return null;
+      }
+
+      const tiersRaw = await this.configService.getString(
+        "leaderboard_roles.tiers",
+        "",
+      );
+      const tiers = this.parseTiers(tiersRaw);
+      if (tiers.length === 0) {
+        logger.info(
+          "No leaderboard role tiers configured, skipping reconciliation.",
+        );
+        return null;
+      }
+
+      const periodRaw = await this.configService.getString(
+        "leaderboard_roles.period",
+        "alltime",
+      );
+      const period = this.normalizePeriod(periodRaw);
+
+      const guild = await this.client.guilds.fetch(guildId);
+      if (!guild) {
+        logger.error(
+          `Guild ${guildId} not found while reconciling leaderboard roles`,
+        );
+        return null;
+      }
+
+      // The widest tier (largest topN) defines how many top users we need to fetch.
+      const maxTopN = Math.max(...tiers.map((t) => t.topN));
+      const tracker = VoiceChannelTracker.getInstance(this.client);
+      const topUsers = await tracker.getTopUsers(maxTopN, period);
+      const rankedUserIds: string[] = topUsers.map((u) => u.userId);
+
+      // Ensure the member cache is populated so we can find current role holders.
+      // For very large guilds this is unavoidable; we accept the one-time fetch.
+      await guild.members.fetch();
+
+      const summary: LeaderboardRoleRunSummary = {
+        ranAt: new Date(),
+        period,
+        tiers: [],
+      };
+
+      for (const tier of tiers) {
+        const tierResult = await this.reconcileTier(guild, tier, rankedUserIds);
+        summary.tiers.push(tierResult);
+      }
+
+      await this.maybeAnnounce(guild, summary);
+
+      logger.info(
+        `Leaderboard role reconciliation complete: ${summary.tiers
+          .map(
+            (t) =>
+              `top${t.topN}(${t.roleName}) +${t.added.length}/-${t.removed.length}`,
+          )
+          .join(", ")}`,
+      );
+
+      return summary;
+    } catch (error) {
+      logger.error("Error during leaderboard role reconciliation:", error);
+      return null;
+    }
+  }
+
+  private async reconcileTier(
+    guild: Guild,
+    tier: ParsedTier,
+    rankedUserIds: string[],
+  ): Promise<LeaderboardRoleRunSummary["tiers"][number]> {
+    const role: Role | null = await guild.roles.fetch(tier.roleId);
+    if (!role) {
+      logger.warn(
+        `Leaderboard tier top${tier.topN}: role ${tier.roleId} not found in guild`,
+      );
+      return {
+        topN: tier.topN,
+        roleId: tier.roleId,
+        roleName: tier.roleId,
+        added: [],
+        removed: [],
+        skippedReason: "role-not-found",
+      };
+    }
+
+    const qualifyingIds = new Set(rankedUserIds.slice(0, tier.topN));
+    const currentHolders = new Set<string>(
+      Array.from(role.members.values()).map((m) => m.id),
+    );
+
+    const added: string[] = [];
+    const removed: string[] = [];
+
+    for (const userId of qualifyingIds) {
+      if (currentHolders.has(userId)) continue;
+      const member = await this.safeFetchMember(guild, userId);
+      if (!member) continue;
+      try {
+        await member.roles.add(role, "Leaderboard role reward (auto-assign)");
+        added.push(userId);
+      } catch (error) {
+        logger.warn(
+          `Failed to add role ${role.name} to ${member.user.tag} (${userId}):`,
+          error,
+        );
+      }
+    }
+
+    for (const userId of currentHolders) {
+      if (qualifyingIds.has(userId)) continue;
+      const member = await this.safeFetchMember(guild, userId);
+      if (!member) continue;
+      try {
+        await member.roles.remove(
+          role,
+          "Leaderboard role reward (auto-revoke)",
+        );
+        removed.push(userId);
+      } catch (error) {
+        logger.warn(
+          `Failed to remove role ${role.name} from ${member.user.tag} (${userId}):`,
+          error,
+        );
+      }
+    }
+
+    return {
+      topN: tier.topN,
+      roleId: tier.roleId,
+      roleName: role.name,
+      added,
+      removed,
+    };
+  }
+
+  private async safeFetchMember(
+    guild: Guild,
+    userId: string,
+  ): Promise<GuildMember | null> {
+    try {
+      return await guild.members.fetch(userId);
+    } catch {
+      // Member left the guild or is unreachable; not an error.
+      return null;
+    }
+  }
+
+  private async maybeAnnounce(
+    guild: Guild,
+    summary: LeaderboardRoleRunSummary,
+  ): Promise<void> {
+    const channelId = await this.configService.getString(
+      "leaderboard_roles.announcement_channel_id",
+      "",
+    );
+    if (!channelId) return;
+
+    const hasChanges = summary.tiers.some(
+      (t) => t.added.length > 0 || t.removed.length > 0,
+    );
+    if (!hasChanges) return;
+
+    try {
+      const channel = await guild.channels.fetch(channelId);
+      if (!channel || !(channel instanceof TextChannel)) {
+        logger.warn(
+          `Leaderboard announcement channel ${channelId} not found or not a text channel`,
+        );
+        return;
+      }
+
+      const embed = new EmbedBuilder()
+        .setTitle("🏆 Voice Leaderboard Roles Updated")
+        .setDescription(
+          `Period: **${summary.period}** · Recalculated <t:${Math.floor(
+            summary.ranAt.getTime() / 1000,
+          )}:R>`,
+        )
+        .setColor(0xf1c40f);
+
+      for (const tier of summary.tiers) {
+        const lines: string[] = [];
+        if (tier.added.length > 0) {
+          lines.push(`Added: ${tier.added.map((id) => `<@${id}>`).join(", ")}`);
+        }
+        if (tier.removed.length > 0) {
+          lines.push(
+            `Removed: ${tier.removed.map((id) => `<@${id}>`).join(", ")}`,
+          );
+        }
+        if (lines.length === 0) continue;
+        embed.addFields({
+          name: `Top ${tier.topN} — ${tier.roleName}`,
+          value: lines.join("\n"),
+          inline: false,
+        });
+      }
+
+      await channel.send({ embeds: [embed] });
+    } catch (error) {
+      logger.error("Failed to post leaderboard role announcement:", error);
+    }
+  }
+
+  public async start(): Promise<void> {
+    if (this.isInitialized) {
+      logger.warn(
+        "Leaderboard role service is already initialized, skipping...",
+      );
+      return;
+    }
+
+    try {
+      const enabled = await this.configService.getBoolean(
+        "leaderboard_roles.enabled",
+        false,
+      );
+
+      if (!enabled) {
+        logger.info("Leaderboard role rewards are disabled");
+        this.isInitialized = true;
+        return;
+      }
+
+      const cronExpression = await this.configService.getString(
+        "leaderboard_roles.update_cron",
+        "0 0 * * 1",
+      );
+
+      if (!this.validateCronExpression(cronExpression)) {
+        logger.error(
+          `Leaderboard role service not started: invalid cron "${cronExpression}"`,
+        );
+        this.isInitialized = true;
+        return;
+      }
+
+      this.job = new CronJob(cronExpression, async () => {
+        await this.runNow();
+      });
+      this.job.start();
+
+      const nextRun = this.job.nextDate();
+      logger.info(
+        `Leaderboard role service started (cron: "${cronExpression}", next run: ${nextRun.toLocaleString()})`,
+      );
+
+      this.isInitialized = true;
+    } catch (error) {
+      logger.error("Error starting leaderboard role service:", error);
+      throw error;
+    }
+  }
+
+  public async reload(): Promise<void> {
+    logger.info("Reloading leaderboard role service...");
+    if (this.job) {
+      this.job.stop();
+      this.job = null;
+    }
+    this.isInitialized = false;
+    await this.start();
+  }
+
+  public destroy(): void {
+    if (this.job) {
+      this.job.stop();
+      this.job = null;
+    }
+    this.isInitialized = false;
+    logger.info("Leaderboard role service destroyed");
+  }
+}


### PR DESCRIPTION
## Summary

Closes #335 — auto-assigns Discord roles to users based on their position in the voice-channel leaderboard, on a cron schedule.

Per the issue follow-up ("we don't need top3/10 etc role, we can choose what cases are used"), the tier configuration is **fully admin-driven**, not hardcoded. Admins configure any list of positions:

```
leaderboard_roles.tiers = "1:111111,3:222222,10:333333"
```

Each tier independently assigns its role to users whose rank ≤ N and revokes it from users who no longer qualify. So `1:roleA,3:roleB,10:roleC` gives the #1 user all three roles, the #2–3 users the latter two, and the #4–10 users only the third.

## Why this shape (WebUI alignment)

I checked the planned roadmap (#367, #382–#386) before implementing:

- **All business logic lives in `src/services/`.** The service exposes a public `runNow()` so the future "Run now" button in the WebUI (analogous to #383/#384) can wire to it without duplicating logic.
- **Config surfaces automatically.** The new keys live in `defaultConfig` + `settingsMetadata`, so the existing read-only WebUI Settings page picks them up with no extra work. When #382 ships the write surface, these will be editable from the browser for free.
- **No new admin slash command.** All admin slash commands are being deleted in #386. Adding one would be net-negative work.
- **No setup-wizard hook.** The legacy wizard is being replaced by a web page in #382.

## Configuration keys

| Key | Default | Description |
| --- | --- | --- |
| `leaderboard_roles.enabled` | `false` | Feature switch |
| `leaderboard_roles.period` | `alltime` | `week` / `month` / `alltime` |
| `leaderboard_roles.update_cron` | `0 0 * * 1` | Cron schedule (default: Mondays 00:00) |
| `leaderboard_roles.tiers` | `""` | Comma-separated `topN:roleId` pairs |
| `leaderboard_roles.announcement_channel_id` | `""` | Optional channel for role-change announcements |

Invalid tier entries (non-numeric `topN`, non-snowflake role ID, malformed `topN:roleId` syntax) are logged and skipped, not fatal.

## Other changes

- Added `"leaderboard_roles"` to the Mongo `Config` model's category enum.
- Fixed a pre-existing omission: `"polls"` was missing from that same enum, even though `polls.*` settings exist and the test allowlist already had it. Any future `polls.*` write would have failed Mongoose validation. Folded the fix in here so the enum stays a single source of truth.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — zero new warnings on new files, zero errors overall
- [x] `npm run format:check` — clean
- [x] `npm test` — 803 passed, 0 failed (added 9 new tests for the service)
- [ ] Manual smoke once deployed to a guild: set `leaderboard_roles.tiers="1:<roleId>"`, set a short cron (e.g. `*/2 * * * *`), confirm the role is added/revoked as expected
- [ ] Manual smoke with `leaderboard_roles.announcement_channel_id` set: confirm the embed posts only when there's an actual diff

https://claude.ai/code/session_018JDhAEPBqMy2NsnCKj8ynM

---
_Generated by [Claude Code](https://claude.ai/code/session_018JDhAEPBqMy2NsnCKj8ynM)_