### PR TITLE
feat(webui): writes for reaction roles, notices, dbtrunk, voice channels (#384)

### DIFF
--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -273,7 +273,7 @@ describe("renderReactionRolesPage", () => {
     expect(html).toContain("No archived mappings");
   });
 
-  it("renders an active row with category/channel resolution", () => {
+  it("renders an active row with category/channel resolution and write controls", () => {
     const html = renderReactionRolesPage({
       ...COMMON,
       enabled: true,
@@ -296,8 +296,39 @@ describe("renderReactionRolesPage", () => {
     expect(html).toContain("Gamer");
     expect(html).toContain("#roles");
     expect(html).toContain('class="tag tag-on">active');
+    expect(html).toContain("/admin/reaction-roles/create");
+    expect(html).toContain("/admin/reaction-roles/archive");
+    expect(html).toContain("/admin/reaction-roles/delete");
+  });
+
+  it("renders unarchive control for archived rows", () => {
+    const html = renderReactionRolesPage({
+      ...COMMON,
+      enabled: true,
+      configChannel: { name: "roles", id: "c1" },
+      active: [],
+      archived: [
+        {
+          emoji: "📦",
+          roleName: "Old",
+          roleId: "r2",
+          categoryName: "Roles",
+          channelName: "old",
+          messageId: "m2",
+          isArchived: true,
+          archivedAt: "2026-05-08T00:00:00.000Z",
+        },
+      ],
+    });
+    expect(html).toContain("/admin/reaction-roles/unarchive");
+    expect(html).toContain("/admin/reaction-roles/delete");
   });
 });
+
+const NOTICE_CATEGORY_OPTIONS = [
+  { value: "general", label: "📋 General" },
+  { value: "rules", label: "📜 Rules" },
+];
 
 describe("renderNoticesPage", () => {
   it("renders the empty state when no notices exist", () => {
@@ -308,11 +339,13 @@ describe("renderNoticesPage", () => {
       headerEnabled: false,
       total: 0,
       groups: [],
+      categoryOptions: NOTICE_CATEGORY_OPTIONS,
     });
     expect(html).toContain("No notices stored");
+    expect(html).toContain("Create a notice");
   });
 
-  it("groups by category and escapes content", () => {
+  it("groups by category, exposes per-row edit/delete, and escapes content", () => {
     const html = renderNoticesPage({
       ...COMMON,
       enabled: true,
@@ -324,19 +357,27 @@ describe("renderNoticesPage", () => {
           category: "rules",
           rows: [
             {
+              id: "n1",
               order: 1,
               title: "Be nice",
+              content: "<3 everyone",
               preview: "<3 everyone",
+              category: "rules",
               messageId: "m1",
               updatedAt: "2026-05-08T00:00:00.000Z",
             },
           ],
         },
       ],
+      categoryOptions: NOTICE_CATEGORY_OPTIONS,
     });
     expect(html).toContain("rules");
     expect(html).toContain("Be nice");
     expect(html).toContain("&lt;3 everyone");
+    expect(html).toContain("/admin/notices/n1/update");
+    expect(html).toContain("/admin/notices/n1/delete");
+    expect(html).toContain("/admin/notices/n1/order");
+    expect(html).toContain("/admin/notices/sync");
   });
 });
 
@@ -360,14 +401,20 @@ describe("renderDatabasePage", () => {
         monthlyMonths: 6,
         yearlyYears: 1,
       },
+      trunkHistory: [],
       collections: [],
     });
     expect(html).toContain("connected");
     expect(html).toContain("No collection statistics");
     expect(html).toContain("30 days");
+    expect(html).toContain("No prior cleanup runs recorded");
+    // Disabled feature → cleanup button is rendered but disabled.
+    expect(html).toMatch(
+      /<button[^>]*type="submit"[^>]*disabled[^>]*>Run cleanup now<\/button>/,
+    );
   });
 
-  it("lists collections with counts when present", () => {
+  it("lists collections with counts and history when present", () => {
     const html = renderDatabasePage({
       ...COMMON,
       connection: { state: "connected", name: "koolbot", host: "mongodb" },
@@ -382,11 +429,25 @@ describe("renderDatabasePage", () => {
         monthlyMonths: 6,
         yearlyYears: 1,
       },
+      trunkHistory: [
+        {
+          ranAt: "2026-05-08T00:00:00.000Z",
+          sessionsRemoved: 17,
+          dataAggregated: 4,
+          executionMs: 1234,
+          errors: 0,
+          result: "success",
+          errorMessage: null,
+        },
+      ],
       collections: [{ name: "configs", count: 42 }],
     });
     expect(html).toContain("configs");
     expect(html).toContain("42");
     expect(html).toContain("0 0 * * *");
+    expect(html).toContain("/admin/database/run-cleanup");
+    expect(html).toContain("17");
+    expect(html).toContain("1234ms");
   });
 });
 
@@ -408,7 +469,7 @@ describe("renderVoiceChannelsPage", () => {
     expect(html).toContain("Voice channel category not found");
   });
 
-  it("renders managed channels with lobby/dynamic/live tags", () => {
+  it("renders managed channels with lobby/dynamic/live tags and cleanup actions", () => {
     const html = renderVoiceChannelsPage({
       ...COMMON,
       enabled: true,
@@ -443,5 +504,29 @@ describe("renderVoiceChannelsPage", () => {
     expect(html).toContain('class="tag tag-warn">dynamic');
     expect(html).toContain('class="tag tag-warn">LIVE');
     expect(html).toContain("Friday night");
+    expect(html).toContain("/admin/voice-channels/reload");
+    expect(html).toContain("/admin/voice-channels/force-reload");
+  });
+
+  it("disables cleanup actions when the feature is off or the category is missing", () => {
+    const html = renderVoiceChannelsPage({
+      ...COMMON,
+      enabled: false,
+      controlPanelEnabled: true,
+      categoryName: "Voice",
+      lobbyName: "Lobby",
+      offlineLobbyName: "Offline Lobby",
+      prefix: "🎮",
+      totalManaged: 0,
+      totalEmpty: 0,
+      channels: [],
+      categoryFound: false,
+    });
+    expect(html).toMatch(
+      /<button[^>]*type="submit"[^>]*disabled[^>]*>Clean up empty channels<\/button>/,
+    );
+    expect(html).toMatch(
+      /<button[^>]*type="submit"[^>]*disabled[^>]*>Force cleanup/,
+    );
   });
 });

--- a/src/services/voice-channel-truncation.ts
+++ b/src/services/voice-channel-truncation.ts
@@ -12,6 +12,12 @@ export interface ICleanupStats {
   executionTime: number;
   errors: string[];
   timestamp: Date;
+  /**
+   * `true` when the run returned early because the 24h minimum interval
+   * hadn't elapsed since the previous cleanup. Lets callers distinguish a
+   * deliberate no-op from a genuine failure without parsing `errors[0]`.
+   */
+  skipped?: boolean;
 }
 
 export interface IRetentionConfig {
@@ -292,6 +298,7 @@ export class VoiceChannelTruncationService {
             executionTime: Date.now() - startTime,
             errors: ["Cleanup skipped: minimum interval not met"],
             timestamp: new Date(),
+            skipped: true,
           };
         }
       }

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -103,6 +103,11 @@ const STYLE = [
   ".helper{background:#0f1115;border:1px solid #2d3748;border-radius:6px;padding:.4rem .6rem;font-size:.85rem}",
   ".helper summary{cursor:pointer;color:#cbd5e1;font-weight:600}",
   ".helper ul{margin:.4rem 0;padding-left:1.2rem}",
+  "form.inline-order{display:flex;gap:.25rem;align-items:center;margin:0}",
+  "form.inline-order input[type=number]{width:5rem;background:#0f1115;color:#e4e6eb;border:1px solid #2d3748;border-radius:6px;padding:.25rem .4rem;font:inherit;font-size:.85rem}",
+  ".edit-details{flex:0 0 100%;margin-bottom:.35rem}",
+  ".edit-details form.stack{margin-top:.5rem}",
+  "button[disabled]{opacity:.5;cursor:not-allowed}",
 ].join("");
 
 const SCRIPT =

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -15,6 +15,31 @@ export function escapeHtml(value: unknown): string {
     .replace(/'/g, "&#39;");
 }
 
+/**
+ * Escape a value for safe interpolation into a single-quoted JavaScript
+ * string inside an HTML attribute (e.g. `onsubmit="return confirm('...')"`).
+ *
+ * `escapeHtml` is not enough: HTML entities are decoded back to characters
+ * before the JS engine sees them, so a `'` in the input would terminate the
+ * JS string and let surrounding markup leak into the script context. Strip
+ * the dangerous characters here, then HTML-escape the result so the
+ * attribute itself is also safe.
+ */
+export function escapeJsInAttr(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  const jsSafe = String(value)
+    .replace(/\\/g, "\\\\")
+    .replace(/'/g, "\\'")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029")
+    // Break any </script> sequence so the string can't escape its tag context.
+    .replace(/<\/(script)/gi, "<\\/$1");
+  return escapeHtml(jsSafe);
+}
+
 interface NavItem {
   href: string;
   label: string;

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -4,7 +4,7 @@
  * without a Discord client or MongoDB.
  */
 
-import { escapeHtml, renderAdminPage } from "./admin-layout.js";
+import { escapeHtml, escapeJsInAttr, renderAdminPage } from "./admin-layout.js";
 
 interface CommonProps {
   csrfToken: string;
@@ -654,11 +654,12 @@ export interface ReactionRolesProps extends CommonProps {
 
 function reactionRoleRow(rr: ReactionRoleRow, csrfInput: string): string {
   const escapedName = escapeHtml(rr.roleName);
+  const jsName = escapeJsInAttr(rr.roleName);
   const actions = rr.isArchived
     ? `<form method="POST" action="/admin/reaction-roles/unarchive">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn">Unarchive</button></form>
-  <form method="POST" action="/admin/reaction-roles/delete" onsubmit="return confirm('Permanently delete reaction role ${escapedName}? This removes the Discord role, category, and channel.');">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn btn-danger">Delete</button></form>`
-    : `<form method="POST" action="/admin/reaction-roles/archive" onsubmit="return confirm('Archive reaction role ${escapedName}? The reaction message will be removed but the role/channels are preserved.');">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn">Archive</button></form>
-  <form method="POST" action="/admin/reaction-roles/delete" onsubmit="return confirm('Permanently delete reaction role ${escapedName}? This removes the Discord role, category, and channel.');">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn btn-danger">Delete</button></form>`;
+  <form method="POST" action="/admin/reaction-roles/delete" onsubmit="return confirm('Permanently delete reaction role ${jsName}? This removes the Discord role, category, and channel.');">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn btn-danger">Delete</button></form>`
+    : `<form method="POST" action="/admin/reaction-roles/archive" onsubmit="return confirm('Archive reaction role ${jsName}? The reaction message will be removed but the role/channels are preserved.');">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn">Archive</button></form>
+  <form method="POST" action="/admin/reaction-roles/delete" onsubmit="return confirm('Permanently delete reaction role ${jsName}? This removes the Discord role, category, and channel.');">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn btn-danger">Delete</button></form>`;
 
   return `<tr>
 <td class="mono">${escapeHtml(rr.emoji)}</td>
@@ -802,7 +803,7 @@ export function renderNoticesPage(props: NoticesProps): string {
       <button type="submit" class="btn btn-primary">Save changes</button>
     </form>
   </details>
-  <form method="POST" action="/admin/notices/${escapeHtml(n.id)}/delete" onsubmit="return confirm('Delete notice &quot;${escapeHtml(n.title)}&quot;?');">${csrfInput}<button type="submit" class="btn btn-danger">Delete</button></form>
+  <form method="POST" action="/admin/notices/${escapeHtml(n.id)}/delete" onsubmit="return confirm('Delete notice \\'${escapeJsInAttr(n.title)}\\'?');">${csrfInput}<button type="submit" class="btn btn-danger">Delete</button></form>
 </td>
 </tr>`,
               )

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -649,30 +649,45 @@ export interface ReactionRolesProps extends CommonProps {
   configChannel: { name: string; id: string } | null;
   active: ReactionRoleRow[];
   archived: ReactionRoleRow[];
+  flash?: FlashMessage | null;
 }
 
-function reactionRoleRow(rr: ReactionRoleRow): string {
+function reactionRoleRow(rr: ReactionRoleRow, csrfInput: string): string {
+  const escapedName = escapeHtml(rr.roleName);
+  const actions = rr.isArchived
+    ? `<form method="POST" action="/admin/reaction-roles/unarchive">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn">Unarchive</button></form>
+  <form method="POST" action="/admin/reaction-roles/delete" onsubmit="return confirm('Permanently delete reaction role ${escapedName}? This removes the Discord role, category, and channel.');">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn btn-danger">Delete</button></form>`
+    : `<form method="POST" action="/admin/reaction-roles/archive" onsubmit="return confirm('Archive reaction role ${escapedName}? The reaction message will be removed but the role/channels are preserved.');">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn">Archive</button></form>
+  <form method="POST" action="/admin/reaction-roles/delete" onsubmit="return confirm('Permanently delete reaction role ${escapedName}? This removes the Discord role, category, and channel.');">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn btn-danger">Delete</button></form>`;
+
   return `<tr>
 <td class="mono">${escapeHtml(rr.emoji)}</td>
-<td>${escapeHtml(rr.roleName)} <span class="muted mono">${escapeHtml(rr.roleId)}</span></td>
+<td>${escapedName} <span class="muted mono">${escapeHtml(rr.roleId)}</span></td>
 <td>${escapeHtml(rr.categoryName)}</td>
 <td>#${escapeHtml(rr.channelName)}</td>
 <td class="mono">${escapeHtml(rr.messageId)}</td>
 <td><span class="tag ${rr.isArchived ? "tag-off" : "tag-on"}">${rr.isArchived ? "archived" : "active"}</span></td>
 <td class="muted">${escapeHtml(rr.archivedAt ?? "")}</td>
+<td class="actions">${actions}</td>
 </tr>`;
 }
 
 export function renderReactionRolesPage(props: ReactionRolesProps): string {
-  const activeRows = props.active.map(reactionRoleRow).join("");
-  const archivedRows = props.archived.map(reactionRoleRow).join("");
+  const csrfInput = `<input type="hidden" name="_csrf" value="${escapeHtml(props.csrfToken)}">`;
+  const activeRows = props.active
+    .map((rr) => reactionRoleRow(rr, csrfInput))
+    .join("");
+  const archivedRows = props.archived
+    .map((rr) => reactionRoleRow(rr, csrfInput))
+    .join("");
   const channelLine = props.configChannel
     ? `<dt>Message channel</dt><dd>#${escapeHtml(props.configChannel.name)} <span class="muted mono">${escapeHtml(props.configChannel.id)}</span></dd>`
-    : `<dt>Message channel</dt><dd class="muted">unset</dd>`;
+    : `<dt>Message channel</dt><dd class="muted">unset — set <code>reactionroles.message_channel_id</code> before creating reaction roles.</dd>`;
 
   const body = `
 <h1>Reaction Roles</h1>
-<p class="subtitle">Per-message reaction-role mappings stored in <code>reaction_role_configs</code>. Read-only.</p>
+<p class="subtitle">Per-message reaction-role mappings. Replaces <code>/reactrole create|archive|unarchive|delete|list|status</code>; the slash commands still work in parallel during migration.</p>
+${renderFlash(props.flash)}
 <div class="card">
   <h2>Status</h2>
   <dl class="kv">
@@ -687,15 +702,29 @@ export function renderReactionRolesPage(props: ReactionRolesProps): string {
   ${
     props.active.length === 0
       ? `<div class="empty">No active reaction-role mappings.</div>`
-      : `<table><thead><tr><th>Emoji</th><th>Role</th><th>Category</th><th>Channel</th><th>Message ID</th><th>Status</th><th>Archived</th></tr></thead><tbody>${activeRows}</tbody></table>`
+      : `<table><thead><tr><th>Emoji</th><th>Role</th><th>Category</th><th>Channel</th><th>Message ID</th><th>Status</th><th>Archived</th><th>Actions</th></tr></thead><tbody>${activeRows}</tbody></table>`
   }
+</div>
+<div class="card">
+  <h2>Create a reaction role</h2>
+  <p class="muted">Creates a Discord role + category + text channel, posts a reaction-role message to the configured channel, and adds the reaction. The new channel preview is <code>${escapeHtml(props.configChannel?.name ?? "(unset)")}</code>.</p>
+  <form method="POST" action="/admin/reaction-roles/create" class="stack">
+    ${csrfInput}
+    <label>Role name
+      <input type="text" name="name" required maxlength="100" placeholder="Gamer">
+    </label>
+    <label>Emoji (Unicode or <code>&lt;:name:id&gt;</code>)
+      <input type="text" name="emoji" required maxlength="100" placeholder="🎮">
+    </label>
+    <button type="submit" class="btn btn-primary">Create reaction role</button>
+  </form>
 </div>
 <div class="card">
   <h2>Archived (last 50)</h2>
   ${
     props.archived.length === 0
       ? `<div class="empty">No archived mappings.</div>`
-      : `<table><thead><tr><th>Emoji</th><th>Role</th><th>Category</th><th>Channel</th><th>Message ID</th><th>Status</th><th>Archived</th></tr></thead><tbody>${archivedRows}</tbody></table>`
+      : `<table><thead><tr><th>Emoji</th><th>Role</th><th>Category</th><th>Channel</th><th>Message ID</th><th>Status</th><th>Archived</th><th>Actions</th></tr></thead><tbody>${archivedRows}</tbody></table>`
   }
 </div>
 `;
@@ -711,11 +740,19 @@ export function renderReactionRolesPage(props: ReactionRolesProps): string {
 // ---------- Notices ----------
 
 export interface NoticeRow {
+  id: string;
   order: number;
   title: string;
+  content: string;
   preview: string;
+  category: string;
   messageId: string;
   updatedAt: string;
+}
+
+export interface NoticeCategoryOption {
+  value: string;
+  label: string;
 }
 
 export interface NoticesProps extends CommonProps {
@@ -724,9 +761,24 @@ export interface NoticesProps extends CommonProps {
   headerEnabled: boolean;
   total: number;
   groups: Array<{ category: string; rows: NoticeRow[] }>;
+  categoryOptions: NoticeCategoryOption[];
+  flash?: FlashMessage | null;
+}
+
+function noticeCategoryOptionsHtml(
+  options: NoticeCategoryOption[],
+  selected?: string,
+): string {
+  return options
+    .map(
+      (o) =>
+        `<option value="${escapeHtml(o.value)}"${o.value === selected ? " selected" : ""}>${escapeHtml(o.label)}</option>`,
+    )
+    .join("");
 }
 
 export function renderNoticesPage(props: NoticesProps): string {
+  const csrfInput = `<input type="hidden" name="_csrf" value="${escapeHtml(props.csrfToken)}">`;
   const groupSections =
     props.groups.length === 0
       ? `<div class="empty">No notices stored.</div>`
@@ -735,24 +787,37 @@ export function renderNoticesPage(props: NoticesProps): string {
             const rows = g.rows
               .map(
                 (n) => `<tr>
-<td>${n.order}</td>
-<td>${escapeHtml(n.title)}</td>
+<td><form method="POST" action="/admin/notices/${escapeHtml(n.id)}/order" class="inline-order">${csrfInput}<input type="number" name="order" value="${n.order}" min="-1000" max="10000" required><button type="submit" class="btn">Save</button></form></td>
+<td>${escapeHtml(n.title)}<div class="muted mono">id: ${escapeHtml(n.id)}</div></td>
 <td class="muted">${escapeHtml(n.preview)}</td>
 <td class="mono muted">${escapeHtml(n.messageId)}</td>
 <td class="muted">${escapeHtml(n.updatedAt)}</td>
+<td class="actions">
+  <details class="helper edit-details"><summary>Edit</summary>
+    <form method="POST" action="/admin/notices/${escapeHtml(n.id)}/update" class="stack">${csrfInput}
+      <label>Title<input type="text" name="title" maxlength="256" value="${escapeHtml(n.title)}" required></label>
+      <label>Content<textarea name="content" rows="6" maxlength="4000" required>${escapeHtml(n.content)}</textarea></label>
+      <label>Category<select name="category">${noticeCategoryOptionsHtml(props.categoryOptions, n.category)}</select></label>
+      <label>Order<input type="number" name="order" min="-1000" max="10000" value="${n.order}" required></label>
+      <button type="submit" class="btn btn-primary">Save changes</button>
+    </form>
+  </details>
+  <form method="POST" action="/admin/notices/${escapeHtml(n.id)}/delete" onsubmit="return confirm('Delete notice &quot;${escapeHtml(n.title)}&quot;?');">${csrfInput}<button type="submit" class="btn btn-danger">Delete</button></form>
+</td>
 </tr>`,
               )
               .join("");
             return `<div class="card">
   <h2>${escapeHtml(g.category)} <span class="muted">(${g.rows.length})</span></h2>
-  <table><thead><tr><th>#</th><th>Title</th><th>Content</th><th>Message ID</th><th>Updated</th></tr></thead><tbody>${rows}</tbody></table>
+  <table><thead><tr><th>Order</th><th>Title</th><th>Content</th><th>Message ID</th><th>Updated</th><th>Actions</th></tr></thead><tbody>${rows}</tbody></table>
 </div>`;
           })
           .join("");
 
   const body = `
 <h1>Notices</h1>
-<p class="subtitle">Notice posts grouped by category. Read-only.</p>
+<p class="subtitle">Notice posts grouped by category. Replaces <code>/notice add|edit|delete|sync</code>; the slash commands still work in parallel during migration. Edit the inline <em>Order</em> field to reorder within a category (lower numbers post first).</p>
+${renderFlash(props.flash)}
 <div class="card">
   <h2>Status</h2>
   <dl class="kv">
@@ -761,6 +826,22 @@ export function renderNoticesPage(props: NoticesProps): string {
     <dt>Header post</dt><dd>${tagOnOff(props.headerEnabled, "enabled", "disabled")}</dd>
     <dt>Total notices</dt><dd>${props.total}</dd>
   </dl>
+  <form method="POST" action="/admin/notices/sync" class="inline-form" onsubmit="return confirm('Resync all notices? This deletes and reposts every notice message.');">
+    ${csrfInput}
+    <button type="submit" class="btn btn-primary">Resync notices to channel</button>
+    <span class="muted">Same effect as <code>/notice sync</code>.</span>
+  </form>
+</div>
+<div class="card">
+  <h2>Create a notice</h2>
+  <form method="POST" action="/admin/notices/create" class="stack">
+    ${csrfInput}
+    <label>Title<input type="text" name="title" maxlength="256" required></label>
+    <label>Content<textarea name="content" rows="5" maxlength="4000" required></textarea></label>
+    <label>Category<select name="category" required>${noticeCategoryOptionsHtml(props.categoryOptions)}</select></label>
+    <label>Order (lower posts first)<input type="number" name="order" min="-1000" max="10000" value="0" required></label>
+    <button type="submit" class="btn btn-primary">Create notice</button>
+  </form>
 </div>
 ${groupSections}
 `;
@@ -774,6 +855,16 @@ ${groupSections}
 }
 
 // ---------- Database ----------
+
+export interface DbTrunkHistoryRow {
+  ranAt: string;
+  sessionsRemoved: number;
+  dataAggregated: number;
+  executionMs: number;
+  errors: number;
+  result: "success" | "failure";
+  errorMessage: string | null;
+}
 
 export interface DatabaseProps extends CommonProps {
   connection: {
@@ -792,18 +883,45 @@ export interface DatabaseProps extends CommonProps {
     monthlyMonths: number;
     yearlyYears: number;
   };
+  trunkHistory: DbTrunkHistoryRow[];
   collections: Array<{ name: string; count: number }>;
+  flash?: FlashMessage | null;
 }
 
 export function renderDatabasePage(props: DatabaseProps): string {
+  const csrfInput = `<input type="hidden" name="_csrf" value="${escapeHtml(props.csrfToken)}">`;
   const collectionsHtml =
     props.collections.length === 0
       ? `<div class="empty">No collection statistics available.</div>`
       : `<table><thead><tr><th>Collection</th><th>Documents (est.)</th></tr></thead><tbody>${props.collections.map((c) => `<tr><td class="mono">${escapeHtml(c.name)}</td><td>${c.count}</td></tr>`).join("")}</tbody></table>`;
 
+  const historyHtml =
+    props.trunkHistory.length === 0
+      ? `<div class="empty">No prior cleanup runs recorded.</div>`
+      : `<table><thead><tr><th>When</th><th>Result</th><th>Sessions removed</th><th>Users processed</th><th>Time</th><th>Errors</th></tr></thead><tbody>${props.trunkHistory
+          .map(
+            (h) => `<tr>
+<td class="muted">${escapeHtml(h.ranAt)}</td>
+<td>${h.result === "success" ? '<span class="tag tag-on">ok</span>' : '<span class="tag tag-off">failed</span>'}</td>
+<td>${h.sessionsRemoved}</td>
+<td>${h.dataAggregated}</td>
+<td class="muted">${h.executionMs}ms</td>
+<td class="muted">${h.errors === 0 ? "—" : `${h.errors}${h.errorMessage ? `: ${escapeHtml(h.errorMessage.slice(0, 80))}` : ""}`}</td>
+</tr>`,
+          )
+          .join("")}</tbody></table>`;
+
+  const runDisabled = props.trunk.isRunning || !props.trunk.enabled;
+  const runHint = !props.trunk.enabled
+    ? "Enable <code>voicetracking.cleanup.enabled</code> first."
+    : props.trunk.isRunning
+      ? "A cleanup is already running."
+      : "Same effect as <code>/dbtrunk run</code>. Subject to the 24-hour minimum interval.";
+
   const body = `
 <h1>Database</h1>
-<p class="subtitle">MongoDB connection state and the voice-channel <code>dbtrunk</code> cleanup status. Read-only.</p>
+<p class="subtitle">MongoDB connection state and the voice-channel <code>dbtrunk</code> cleanup. Replaces <code>/dbtrunk status|run</code>; the slash commands still work in parallel during migration.</p>
+${renderFlash(props.flash)}
 <div class="card">
   <h2>Connection</h2>
   <dl class="kv">
@@ -825,6 +943,15 @@ export function renderDatabasePage(props: DatabaseProps): string {
     <dt>Monthly summaries retention</dt><dd>${props.trunk.monthlyMonths} months</dd>
     <dt>Yearly summaries retention</dt><dd>${props.trunk.yearlyYears} years</dd>
   </dl>
+  <form method="POST" action="/admin/database/run-cleanup" class="inline-form" onsubmit="return confirm('Run voice-channel data cleanup now?');">
+    ${csrfInput}
+    <button type="submit" class="btn btn-primary"${runDisabled ? " disabled" : ""}>Run cleanup now</button>
+    <span class="muted">${runHint}</span>
+  </form>
+</div>
+<div class="card">
+  <h2>Last 10 cleanup runs</h2>
+  ${historyHtml}
 </div>
 <div class="card"><h2>Collections</h2>${collectionsHtml}</div>
 `;
@@ -859,9 +986,11 @@ export interface VoiceChannelsProps extends CommonProps {
   totalEmpty: number;
   channels: VoiceChannelRow[];
   categoryFound: boolean;
+  flash?: FlashMessage | null;
 }
 
 export function renderVoiceChannelsPage(props: VoiceChannelsProps): string {
+  const csrfInput = `<input type="hidden" name="_csrf" value="${escapeHtml(props.csrfToken)}">`;
   const rows = props.channels
     .map((ch) => {
       const tag = ch.isLobby
@@ -884,9 +1013,17 @@ export function renderVoiceChannelsPage(props: VoiceChannelsProps): string {
       ? `<div class="empty">Category exists but contains no voice channels.</div>`
       : `<table><thead><tr><th>Name</th><th>Type</th><th>Users</th><th>Custom name</th><th>Channel ID</th></tr></thead><tbody>${rows}</tbody></table>`;
 
+  const reloadDisabled = !props.enabled || !props.categoryFound;
+  const reloadHint = !props.enabled
+    ? "Enable <code>voicechannels.enabled</code> first."
+    : !props.categoryFound
+      ? "Category not found in this guild."
+      : "";
+
   const body = `
 <h1>Voice Channels</h1>
-<p class="subtitle">Voice-channel category contents and live state. Read-only.</p>
+<p class="subtitle">Voice-channel category contents and live state. Replaces <code>/vc reload|force-reload</code>; the slash commands still work in parallel during migration.</p>
+${renderFlash(props.flash)}
 <div class="card">
   <h2>Status</h2>
   <dl class="kv">
@@ -899,6 +1036,20 @@ export function renderVoiceChannelsPage(props: VoiceChannelsProps): string {
     <dt>Total in category</dt><dd>${props.totalManaged}</dd>
     <dt>Empty channels</dt><dd>${props.totalEmpty}</dd>
   </dl>
+</div>
+<div class="card">
+  <h2>Cleanup actions</h2>
+  <form method="POST" action="/admin/voice-channels/reload" class="inline-form" onsubmit="return confirm('Clean up empty dynamic voice channels now?');">
+    ${csrfInput}
+    <button type="submit" class="btn btn-primary"${reloadDisabled ? " disabled" : ""}>Clean up empty channels</button>
+    <span class="muted">Same effect as <code>/vc reload</code>.</span>
+  </form>
+  <form method="POST" action="/admin/voice-channels/force-reload" class="inline-form" onsubmit="return confirm('Force cleanup of ALL unmanaged channels in the category and re-create lobby channels?');">
+    ${csrfInput}
+    <button type="submit" class="btn btn-danger"${reloadDisabled ? " disabled" : ""}>Force cleanup &amp; ensure lobby</button>
+    <span class="muted">Same effect as <code>/vc force-reload</code>.</span>
+  </form>
+  ${reloadHint ? `<p class="muted">${reloadHint}</p>` : ""}
 </div>
 <div class="card"><h2>Channels</h2>${channelsHtml}</div>
 `;

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -31,8 +31,10 @@ import { PollItem } from "../models/poll-item.js";
 import { ReactionRoleService } from "../services/reaction-role-service.js";
 import { ReactionRoleConfig } from "../models/reaction-role-config.js";
 import Notice from "../models/notice.js";
+import { NOTICE_CATEGORIES } from "../content/notice-categories.js";
 import { VoiceChannelTruncationService } from "../services/voice-channel-truncation.js";
 import { VoiceChannelManager } from "../services/voice-channel-manager.js";
+import { WebAuditLog } from "../models/web-audit-log.js";
 import type { AuthenticatedRequest } from "./session.js";
 import { getDisplayedRemainingMs } from "./admin-layout.js";
 import {
@@ -47,7 +49,9 @@ import {
   renderSettingsPage,
   renderVoiceChannelsPage,
   type ChannelOption,
+  type DbTrunkHistoryRow,
   type FlashMessage,
+  type NoticeCategoryOption,
   type ReactionRoleRow,
   type RoleOption,
   type SettingRow,
@@ -579,6 +583,7 @@ export function createReadOnlyRouter(
             : null,
           active: active.map(shape),
           archived: archived.map(shape),
+          flash: readFlash(req),
         }),
       );
     }),
@@ -609,13 +614,23 @@ export function createReadOnlyRouter(
       const groups = Array.from(grouped.entries()).map(([category, list]) => ({
         category,
         rows: list.map((n) => ({
+          id: String(n._id),
           order: n.order,
           title: n.title,
+          content: n.content,
           preview:
             n.content.length > 120 ? `${n.content.slice(0, 120)}…` : n.content,
+          category: n.category,
           messageId: n.messageId ?? "",
           updatedAt: new Date(n.updatedAt).toISOString(),
         })),
+      }));
+
+      const categoryOptions: NoticeCategoryOption[] = Object.entries(
+        NOTICE_CATEGORIES,
+      ).map(([value, info]) => ({
+        value,
+        label: `${info.emoji} ${info.label}`,
       }));
 
       res.type("text/html").send(
@@ -628,6 +643,8 @@ export function createReadOnlyRouter(
           headerEnabled,
           total: notices.length,
           groups,
+          categoryOptions,
+          flash: readFlash(req),
         }),
       );
     }),
@@ -695,6 +712,36 @@ export function createReadOnlyRouter(
           mongoose.connection.readyState
         ] ?? "unknown";
 
+      const historyDocs = await WebAuditLog.find({
+        guildId: common.guildId,
+        action: "dbtrunk.run",
+      })
+        .sort({ createdAt: -1 })
+        .limit(10)
+        .lean()
+        .catch(() => [] as Array<Record<string, unknown>>);
+
+      const trunkHistory: DbTrunkHistoryRow[] = historyDocs.map((h) => {
+        const details = (h.details ?? {}) as {
+          sessionsRemoved?: number;
+          dataAggregated?: number;
+          executionTime?: number;
+          errors?: number;
+        };
+        return {
+          ranAt:
+            h.createdAt instanceof Date
+              ? h.createdAt.toISOString()
+              : String(h.createdAt ?? ""),
+          sessionsRemoved: details.sessionsRemoved ?? 0,
+          dataAggregated: details.dataAggregated ?? 0,
+          executionMs: details.executionTime ?? 0,
+          errors: details.errors ?? 0,
+          result: (h.result as "success" | "failure") ?? "success",
+          errorMessage: (h.errorMessage as string | null) ?? null,
+        };
+      });
+
       res.type("text/html").send(
         renderDatabasePage({
           ...common,
@@ -723,7 +770,9 @@ export function createReadOnlyRouter(
             monthlyMonths,
             yearlyYears,
           },
+          trunkHistory,
           collections,
+          flash: readFlash(req),
         }),
       );
     }),
@@ -811,6 +860,7 @@ export function createReadOnlyRouter(
           totalEmpty,
           channels,
           categoryFound,
+          flash: readFlash(req),
         }),
       );
     }),

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -1,10 +1,9 @@
 /**
- * State-changing route handlers for the WebUI (issue #383). Mounted onto
- * the WebUI router behind `requireSession` and `requireCsrf`. Every
- * handler is a thin wrapper around `ScheduledAnnouncementService`,
- * `PollService`, or `VoiceChannelAnnouncer` — there is no business
- * logic here. Each write records exactly one audit entry via
- * `recordAudit()`.
+ * State-changing route handlers for the WebUI (issues #383 and #384).
+ * Mounted onto the WebUI router behind `requireSession` and
+ * `requireCsrf`. Every handler is a thin wrapper around an existing
+ * service — there is no business logic here. Each write records exactly
+ * one audit entry via `recordAudit()`.
  */
 
 import {
@@ -19,9 +18,16 @@ import logger from "../utils/logger.js";
 import { ScheduledAnnouncementService } from "../services/scheduled-announcement-service.js";
 import { PollService } from "../services/poll-service.js";
 import { VoiceChannelAnnouncer } from "../services/voice-channel-announcer.js";
+import { ReactionRoleService } from "../services/reaction-role-service.js";
+import { NoticesChannelManager } from "../services/notices-channel-manager.js";
+import { VoiceChannelTruncationService } from "../services/voice-channel-truncation.js";
+import { VoiceChannelManager } from "../services/voice-channel-manager.js";
+import { ConfigService } from "../services/config-service.js";
 import type { IScheduledAnnouncement } from "../models/scheduled-announcement.js";
 import type { IPollSchedule } from "../models/poll-schedule.js";
 import type { IPollItem } from "../models/poll-item.js";
+import Notice from "../models/notice.js";
+import { NOTICE_CATEGORIES } from "../content/notice-categories.js";
 import { requireCsrf } from "./csrf.js";
 import type { AuthenticatedRequest } from "./session.js";
 import { recordAudit } from "./audit.js";
@@ -53,6 +59,12 @@ function getString(req: AuthenticatedRequest, name: string): string {
 function getCheckbox(req: AuthenticatedRequest, name: string): boolean {
   const raw = (req.body as Record<string, unknown> | undefined)?.[name];
   return typeof raw === "string" && raw.length > 0;
+}
+
+function parseIntInRange(raw: string, min: number, max: number): number | null {
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < min || n > max) return null;
+  return n;
 }
 
 /**
@@ -739,6 +751,685 @@ export function createWriteRouter(
         flashRedirect(res, "/admin/polls", {
           type: "err",
           text: `Import failed: ${text}`,
+        });
+      }
+    }),
+  );
+
+  // ============================================================
+  // Reaction Roles (issue #384)
+  // ============================================================
+
+  router.post(
+    "/reaction-roles/create",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const name = getString(req, "name");
+      const emoji = getString(req, "emoji");
+
+      if (!name || !emoji) {
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: "err",
+          text: "Role name and emoji are both required.",
+        });
+        return;
+      }
+
+      const service = ReactionRoleService.getInstance(client);
+      try {
+        const result = await service.createReactionRole(
+          session.guildId,
+          name,
+          emoji,
+        );
+        await recordAudit(session, {
+          action: "reactionrole.create",
+          targetId: result.roleId ?? null,
+          details: {
+            roleName: name,
+            emoji,
+            categoryId: result.categoryId,
+            channelId: result.channelId,
+            messageId: result.messageId,
+          },
+          result: result.success ? "success" : "failure",
+          errorMessage: result.success ? null : result.message,
+        });
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: result.success ? "ok" : "err",
+          text: result.message,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Create reaction role failed", err);
+        await recordAudit(session, {
+          action: "reactionrole.create",
+          details: { roleName: name, emoji },
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: "err",
+          text: `Failed to create reaction role: ${text}`,
+        });
+      }
+    }),
+  );
+
+  router.post(
+    "/reaction-roles/archive",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const roleName = getString(req, "roleName");
+      if (!roleName) {
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: "err",
+          text: "Role name is required.",
+        });
+        return;
+      }
+      const service = ReactionRoleService.getInstance(client);
+      try {
+        const result = await service.archiveReactionRole(
+          session.guildId,
+          roleName,
+        );
+        await recordAudit(session, {
+          action: "reactionrole.archive",
+          targetId: roleName,
+          details: { roleName },
+          result: result.success ? "success" : "failure",
+          errorMessage: result.success ? null : result.message,
+        });
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: result.success ? "ok" : "err",
+          text: result.message,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Archive reaction role failed", err);
+        await recordAudit(session, {
+          action: "reactionrole.archive",
+          targetId: roleName,
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: "err",
+          text: `Failed to archive ${roleName}: ${text}`,
+        });
+      }
+    }),
+  );
+
+  router.post(
+    "/reaction-roles/unarchive",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const roleName = getString(req, "roleName");
+      if (!roleName) {
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: "err",
+          text: "Role name is required.",
+        });
+        return;
+      }
+      const service = ReactionRoleService.getInstance(client);
+      try {
+        const result = await service.unarchiveReactionRole(
+          session.guildId,
+          roleName,
+        );
+        await recordAudit(session, {
+          action: "reactionrole.unarchive",
+          targetId: roleName,
+          details: { roleName },
+          result: result.success ? "success" : "failure",
+          errorMessage: result.success ? null : result.message,
+        });
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: result.success ? "ok" : "err",
+          text: result.message,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Unarchive reaction role failed", err);
+        await recordAudit(session, {
+          action: "reactionrole.unarchive",
+          targetId: roleName,
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: "err",
+          text: `Failed to unarchive ${roleName}: ${text}`,
+        });
+      }
+    }),
+  );
+
+  router.post(
+    "/reaction-roles/delete",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const roleName = getString(req, "roleName");
+      if (!roleName) {
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: "err",
+          text: "Role name is required.",
+        });
+        return;
+      }
+      const service = ReactionRoleService.getInstance(client);
+      try {
+        const result = await service.deleteReactionRole(
+          session.guildId,
+          roleName,
+        );
+        await recordAudit(session, {
+          action: "reactionrole.delete",
+          targetId: roleName,
+          details: { roleName },
+          result: result.success ? "success" : "failure",
+          errorMessage: result.success ? null : result.message,
+        });
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: result.success ? "ok" : "err",
+          text: result.message,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Delete reaction role failed", err);
+        await recordAudit(session, {
+          action: "reactionrole.delete",
+          targetId: roleName,
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: "err",
+          text: `Failed to delete ${roleName}: ${text}`,
+        });
+      }
+    }),
+  );
+
+  // ============================================================
+  // Notices (issue #384)
+  // ============================================================
+
+  const NOTICE_CATEGORY_KEYS = new Set(Object.keys(NOTICE_CATEGORIES));
+
+  router.post(
+    "/notices/create",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const title = getString(req, "title");
+      const content = getString(req, "content");
+      const category = getString(req, "category");
+      const orderRaw = getString(req, "order");
+
+      if (!title || !content || !category) {
+        flashRedirect(res, "/admin/notices", {
+          type: "err",
+          text: "Title, content, and category are all required.",
+        });
+        return;
+      }
+      if (title.length > 256) {
+        flashRedirect(res, "/admin/notices", {
+          type: "err",
+          text: "Title must be 256 characters or fewer.",
+        });
+        return;
+      }
+      if (content.length > 4000) {
+        flashRedirect(res, "/admin/notices", {
+          type: "err",
+          text: "Content must be 4000 characters or fewer.",
+        });
+        return;
+      }
+      if (!NOTICE_CATEGORY_KEYS.has(category)) {
+        flashRedirect(res, "/admin/notices", {
+          type: "err",
+          text: `Unknown category: ${category}.`,
+        });
+        return;
+      }
+      const order = parseIntInRange(orderRaw || "0", -1000, 10000);
+      if (order === null) {
+        flashRedirect(res, "/admin/notices", {
+          type: "err",
+          text: "Order must be an integer between -1000 and 10000.",
+        });
+        return;
+      }
+
+      try {
+        const enabled = await ConfigService.getInstance().getBoolean(
+          "notices.enabled",
+          false,
+        );
+        const notice = await new Notice({
+          title,
+          content,
+          category,
+          order,
+          createdBy: session.discordUserId,
+        }).save();
+
+        let postedMessageId: string | null = null;
+        if (enabled) {
+          const manager = NoticesChannelManager.getInstance(client);
+          postedMessageId = await manager.postNotice(notice);
+          if (postedMessageId) {
+            notice.messageId = postedMessageId;
+            await notice.save();
+          }
+        }
+
+        await recordAudit(session, {
+          action: "notice.create",
+          targetId: String(notice._id),
+          details: {
+            title,
+            category,
+            order,
+            posted: postedMessageId !== null,
+            featureEnabled: enabled,
+          },
+          result: "success",
+        });
+        flashRedirect(res, "/admin/notices", {
+          type: "ok",
+          text: enabled
+            ? `Created notice ${notice._id} and posted to channel.`
+            : `Created notice ${notice._id}. Enable notices.enabled to post it to a channel.`,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Create notice failed", err);
+        await recordAudit(session, {
+          action: "notice.create",
+          details: { title, category, order },
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/notices", {
+          type: "err",
+          text: `Failed to create notice: ${text}`,
+        });
+      }
+    }),
+  );
+
+  router.post(
+    "/notices/:id/update",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const id = String(req.params.id);
+      const title = getString(req, "title");
+      const content = getString(req, "content");
+      const category = getString(req, "category");
+      const orderRaw = getString(req, "order");
+
+      if (!title || !content || !category) {
+        flashRedirect(res, "/admin/notices", {
+          type: "err",
+          text: "Title, content, and category are all required.",
+        });
+        return;
+      }
+      if (!NOTICE_CATEGORY_KEYS.has(category)) {
+        flashRedirect(res, "/admin/notices", {
+          type: "err",
+          text: `Unknown category: ${category}.`,
+        });
+        return;
+      }
+      const order = parseIntInRange(orderRaw, -1000, 10000);
+      if (order === null) {
+        flashRedirect(res, "/admin/notices", {
+          type: "err",
+          text: "Order must be an integer between -1000 and 10000.",
+        });
+        return;
+      }
+
+      try {
+        const notice = await Notice.findById(id);
+        if (!notice) {
+          await recordAudit(session, {
+            action: "notice.update",
+            targetId: id,
+            result: "failure",
+            errorMessage: "not found",
+          });
+          flashRedirect(res, "/admin/notices", {
+            type: "err",
+            text: `Notice ${id} not found.`,
+          });
+          return;
+        }
+
+        notice.title = title;
+        notice.content = content;
+        notice.category = category;
+        notice.order = order;
+        await notice.save();
+
+        const enabled = await ConfigService.getInstance().getBoolean(
+          "notices.enabled",
+          false,
+        );
+        if (enabled) {
+          const manager = NoticesChannelManager.getInstance(client);
+          if (notice.messageId) {
+            await manager.deleteNoticeMessage(notice.messageId);
+          }
+          const newMessageId = await manager.postNotice(notice);
+          if (newMessageId) {
+            notice.messageId = newMessageId;
+            await notice.save();
+          }
+        }
+
+        await recordAudit(session, {
+          action: "notice.update",
+          targetId: id,
+          details: { title, category, order, reposted: enabled },
+          result: "success",
+        });
+        flashRedirect(res, "/admin/notices", {
+          type: "ok",
+          text: `Updated notice ${id}.`,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Update notice failed", err);
+        await recordAudit(session, {
+          action: "notice.update",
+          targetId: id,
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/notices", {
+          type: "err",
+          text: `Failed to update notice ${id}: ${text}`,
+        });
+      }
+    }),
+  );
+
+  router.post(
+    "/notices/:id/order",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const id = String(req.params.id);
+      const orderRaw = getString(req, "order");
+      const order = parseIntInRange(orderRaw, -1000, 10000);
+      if (order === null) {
+        flashRedirect(res, "/admin/notices", {
+          type: "err",
+          text: "Order must be an integer between -1000 and 10000.",
+        });
+        return;
+      }
+      try {
+        const notice = await Notice.findById(id);
+        if (!notice) {
+          await recordAudit(session, {
+            action: "notice.reorder",
+            targetId: id,
+            result: "failure",
+            errorMessage: "not found",
+          });
+          flashRedirect(res, "/admin/notices", {
+            type: "err",
+            text: `Notice ${id} not found.`,
+          });
+          return;
+        }
+        const previous = notice.order;
+        notice.order = order;
+        await notice.save();
+        await recordAudit(session, {
+          action: "notice.reorder",
+          targetId: id,
+          details: { from: previous, to: order, category: notice.category },
+          result: "success",
+        });
+        flashRedirect(res, "/admin/notices", {
+          type: "ok",
+          text: `Reordered notice ${id}: ${previous} → ${order}. Resync to refresh channel order.`,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Reorder notice failed", err);
+        await recordAudit(session, {
+          action: "notice.reorder",
+          targetId: id,
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/notices", {
+          type: "err",
+          text: `Failed to reorder notice ${id}: ${text}`,
+        });
+      }
+    }),
+  );
+
+  router.post(
+    "/notices/:id/delete",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const id = String(req.params.id);
+      try {
+        const notice = await Notice.findById(id);
+        if (!notice) {
+          await recordAudit(session, {
+            action: "notice.delete",
+            targetId: id,
+            result: "failure",
+            errorMessage: "not found",
+          });
+          flashRedirect(res, "/admin/notices", {
+            type: "err",
+            text: `Notice ${id} not found.`,
+          });
+          return;
+        }
+        const manager = NoticesChannelManager.getInstance(client);
+        if (notice.messageId) {
+          await manager.deleteNoticeMessage(notice.messageId);
+        }
+        await Notice.findByIdAndDelete(id);
+        await recordAudit(session, {
+          action: "notice.delete",
+          targetId: id,
+          details: { title: notice.title, category: notice.category },
+          result: "success",
+        });
+        flashRedirect(res, "/admin/notices", {
+          type: "ok",
+          text: `Deleted notice ${id}.`,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Delete notice failed", err);
+        await recordAudit(session, {
+          action: "notice.delete",
+          targetId: id,
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/notices", {
+          type: "err",
+          text: `Failed to delete notice ${id}: ${text}`,
+        });
+      }
+    }),
+  );
+
+  router.post(
+    "/notices/sync",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      try {
+        const manager = NoticesChannelManager.getInstance(client);
+        await manager.syncNotices();
+        const count = await Notice.countDocuments();
+        await recordAudit(session, {
+          action: "notice.sync",
+          details: { count },
+          result: "success",
+        });
+        flashRedirect(res, "/admin/notices", {
+          type: "ok",
+          text: `Synced ${count} notices to channel.`,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Notice sync failed", err);
+        await recordAudit(session, {
+          action: "notice.sync",
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/notices", {
+          type: "err",
+          text: `Failed to sync notices: ${text}`,
+        });
+      }
+    }),
+  );
+
+  // ============================================================
+  // Database — dbtrunk (issue #384)
+  // ============================================================
+
+  router.post(
+    "/database/run-cleanup",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const service = VoiceChannelTruncationService.getInstance(client);
+      try {
+        const stats = await service.runCleanup();
+        const skipped =
+          stats.errors.length === 1 &&
+          stats.errors[0] === "Cleanup skipped: minimum interval not met";
+        const hasErrors = stats.errors.length > 0 && !skipped;
+        await recordAudit(session, {
+          action: "dbtrunk.run",
+          details: {
+            sessionsRemoved: stats.sessionsRemoved,
+            dataAggregated: stats.dataAggregated,
+            executionTime: stats.executionTime,
+            errors: hasErrors ? stats.errors.length : 0,
+            skipped,
+          },
+          result: hasErrors ? "failure" : "success",
+          errorMessage: hasErrors ? stats.errors.slice(0, 3).join("; ") : null,
+        });
+        if (skipped) {
+          flashRedirect(res, "/admin/database", {
+            type: "warn",
+            text: "Cleanup skipped: 24-hour minimum interval not met since the last run.",
+          });
+          return;
+        }
+        if (hasErrors) {
+          flashRedirect(res, "/admin/database", {
+            type: "err",
+            text: `Cleanup finished with errors: ${stats.errors.slice(0, 3).join("; ")}`,
+          });
+          return;
+        }
+        flashRedirect(res, "/admin/database", {
+          type: "ok",
+          text: `Cleanup complete. Removed ${stats.sessionsRemoved} sessions across ${stats.dataAggregated} users in ${stats.executionTime}ms.`,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("dbtrunk run failed", err);
+        await recordAudit(session, {
+          action: "dbtrunk.run",
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/database", {
+          type: "err",
+          text: `Cleanup failed: ${text}`,
+        });
+      }
+    }),
+  );
+
+  // ============================================================
+  // Voice Channels (issue #384)
+  // ============================================================
+
+  router.post(
+    "/voice-channels/reload",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const manager = VoiceChannelManager.getInstance(client);
+      try {
+        await manager.cleanupEmptyChannels();
+        await recordAudit(session, {
+          action: "voicechannels.reload",
+          result: "success",
+        });
+        flashRedirect(res, "/admin/voice-channels", {
+          type: "ok",
+          text: "Cleaned up empty voice channels.",
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("VC reload failed", err);
+        await recordAudit(session, {
+          action: "voicechannels.reload",
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/voice-channels", {
+          type: "err",
+          text: `Cleanup failed: ${text}`,
+        });
+      }
+    }),
+  );
+
+  router.post(
+    "/voice-channels/force-reload",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const manager = VoiceChannelManager.getInstance(client);
+      try {
+        await manager.cleanupEmptyChannels();
+        const guild = await client.guilds.fetch(session.guildId);
+        await manager.ensureLobbyChannels(guild);
+        await recordAudit(session, {
+          action: "voicechannels.force-reload",
+          result: "success",
+        });
+        flashRedirect(res, "/admin/voice-channels", {
+          type: "ok",
+          text: "Force cleanup complete. Unmanaged channels removed and lobby channels ensured.",
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("VC force-reload failed", err);
+        await recordAudit(session, {
+          action: "voicechannels.force-reload",
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/voice-channels", {
+          type: "err",
+          text: `Force cleanup failed: ${text}`,
         });
       }
     }),

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -774,6 +774,26 @@ export function createWriteRouter(
         });
         return;
       }
+      // Discord caps role names at 100 chars. Validate here so we surface a
+      // clean flash instead of letting the Discord API reject the create
+      // mid-rollback.
+      if (name.length > 100) {
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: "err",
+          text: "Role name must be 100 characters or fewer.",
+        });
+        return;
+      }
+      // Emoji input is either a single Unicode codepoint cluster or a custom
+      // emoji markup like `<:name:id>` / `<a:name:id>`. 100 chars is well past
+      // any legitimate input and matches the form's `maxlength`.
+      if (emoji.length > 100) {
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: "err",
+          text: "Emoji input must be 100 characters or fewer.",
+        });
+        return;
+      }
 
       const service = ReactionRoleService.getInstance(client);
       try {
@@ -1041,11 +1061,19 @@ export function createWriteRouter(
           },
           result: "success",
         });
+        let flashType: Flash["type"] = "ok";
+        let flashText: string;
+        if (!enabled) {
+          flashText = `Created notice ${notice._id}. Enable notices.enabled to post it to a channel.`;
+        } else if (postedMessageId !== null) {
+          flashText = `Created notice ${notice._id} and posted to channel.`;
+        } else {
+          flashType = "warn";
+          flashText = `Created notice ${notice._id} but the channel post failed. Check the bot's logs and use Resync to retry.`;
+        }
         flashRedirect(res, "/admin/notices", {
-          type: "ok",
-          text: enabled
-            ? `Created notice ${notice._id} and posted to channel.`
-            : `Created notice ${notice._id}. Enable notices.enabled to post it to a channel.`,
+          type: flashType,
+          text: flashText,
         });
       } catch (err) {
         const text = err instanceof Error ? err.message : "Unknown error";
@@ -1123,7 +1151,12 @@ export function createWriteRouter(
           "notices.enabled",
           false,
         );
+        // `postNotice()` catches its own errors and returns null on failure.
+        // Track the actual outcome so the audit/flash don't lie about a repost.
+        let repostAttempted = false;
+        let repostSucceeded = false;
         if (enabled) {
+          repostAttempted = true;
           const manager = NoticesChannelManager.getInstance(client);
           if (notice.messageId) {
             await manager.deleteNoticeMessage(notice.messageId);
@@ -1131,16 +1164,35 @@ export function createWriteRouter(
           const newMessageId = await manager.postNotice(notice);
           if (newMessageId) {
             notice.messageId = newMessageId;
-            await notice.save();
+            repostSucceeded = true;
+          } else {
+            // We deleted (or tried to delete) the old message but couldn't
+            // post a replacement. Clear the now-stale messageId so the next
+            // sync doesn't try to delete a message that no longer exists.
+            notice.messageId = undefined;
           }
+          await notice.save();
         }
 
         await recordAudit(session, {
           action: "notice.update",
           targetId: id,
-          details: { title, category, order, reposted: enabled },
+          details: {
+            title,
+            category,
+            order,
+            repostAttempted,
+            repostSucceeded,
+          },
           result: "success",
         });
+        if (repostAttempted && !repostSucceeded) {
+          flashRedirect(res, "/admin/notices", {
+            type: "warn",
+            text: `Updated notice ${id} but the channel post failed. Use Resync to retry.`,
+          });
+          return;
+        }
         flashRedirect(res, "/admin/notices", {
           type: "ok",
           text: `Updated notice ${id}.`,
@@ -1317,9 +1369,7 @@ export function createWriteRouter(
       const service = VoiceChannelTruncationService.getInstance(client);
       try {
         const stats = await service.runCleanup();
-        const skipped =
-          stats.errors.length === 1 &&
-          stats.errors[0] === "Cleanup skipped: minimum interval not met";
+        const skipped = stats.skipped === true;
         const hasErrors = stats.errors.length > 0 && !skipped;
         await recordAudit(session, {
           action: "dbtrunk.run",


### PR DESCRIPTION
## Summary

Closes #384. Final batch of write-enabled WebUI pages — replaces `/reactrole`, `/notice`, `/dbtrunk`, and `/vc` with form-driven flows behind the existing CSRF + session middleware. Slash commands still work in parallel.

All writes route through the existing services (`reaction-role-service`, `notices-channel-manager`, `voice-channel-truncation`, `voice-channel-manager`); no new business logic. Each request emits exactly one `WebAuditLog` entry via `recordAudit()`.

### What's new per page

- **Reaction Roles** (`/admin/reaction-roles`): create form (name + emoji), per-row Archive / Unarchive / Delete actions with confirmation prompts.
- **Notices** (`/admin/notices`): create form, per-row Edit (collapsible) / Delete, inline numeric Order field for reordering within a category (replaces drag-to-reorder), and a Resync button. Mirrors `/notice add|edit|delete|sync`.
- **Database** (`/admin/database`): "Run cleanup now" button calling `runCleanup()`, with the 24h minimum-interval surfaced as a warn flash. Adds a last-10 cleanup-runs history sourced from `WebAuditLog`.
- **Voice Channels** (`/admin/voice-channels`): "Clean up empty channels" and "Force cleanup & ensure lobby" actions wired to `cleanupEmptyChannels()` / `ensureLobbyChannels()`. Disabled when the feature is off or the category is missing.

### Audit-log actions

`reactionrole.create|archive|unarchive|delete`, `notice.create|update|reorder|delete|sync`, `dbtrunk.run`, `voicechannels.reload|force-reload`.

### Notes on scope

- The issue mentions "drag-to-reorder" and a "live message preview" for reaction roles. The existing WebUI scaffold is server-rendered, no client-side framework — drag-to-reorder is implemented as a per-row inline Order input + Resync (functionally equivalent, matches the scaffold's HTML-first style). Live preview for the reaction-role embed is omitted for the same reason; the embed is unchanged from `/reactrole create`.
- The `read-only` pill in the banner is left as-is; it's existing copy from the scaffold and predates the write surface from #383.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — 0 errors (preexisting warnings only).
- [x] `npm run format:check` — clean.
- [x] `npm test` — 810/810 pass (1 preexisting skip). `admin-views.test.ts` extended for new props (reaction-role write controls, notices id/content/categoryOptions, database trunkHistory, voice-channels disabled-button state).
- [ ] Manual smoke against a running guild: create + archive + delete a reaction role; add + reorder + sync notices; trigger `dbtrunk.run`; trigger `vc reload` and `force-reload`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GDW8oy93C58sLGRNf9hpYF)_