### PR TITLE
fix(voice): reconcile userChannels when cleanupUserChannel hits 10003

### DIFF
--- a/__tests__/services/voice-channel-manager-cleanup.test.ts
+++ b/__tests__/services/voice-channel-manager-cleanup.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@jest/globals";
 import {
   ChannelType,
+  DiscordAPIError,
   type Client,
   type VoiceChannel,
   type GuildMember,
@@ -262,6 +263,82 @@ describe("VoiceChannelManager - Channel Cleanup with Custom Names", () => {
       // Assert: Channel.delete should only be called once, not twice
       // This verifies the channelsBeingDeleted Set prevents double deletion
       expect(mockChannel.delete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("cleanupUserChannel resilience (issue #404)", () => {
+    function makeUnknownChannelError(): DiscordAPIError {
+      // DiscordAPIError's constructor signature has shifted between
+      // discord.js versions and `name` is a getter on its prototype, so we
+      // build the instance via Object.create + defineProperty rather than
+      // calling the constructor.
+      const error = Object.create(DiscordAPIError.prototype) as DiscordAPIError;
+      Object.defineProperties(error, {
+        rawError: {
+          value: { message: "Unknown Channel", code: 10003 },
+          writable: true,
+        },
+        code: { value: 10003, writable: true },
+        status: { value: 404, writable: true },
+        method: { value: "DELETE", writable: true },
+        url: {
+          value: "https://discord.com/api/v10/channels/channel-id",
+          writable: true,
+        },
+        message: { value: "Unknown Channel", writable: true },
+      });
+      return error;
+    }
+
+    it("removes the userChannels entry when channel.delete throws 10003 (Unknown Channel)", async () => {
+      // Setup: owner has a channel entry whose remote channel has already
+      // been deleted on Discord's side.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (manager as any).userChannels.set("owner-id", mockChannel);
+      mockMembers.clear();
+      Object.defineProperty(mockChannel, "members", {
+        value: mockMembers as Collection<string, GuildMember>,
+        writable: true,
+      });
+      (mockChannel.delete as jest.Mock).mockRejectedValue(
+        makeUnknownChannelError(),
+      );
+
+      // Drive cleanupUserChannel directly: handleVoiceStateUpdate also
+      // invokes cleanupEmptyChannel afterwards, which would muddy the
+      // assertion we care about here.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (manager as any).cleanupUserChannel("owner-id");
+
+      // The userChannels entry must be cleared so subsequent lobby joins
+      // aren't silently skipped with "already has a channel".
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const userChannels: Map<string, VoiceChannel> = (manager as any)
+        .userChannels;
+      expect(userChannels.has("owner-id")).toBe(false);
+    });
+
+    it("keeps the userChannels entry when channel.delete throws a non-10003 error", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (manager as any).userChannels.set("owner-id", mockChannel);
+      mockMembers.clear();
+      Object.defineProperty(mockChannel, "members", {
+        value: mockMembers as Collection<string, GuildMember>,
+        writable: true,
+      });
+      (mockChannel.delete as jest.Mock).mockRejectedValue(
+        new Error("transient network failure"),
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (manager as any).cleanupUserChannel("owner-id");
+
+      // Non-10003 failures are transient: leave the entry so the periodic
+      // cleanup can retry, instead of dropping ownership tracking on the floor.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const userChannels: Map<string, VoiceChannel> = (manager as any)
+        .userChannels;
+      expect(userChannels.has("owner-id")).toBe(true);
     });
   });
 

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -3,6 +3,7 @@ import {
   VoiceChannel,
   CategoryChannel,
   ChannelType,
+  DiscordAPIError,
   GuildMember,
   Guild,
   Client,
@@ -14,6 +15,19 @@ import {
   PermissionFlagsBits,
   Message,
 } from "discord.js";
+
+// Discord REST error code 10003 — the channel no longer exists. For our
+// cleanup paths this is a success condition: the remote resource is already
+// gone, so we should reconcile in-memory state instead of bailing out and
+// leaving stale entries behind (issue #404, follow-up to #339).
+const UNKNOWN_CHANNEL_ERROR_CODE = 10003;
+
+function isUnknownChannelError(error: unknown): boolean {
+  return (
+    error instanceof DiscordAPIError &&
+    error.code === UNKNOWN_CHANNEL_ERROR_CODE
+  );
+}
 import logger from "../utils/logger.js";
 import { VoiceChannelTracker } from "../services/voice-channel-tracker.js";
 import { ConfigService } from "./config-service.js";
@@ -1096,24 +1110,43 @@ export class VoiceChannelManager {
   }
 
   private async cleanupUserChannel(userId: string): Promise<void> {
-    try {
-      const channel = this.userChannels.get(userId);
-      if (channel && channel.members.size === 0) {
-        // Clean up waiting room if one exists
-        await this.removeWaitingRoom(channel.id);
-        // Clean up live status
-        this.liveChannels.delete(channel.id);
-        await channel.delete();
-        this.userChannels.delete(userId);
-        // Clean up custom name tracking
-        this.customChannelNames.delete(channel.id);
-        // Clean up ownership queue
-        this.ownershipQueue.delete(channel.id);
-        logger.info(`Cleaned up voice channel ${channel.name}`);
-      }
-    } catch (error) {
-      logger.error("Error cleaning up user channel:", error);
+    const channel = this.userChannels.get(userId);
+    if (!channel || channel.members.size !== 0) {
+      return;
     }
+
+    const channelId = channel.id;
+    const channelName = channel.name;
+
+    try {
+      // Clean up waiting room if one exists
+      await this.removeWaitingRoom(channelId);
+      // Clean up live status
+      this.liveChannels.delete(channelId);
+      await channel.delete();
+      logger.info(`Cleaned up voice channel ${channelName}`);
+    } catch (error) {
+      if (isUnknownChannelError(error)) {
+        // Channel is already gone on Discord's side — treat as success and
+        // fall through to reconcile local state.
+        logger.warn(
+          `Voice channel ${channelName} (${channelId}) already deleted on Discord; reconciling local state.`,
+        );
+      } else {
+        // Unexpected failure (rate limit, permissions, etc.). Leave the
+        // userChannels entry intact so the periodic cleanup can retry later.
+        logger.error("Error cleaning up user channel:", error);
+        return;
+      }
+    }
+
+    // Always reconcile in-memory state when the channel is gone (either we
+    // just deleted it, or it was already gone). A stale userChannels entry
+    // would otherwise lock the user out of future lobby joins until the bot
+    // restarts (issue #404).
+    this.userChannels.delete(userId);
+    this.customChannelNames.delete(channelId);
+    this.ownershipQueue.delete(channelId);
   }
 
   /**
@@ -1152,8 +1185,19 @@ export class VoiceChannelManager {
       this.channelsBeingDeleted.add(channel.id);
 
       // Delete the channel
-      await channel.delete();
-      logger.info(`Cleaned up empty voice channel ${channel.name}`);
+      try {
+        await channel.delete();
+        logger.info(`Cleaned up empty voice channel ${channel.name}`);
+      } catch (error) {
+        if (isUnknownChannelError(error)) {
+          // Already gone on Discord's side — fall through and reconcile.
+          logger.warn(
+            `Empty voice channel ${channel.name} (${channel.id}) already deleted on Discord; reconciling local state.`,
+          );
+        } else {
+          throw error;
+        }
+      }
 
       // Clean up all tracking for this channel
       if (ownerId) {

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -15,6 +15,11 @@ import {
   PermissionFlagsBits,
   Message,
 } from "discord.js";
+import logger from "../utils/logger.js";
+import { VoiceChannelTracker } from "../services/voice-channel-tracker.js";
+import { ConfigService } from "./config-service.js";
+
+const configService = ConfigService.getInstance();
 
 // Discord REST error code 10003 — the channel no longer exists. For our
 // cleanup paths this is a success condition: the remote resource is already
@@ -28,11 +33,6 @@ function isUnknownChannelError(error: unknown): boolean {
     error.code === UNKNOWN_CHANNEL_ERROR_CODE
   );
 }
-import logger from "../utils/logger.js";
-import { VoiceChannelTracker } from "../services/voice-channel-tracker.js";
-import { ConfigService } from "./config-service.js";
-
-const configService = ConfigService.getInstance();
 
 export class VoiceChannelManager {
   private static instance: VoiceChannelManager;


### PR DESCRIPTION
## Summary

Fixes #404 — a follow-up to #339 where the AFK→lobby lockout still reproduced because `cleanupUserChannel` didn't reconcile in-memory state when Discord returned `DiscordAPIError[10003] Unknown Channel`.

- **`cleanupUserChannel`**: Treat `10003` as a successful cleanup (the remote channel is already gone) and always clear `userChannels` / `customChannelNames` / `ownershipQueue` for the channel. Non-10003 failures (rate limits, transient network errors) still leave the entry intact so the periodic cleanup can retry — we don't want to drop ownership tracking on the floor for the channel that still exists on Discord.
- **`cleanupEmptyChannel`**: Same pattern was present here, so the 10003 handling now lives on the inner `channel.delete()` call as well. Other failures bubble up to the existing catch.
- Added `isUnknownChannelError` helper + `DiscordAPIError` import.

## Why it locked users out

```
2026-05-11T18:28:57.432Z [INFO]: Creating channel for lonix who joined the lobby
2026-05-11T18:28:57.432Z [INFO]: User lonix already has a channel, skipping creation
2026-05-11T18:29:01.754Z [ERROR]: Error cleaning up user channel: Unknown Channel
DiscordAPIError[10003]: Unknown Channel
   at VoiceChannelManager.cleanupUserChannel ...
2026-05-11T18:29:01.755Z [INFO]: User lonix already has a channel, skipping creation
```

A stale `userChannels` entry from a previous session (whose Discord channel had since been deleted by the periodic empty-channel sweep) caused the early-return in `createUserChannel`. The subsequent attempt to clean it up failed with `10003`, so the entry stuck around until the bot restarted.

## Test plan

- [x] `node --experimental-vm-modules node_modules/jest/bin/jest.js __tests__/services/voice-channel-manager` — 42 passed, 1 skipped (pre-existing)
- [x] Full suite — 829 passed, 1 skipped, 92 suites
- [x] `npm run build` (tsc)
- [x] `npm run lint` (0 errors)
- [x] `npm run format:check`
- [x] New tests in `voice-channel-manager-cleanup.test.ts`:
  - removes the `userChannels` entry when `channel.delete` throws 10003
  - keeps the `userChannels` entry when `channel.delete` throws a non-10003 error

https://claude.ai/code/session_01DeEFZLEkNb3LvPr1DV78YV

---
_Generated by [Claude Code](https://claude.ai/code/session_01DeEFZLEkNb3LvPr1DV78YV)_