### PR TITLE
docs: rework for v1.0 Web UI surface (#387)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,9 +19,50 @@ MONGODB_URI=mongodb://mongodb:27017/koolbot
 
 # Environment Settings (Optional)
 # Set DEBUG=true before startup for detailed logging during troubleshooting.
-# DEBUG is launch-time environment configuration (not a runtime /config setting).
+# DEBUG is launch-time environment configuration (not a runtime setting).
 DEBUG=false
 NODE_ENV=production
+
+# =============================================================================
+# Web UI (Optional but recommended — this is the only admin surface)
+# =============================================================================
+# The Web UI replaces every admin slash command (/config set, /permissions,
+# /setup, /announce, /poll, /reactrole, /notice, /dbtrunk, /vc, /botstats).
+# In Discord, run `/config` to receive a one-time DM sign-in link.
+#
+# See WEBUI.md for full setup, reverse-proxy guidance, and Caddy / nginx /
+# Traefik examples.
+
+# Master switch. When false (default), /admin/* routes are not mounted and
+# `/config` in Discord replies "the web UI is disabled".
+WEBUI_ENABLED=false
+
+# Public URL the bot uses to build the DM'd sign-in link. Must be reachable
+# from the admin's browser. Examples:
+#   - Local-only:      http://localhost:3000
+#   - Reverse proxy:   https://bot.example.com
+# No trailing slash needed.
+WEBUI_BASE_URL=http://localhost:3000
+
+# HMAC key for token hashes and signed cookies. Generate with:
+#   openssl rand -base64 32
+# Rotating this invalidates every existing session and outstanding link.
+# Treat this like DISCORD_TOKEN — anyone who reads it can forge cookies.
+WEBUI_SESSION_SECRET=replace-me-with-openssl-rand-base64-32
+
+# Optional tuning (defaults shown).
+# Magic-link TTL from issuance, in minutes. Short windows reduce blast radius
+# if a link leaks before redemption.
+WEBUI_SESSION_TTL_MINUTES=10
+
+# Sliding inactivity window for the post-redemption cookie, in minutes.
+# Hard-capped at the session's server-side expiresAt.
+WEBUI_INACTIVITY_TIMEOUT_MINUTES=30
+
+# Reverse proxy hop count. Set to 1 when running behind Caddy/nginx/Traefik
+# terminating TLS in front of the bot. Required for accurate rate-limiting
+# by client IP. Leave unset for direct access.
+# WEBUI_TRUST_PROXY=1
 
 # =============================================================================
 # How to get your Discord credentials:
@@ -33,6 +74,6 @@ NODE_ENV=production
 # 5. GUILD_ID: Your Discord Server → Right-click server icon → Copy ID
 #    (Enable Developer Mode in Discord: User Settings → Advanced → Developer Mode)
 #
-# Note: All other bot settings are configured through Discord commands
-# after the bot starts. See README.md for setup instructions.
+# Note: All other bot settings are configured through the Web UI after the
+# bot starts. See README.md for setup instructions and WEBUI.md for details.
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,11 @@ WEBUI_ENABLED=false
 #   - Local-only:      http://localhost:3000
 #   - Reverse proxy:   https://bot.example.com
 # No trailing slash needed.
+#
+# Cookie-Secure note: the Web UI marks its session cookie `Secure` whenever
+# NODE_ENV=production. Plain-HTTP sign-in (the localhost example above) only
+# works reliably when NODE_ENV is NOT production — set NODE_ENV=development
+# while testing locally, or terminate TLS in front of the bot.
 WEBUI_BASE_URL=http://localhost:3000
 
 # HMAC key for token hashes and signed cookies. Generate with:

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -409,8 +409,14 @@ sign-in link via DM. Every administrative action — settings, permissions,
 the setup wizard, announcements, polls, reaction roles, notices, voice
 channel management, database cleanup, bot stats — happens in the Web UI.
 
-**Permission:** Discord **Administrator** by default (overridable via the
-`/permissions` UI inside the Web UI itself).
+**Permission:** Discord **Administrator** by default. `/config` is
+registered with `setDefaultMemberPermissions(Administrator)`, so
+Discord itself blocks non-administrators from invoking it before the
+bot ever sees the interaction. To grant `/config` to non-admin roles,
+override the command's permissions in Discord
+(**Server Settings → Integrations → KoolBot → /config**); the Web UI's
+Permissions page can only further restrict who is allowed once Discord
+has admitted the interaction.
 
 **Prerequisites:** Operator must have set `WEBUI_ENABLED=true`,
 `WEBUI_BASE_URL`, and `WEBUI_SESSION_SECRET` in `.env` and restarted the
@@ -426,8 +432,10 @@ No subcommands, no parameters.
 
 **Behavior:**
 
-1. Bot verifies you have the Administrator permission (or a role that
-   `permissions-service` permits to run `config`).
+1. Discord routes the interaction to the bot (it only does this for
+   members the command's Discord-level permissions allow — Administrator
+   by default; non-admin roles allowed only when an operator has added
+   them via Server Settings → Integrations).
 2. Bot revokes any prior unrevoked sessions you have.
 3. Bot generates a single-use token bound to your Discord user ID
    (default TTL: 10 minutes; configurable via
@@ -439,9 +447,17 @@ No subcommands, no parameters.
 6. You configure the bot in the Web UI. The session sliding window
    defaults to 30 minutes of inactivity and is hard-capped at the
    server-side TTL.
-7. You click **Finish** (or close the tab; or the inactivity timer
-   fires; or you re-run `/config`, which revokes the current session).
-   The cookie clears and `/admin/*` returns 401.
+7. You end the session one of four ways:
+   - Click **Finish** — server-side revoke + cookie cleared, immediate.
+   - Re-run `/config` — server-side revoke of the prior session +
+     fresh link minted.
+   - Idle past the inactivity window or hard TTL — the next request
+     rejects the cookie (the server-side row stays in MongoDB until
+     it's TTL-expired or explicitly revoked).
+   - Close the tab — the cookie sticks around in your browser and the
+     session row stays valid in MongoDB until idle/TTL, so closing the
+     tab is **not** equivalent to signing out. Click Finish if you want
+     a hard end.
 
 **Example responses:**
 
@@ -513,7 +529,10 @@ chat. Only you (the channel owner) can use it.
 
 **Features:**
 
-- Only visible to the channel owner
+- Posted into the voice channel's text chat — visible to everyone with
+  access to that channel; only the channel owner can interact with the
+  buttons (non-owners get an ephemeral "Only the channel owner can use
+  these controls" reply if they click)
 - Updates dynamically as privacy / live / waiting-room state changes
 - Persists until the channel is deleted
 - Posted automatically every time a new channel is created
@@ -536,7 +555,7 @@ Privacy: 🌐 Public
 [✏️ Rename] [🔒 Make Private] [👥 Invite] [👑 Transfer]
 [⬜ Go Offline] [🗑️ Remove Waiting Room]
 
-Only you can see and use these controls
+Only the channel owner can use these controls
 ```
 
 ### Rename channel
@@ -551,8 +570,12 @@ Make Public** opens it back up.
 
 ### Invite users
 
-While the channel is private, click **👥 Invite** and pick a user from
-the menu. They get a DM notification with permission to join.
+While the channel is private, click **👥 Invite**. The bot replies with
+an ephemeral message explaining how to grant a user access:
+right-click their name in Discord and **Edit Channel Permissions** for
+this channel. (The button is intentionally an instructions handoff, not
+an interactive user picker — Discord's per-user channel permission
+panel covers the actual grant.)
 
 ### Transfer ownership
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,62 +1,53 @@
 # KoolBot Commands Reference
 
-Complete reference for all KoolBot commands with examples and detailed explanations.
+Complete reference for every slash command KoolBot registers with Discord.
 
-> **Note:** All commands must be enabled through configuration before they appear in Discord.
-> The supported way to do this is the WebUI Settings page (run `/config` to get a
-> single-use sign-in link). The legacy slash equivalents — `/config set
-> key:command.enabled value:true` followed by `/config reload` — still work for the
-> current release but are deprecated; see the banner below.
+KoolBot's slash-command surface is intentionally small. All
+**day-to-day chat interaction** stays in Discord (`/ping`, `/voicestats`,
+`/seen`, `/quote`, `/achievements`, `/amikool`, `/help`). All
+**administration and configuration** lives in the Web UI, reached via the
+single `/config` launcher.
 
----
-
-> ⚠️ **Deprecation notice (v1.0 migration):** The following admin slash commands are
-> **deprecated** and will be removed in 1.0. They still work, but each invocation now
-> emits a deprecation embed pointing at the WebUI. Run `/config` to open the WebUI
-> launcher instead.
->
-> - `/permissions`, `/setup`, `/announce`, `/announce-vc-stats`, `/poll`,
->   `/reactrole`, `/notice`, `/dbtrunk`, `/vc`, `/botstats`
-> - Every `/config` subcommand except the launcher (i.e. `/config list`,
->   `/config set`, `/config import`, `/config export`, `/config reset`,
->   `/config reload`). The `/config web` launcher itself is **not** deprecated.
->
-> User-facing commands (`/ping`, `/voicestats`, `/seen`, `/quote`, `/achievements`,
-> `/amikool`, `/help`) are unaffected.
+> **Note:** Most commands must be enabled before they appear in Discord.
+> Toggle them from the Web UI's **Settings** page (run `/config` to get a
+> single-use sign-in link), then click **Reload commands to Discord** to
+> push the registration change.
 
 ---
 
 ## 📋 Table of Contents
 
-- [User Commands](#-user-commands) - Available to all server members
-- [Admin Commands](#-admin-commands) - Require Administrator permission
-  - [/setup](#setup) - Interactive setup wizard (recommended for first-time setup)
-  - [/config](#config) - Configuration management
-  - [/permissions](#permissions) - Role-based access control
-  - [/vc](#vc) - Voice channel management
-- [Configuration Management](#config) - Detailed `/config` command guide
-- [Quick Command Reference](#-quick-command-reference) - Summary table
+- [User Commands](#-user-commands)
+  - [/ping](#ping)
+  - [/help](#help)
+  - [/voicestats](#voicestats)
+  - [/seen](#seen)
+  - [/achievements](#achievements)
+  - [/quote](#quote)
+  - [/amikool](#amikool)
+- [Admin: Web UI launcher](#-admin-web-ui-launcher)
+  - [/config](#config)
+- [Voice Channel Control Panel](#voice-channel-control-panel)
+- [Permission Requirements](#-permission-requirements)
+- [Quick Command Reference](#-quick-command-reference)
 
 ---
 
 ## 👥 User Commands
 
-Commands available to all server members.
+Commands available to all server members. Per-command role gating can be
+applied from the Web UI's **Permissions** page; without gating, the
+command is open to everyone.
 
 ### `/ping`
 
 **Description:** Check if the bot is responding and measure latency.
 
-**Configuration:**
-
-```bash
-/config set key:ping.enabled value:true
-/config reload
-```
+**Enable:** Web UI → Settings → set `ping.enabled = true` → Reload commands.
 
 **Usage:**
 
-```bash
+```text
 /ping
 ```
 
@@ -68,32 +59,33 @@ Bot Latency: 45ms
 API Latency: 123ms
 ```
 
-**Use Cases:**
+**Use cases:**
 
 - Verify bot is online and responsive
 - Check connection quality
-- Troubleshoot lag issues
+- Troubleshoot lag
 
 ---
 
 ### `/help`
 
-**Description:** Get help with KoolBot commands. Lists all available commands or shows detailed information about a specific command.
+**Description:** Get help with KoolBot commands. Lists all available commands
+or shows detailed information about a specific command.
 
-**Note:** This is a core command that is **always enabled** and does not require configuration.
+**Note:** Core command, **always enabled**, no configuration needed.
 
 **Usage:**
 
-```bash
-/help                    # List all commands
-/help command:ping       # Get detailed help for a specific command
+```text
+/help                    # List all enabled commands
+/help command:ping       # Detailed help for one command
 ```
 
 **Parameters:**
 
-- `command` (optional) - Name of the command to get detailed help for
+- `command` (optional) — Name of the command to get detailed help for
 
-**Example Responses:**
+**Example responses:**
 
 ```text
 # List all commands
@@ -110,39 +102,28 @@ Usage: /ping
 Status: ✅ Enabled
 ```
 
-**Use Cases:**
-
-- Discover available commands
-- Learn command syntax
-- Check if a command is enabled
-- New user onboarding
-
 ---
 
 ### `/voicestats`
 
-**Description:** Voice channel statistics and leaderboards. This unified command combines leaderboard (`top`) and personal stats (`user`) functionality.
+**Description:** Voice channel statistics and leaderboards. Combines
+leaderboard (`top`) and personal stats (`user`) functionality.
 
-**Configuration:**
+**Enable:** Web UI → Settings:
 
-```bash
-# Requires voice tracking to be enabled
-/config set key:voicetracking.enabled value:true
-/config reload
+- `voicetracking.enabled = true`
+- `voicetracking.stats.top.enabled = true` (for `top` subcommand)
+- `voicetracking.stats.user.enabled = true` (for `user` subcommand)
 
-# Optional: Enable individual subcommands
-/config set key:voicetracking.stats.top.enabled value:true
-/config set key:voicetracking.stats.user.enabled value:true
-/config reload
-```
+Then click **Reload commands to Discord**.
 
 #### Subcommand: `top`
 
-**Description:** View voice channel activity leaderboards showing top users by time spent.
+View voice channel activity leaderboards.
 
 **Usage:**
 
-```bash
+```text
 /voicestats top
 /voicestats top limit:20
 /voicestats top period:month
@@ -151,12 +132,12 @@ Status: ✅ Enabled
 
 **Parameters:**
 
-- `limit` (optional) - Number of users to display (1-50, default: 10)
-- `period` (optional) - Time period: `week`, `month`, `alltime` (default: week)
+- `limit` (optional) — Number of users to display (1-50, default: 10)
+- `period` (optional) — `week` / `month` / `alltime` (default: `week`)
 
-**Example Response:**
+**Example response:**
 
-```json
+```text
 Top Voice Channel Users (week):
 🥇 Alice: 24h 15m
 🥈 Bob: 18h 32m
@@ -165,19 +146,13 @@ Top Voice Channel Users (week):
 5. Emma: 6h 10m
 ```
 
-**Use Cases:**
-
-- See who's most active in voice channels
-- Create friendly competition
-- Recognize community engagement
-
 #### Subcommand: `user`
 
-**Description:** View personal voice channel statistics and activity history for yourself or another user.
+View personal voice channel statistics for yourself or another user.
 
 **Usage:**
 
-```bash
+```text
 /voicestats user
 /voicestats user user:@Alice
 /voicestats user period:month
@@ -186,12 +161,12 @@ Top Voice Channel Users (week):
 
 **Parameters:**
 
-- `user` (optional) - The user to show statistics for (defaults to yourself)
-- `period` (optional) - Time period: `week`, `month`, `alltime` (default: week)
+- `user` (optional) — Defaults to yourself
+- `period` (optional) — `week` / `month` / `alltime` (default: `week`)
 
-**Example Response:**
+**Example response:**
 
-```json
+```text
 Voice Channel Statistics for Alice (week):
 Total Time: 24h 15m
 Last Seen: 2026-01-29 12:00:00
@@ -202,78 +177,58 @@ Recent Sessions:
 • Music Lounge: 1h 30m
 ```
 
-**Use Cases:**
-
-- Track your own voice channel usage
-- View another user's activity
-- See activity trends
-- Check recent session history
-
 ---
 
 ### `/seen`
 
 **Description:** Check when a user was last active in voice channels.
 
-**Configuration:**
+**Enable:** Web UI → Settings:
 
-```bash
-/config set key:voicetracking.enabled value:true
-/config set key:voicetracking.seen.enabled value:true
-/config reload
-```
+- `voicetracking.enabled = true`
+- `voicetracking.seen.enabled = true`
+
+Then reload commands.
 
 **Usage:**
 
-```bash
+```text
 /seen user:@Username
 ```
 
 **Parameters:**
 
-- `user` (required) - The user to look up
+- `user` (required) — The user to look up
 
-**Example Response:**
+**Example response:**
 
-```json
+```text
 👤 Alice was last seen:
 🕐 2 hours ago
 📍 In: Gaming Room
 ⏱️ Duration: 3h 45m
 ```
 
-**Use Cases:**
-
-- Check if someone has been online recently
-- See what channel they were in
-- Track member activity patterns
-
 ---
 
 ### `/achievements`
 
-**Description:** View earned badges and achievements from voice channel activity. Displays persistent accolades earned through milestones and participation.
+**Description:** View earned accolades and badges from voice channel activity.
 
-**Configuration:**
-
-```bash
-# Enable achievements system
-/config set key:achievements.enabled value:true
-/config reload
-```
+**Enable:** Web UI → Settings → `achievements.enabled = true` → Reload commands.
 
 **Usage:**
 
-```bash
-/achievements                    # View your own achievements
-/achievements user:@Username     # View another user's achievements
+```text
+/achievements                    # View your own accolades
+/achievements user:@Username     # View another user's accolades
 ```
 
 **Parameters:**
 
-- `user` (optional) - The user to view achievements for (defaults to yourself)
+- `user` (optional) — Defaults to yourself
 
-**Example Response:**
+**Example response:**
 
 ```text
 🏆 Alice's Achievements
@@ -301,88 +256,75 @@ Total Accolades: 4
 Total Achievements: 0
 ```
 
-**Available Accolades:**
+**Available accolades:**
 
-- 🎉 **First Steps** - Spent your first hour in voice chat
-- 🎖️ **Voice Veteran** - Reached 100 hours
-- 🏅 **Voice Elite** - Reached 500 hours
-- 🏆 **Voice Master** - Reached 1000 hours
-- 👑 **Voice Legend** - Reached 8765 hours (1 year!)
-- 🏃 **Marathon Runner** - Completed a 4+ hour session
-- 🦸 **Ultra Marathoner** - Completed an 8+ hour session
-- 🦋 **Social Butterfly** - Voiced with 10+ unique users
-- 🤝 **Connector** - Voiced with 25+ unique users
-- 🦉 **Night Owl** - 50+ hours late night (10 PM - 6 AM UTC)
-- 🐦 **Early Bird** - 50+ hours early morning (6 AM - 10 AM UTC)
-- 🎮 **Weekend Warrior** - 100+ hours on weekends
-- 💼 **Weekday Warrior** - 100+ hours on weekdays
-- 🔥 **On a Roll** - Connected for 7 consecutive days (5+ min/day)
-- ⚡ **Dedicated AF** - Connected for 14 consecutive days (5+ min/day)
-- 💀 **No-Lifer** - Connected for 30 consecutive days (5+ min/day)
-- 🗣️ **Quotable** - Been quoted for the first time
-- 📝 **Quote Master** - Added 10 quotes to the collection
-- 📚 **Quote Collector** - Added 50 quotes to the collection
-- 🏆 **Quote Legend** - Added 100 quotes to the collection
-- ⭐ **Widely Quoted** - Been quoted 25 times
-- 💫 **Quote Icon** - Been quoted 50 times
-- 🔥 **Viral Quote** - Have a quote with 10+ likes
+- 🎉 **First Steps** — First hour in voice chat
+- 🎖️ **Voice Veteran** — 100 hours
+- 🏅 **Voice Elite** — 500 hours
+- 🏆 **Voice Master** — 1000 hours
+- 👑 **Voice Legend** — 8765 hours (1 year!)
+- 🏃 **Marathon Runner** — 4+ hour session
+- 🦸 **Ultra Marathoner** — 8+ hour session
+- 🦋 **Social Butterfly** — 10+ unique users
+- 🤝 **Connector** — 25+ unique users
+- 🦉 **Night Owl** — 50+ late-night hours (10 PM - 6 AM UTC)
+- 🐦 **Early Bird** — 50+ early-morning hours (6 AM - 10 AM UTC)
+- 🎮 **Weekend Warrior** — 100+ weekend hours
+- 💼 **Weekday Warrior** — 100+ weekday hours
+- 🔥 **On a Roll** — 7 consecutive days (5+ min/day)
+- ⚡ **Dedicated AF** — 14 consecutive days (5+ min/day)
+- 💀 **No-Lifer** — 30 consecutive days (5+ min/day)
+- 🗣️ **Quotable** — Been quoted for the first time
+- 📝 **Quote Master** — Added 10 quotes
+- 📚 **Quote Collector** — Added 50 quotes
+- 🏆 **Quote Legend** — Added 100 quotes
+- ⭐ **Widely Quoted** — Been quoted 25 times
+- 💫 **Quote Icon** — Been quoted 50 times
+- 🔥 **Viral Quote** — Have a quote with 10+ likes
 
-**Note on Time-Based Accolades:**
+**Notes on time-based accolades:**
 
-- **Night Owl** and **Early Bird** times are calculated in **UTC timezone** (the bot's server time)
-- These times may differ from your local timezone depending on your location
-- **Weekend Warrior** and **Weekday Warrior** use UTC for determining day of week
-- Calculate your local time offset from UTC to know when these periods occur in your timezone
+- Night Owl / Early Bird use **UTC**, not your local timezone
+- Weekend Warrior / Weekday Warrior use UTC day-of-week
 
-**Notification System:**
+**Notifications:**
 
-When you earn a new accolade, you'll receive:
-
-- A DM from the bot with details about your achievement
-- Announcement in the weekly voice stats channel
-
-**Use Cases:**
-
-- Track your voice activity milestones
-- View your collection of earned badges
-- Compare achievements with friends
-- Get motivated to participate more
+When you earn a new accolade you receive a DM (if DMs are open) and an
+announcement in the configured weekly voice stats channel.
 
 ---
 
 ### `/quote`
 
-**Description:** Add and manage memorable quotes in a dedicated bot-managed channel. All quotes are posted in a channel where users can react with 👍/👎.
+**Description:** Add and manage memorable quotes in a dedicated bot-managed
+channel. All quotes are posted in a channel where users can react with
+👍/👎.
 
-**Configuration:**
+**Enable:** Web UI → Settings:
 
-```bash
-# Enable quotes and set channel
-/config set key:quotes.enabled value:true
-/config set key:quotes.channel_id value:"YOUR_CHANNEL_ID"
-/config set key:quotes.cooldown value:60
-/config set key:quotes.max_length value:1000
-/config reload
-```
+- `quotes.enabled = true`
+- `quotes.channel_id = <channel-id>`
+- (Optional) `quotes.cooldown`, `quotes.max_length`, `quotes.add_roles`,
+  `quotes.delete_roles`
 
-**Subcommands:**
+Then reload commands.
 
 #### `/quote add`
 
-Add a new quote to the quote channel.
+Add a new quote.
 
 **Usage:**
 
-```bash
+```text
 /quote add text:"Great quote!" author:@Alice
 ```
 
 **Parameters:**
 
-- `text` (required): The quote text to add
-- `author` (required): The user who said the quote (mention/select the user)
+- `text` (required) — The quote text
+- `author` (required) — Who said it
 
-**Example Response:**
+**Example response:**
 
 ```text
 ✅ Quote added successfully and posted to the quote channel!
@@ -394,7 +336,7 @@ Edit an existing quote that you added.
 
 **Usage:**
 
-```bash
+```text
 /quote edit id:"697bdfe2808f7d245289392c" text:"Updated quote!"
 /quote edit id:"697bdfe2808f7d245289392c" author:@Bob
 /quote edit id:"697bdfe2808f7d245289392c" text:"New text" author:@Bob
@@ -402,267 +344,50 @@ Edit an existing quote that you added.
 
 **Parameters:**
 
-- `id` (required): The quote ID (found in the quote footer in the channel)
-- `text` (optional): The new quote text
-- `author` (optional): The new author (mention/select the user)
+- `id` (required) — Quote ID (in the quote footer)
+- `text` (optional) — New quote text
+- `author` (optional) — New author
 
 **Notes:**
 
 - You can only edit quotes that you added
-- At least one field (text or author) must be provided
-- The quote message in the channel will be updated automatically
+- At least one of `text` or `author` must be provided
 
-**Example Response:**
+**How it works:**
 
-```text
-✅ Quote updated successfully!
-```
+1. User submits a quote via `/quote add`
+2. Bot posts it as an embed in the configured quote channel
+3. Bot adds 👍 / 👎 reactions
+4. Users browse by scrolling the channel and vote with reactions
+5. Bot cleans up unauthorized messages every few minutes
 
-**How It Works:**
+**Security:**
 
-1. User submits a quote using `/quote add` command
-2. Bot posts the quote as an embed in the configured quote channel
-3. Bot automatically adds 👍 and 👎 reactions to the message
-4. Users browse quotes by scrolling through the channel
-5. Users react with 👍 or 👎 to vote on quotes
-6. Users can edit their own quotes using `/quote edit` with the quote ID
-7. Bot automatically cleans up any unauthorized messages (every 5 minutes)
-8. An informational header post explains the channel usage (auto-recreated if deleted)
-
-**Security Features:**
-
-- **Strict Permissions**: Channel is automatically configured so only the bot can post messages
-- **Auto-Cleanup**: Removes any non-bot messages every 5 minutes (configurable)
-- **User Access**: Users can view, read history, and add reactions only
-- **Informational Header**: Pinned post explains how the quote channel works
-
-**Example Response:**
-
-```text
-✅ Quote added successfully and posted to the quote channel!
-```
-
-**Quote Display in Channel:**
-
-Each quote appears as an embed with:
-
-- The quote text
-- Author (mentioned user)
-- Who added it
-- Quote ID (in footer)
-- 👍 and 👎 reactions for voting
-
-**Advanced Configuration:**
-
-```bash
-# Restrict who can add quotes (role IDs)
-/config set key:quotes.add_roles value:"123456789,987654321"
-
-# Set maximum quote length
-/config set key:quotes.max_length value:500
-
-# Set cooldown between adding quotes (seconds)
-/config set key:quotes.cooldown value:120
-
-# Set cleanup interval (minutes, default: 5)
-/config set key:quotes.cleanup_interval value:10
-
-# Disable header post (default: enabled)
-/config set key:quotes.header_enabled value:false
-
-# Disable header pinning (default: enabled)
-/config set key:quotes.header_pin_enabled value:false
-```
-
-**Use Cases:**
-
-- Preserve memorable server moments
-- Create a community quote wall
-- Natural browsing via channel scroll
-- Engage through Discord reactions
-- Simple, streamlined quote management
-- Protected channel prevents spam/abuse
-
-**Setup Steps:**
-
-1. Create a dedicated text channel for quotes (e.g., #quotes)
-2. Get the channel ID (right-click channel → Copy ID)
-3. Configure: `/config set key:quotes.channel_id value:"CHANNEL_ID"`
-4. Enable: `/config set key:quotes.enabled value:true`
-5. Reload: `/config reload`
-6. Bot will automatically set strict permissions on the channel
-
----
-
-### `/notice`
-
-> ⚠️ **Deprecated:** will be removed in 1.0. Manage notices from the WebUI
-> (run `/config` to get a sign-in link).
-
-**Description:** Manage server notices in a protected bot-controlled channel. Perfect for server rules, game server info, bot feature help, and important announcements.
-
-**Configuration:**
-
-```bash
-# Enable notices and set channel
-/config set key:notices.enabled value:true
-/config set key:notices.channel_id value:"YOUR_CHANNEL_ID"
-/config reload
-```
-
-**Subcommands:**
-
-#### `/notice add`
-
-Add a new notice to the channel.
-
-**Parameters:**
-
-- `title` (required) - Notice title (max 256 characters)
-- `content` (required) - Notice content (max 4000 characters)
-- `category` (required) - Category: General, Rules, Information, Help, or Game Servers
-- `order` (optional) - Display order (lower numbers appear first, default: 0)
-
-**Usage:**
-
-```bash
-/notice add title:"Server Rules" content:"1. Be respectful\n2. No spam..." category:"Rules" order:1
-/notice add title:"Minecraft Server" content:"IP: mc.example.com\nPort: 25565" category:"Game Servers" order:10
-/notice add title:"Bot Commands Help" content:"Use /help to see available commands" category:"Help" order:20
-```
-
-#### `/notice edit`
-
-Edit an existing notice.
-
-**Parameters:**
-
-- `id` (required) - Notice ID (visible in notice channel footer)
-- `title` (optional) - New title
-- `content` (optional) - New content
-- `category` (optional) - New category
-- `order` (optional) - New display order
-
-**Usage:**
-
-```bash
-/notice edit id:"abc123" title:"Updated Rules" content:"New rules text..."
-/notice edit id:"abc123" order:5
-```
-
-#### `/notice delete`
-
-Delete a notice.
-
-**Parameters:**
-
-- `id` (required) - Notice ID (visible in notice channel footer)
-
-**Usage:**
-
-```bash
-/notice delete id:"abc123"
-```
-
-**Note:** You can find notice IDs by viewing the notices in the channel - each notice shows its ID in the footer.
-
-#### `/notice sync`
-
-Recreate all notices in the channel (useful after cleanup or channel issues).
-
-**Usage:**
-
-```bash
-/notice sync
-```
-
-**How It Works:**
-
-1. Admin creates notices using `/notice add` with title, content, and category
-2. Bot posts each notice as a rich embed in the configured notices channel
-3. Bot automatically creates a "Bot Features" notice listing enabled features
-4. Notices are displayed in order by category, then by custom order number
-5. Channel is read-only for regular users (only bot can post)
-6. Bot automatically removes any unauthorized messages every 5 minutes
-7. An informational header post explains the channel purpose (auto-recreated if deleted)
-8. Notices persist in database and survive bot restarts
-9. Notice IDs are visible in each notice's footer for editing/deletion
-
-**Security Features:**
-
-- **Strict Permissions**: Channel is automatically configured so only the bot can post messages
-- **Auto-Cleanup**: Removes any non-bot messages every 5 minutes (configurable)
-- **User Access**: Users can view, read history, and add reactions only
-- **Persistent**: Notices stored in MongoDB, auto-repost on bot restart
-- **Informational Header**: Pinned post explains the channel's purpose
-
-**Notice Categories:**
-
-- **📋 General** - General server information
-- **📜 Rules** - Server rules and guidelines
-- **ℹ️ Information** - Important server info
-- **❓ Help** - Bot feature help and guides
-- **🎮 Game Servers** - Game server connection information
-
-**Advanced Configuration:**
-
-```bash
-# Set cleanup interval (minutes, default: 5)
-/config set key:notices.cleanup_interval value:10
-
-# Disable header post (default: enabled)
-/config set key:notices.header_enabled value:false
-
-# Disable header pinning (default: enabled)
-/config set key:notices.header_pin_enabled value:false
-```
-
-**Use Cases:**
-
-- Post server rules that can't be deleted/modified by users
-- Share game server connection info that stays up-to-date
-- Provide bot feature help and usage guides
-- Important announcements that need to stay visible
-- Protected information channel that prevents spam
-
-**Setup Steps:**
-
-1. Create a dedicated text channel for notices (e.g., #notices or #info)
-2. Get the channel ID (right-click channel → Copy ID)
-3. Configure: `/config set key:notices.channel_id value:"CHANNEL_ID"`
-4. Enable: `/config set key:notices.enabled value:true`
-5. Reload: `/config reload`
-6. Bot will automatically set strict permissions on the channel
-7. Add your first notice: `/notice add title:"Welcome" content:"Welcome to our server!" category:"General"`
-
-**Permissions:**
-
-- Everyone can view quotes in the channel
-- Everyone can add reactions to quotes
-- Only bot can post messages (auto-configured)
-- Adding quotes via command respects `quotes.add_roles` configuration (empty = everyone can add)
+The bot configures the quote channel so that only the bot can post.
+Users can read and react only. Unauthorized messages are removed by a
+periodic cleanup job. A pinned header explains the channel's purpose
+and is auto-recreated if deleted.
 
 ---
 
 ### `/amikool`
 
-**Description:** Check if you have a specific role (for role verification).
+**Description:** Check if you have a specific role (fun role verification).
 
-**Configuration:**
+**Enable:** Web UI → Settings:
 
-```bash
-/config set key:amikool.enabled value:true
-/config set key:amikool.role.name value:"Kool Members"
-/config reload
-```
+- `amikool.enabled = true`
+- `amikool.role.name = "Kool Members"` (or whatever role you check for)
+
+Then reload commands.
 
 **Usage:**
 
-```bash
+```text
 /amikool
 ```
 
-**Example Responses:**
+**Example responses:**
 
 ```text
 ✅ Yes, you are kool! You have the "Kool Members" role.
@@ -670,849 +395,135 @@ Recreate all notices in the channel (useful after cleanup or channel issues).
 ❌ Sorry, you don't have the "Kool Members" role.
 ```
 
-**Use Cases:**
-
-- Fun role verification
-- Check membership status
-- Confirm permissions
-
 ---
 
-## 🔧 Admin Commands
+## 🔧 Admin: Web UI launcher
 
-Commands that require Administrator permission in Discord.
-
----
+KoolBot has exactly one admin slash command. It does one thing: mint a
+single-use sign-in link for the admin Web UI and DM it to you.
 
 ### `/config`
 
-> ⚠️ **Deprecated:** every `/config` subcommand below — `list`, `set`, `import`,
-> `export`, `reset`, `reload` — is deprecated and will be removed in 1.0. The
-> `/config web` launcher (which DMs you a single-use WebUI sign-in link) is
-> **not** deprecated and remains the supported admin entry point.
+**Description:** Open the admin web UI. Sends you a single-use, time-limited
+sign-in link via DM. Every administrative action — settings, permissions,
+the setup wizard, announcements, polls, reaction roles, notices, voice
+channel management, database cleanup, bot stats — happens in the Web UI.
 
-**Description:** Comprehensive configuration management for all bot settings.
+**Permission:** Discord **Administrator** by default (overridable via the
+`/permissions` UI inside the Web UI itself).
+
+**Prerequisites:** Operator must have set `WEBUI_ENABLED=true`,
+`WEBUI_BASE_URL`, and `WEBUI_SESSION_SECRET` in `.env` and restarted the
+bot. See [WEBUI.md](WEBUI.md).
 
 **Usage:**
-
-```bash
-/config list                              # List all settings
-/config get key:ping.enabled              # Get specific setting
-/config set key:ping.enabled value:true   # Set a value
-/config reset key:ping.enabled            # Reset to default
-/config reload                            # Reload commands to Discord
-/config export                            # Export config to YAML
-/config import                            # Import config from YAML (attach file)
-```
-
-**Subcommands:**
-
-#### `/config list`
-
-Displays all configuration settings organized by category.
-
-**Example Response:**
 
 ```text
-📋 Configuration Settings
-
-Commands:
-  ping.enabled: true
-  quotes.enabled: false
-  amikool.enabled: true
-
-Voice Channels:
-  voicechannels.enabled: true
-  voicechannels.category.name: "Voice Channels"
-  ...
+/config
 ```
 
-#### `/config get`
+No subcommands, no parameters.
 
-Get the value of a specific setting.
+**Behavior:**
 
-**Parameters:**
+1. Bot verifies you have the Administrator permission (or a role that
+   `permissions-service` permits to run `config`).
+2. Bot revokes any prior unrevoked sessions you have.
+3. Bot generates a single-use token bound to your Discord user ID
+   (default TTL: 10 minutes; configurable via
+   `WEBUI_SESSION_TTL_MINUTES`).
+4. Bot DMs you a unique URL of the form
+   `https://your-bot.example.com/admin/s/<token>`.
+5. You open the link. The bot exchanges the token for a signed session
+   cookie scoped to your user ID and redirects to `/admin/`.
+6. You configure the bot in the Web UI. The session sliding window
+   defaults to 30 minutes of inactivity and is hard-capped at the
+   server-side TTL.
+7. You click **Finish** (or close the tab; or the inactivity timer
+   fires; or you re-run `/config`, which revokes the current session).
+   The cookie clears and `/admin/*` returns 401.
 
-- `key` (required) - The setting key (e.g., `ping.enabled`)
+**Example responses:**
 
-**Example:**
+DM is delivered:
 
-```bash
-/config get key:voicetracking.enabled
-→ voicetracking.enabled: true
+```text
+✅ I've DMed you a single-use sign-in link. Check your direct messages.
 ```
 
-#### `/config set`
+DM is blocked (fallback to ephemeral reply, visible only to you):
 
-Update a configuration value.
-
-**Parameters:**
-
-- `key` (required) - The setting key
-- `value` (required) - The new value
-
-**Examples:**
-
-```bash
-# Enable a feature
-/config set key:ping.enabled value:true
-
-# Set a string value
-/config set key:voicechannels.lobby.name value:"🟢 Join Here"
-
-# Set a number
-/config set key:quotes.cooldown value:120
-
-# Set comma-separated list
-/config set key:voicetracking.excluded_channels value:"123,456,789"
+```text
+🔗 Koolbot admin sign-in link
+https://bot.example.com/admin/s/9f4b...
+This link is single-use and expires in about 10 minute(s).
+If you did not run /config, ignore this message.
 ```
 
-#### `/config reset`
+Web UI disabled:
 
-Reset a setting to its default value.
-
-**Parameters:**
-
-- `key` (required) - The setting key to reset
-
-**Example:**
-
-```bash
-/config reset key:ping.enabled
-→ ✅ Reset ping.enabled to default value: false
+```text
+The web UI is disabled. Ask an operator to set WEBUI_ENABLED=true and restart the bot.
 ```
 
-#### `/config reload`
+Missing required env vars:
 
-Reload all commands to Discord API. **Required after enabling/disabling commands.**
-
-**Example:**
-
-```bash
-/config reload
-→ ✅ Commands reloaded successfully!
+```text
+❌ Web UI is enabled but missing env vars: WEBUI_BASE_URL, WEBUI_SESSION_SECRET
 ```
 
-**When to use:**
+**Why a launcher and not subcommands?**
 
-- After enabling/disabling any command
-- After changing command-related settings
-- If commands don't appear in Discord
+The slash command surface is genuinely bad at editing long lists,
+permission matrices, YAML, and structured configuration. The Web UI is
+the right home for that. Keeping a single launcher means:
 
-#### `/config export`
+- No persistent OAuth setup for casual operators.
+- The admin endpoint is dark unless an admin is actively configuring.
+- A leaked link is useless after one redemption or after the TTL.
+- Fat-fingering a setting has zero remediation cost — just close the tab.
 
-Export current configuration to a YAML file.
-
-**Example:**
-
-```bash
-/config export
-→ 📄 config-2026-01-15.yaml (attached file)
-```
-
-**Use Cases:**
-
-- Backup configuration
-- Transfer settings between instances
-- Version control settings
-
-#### `/config import`
-
-Import configuration from a YAML file.
-
-**Usage:**
-
-```bash
-/config import (attach YAML file)
-```
-
-**Use Cases:**
-
-- Restore from backup
-- Clone settings to new instance
-- Bulk configuration updates
+📖 **[Web UI Guide →](WEBUI.md)**
 
 ---
 
-### `/permissions`
+## Voice Channel Control Panel
 
-> ⚠️ **Deprecated:** will be removed in 1.0. Manage permissions from the WebUI
-> (run `/config` to get a sign-in link).
+**Note:** This is not a slash command. It is the inline component-based
+panel posted in a dynamically created voice channel's text chat.
 
-**Description:** Manage role-based command access control. This feature allows admins to restrict which commands can be used by
-specific Discord roles.
+**Description:** When you create a voice channel (by joining the lobby),
+an interactive control panel is automatically sent to the channel's text
+chat. Only you (the channel owner) can use it.
 
-**Command Name Format:** Command names are used directly (e.g., `quote`, `voicestats`)
+**Enable:** Web UI → Settings → `voicechannels.controlpanel.enabled = true`
+(default: `true`).
 
-**Key Features:**
+**Buttons (row 1):**
 
-- **Multi-role support** - Assign multiple roles to a single command
-- **OR logic** - Users need ANY of the assigned roles to execute the command
-- **Admin bypass** - Administrators always have access to all commands
-- **Default open** - Commands without permissions are accessible to everyone
+- **✏️ Rename** — Rename your channel (modal)
+- **🔒 Make Private / 🌐 Make Public** — Toggle privacy mode
+- **👥 Invite** — Invite a user to your private channel
+- **👑 Transfer** — Transfer ownership to another user in the channel
 
-**Subcommands:**
+**Buttons (row 2):**
 
-#### `/permissions set`
-
-Set command permissions (replaces any existing permissions).
-
-> **Note:** In Discord's slash command UI, `command` and `role` are option names. Select `quote` for the **command** option
-> and `@Moderator`, `@VIP`, etc. for the **role** options. The `command:value` notation in examples below represents the
-> option structure, not literal text you type.
-
-**Usage:**
-
-```bash
-/permissions set command:quote role:@Moderator
-/permissions set command:quote role:@Moderator role:@VIP role:@Admin
-/permissions set command:voicestats role:@Member
-```
-
-**Parameters:**
-
-- `command` (required) - Command name (autocomplete available)
-- `role1` (required) - First role that can use this command
-- `role2-5` (optional) - Additional roles (up to 5 total)
-
-**Example Response:**
-
-```text
-✅ Set permissions for `/quote` to: @Moderator, @VIP, @Admin
-```
-
-**Use Cases:**
-
-- Restrict powerful commands to trusted roles
-- Limit access to resource-intensive commands
-- Create role-specific command sets
-
-#### `/permissions add`
-
-Add roles to existing command permissions without removing current ones.
-
-**Usage:**
-
-```bash
-/permissions add command:quote role:@Contributor
-/permissions add command:quote role:@VIP role:@Premium
-```
-
-**Parameters:**
-
-- `command` (required) - Command name
-- `role1` (required) - First role to add
-- `role2-5` (optional) - Additional roles to add
-
-**Example Response:**
-
-```text
-✅ Added roles to `/quote`: @Contributor
-```
-
-**Use Cases:**
-
-- Incrementally expand access
-- Grant access to new roles without reconfiguring
-
-#### `/permissions remove`
-
-Remove specific roles from command permissions.
-
-**Usage:**
-
-```bash
-/permissions remove command:quote role:@VIP
-/permissions remove command:quote role:@Moderator role:@VIP
-```
-
-**Parameters:**
-
-- `command` (required) - Command name
-- `role1` (required) - First role to remove
-- `role2-5` (optional) - Additional roles to remove
-
-**Example Response:**
-
-```text
-✅ Removed roles from `/quote`: @VIP
-```
-
-**Note:** If all roles are removed, the permission entry is deleted automatically (command becomes accessible to everyone).
-
-**Use Cases:**
-
-- Revoke access from specific roles
-- Clean up outdated permissions
-
-#### `/permissions clear`
-
-Remove all permissions for a command, or remove all commands from a role/user.
-
-**Usage:**
-
-```bash
-# Clear permissions for a specific command
-/permissions clear command:quote
-
-# Clear all commands that have a specific role
-/permissions clear role:@Moderator
-
-# Clear all commands accessible via a user's roles
-/permissions clear user:@username
-```
-
-**Parameters:**
-
-- `command` (optional) - Command name to clear permissions for
-- `role` (optional) - Remove this role from all commands
-- `user` (optional) - Remove all of this user's roles from all commands
-
-**Note:** You must specify at least one parameter (command, role, or user).
-
-**Example Responses:**
-
-```text
-# Clearing a command
-✅ Cleared all permissions for `/quote`. It is now accessible to everyone.
-
-# Clearing a role from all commands
-✅ Removed @Moderator from 3 command(s).
-
-# Clearing a user's roles from all commands
-✅ Removed @username's roles from 5 command(s).
-```
-
-**Use Cases:**
-
-- Reset command to default open access
-- Remove all restrictions for a command
-- Remove a role from all commands when role is being deleted
-- Clean up permissions when removing a user's access
-
-#### `/permissions list`
-
-View the permission matrix showing all commands with role restrictions, or filter by a specific command.
-
-**Usage:**
-
-```bash
-# List all command permissions
-/permissions list
-
-# View permissions for a specific command
-/permissions list command:quote
-```
-
-**Parameters:**
-
-- `command` (optional) - Filter by specific command name
-
-**Example Responses:**
-
-```text
-# Listing all permissions
-Command Permissions
-
-Commands with role restrictions:
-
-/quote
-@Moderator, @VIP
-
-/voicestats
-@Member
-
-Commands not listed are accessible to everyone.
-Admins bypass all restrictions.
-
-# Listing a specific command
-Permissions for /quote
-
-Roles that can use this command:
-@Moderator, @VIP
-
-Admins bypass all restrictions.
-
-# When command has no permissions
-ℹ️ No permissions configured for `/quote`. It is accessible to everyone.
-```
-
-**Use Cases:**
-
-- Audit current permissions
-- Review access control setup
-- Documentation and planning
-- Check permissions for a specific command
-
-#### `/permissions view`
-
-Check what commands a specific user or role can access.
-
-**Usage:**
-
-```bash
-/permissions view user:@username
-/permissions view role:@Moderator
-```
-
-**Parameters:**
-
-- `user` (optional) - User to check
-- `role` (optional) - Role to check
-
-**Note:** Must specify either user OR role, not both.
-
-**Example Responses:**
-
-```text
-# View user permissions
-Permissions for username#1234
-Can access 12 command(s):
-`/ping`, `/help`, `/quote`, `/voicestats`, ...
-
-# View role permissions
-Permissions for Moderator
-Can access 15 command(s):
-`/ping`, `/help`, `/quote`, `/voicestats`, `/config`, ...
-```
-
-**Use Cases:**
-
-- Troubleshoot access issues
-- Verify role permissions
-- User support
-
-**Important Notes:**
-
-- **Always enabled** - Permissions are a core feature, no configuration needed
-- **Admin commands** - Commands like `/config`, `/vc`, `/dbtrunk` automatically require Administrator permission
-- **Permission inheritance** - Users inherit permissions from all their roles (OR logic)
-- **Default behavior** - When no permissions are set, everyone has access (except admin-only commands)
-- **Cache** - Permissions are cached for performance; changes take effect immediately
-
-**Examples:**
-
-```bash
-# Restrict quote command to moderators and VIPs
-/permissions set command:quote role:@Moderator role:@VIP
-
-# Add contributors to the allowed list
-/permissions add command:quote role:@Contributor
-
-# Check what @user123 can access
-/permissions view user:@user123
-
-# See all permission rules
-/permissions list
-
-# Make quote accessible to everyone again
-/permissions clear command:quote
-```
-
----
-
-### `/reactrole`
-
-> ⚠️ **Deprecated:** will be removed in 1.0. Manage reaction roles from the
-> WebUI (run `/config` to get a sign-in link).
-
-**Description:** Manage reaction-based roles. Allows users to self-assign roles by reacting to a message. Automatically creates
-Discord roles, categories, and channels with proper permissions.
-
-**Configuration:**
-
-```bash
-# Enable reaction roles feature
-/config set key:reactionroles.enabled value:true
-
-# Set channel for reaction role messages
-/config set key:reactionroles.message_channel_id value:"CHANNEL_ID"
-
-# Reload commands
-/config reload
-```
-
-**Permissions:** Requires Administrator permission
-
-**Subcommands:**
-
-#### `/reactrole create`
-
-Create a new reaction role with associated Discord role, category, and channel.
-
-**Usage:**
-
-```bash
-/reactrole create name:"Gaming" emoji:🎮
-/reactrole create name:"Movie Night" emoji:🎬
-/reactrole create name:"Music Lovers" emoji:🎵
-```
-
-**Parameters:**
-
-- `name` (required) - Name for the role, category, and channel
-- `emoji` (required) - Emoji users will react with to get the role
-
-**What it creates:**
-
-1. A Discord role with the specified name
-2. A category channel (visible only to role members)
-3. A text channel inside the category
-4. A reaction message in the configured message channel
-
-**Example Response:**
-
-```text
-✅ Reaction Role Created
-Successfully created reaction role Gaming!
-Role: @Gaming
-Category: #Gaming
-Channel: #gaming
-Users can now react to get this role!
-```
-
-**Use Cases:**
-
-- Create opt-in interest groups (gaming, movies, music)
-- Organize by game/activity with private channels
-- Event-based roles (tournament participants)
-- Community segmentation
-
-#### `/reactrole archive`
-
-Archive a reaction role. Disables reactions but keeps the role, category, and channels.
-
-**Usage:**
-
-```bash
-/reactrole archive name:"Gaming"
-```
-
-**Parameters:**
-
-- `name` (required) - Name of the reaction role to archive
-
-**What it does:**
-
-- Marks the role as archived
-- Removes the reaction message
-- Keeps the Discord role intact
-- Preserves the category and channels
-- Users can no longer get the role via reactions
-- Existing role members keep their access
-
-**Example Response:**
-
-```text
-📦 Reaction Role Archived
-Successfully archived reaction role Gaming. Role and channels are preserved but reactions are disabled.
-The reaction message has been removed
-```
-
-**Use Cases:**
-
-- Temporarily disable new sign-ups
-- Preserve channels for existing members
-- Archive inactive communities without deletion
-
-#### `/reactrole unarchive`
-
-Unarchive a reaction role to re-enable reactions.
-
-**Usage:**
-
-```bash
-/reactrole unarchive name:"Gaming"
-```
-
-**Parameters:**
-
-- `name` (required) - Name of the reaction role to unarchive
-
-**What it does:**
-
-- Marks the role as active again
-- Creates a new reaction message in the configured channel
-- Users can now react to get the role again
-- All existing channels and permissions remain unchanged
-
-**Example Response:**
-
-```text
-📤 Reaction Role Unarchived
-Successfully unarchived reaction role Gaming. Users can now react to get this role again!
-```
-
-**Use Cases:**
-
-- Re-enable sign-ups after a temporary pause
-- Reactivate seasonal communities
-- Resume role assignment after maintenance
-
-#### `/reactrole delete`
-
-Completely delete a reaction role and all associated resources.
-
-**Usage:**
-
-```bash
-/reactrole delete name:"Gaming"
-```
-
-**Parameters:**
-
-- `name` (required) - Name of the reaction role to delete
-
-**What it deletes:**
-
-- The Discord role
-- The category and all channels inside it
-- The reaction message
-- The database configuration
-
-**Example Response:**
-
-```text
-🗑️ Reaction Role Deleted
-Successfully deleted reaction role Gaming and all associated resources.
-All resources have been permanently removed
-```
-
-**Warning:** This action is permanent and cannot be undone!
-
-**Use Cases:**
-
-- Remove obsolete reaction roles
-- Clean up old communities
-- Free up Discord server space
-
-#### `/reactrole list`
-
-List all configured reaction roles.
-
-**Usage:**
-
-```bash
-/reactrole list
-```
-
-**Example Response:**
-
-```text
-📋 Reaction Roles
-Found 3 reaction role(s)
-
-🎮 Gaming
-Status: ✅ Active
-Role: @Gaming
-Category: #Gaming
-Channel: #gaming
-Created: 1/15/2026
-
-🎬 Movie Night
-Status: 📦 Archived
-Role: @Movie Night
-Category: #Movie Night
-Channel: #movie-night
-Created: 1/10/2026
-```
-
-**Use Cases:**
-
-- View all reaction roles at a glance
-- Check which roles are active vs archived
-- Audit reaction role configuration
-
-#### `/reactrole status`
-
-Check detailed status of a specific reaction role.
-
-**Usage:**
-
-```bash
-/reactrole status name:"Gaming"
-```
-
-**Parameters:**
-
-- `name` (required) - Name of the reaction role to check
-
-**Example Response:**
-
-```text
-🎮 Gaming
-Status: ✅ Active
-Role ID: 123456789
-Category ID: 987654321
-Channel ID: 111222333
-Created: 1/15/2026, 3:30:00 PM
-Last Updated: 1/15/2026, 3:30:00 PM
-Message ID: 444555666
-```
-
-**Use Cases:**
-
-- Get IDs for advanced configuration
-- Debug permission issues
-- Verify role configuration
-
----
-
-**Setup Guide:**
-
-1. Create a dedicated channel for reaction role messages (e.g., #get-roles)
-1. Get the channel ID (right-click channel → Copy ID)
-1. Configure the bot:
-
-```bash
-/config set key:reactionroles.enabled value:true
-/config set key:reactionroles.message_channel_id value:"YOUR_CHANNEL_ID"
-/config reload
-```
-
-1. Create your first reaction role:
-
-```bash
-/reactrole create name:"Gaming" emoji:🎮
-```
-
-1. Users can now react in the configured channel to get roles!
-
-**How it works:**
-
-- Users react to the message with the specified emoji
-- Bot automatically assigns the role
-- Users gain access to the private category and channels
-- Removing the reaction removes the role and access
-- Category permissions are automatically maintained
-
-**Best Practices:**
-
-- Use clear, descriptive names for roles
-- Choose easily recognizable emojis
-- Pin the reaction message in the channel
-- Organize reaction messages with category separators
-- Archive roles instead of deleting to preserve data and allow reactivation
-- Use unarchive to re-enable roles after maintenance or seasonal breaks
-- Use archived roles for seasonal/temporary communities
-
----
-
-### `/vc`
-
-> ⚠️ **Deprecated:** will be removed in 1.0. Manage voice channels from the
-> WebUI (run `/config` to get a sign-in link). The user-facing voice channel
-> control panel buttons inside Discord are **not** affected.
-
-**Description:** Voice channel management, cleanup tools, and user customization.
-
-**Configuration:**
-
-```bash
-/config set key:voicechannels.enabled value:true
-/config reload
-```
-
-**Subcommands:**
-
-#### `/vc reload`
-
-Clean up empty dynamically created voice channels.
-
-**Usage:**
-
-```bash
-/vc reload
-```
-
-**What it does:**
-
-- Removes empty user-created channels
-- Keeps channels with active users
-- Preserves the lobby channel
-
-**Example Response:**
-
-```text
-🧹 Cleaned up 3 empty voice channels
-```
-
-**Use Cases:**
-
-- Manual cleanup of abandoned channels
-- Server organization
-- Free up channel slots
-
-#### `/vc force-reload`
-
-Force cleanup of ALL unmanaged channels in the voice category.
-
-**Usage:**
-
-```bash
-/vc force-reload
-```
-
-**Warning:** This is destructive! It removes ALL channels except the lobby, even if they have users.
-
-**What it does:**
-
-- Removes ALL unmanaged channels in category
-- Keeps only the lobby channel
-- Does not remove manually created channels outside the category
-
-**Example Response:**
-
-```text
-⚠️ Force cleanup completed
-Removed 8 channels from Voice Channels category
-```
-
-**Use Cases:**
-
-- Reset voice channel setup
-- Fix corrupted channel states
-- Emergency cleanup
-
----
-
-### Voice Channel Control Panel
-
-**Description:** When you create a voice channel, an interactive control panel is automatically sent to the channel's text chat (if
-available). This provides quick access to customization options.
-
-**Configuration:**
-
-```bash
-/config set key:voicechannels.controlpanel.enabled value:true  # Default: true
-/config reload
-```
-
-**Control Panel Buttons (Row 1):**
-
-- **✏️ Rename** - Opens a modal to rename your channel
-- **🔒 Make Private / 🌐 Make Public** - Toggle privacy mode
-- **👥 Invite** - Invite users to your private channel
-- **👑 Transfer** - Shows how to transfer ownership
-
-**Control Panel Buttons (Row 2):**
-
-- **🔴 Go Live / ⬜ Go Offline** - Mark your channel as live (streaming disclaimer)
-- **⏳ Waiting Room / 🗑️ Remove Waiting Room** - Toggle a companion waiting room channel
+- **🔴 Go Live / ⬜ Go Offline** — Mark the channel as live with a streaming disclaimer
+- **⏳ Waiting Room / 🗑️ Remove Waiting Room** — Toggle a companion waiting room
 
 **Features:**
 
-- Only visible to channel owner
-- Updates dynamically when privacy mode, live status, or waiting room changes
-- Persists until channel is deleted
-- Posted every time a new channel is created
+- Only visible to the channel owner
+- Updates dynamically as privacy / live / waiting-room state changes
+- Persists until the channel is deleted
+- Posted automatically every time a new channel is created
 
 **Requirements:**
 
-- Server must have text channels associated with voice channels (community servers)
+- Discord server must support text channels associated with voice channels
 - `voicechannels.controlpanel.enabled` must be `true`
 
-**Example Control Panel:**
+**Example panel:**
 
 ```text
 🎮 Voice Channel Controls
@@ -1528,1012 +539,190 @@ Privacy: 🌐 Public
 Only you can see and use these controls
 ```
 
-**Available Actions:**
+### Rename channel
 
-#### Rename Channel
+Click **✏️ Rename** to open a modal where you can enter a new name. No
+placeholder requirements — use any name.
 
-Click the **✏️ Rename** button to open a modal where you can enter a new name for your channel. No placeholder requirements - use any name you want!
+### Toggle privacy
 
-#### Toggle Privacy
+**🔒 Make Private** restricts the channel to you and invited users. **🌐
+Make Public** opens it back up.
 
-Click the **🔒 Make Private** button to make your channel invite-only. Only you and invited users will be able to join. Click **🌐
-Make Public** to allow anyone to join again.
+### Invite users
 
-#### Invite Users
+While the channel is private, click **👥 Invite** and pick a user from
+the menu. They get a DM notification with permission to join.
 
-When your channel is private, click the **👥 Invite** button to see instructions on inviting users. Select a user to grant them
-permission to join your channel. They'll receive a DM notification.
+### Transfer ownership
 
-#### Transfer Ownership
+**👑 Transfer** opens a dropdown of users currently in the channel.
+Pick one to hand over ownership instantly.
 
-Click the **👑 Transfer** button to select a user from a dropdown menu. Only users currently in the channel will appear. Transfer ownership instantly.
+### Go Live
 
-#### Go Live
+**🔴 Go Live** adds a `🔴` prefix to your channel name, posts a Terms-of-
+Service disclaimer in the channel text chat, and notifies anyone joining
+that the channel is live. **⬜ Go Offline** removes the prefix and
+indicator.
 
-Click **🔴 Go Live** to mark your channel as live. This will:
+### Waiting Room
 
-- Add a `🔴` prefix to your channel name (auto-removed when you go offline)
-- Post a disclaimer in the channel text chat about platform Terms of Service
-- Notify anyone who joins the channel that it is live
-
-Click **⬜ Go Offline** to remove the live indicator.
-
-#### Waiting Room
-
-Click **⏳ Waiting Room** to create a companion waiting room channel for your voice channel. Users can join the waiting room and
-you (the owner) will receive a notification in the channel with a **🚪 Let In** button to move them into your channel.
-
-- Waiting room users cannot speak (mic muted)
-- When deleted or when you remove it, remaining users are automatically moved into your channel
-- Click **🗑️ Remove Waiting Room** to delete it
-
----
-
-- Return to default settings
-- Fix misconfigured preferences
-- Start fresh with new preferences
-
----
-
-### `/dbtrunk`
-
-> ⚠️ **Deprecated:** will be removed in 1.0. Run database cleanup from the
-> WebUI (run `/config` to get a sign-in link).
-
-**Description:** Database cleanup management for voice tracking data.
-
-**Configuration:**
-
-```bash
-/config set key:voicetracking.cleanup.enabled value:true
-/config reload
-```
-
-**Subcommands:**
-
-#### `/dbtrunk status`
-
-Show cleanup service status and statistics.
-
-**Usage:**
-
-```bash
-/dbtrunk status
-```
-
-**Example Response:**
-
-```text
-📊 Cleanup Service Status
-
-Status: ✅ Running
-Database: ✅ Connected
-Schedule: Daily at 00:00
-
-Last Cleanup: 2026-01-14 00:00:15
-Sessions Removed: 1,247
-Data Aggregated: 89 records
-
-Retention Policy:
-  Detailed Sessions: 30 days
-  Monthly Summaries: 6 months
-  Yearly Summaries: 1 year
-```
-
-**Use Cases:**
-
-- Check cleanup status
-- Verify database health
-- Monitor data retention
-
-#### `/dbtrunk run`
-
-Manually trigger database cleanup now.
-
-**Usage:**
-
-```bash
-/dbtrunk run
-```
-
-**What it does:**
-
-- Removes old detailed sessions (older than retention period)
-- Removes old monthly summaries
-- Removes old yearly summaries
-- Preserves aggregated statistics
-
-**Example Response:**
-
-```text
-🧹 Cleanup completed successfully!
-
-Detailed sessions removed: 1,247
-Monthly summaries removed: 12
-Yearly summaries removed: 1
-Total space freed: 15.4 MB
-Duration: 3.2 seconds
-```
-
-**Use Cases:**
-
-- Manual cleanup between scheduled runs
-- Free up database space immediately
-- Test cleanup configuration
-
----
-
-### `/announce-vc-stats`
-
-> ⚠️ **Deprecated:** will be removed in 1.0. Trigger the weekly VC stats post
-> from the WebUI (run `/config` to get a sign-in link).
-
-**Description:** Manually trigger the weekly voice channel statistics announcement.
-
-**Configuration:**
-
-```bash
-/config set key:voicetracking.enabled value:true
-/config set key:voicetracking.announcements.enabled value:true
-/config set key:voicetracking.announcements.channel value:"voice-stats"
-/config reload
-```
-
-**Usage:**
-
-```bash
-/announce-vc-stats
-```
-
-**What it does:**
-
-- Posts top voice channel users to configured channel
-- Shows weekly statistics
-- Includes medals for top 3 users
-
-**Example Response (in configured channel):**
-
-```text
-📊 Weekly Voice Channel Stats
-
-🥇 Alice: 45h 30m
-🥈 Bob: 38h 15m
-🥉 Charlie: 32h 20m
-4. David: 28h 10m
-5. Emma: 24h 45m
-...
-
-Total server voice time: 324h 15m
-Active users: 47
-```
-
-**Use Cases:**
-
-- Post stats on-demand
-- Test announcement format
-- Share stats outside regular schedule
-
-**Automatic Announcements:**
-
-```bash
-# Configure automatic weekly announcements
-/config set key:voicetracking.announcements.schedule value:"0 16 * * 5"
-# Every Friday at 4 PM
-```
-
----
-
-### `/announce`
-
-> ⚠️ **Deprecated:** will be removed in 1.0. Manage scheduled announcements
-> from the WebUI (run `/config` to get a sign-in link).
-
-**Description:** Manage scheduled announcements to automatically send messages to channels on a schedule.
-
-**Configuration:**
-
-```bash
-/config set key:announcements.enabled value:true
-/config reload
-```
-
-**Subcommands:**
-
-#### Create a scheduled announcement
-
-```bash
-/announce create cron:"0 9 * * *" channel:#general message:"Good morning!" placeholders:true
-```
-
-**Parameters:**
-
-- `cron` (required) - Cron schedule expression
-  - `0 9 * * *` - Daily at 9 AM
-  - `0 12 * * 1` - Every Monday at noon
-  - `0 0 * * 0` - Every Sunday at midnight
-  - `*/30 * * * *` - Every 30 minutes
-- `channel` (required) - Channel to send announcements to
-- `message` (required) - Message content
-- `placeholders` (optional) - Enable dynamic placeholders (default: false)
-- `embed_title` (optional) - Add an embed with title
-- `embed_description` (optional) - Embed description
-- `embed_color` (optional) - Embed color (hex code, e.g., #FF0000)
-
-**Supported Placeholders:**
-
-When `placeholders` is enabled, you can use:
-
-- `{server_name}` - Server name
-- `{member_count}` - Current member count
-- `{date}` - Current date
-- `{time}` - Current time
-- `{day}` - Day of week (e.g., Monday)
-- `{month}` - Month name (e.g., January)
-- `{year}` - Current year
-
-**Examples:**
-
-```bash
-# Daily morning announcement
-/announce create cron:"0 9 * * *" channel:#general \
-  message:"Good morning, {server_name}! We have {member_count} members!" \
-  placeholders:true
-
-# Weekly event reminder with embed
-/announce create cron:"0 18 * * 5" channel:#events \
-  message:"Weekly game night starting soon!" \
-  embed_title:"🎮 Game Night" \
-  embed_description:"Join us for games this Friday evening!" \
-  embed_color:#5865F2
-
-# Monthly server stats
-/announce create cron:"0 0 1 * *" channel:#announcements \
-  message:"Monthly server update for {month} {year}" \
-  placeholders:true
-```
-
-#### List scheduled announcements
-
-```bash
-/announce list
-```
-
-Shows all scheduled announcements with their:
-
-- ID
-- Status (enabled/disabled)
-- Channel
-- Cron schedule
-- Message preview
-
-#### Delete an announcement
-
-```bash
-/announce delete id:123abc456def
-```
-
-**Parameters:**
-
-- `id` (required) - Announcement ID from `/announce list`
-
-**Example Response:**
-
-```text
-✅ Announcement Created
-
-Announcement ID: `65f4a3b2c1d9e8f7a6b5c4d3`
-Channel: #general
-Schedule: `0 9 * * *`
-Placeholders: Enabled
-Message: Good morning, {server_name}!
-```
-
-**Use Cases:**
-
-- Daily/weekly automated announcements
-- Event reminders
-- Server updates
-- Community engagement messages
-- Rule reminders
-- Automated status updates
-
----
-
-### `/poll`
-
-> ⚠️ **Deprecated:** will be removed in 1.0. Manage poll schedules and the
-> poll-question library from the WebUI (run `/config` to get a sign-in link).
-
-**Description:** Manage periodic polls for icebreaker discussions and community engagement.
-Posts Discord native polls on a schedule with questions from URL sources or database storage.
-
-**Configuration:**
-
-```bash
-/config set key:polls.enabled value:true
-/config set key:polls.default_duration_hours value:24    # Default poll duration
-/config set key:polls.cooldown_days value:7              # Days before reusing poll
-/config reload
-```
-
-**Features:**
-
-- 🗳️ **Native Discord Polls** - Uses Discord's built-in poll feature
-- 📅 **Scheduled Posting** - Automatic polls via cron schedules  
-- 📥 **URL Import** - Fetch poll questions from YAML/JSON files
-- 🔄 **Smart Rotation** - Avoid repeating polls within cooldown period
-- 💾 **Database Storage** - Store and manage poll questions locally
-- 🔔 **Role Pinging** - Optional role mentions when posting
-- 🎲 **Multi-Select** - Support for multiple answer selections
-
-**Subcommands:**
-
-#### Create a poll schedule
-
-```bash
-/poll create channel:#daily-questions schedule:"0 12 * * *" duration:24 ping_role:@Everyone
-```
-
-**Parameters:**
-
-- `channel` (required) - Channel to post polls in
-- `schedule` (required) - Cron schedule expression
-  - `0 12 * * *` - Daily at noon
-  - `0 9 * * 1` - Every Monday at 9 AM
-  - `0 18 * * 5` - Every Friday at 6 PM
-- `duration` (optional) - Poll duration in hours (1-768, default: 24)
-- `ping_role` (optional) - Role to mention when posting polls
-
-**Example:**
-
-```bash
-/poll create channel:#icebreakers schedule:"0 14 * * *" duration:48 ping_role:@Community
-```
-
-#### Import poll questions from URL
-
-```bash
-/poll import-url url:https://example.com/polls.yaml
-```
-
-Imports poll questions from a remote YAML or JSON file and saves them to the database.
-
-**Supported URL Formats:**
-
-**YAML:**
-
-```yaml
-polls:
-  - question: "What's your favorite programming language?"
-    answers:
-      - "JavaScript"
-      - "Python"
-      - "Go"
-      - "Rust"
-    multiselect: false
-    tags: ["tech", "icebreaker"]
-  
-  - question: "Would you rather fight 100 duck-sized horses or 1 horse-sized duck?"
-    answers:
-      - "100 duck-sized horses"
-      - "1 horse-sized duck"
-      - "Neither, I'm out!"
-    multiselect: false
-    tags: ["funny", "absurd"]
-```
-
-**JSON:**
-
-```json
-{
-  "polls": [
-    {
-      "question": "What's your favorite season?",
-      "answers": ["Spring", "Summer", "Fall", "Winter"],
-      "multiselect": false,
-      "tags": ["general"]
-    }
-  ]
-}
-```
-
-**Import Result:**
-
-```text
-📥 Import Results
-
-Imported: 15
-Skipped: 3
-Errors: 0
-```
-
-#### Add a poll question manually
-
-```bash
-/poll add-item question:"What's your favorite food?" \
-  answers:"Pizza, Tacos, Sushi, Burgers" \
-  multiselect:false \
-  tags:"food,icebreaker"
-```
-
-**Parameters:**
-
-- `question` (required) - Poll question (max 300 characters)
-- `answers` (required) - Comma-separated list of 2-10 answers
-- `multiselect` (optional) - Allow multiple selections (default: false)
-- `tags` (optional) - Comma-separated tags for categorization
-
-#### List poll schedules
-
-```bash
-/poll list
-```
-
-Shows all configured poll schedules with:
-
-- Schedule ID
-- Status (enabled/disabled)
-- Target channel
-- Cron schedule
-- Poll duration
-- Ping role
-- Last run time
-
-**Example Response:**
-
-```text
-📊 Poll Schedules
-Total: 2 schedule(s)
-
-✅ 65f8a9b3c2d1e4f6a7b8c5d4
-Channel: #daily-questions
-Schedule: `0 12 * * *`
-Duration: 24h
-Ping Role: @Everyone
-Last Run: 2/14/2026, 12:00:00 PM
-
-✅ 65f8b2c4d3e5f7a8b9c6d5e4
-Channel: #friday-fun
-Schedule: `0 18 * * 5`
-Duration: 48h
-Ping Role: None
-Last Run: Never
-```
-
-#### List poll questions
-
-```bash
-/poll list-items
-```
-
-Shows all stored poll questions with:
-
-- Poll ID
-- Status (enabled/disabled)
-- Question text (truncated)
-- Number of answers
-- Usage count
-- Last used date
-
-**Example Response:**
-
-```text
-📊 Poll Questions
-Total: 25 question(s)
-
-✅ 65f8c3d4e5f6a7b8c9d6e5f6
-Q: What's your favorite programming language?
-Answers: 4
-Used: 3 times
-Last: 2/10/2026, 2:00:00 PM
-
-✅ 65f8d4e5f6a7b8c9d6e5f7a8
-Q: Would you rather fight 100 duck-sized horses...
-Answers: 3
-Used: 1 times
-Last: 1/28/2026, 12:00:00 PM
-```
-
-#### Delete a poll schedule
-
-```bash
-/poll delete id:65f8a9b3c2d1e4f6a7b8c5d4
-```
-
-**Parameters:**
-
-- `id` (required) - Schedule ID from `/poll list`
-
-#### Delete a poll question
-
-```bash
-/poll delete-item id:65f8c3d4e5f6a7b8c9d6e5f6
-```
-
-**Parameters:**
-
-- `id` (required) - Poll item ID from `/poll list-items`
-
-#### Test a poll schedule
-
-```bash
-/poll test schedule_id:65f8a9b3c2d1e4f6a7b8c5d4
-```
-
-Posts a poll immediately from the specified schedule for testing purposes.
-
-**Parameters:**
-
-- `schedule_id` (required) - Schedule ID to test
-
-**Poll Selection Logic:**
-
-The bot intelligently selects polls to avoid repetition:
-
-1. **Cooldown Period** - Polls used within the cooldown period (default 7 days) are skipped
-2. **Usage Count** - Prioritizes less-used polls
-3. **Randomization** - Randomly selects from the top 20% least-used eligible polls
-4. **Fallback** - If all polls are within cooldown, uses the oldest-used poll
-
-**Example Workflow:**
-
-```bash
-# 1. Enable the feature
-/config set key:polls.enabled value:true
-/config reload
-
-# 2. Import poll questions from a URL
-/poll import-url url:https://mysite.com/icebreaker-polls.yaml
-→ Imported: 20 polls
-
-# 3. Or add polls manually
-/poll add-item question:"Cats or dogs?" answers:"Cats, Dogs, Both!, Neither" multiselect:false
-
-# 4. Create a schedule
-/poll create channel:#daily-questions schedule:"0 12 * * *" duration:24 ping_role:@Community
-
-# 5. Test it immediately
-/poll test schedule_id:65f8a9b3c2d1e4f6a7b8c5d4
-→ ✅ Test poll posted successfully
-
-# 6. View schedules
-/poll list
-
-# 7. View all poll questions
-/poll list-items
-```
-
-**Use Cases:**
-
-- Daily icebreaker questions to spark conversations
-- Weekly "Would You Rather" discussions
-- Team building and getting-to-know-you activities
-- Community engagement and feedback polls
-- Fun hypothetical scenarios
-- Topic voting for events or discussions
-
-**Tips:**
-
-- **Start Small** - Import 10-15 polls initially to test the rotation
-- **Diversify** - Mix serious and funny questions for variety
-- **Tag Wisely** - Use tags to organize polls by theme
-- **Monitor Usage** - Check `/poll list-items` to see which polls are popular
-- **Update Regularly** - Add new polls monthly to keep content fresh
-- **Cooldown Balance** - Adjust cooldown period based on pool size (more polls = longer cooldown works better)
-
----
-**Notes:**
-
-- Announcements persist across bot restarts
-- All times use the server's timezone
-- Invalid cron expressions are rejected
-- Only administrators can manage announcements
-
----
-
-### `/setup`
-
-> ⚠️ **Deprecated:** will be removed in 1.0. Run the setup wizard from the
-> WebUI (run `/config` to get a sign-in link).
-
-**Description:** Interactive setup wizard to guide you through configuring KoolBot features.
-This is the recommended way to set up your server for the first time or configure new features.
-
-**Note:** This command is always available to administrators as a core feature.
-
-**Usage:**
-
-```bash
-/setup wizard                       # Start full setup wizard
-/setup wizard feature:voicechannels # Configure specific feature
-```
-
-**Subcommands:**
-
-#### `/setup wizard [feature]`
-
-Start the interactive configuration wizard. Optionally specify a feature to configure directly.
-
-**Parameters:**
-
-- `feature` (optional) - Choose a specific feature to configure:
-  - `voicechannels` - Dynamic voice channel management
-  - `voicetracking` - Voice activity tracking
-  - `quotes` - Quote system
-  - `gamification` - Achievement badges
-  - `logging` - Core event logging
-
-**What it does:**
-
-The wizard provides a guided, step-by-step setup experience:
-
-1. **Auto-detects existing resources** - Finds existing categories, channels, and suggests using them
-2. **Feature selection** - Choose which features to enable (full wizard) or configure a specific feature
-3. **Interactive configuration** - Uses buttons, select menus, and modals to collect settings
-4. **Validates input** - Ensures channels exist and settings are valid
-5. **Applies configuration** - Automatically sets all related config keys
-6. **Shows summary** - Displays what was configured
-
-**Example Flow (Full Wizard):**
-
-```text
-Step 1: Feature Selection
-┌────────────────────────────────┐
-│ Select features to configure:  │
-│ ☑ Voice Channels              │
-│ ☑ Voice Tracking              │
-│ ☐ Quote System                │
-│ ☐ Achievements                │
-│ ☐ Core Logging                │
-│                                │
-│ [Continue] [Cancel]            │
-└────────────────────────────────┘
-
-Step 2: Voice Channels Setup
-┌────────────────────────────────┐
-│ Voice Channels Configuration   │
-│                                │
-│ Category: Voice Channels       │
-│ Lobby Name: 🟢 Lobby          │
-│                                │
-│ [Next] [Back] [Cancel]         │
-└────────────────────────────────┘
-
-Step 3: Confirmation
-✅ Configuration Complete!
-Voice Channels: Enabled
-Voice Tracking: Enabled
-Quote System: Disabled
-Achievements: Disabled
-Core Logging: Disabled
-
-Run /config reload to apply changes.
-```
-
-#### Example: Specific Feature Setup
-
-```bash
-/setup wizard feature:voicetracking
-```
-
-This will:
-
-- Skip feature selection
-- Go directly to voice tracking configuration
-- Configure tracking settings, excluded channels, and admin roles
-- Enable the feature upon completion
-
-#### Benefits over manual configuration
-
-- **Beginner-friendly** - No need to know exact config keys
-- **Auto-detection** - Suggests existing channels and categories
-- **Guided workflow** - Step-by-step with explanations
-- **Error prevention** - Validates all inputs before applying
-- **Bulk configuration** - Sets multiple related settings at once
-- **Interactive** - Uses Discord's UI components for better UX
-
-**When to use:**
-
-- **First-time setup** - Easiest way to get started
-- **New features** - Enable and configure additional features
-- **Troubleshooting** - Reconfigure features that aren't working
-- **Channel changes** - Update channel references after reorganization
-
-**Use Cases:**
-
-- Initial server setup
-- Onboarding new administrators
-- Enabling new features
-- Reconfiguring after channel reorganization
-- Troubleshooting misconfigured features
-
-**Notes:**
-
-- Sessions expire after 15 minutes of inactivity
-- All interactions are ephemeral (only visible to you)
-- Requires Administrator permission
-- Changes take effect after `/config reload`
-- Wizard validates that channels exist before applying
-
----
-
-### `/botstats`
-
-> ⚠️ **Deprecated:** will be removed in 1.0. View bot stats on the WebUI
-> dashboard (run `/config` to get a sign-in link).
-
-**Description:** View bot performance and usage statistics.
-
-**Usage:**
-
-```bash
-/botstats
-```
-
-**Example Response:**
-
-```text
-🤖 KoolBot Statistics
-
-Uptime: 7 days, 14 hours, 23 minutes
-Version: 1.0.0
-
-Performance:
-  Memory Usage: 245 MB
-  CPU Usage: 3.2%
-  Database: Connected
-  Latency: 45ms
-
-Activity:
-  Guilds: 1
-  Users Tracked: 347
-  Voice Sessions Today: 89
-  Commands Executed: 2,451
-
-Most Used Commands:
-  1. /voicestats - 1,526 times
-  2. /ping - 421 times
-  3. /quote - 315 times
-```
-
-**Use Cases:**
-
-- Monitor bot health
-- Check resource usage
-- View usage statistics
-- Troubleshoot performance issues
+**⏳ Waiting Room** creates a companion waiting-room channel. Joiners
+land there muted; you (the owner) get a notification with a **🚪 Let In**
+button to admit them. **🗑️ Remove Waiting Room** deletes it.
 
 ---
 
 ## 🔒 Permission Requirements
 
-### User Command Permissions
+### User command permissions
 
-| Command         | Permission Level | Additional Requirements                   |
-| --------------- | ---------------- | ----------------------------------------- |
-| `/ping`         | Everyone         | Command must be enabled                   |
-| `/voicestats`   | Everyone         | Voice tracking enabled                    |
-| `/achievements` | Everyone         | Achievements enabled                      |
-| `/seen`         | Everyone         | Voice tracking + seen enabled             |
-| `/quote`        | Everyone\*       | Quotes enabled (\*may be role-restricted) |
-| `/amikool`      | Everyone         | Command enabled + role configured         |
+| Command         | Permission Level | Additional Requirements                    |
+| --------------- | ---------------- | ------------------------------------------ |
+| `/ping`         | Everyone\*       | Command must be enabled                    |
+| `/voicestats`   | Everyone\*       | Voice tracking enabled                     |
+| `/achievements` | Everyone\*       | Achievements enabled                       |
+| `/seen`         | Everyone\*       | Voice tracking + seen enabled              |
+| `/quote`        | Everyone\*       | Quotes enabled                             |
+| `/amikool`      | Everyone\*       | Command enabled + role configured          |
 
-### Admin Command Permissions
+\* Per-command role gating can be added in the Web UI's **Permissions** page.
 
-All admin commands require **Administrator** permission in Discord.
+### Admin command permissions
 
-| Command              | Additional Requirements                          |
-| -------------------- | ------------------------------------------------ |
-| `/setup`             | Administrator permission                         |
-| `/config`            | Administrator permission                         |
-| `/permissions`       | Administrator permission                         |
-| `/vc`                | Administrator + voice channels enabled           |
-| `/dbtrunk`           | Administrator + cleanup enabled                  |
-| `/announce-vc-stats` | Administrator + tracking & announcements enabled |
-| `/botstats`          | Administrator permission                         |
+| Command   | Permission                                                       |
+| --------- | ---------------------------------------------------------------- |
+| `/config` | Administrator (overridable in the Web UI's Permissions page)     |
 
-### Bot Permissions Required
+### Bot permissions required
 
-The bot needs these Discord permissions to function:
+The bot needs these Discord permissions:
 
 **Essential:**
 
-- Read Messages/View Channels
+- Read Messages / View Channels
 - Send Messages
 - Use Slash Commands
+- Embed Links
+- Attach Files
 
-**For Voice Features:**
+**For voice features:**
 
 - Manage Channels (create/delete voice channels)
 - Move Members (move users to created channels)
 - View Channel (see voice channels)
 - Connect (for voice state updates)
 
-**For Configuration:**
+**For reaction roles:**
 
-- Embed Links (for rich responses)
-- Attach Files (for config export/import)
+- Manage Roles (the bot's highest role must sit above any role it grants)
+
+**For leaderboard role rewards:**
+
+- Manage Roles (same hierarchy rule as above)
 
 ---
 
 ## 📚 Quick Command Reference
 
-### User Commands Summary
+### User commands
 
-```bash
+```text
 /ping                               # Check bot status
 /help [command]                     # Get help on commands
-/voicestats top [period] [limit]   # Voice leaderboards
-/voicestats user [user] [period]   # Voice channel stats
-/achievements [user]               # View earned badges
-/seen user:@User                   # Last seen info
-/quote text:"..." author:"@User"   # Add quote to channel
-/amikool                           # Role verification
+/voicestats top [period] [limit]    # Voice leaderboards
+/voicestats user [user] [period]    # Personal voice stats
+/achievements [user]                # View earned accolades
+/seen user:@User                    # Last-seen lookup
+/quote add text:"..." author:@User  # Add a quote
+/quote edit id:"..." [text:"..."] [author:@User]
+/amikool                            # Role verification
 ```
 
-### Admin Commands Summary
+### Admin command
 
-```bash
-# Initial Setup (Recommended)
-/setup wizard                      # Interactive setup wizard
-/setup wizard feature:...          # Configure specific feature
-
-# Configuration
-/config list                       # List all settings
-/config get key:...                # Get setting value
-/config set key:... value:...      # Set setting value
-/config reset key:...              # Reset to default
-/config reload                     # Reload commands
-/config export                     # Export config
-/config import                     # Import config
-
-# Permissions
-/permissions set command:... role:...   # Set command permissions
-/permissions add command:... role:...   # Add role to command
-/permissions remove command:... role:...# Remove role from command
-/permissions list                       # View all permissions
-/permissions list command:...           # View permissions for a command
-/permissions view user:...              # Check user access
-/permissions view role:...              # Check role access
-/permissions clear command:...          # Clear command restrictions
-/permissions clear role:...             # Remove role from all commands
-/permissions clear user:...             # Remove user's roles from all commands
-
-# Voice Management
-/vc reload                         # Clean empty channels
-/vc force-reload                   # Force cleanup all
-
-# Database Management
-/dbtrunk status                    # Cleanup status
-/dbtrunk run                       # Run cleanup now
-
-# Other Admin
-/announce-vc-stats                 # Post stats now
-/announce create                   # Schedule announcement
-/announce list                     # View announcements
-/announce delete                   # Remove announcement
-/reactrole create                  # Create reaction role
-/reactrole list                    # View reaction roles
-/reactrole archive                 # Archive reaction role
-/reactrole unarchive               # Unarchive reaction role
-/reactrole delete                  # Delete reaction role
-/reactrole status                  # Check role status
-/botstats                          # Bot statistics
+```text
+/config                             # Open the admin Web UI (DMs a sign-in link)
 ```
+
+Once in the Web UI:
+
+| Page              | Replaces (legacy slash command)                                |
+| ----------------- | ------------------------------------------------------------- |
+| Dashboard         | `/botstats`                                                   |
+| Settings          | `/config list`, `get`, `set`, `reset`, `import`, `export`, `reload` |
+| Permissions       | `/permissions set/add/remove/clear/list/view`                 |
+| Setup Wizard      | `/setup wizard`                                               |
+| Announcements     | `/announce create/list/delete`, `/announce-vc-stats`          |
+| Polls             | `/poll create/list/add-item/import-url/delete/delete-item/test/list-items` |
+| Reaction Roles    | `/reactrole create/archive/unarchive/delete/list/status`      |
+| Notices           | `/notice add/edit/delete/sync`                                |
+| Voice Channels    | `/vc reload`, `/vc force-reload`                              |
+| Database          | `/dbtrunk status`, `/dbtrunk run`                             |
+| Bootstrap         | (new — read-only `.env` diagnostics)                          |
 
 ---
 
 ## 🎯 Common Workflows
 
-### Initial Bot Setup
+### Initial bot setup
 
-#### Option 1: Using Setup Wizard (Recommended for beginners)
+1. Run `/config` in Discord.
+2. Open the DM'd link.
+3. Click **Setup Wizard** in the navigation.
+4. Pick the features you want (voice channels, voice tracking, quotes,
+   achievements, logging, etc.). The wizard auto-detects existing
+   channels and applies the related settings for you.
+5. On the **Settings** page, hit **Reload commands to Discord** if the
+   wizard enabled any commands that should now appear in Discord.
 
-```bash
-# Use the interactive setup wizard for guided configuration
-/setup wizard
+### Enable a single command
 
-# Or configure specific features
-/setup wizard feature:voicechannels
-/setup wizard feature:voicetracking
-```
+1. `/config` → open the Web UI.
+2. **Settings** → find `<command>.enabled`, set to `true`, save.
+3. Click **Reload commands to Discord**.
+4. Wait a minute or two for Discord to sync.
 
-The wizard will:
+### Manage permissions
 
-- Auto-detect existing channels
-- Guide you through each feature
-- Validate all settings
-- Apply configuration automatically
+1. `/config` → open the Web UI.
+2. **Permissions** → pick a command, pick the roles allowed to use it.
+3. Save. Changes take effect immediately.
 
-#### Option 2: Manual Configuration (Advanced users)
+### Schedule an announcement
 
-```bash
-# 1. Enable basic commands
-/config set key:ping.enabled value:true
-/config reload
+1. `/config` → open the Web UI.
+2. **Announcements** → New announcement.
+3. Pick a channel, a cron schedule (`0 9 * * *` = daily 9 AM), the
+   message, and optional embed fields.
+4. Save. The announcement persists across bot restarts.
 
-# 2. Setup voice channels (use wizard)
-/setup wizard feature:voicechannels
-/config reload
+### Trigger weekly voice stats now
 
-# 3. Enable tracking
-/config set key:voicetracking.enabled value:true
-/config set key:voicetracking.seen.enabled value:true
-/config reload
+1. `/config` → open the Web UI.
+2. **Announcements** → click **Post weekly stats now**.
 
-# 4. Enable weekly announcements
-/config set key:voicetracking.announcements.enabled value:true
-/config set key:voicetracking.announcements.channel value:"voice-stats"
-/config reload
+### Manual database cleanup
 
-# 5. Enable achievements system
-/config set key:achievements.enabled value:true
-/config reload
+1. `/config` → open the Web UI.
+2. **Database** → click **Run cleanup now**.
 
-# 6. Setup data cleanup
-/config set key:voicetracking.cleanup.enabled value:true
-/config reload
+### Backup and restore configuration
 
-# 7. Setup quote channel (optional)
-/config set key:quotes.enabled value:true
-/config set key:quotes.channel_id value:"YOUR_QUOTE_CHANNEL_ID"
-/config reload
-```
+- **Settings** page → **Export** to download a YAML file.
+- **Settings** page → **Import** to upload YAML; preview the diff before
+  apply. Bootstrap env vars are excluded from both directions.
 
-### Enable Quote Channel
+### Reset a single setting
 
-```bash
-# 1. Create a dedicated text channel in Discord (e.g., #quotes)
-# 2. Right-click the channel → Copy ID
-# 3. Configure the bot:
-/config set key:quotes.enabled value:true
-/config set key:quotes.channel_id value:"YOUR_CHANNEL_ID"
-/config reload
+- **Settings** page → find the key → click **Reset to default**.
 
-# 4. Test it
-/quote text:"Hello World!" author:"@YourName"
-```
+### Troubleshooting commands not appearing
 
-### Enable Logging
-
-```bash
-# Create channels in Discord first, then:
-/config set key:core.startup.enabled value:true
-/config set key:core.startup.channel_id value:YOUR_CHANNEL_ID
-
-/config set key:core.errors.enabled value:true
-/config set key:core.errors.channel_id value:YOUR_CHANNEL_ID
-
-/config set key:core.cleanup.enabled value:true
-/config set key:core.cleanup.channel_id value:YOUR_CHANNEL_ID
-```
-
-### Troubleshooting Commands Not Appearing
-
-```bash
-# 1. Check if command is enabled
-/config get key:ping.enabled
-
-# 2. Enable if needed
-/config set key:ping.enabled value:true
-
-# 3. MUST reload commands
-/config reload
-
-# 4. Wait a few minutes for Discord to sync
-```
-
-### Backup and Restore Configuration
-
-```bash
-# Backup
-/config export
-# Save the file somewhere safe
-
-# Restore
-/config import
-# Attach the saved YAML file
-```
+1. Web UI → **Settings** → verify `<command>.enabled = true`.
+2. Click **Reload commands to Discord**.
+3. Wait 2-5 minutes for Discord to sync.
 
 ---
 
@@ -2541,59 +730,62 @@ The wizard will:
 
 ### "Command not found" or command doesn't appear
 
-**Solutions:**
-
-1. Check if enabled: `/config get key:commandname.enabled`
-2. Enable it: `/config set key:commandname.enabled value:true`
-3. **Reload commands: `/config reload`** (Required!)
-4. Wait 2-5 minutes for Discord to sync
+1. Web UI → **Settings** → check `<command>.enabled`.
+2. Set it to `true` if needed, save.
+3. **Reload commands to Discord** (required).
+4. Wait 2-5 minutes.
 
 ### "Permission denied" errors
 
-**Check:**
-
-- Do you have Administrator permission?
-- Is the bot role high enough in the hierarchy?
-- Is the feature enabled in configuration?
+- Do you have Administrator permission (for `/config`)?
+- Is the bot's role high enough in the Discord role hierarchy?
+- Is the feature enabled in the Web UI's Settings page?
+- For `/config`: is `WEBUI_ENABLED=true` and are the other `WEBUI_*`
+  env vars set? Check the bot logs for `WebUI mounted at /admin`.
 
 ### Voice commands not working
 
-**Verify:**
+Web UI → **Settings** → verify both:
 
-```bash
-/config get key:voicechannels.enabled
-/config get key:voicetracking.enabled
-```
+- `voicechannels.enabled = true`
+- `voicetracking.enabled = true`
 
-Both should be `true`. If not:
-
-```bash
-/config set key:voicechannels.enabled value:true
-/config set key:voicetracking.enabled value:true
-/config reload
-```
+Then click **Reload commands to Discord**.
 
 ### Stats showing as empty
 
-**Possible causes:**
+- Tracking might have been enabled recently (give it time).
+- Channels you care about might be in `voicetracking.excluded_channels`.
+- Users have to actually have been in voice channels since tracking
+  started.
 
-- Tracking recently enabled (give it time)
-- Channels are excluded
-- Users not in voice channels yet
+Verify excluded channels on the Settings page.
 
-**Check excluded channels:**
+### Magic link doesn't arrive
 
-```bash
-/config get key:voicetracking.excluded_channels
-```
+- DMs from server members might be disabled. The bot falls back to an
+  ephemeral reply in the channel where you ran `/config` — check there.
+- The bot might not have permission to DM you for other reasons. Run
+  `/config` again and look at the channel reply.
+
+### Magic link 404s when clicked
+
+- Already used (single-use).
+- Expired (default 10 minutes).
+- Superseded by a newer `/config` invocation.
+
+Run `/config` again.
+
+See [WEBUI.md → Troubleshooting](WEBUI.md#troubleshooting) for more.
 
 ---
 
-## 📖 Related Documentation
+## 📖 Related documentation
 
-- **[README.md](README.md)** - Bot overview and quick start
-- **[SETTINGS.md](SETTINGS.md)** - Complete configuration reference
-- **[TROUBLESHOOTING.md](TROUBLESHOOTING.md)** - Detailed troubleshooting guide
+- **[README.md](README.md)** — Bot overview and quick start
+- **[WEBUI.md](WEBUI.md)** — Web UI setup, magic-link flow, reverse-proxy guidance
+- **[SETTINGS.md](SETTINGS.md)** — Complete configuration reference
+- **[TROUBLESHOOTING.md](TROUBLESHOOTING.md)** — General troubleshooting
 
 ---
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -614,9 +614,14 @@ button to admit them. **🗑️ Remove Waiting Room** deletes it.
 
 ### Admin command permissions
 
-| Command   | Permission                                                       |
-| --------- | ---------------------------------------------------------------- |
-| `/config` | Administrator (overridable in the Web UI's Permissions page)     |
+| Command   | Permission                                                                                                     |
+| --------- | -------------------------------------------------------------------------------------------------------------- |
+| `/config` | Administrator (Discord-level default; to widen to non-admin roles, override in Server Settings → Integrations) |
+
+The Web UI's Permissions page can only **further restrict** who is
+allowed to use `/config` once Discord has admitted the interaction. It
+cannot widen access past Discord's `setDefaultMemberPermissions(Administrator)`
+gate.
 
 ### Bot permissions required
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -648,19 +648,19 @@ The bot needs these Discord permissions:
 
 Once in the Web UI:
 
-| Page              | Replaces (legacy slash command)                                |
-| ----------------- | ------------------------------------------------------------- |
-| Dashboard         | `/botstats`                                                   |
-| Settings          | `/config list`, `get`, `set`, `reset`, `import`, `export`, `reload` |
-| Permissions       | `/permissions set/add/remove/clear/list/view`                 |
-| Setup Wizard      | `/setup wizard`                                               |
-| Announcements     | `/announce create/list/delete`, `/announce-vc-stats`          |
-| Polls             | `/poll create/list/add-item/import-url/delete/delete-item/test/list-items` |
-| Reaction Roles    | `/reactrole create/archive/unarchive/delete/list/status`      |
-| Notices           | `/notice add/edit/delete/sync`                                |
-| Voice Channels    | `/vc reload`, `/vc force-reload`                              |
-| Database          | `/dbtrunk status`, `/dbtrunk run`                             |
-| Bootstrap         | (new — read-only `.env` diagnostics)                          |
+| Page           | Replaces (legacy slash command)                                            |
+| -------------- | -------------------------------------------------------------------------- |
+| Dashboard      | `/botstats`                                                                |
+| Settings       | `/config list`, `get`, `set`, `reset`, `import`, `export`, `reload`        |
+| Permissions    | `/permissions set/add/remove/clear/list/view`                              |
+| Setup Wizard   | `/setup wizard`                                                            |
+| Announcements  | `/announce create/list/delete`, `/announce-vc-stats`                       |
+| Polls          | `/poll create/list/add-item/import-url/delete/delete-item/test/list-items` |
+| Reaction Roles | `/reactrole create/archive/unarchive/delete/list/status`                   |
+| Notices        | `/notice add/edit/delete/sync`                                             |
+| Voice Channels | `/vc reload`, `/vc force-reload`                                           |
+| Database       | `/dbtrunk status`, `/dbtrunk run`                                          |
+| Bootstrap      | (new — read-only `.env` diagnostics)                                       |
 
 ---
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -5,6 +5,8 @@ Complete guide for developers extending or maintaining KoolBot.
 ## Table of Contents
 
 - [Architecture Overview](#architecture-overview)
+- [The `src/web/` Web UI](#the-srcweb-web-ui)
+- [The "no business logic outside services" rule](#the-no-business-logic-outside-services-rule)
 - [Common Patterns](#common-patterns)
   - [Bot-Controlled Channel Header Posts](#bot-controlled-channel-header-posts)
   - [Service Singleton Pattern](#service-singleton-pattern)
@@ -21,9 +23,28 @@ KoolBot follows a service-oriented architecture where each service owns a specif
 
 ```text
 src/
-├── index.ts              # Entry point, service initialization
-├── commands/             # Discord slash commands
-├── services/             # Business logic services
+├── index.ts              # Entry point, service initialization, Express bootstrap
+├── commands/             # Discord slash commands (small surface from v1.0)
+│   ├── achievements.ts
+│   ├── amikool.ts
+│   ├── config.ts         # Web UI launcher (the only admin command)
+│   ├── help.ts
+│   ├── ping.ts
+│   ├── quote.ts
+│   ├── seen.ts
+│   └── voicestats.ts
+├── services/             # Business logic services (single source of truth)
+├── web/                  # Web UI router — mounted at /admin when WEBUI_ENABLED=true
+│   ├── index.ts          # createWebRouter(client) — composes the router
+│   ├── session.ts        # Cookie session middleware + permission revalidation
+│   ├── csrf.ts           # CSRF (double-submit cookie)
+│   ├── cookies.ts        # Signed cookie helpers
+│   ├── rate-limit.ts     # In-memory rate limiter
+│   ├── read-only-routes.ts  # Dashboard, Bootstrap, Settings, etc. (GET)
+│   ├── write-routes.ts   # POST handlers (settings, permissions, wizard, etc.)
+│   ├── admin-layout.ts   # Shared layout + escapeHtml/escapeJsInAttr helpers
+│   ├── admin-views.ts    # Page renderers for the admin pages
+│   └── views.ts          # Sign-in / sign-out / invalid-link views
 ├── models/               # MongoDB schemas
 ├── handlers/             # Event handlers
 └── utils/                # Shared utilities
@@ -38,6 +59,8 @@ Services follow the **Singleton Pattern** and are initialized in `src/index.ts`:
 ConfigService
 CommandManager
 VoiceChannelManager
+WebSessionService          // magic-link tokens, used by /config and /admin/s/<token>
+PermissionsService         // re-checked on every /admin/* request
 ```
 
 - **ConfigService**: Configuration management with MongoDB persistence
@@ -45,6 +68,126 @@ VoiceChannelManager
 - **VoiceChannelManager**: Dynamic voice channel lifecycle
 - **QuoteChannelManager**: Quote channel management and permissions
 - **DiscordLogger**: Logging to Discord channels
+- **WebSessionService**: Magic-link issuance, redemption, revocation
+- **PermissionsService**: Per-command role gating (admins always bypass)
+
+---
+
+## The `src/web/` Web UI
+
+The Web UI is the only admin surface from v1.0 onward. It mounts on the
+**same Express server** that already exposes `/health` (port 3000 inside
+the container). When `WEBUI_ENABLED=true` and the required `WEBUI_*` env
+vars are set, `src/index.ts` calls `createWebRouter(client)` and
+`app.use("/admin", router)`. When `WEBUI_ENABLED` is false, the router
+is never created and `/admin/*` returns 404.
+
+### Auth flow
+
+1. `/config` Discord slash command → `WebSessionService.create(uid, gid)`
+   inserts a `WebSession` row (token hashed with HMAC-SHA256 over
+   `WEBUI_SESSION_SECRET`) and DMs the URL.
+2. Browser hits `GET /admin/s/<token>` → `WebSessionService.redeem()`
+   atomically `findOneAndUpdate({usedAt: null, ...}, {usedAt: now})`,
+   the route sets a signed session cookie and redirects to `/admin/`.
+3. Every subsequent request runs `createSessionMiddleware(client)` which:
+   - Verifies the HMAC-signed cookie
+   - Enforces the sliding inactivity window
+   - Re-fetches the `WebSession` row to enforce server-side revocation
+   - Hard-caps the session at `expiresAt`
+   - **Re-checks `PermissionsService.checkCommandPermission(uid, gid, "config")`**
+     so demoting an admin in Discord kicks them out immediately
+4. `POST /admin/finish` revokes the session in MongoDB, clears the cookie.
+
+The cookie value carries `sid`, `uid`, `gid`, `iat`, `act` — all
+validated against the DB row on every request. Holding only the cookie
+isn't enough; the DB row has to also be unrevoked, unexpired, and match.
+
+### CSRF
+
+All state-changing routes (POSTs in `write-routes.ts`) use the
+double-submit cookie pattern via `csrf.ts`. The `ensureCsrfCookie`
+middleware sets a `koolbot_csrf` cookie on every request; `requireCsrf`
+checks that the form's hidden `_csrf` field matches.
+
+### Rate limiting
+
+`createRateLimiter({ windowMs, max, keyName })` is keyed by `req.ip`.
+The `/admin/s/<token>` redemption endpoint is rate-limited to 10
+attempts per minute per IP; `/admin/finish` to 30. To make this work
+behind a reverse proxy, operators set `WEBUI_TRUST_PROXY` to the hop
+count.
+
+### Views
+
+Pages are server-rendered HTML strings composed in `admin-views.ts` and
+wrapped by `renderAdminPage` from `admin-layout.ts`. There is no SPA, no
+JS bundle, no CDN. All values are escaped through `escapeHtml` /
+`escapeJsInAttr` at the boundary.
+
+The always-visible **session expires in X · [Finish]** banner is part of
+the shared layout and reads `WebSessionContext.expiresAt` to render the
+remaining time.
+
+---
+
+## The "no business logic outside services" rule
+
+This is the single hardest rule for `src/web/`:
+
+> **Routes in `src/web/` are thin wrappers over `src/services/`. No
+> business logic, validation, or data shape lives in the web layer.**
+
+Concretely:
+
+- ✅ A route reads form fields, calls a service method, renders the result.
+- ✅ A route translates a service error into an HTTP status code.
+- ❌ A route doing schema validation that the service doesn't already do.
+- ❌ A route reaching into Mongoose models directly.
+- ❌ A route making Discord API calls that aren't going through a service.
+
+The reason: the slash-command surface (`src/commands/`) and the Web UI
+surface (`src/web/`) **must share one validation path**, one permission
+check, and one source of truth. If a setting is valid in one place but
+rejected in the other, that's a bug — and it's a bug we structurally
+prevent by keeping the logic in services and giving both surfaces the
+same client view.
+
+If you find yourself wanting to add a `if (input.length > 200)` check
+inside a write-route handler, stop. Add it to the service. The web
+layer should just call the service and react to its return value.
+
+### Adding a write route
+
+```typescript
+// src/web/write-routes.ts (example)
+router.post(
+  "/admin/myfeature/save",
+  requireCsrf,
+  requireSession,
+  async (req: AuthenticatedRequest, res: Response) => {
+    const { name, value } = req.body;
+    try {
+      await MyFeatureService.getInstance().updateThing(name, value);
+      res.redirect(303, "/admin/myfeature");
+    } catch (err) {
+      // Translate service errors → HTTP. Do not validate here.
+      if (err instanceof ValidationError) {
+        res.status(400).type("text/html").send(renderError(err.message));
+        return;
+      }
+      throw err;
+    }
+  },
+);
+```
+
+Service methods own:
+
+- Input validation (throw a typed error on bad input)
+- Authorization decisions beyond the basic "has a valid session"
+- Persistence (MongoDB writes)
+- Side effects (Discord API calls, cron job changes, log emission)
 
 ---
 
@@ -313,18 +456,14 @@ const embed = new EmbedBuilder()
 
 #### Configuration Examples
 
-Users can manage headers via Discord commands:
+Users can manage headers from the Web UI's Settings page:
 
-```bash
-# Disable header
-/config set key:feature.header_enabled value:false
-/config reload
+- `feature.header_enabled` → `false` to disable the header entirely.
+- `feature.header_enabled` → `true` and `feature.header_pin_enabled` →
+  `false` to keep the header but stop pinning it.
 
-# Enable without pinning
-/config set key:feature.header_enabled value:true
-/config set key:feature.header_pin_enabled value:false
-/config reload
-```
+(No command reload required — these are pure config flags read by the
+service on its next pass.)
 
 #### Testing
 
@@ -401,7 +540,23 @@ await myService.initialize();
 
 ### Configuration Management
 
-Configuration uses a two-tier system: environment variables for secrets, MongoDB for runtime config.
+Configuration uses a two-tier system:
+
+| Tier                | Stored in | Who edits it           | Reload          |
+| ------------------- | --------- | ---------------------- | --------------- |
+| Bootstrap / secrets | `.env`    | Operator (host shell)  | Restart process |
+| Feature settings    | MongoDB   | Admin via Web UI       | Live            |
+
+**Rule:** if a value is read at startup (Discord token, Mongo URI,
+`WEBUI_*` secrets), it goes in `.env`. Anything else lives in MongoDB
+and is edited through the Web UI's Settings page. `src/services/config-service.ts`
+is the only thing that reads MongoDB-backed settings; only
+`src/index.ts`, `src/web/`, and `src/services/web-session-service.ts`
+read `process.env`.
+
+The protected-keys list lives at the top of `src/web/write-routes.ts`
+(`PROTECTED_KEYS`). It is hand-maintained — when you add a new env var,
+add it there too so YAML import can't overwrite it.
 
 #### Adding New Config Keys
 
@@ -419,7 +574,7 @@ export const defaultConfig: ConfigSchema = {
 };
 ```
 
-**Step 2**: Access in code:
+**Step 2**: Access in code (only inside a service):
 
 ```typescript
 const enabled = await configService.getBoolean("myfeature.enabled", false);
@@ -428,12 +583,18 @@ const setting = await configService.getString("myfeature.setting", "default");
 
 **Step 3**: Document in `SETTINGS.md`.
 
+**Step 4**: If the setting needs to appear on the Setup Wizard, add it to
+`WIZARD_FEATURE_SETTINGS` in `src/web/write-routes.ts`. The Settings page
+discovers settings from `defaultConfig` automatically.
+
 #### Configuration Best Practices
 
 - Use dot notation: `feature.subsetting`
 - Group by domain: `voicechannels.*`, `quotes.*`, etc.
 - Always provide defaults
-- Never access `process.env` directly (except in config service)
+- **Never access `process.env` directly outside `src/index.ts`,
+  `src/web/`, and `src/services/web-session-service.ts`.** Every other
+  caller goes through `ConfigService`.
 - Use appropriate type methods: `getBoolean()`, `getString()`, `getNumber()`
 
 ---
@@ -463,10 +624,18 @@ const setting = await configService.getString("myfeature.setting", "default");
    - [ ] Test manually in Discord
    - [ ] Verify edge cases
 
-5. **Documentation**
-   - [ ] Update `COMMANDS.md`
-   - [ ] Update `SETTINGS.md`
-   - [ ] Add to `DEVELOPER_GUIDE.md`
+5. **Web UI surface** (if applicable)
+   - [ ] Add a read-only view in `src/web/read-only-routes.ts` / `admin-views.ts`
+   - [ ] Add write handlers in `src/web/write-routes.ts` (CSRF + session required)
+   - [ ] Link the page from `NAV_ITEMS` in `admin-layout.ts`
+   - [ ] Routes stay thin — no business logic outside services
+
+6. **Documentation**
+   - [ ] Update `COMMANDS.md` (only if there's a user-facing slash command — admin commands now live in the Web UI)
+   - [ ] Update `SETTINGS.md` with new DB-backed keys
+   - [ ] Update `WEBUI.md` if you added a new page or env var
+   - [ ] Update `.env.example` if you added a bootstrap env var
+   - [ ] Add to `DEVELOPER_GUIDE.md` if you established a reusable pattern
    - [ ] Update `DOCS_SUMMARY.md`
 
 ---
@@ -582,10 +751,11 @@ try {
 
 ## Additional Resources
 
-- [CONTRIBUTING.md](./CONTRIBUTING.md) - Contribution guidelines
-- [SETTINGS.md](./SETTINGS.md) - Configuration reference
-- [COMMANDS.md](./COMMANDS.md) - Command documentation
-- [TESTING.md](./TESTING.md) - Testing documentation
+- [CONTRIBUTING.md](./CONTRIBUTING.md) — Contribution guidelines
+- [WEBUI.md](./WEBUI.md) — Web UI setup, magic-link flow, reverse-proxy guidance
+- [SETTINGS.md](./SETTINGS.md) — Configuration reference
+- [COMMANDS.md](./COMMANDS.md) — Command documentation
+- [TESTING.md](./TESTING.md) — Testing documentation
 
 ---
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -6,7 +6,7 @@ Complete guide for developers extending or maintaining KoolBot.
 
 - [Architecture Overview](#architecture-overview)
 - [The `src/web/` Web UI](#the-srcweb-web-ui)
-- [The "no business logic outside services" rule](#the-no-business-logic-outside-services-rule)
+- [The "thin HTTP layer over services" goal](#the-thin-http-layer-over-services-goal)
 - [Common Patterns](#common-patterns)
   - [Bot-Controlled Channel Header Posts](#bot-controlled-channel-header-posts)
   - [Service Singleton Pattern](#service-singleton-pattern)
@@ -95,8 +95,15 @@ is never created and `/admin/*` returns 404.
    - Enforces the sliding inactivity window
    - Re-fetches the `WebSession` row to enforce server-side revocation
    - Hard-caps the session at `expiresAt`
-   - **Re-checks `PermissionsService.checkCommandPermission(uid, gid, "config")`**
-     so demoting an admin in Discord kicks them out immediately
+   - **Re-checks `PermissionsService.checkCommandPermission(uid, gid, "config")`.**
+     This returns `false` (and the middleware logs the user out) only
+     when explicit role gating is configured for `config` on the Web UI's
+     Permissions page and the user's roles no longer match. With no
+     explicit gating, the check returns `true` and a demoted admin keeps
+     their existing session — the magic-link gate at `/admin/s/<token>`
+     is the primary defense, not this revalidation. If you want demotions
+     to log existing sessions out, configure Permissions → `config` to
+     an admin-only role.
 4. `POST /admin/finish` revokes the session in MongoDB, clears the cookie.
 
 The cookie value carries `sid`, `uid`, `gid`, `iat`, `act` — all
@@ -131,38 +138,40 @@ remaining time.
 
 ---
 
-## The "no business logic outside services" rule
+## The "thin HTTP layer over services" goal
 
-This is the single hardest rule for `src/web/`:
+The goal — not yet fully reached in the existing code — is to keep
+`src/web/` as a thin HTTP layer over `src/services/`:
 
-> **Routes in `src/web/` are thin wrappers over `src/services/`. No
-> business logic, validation, or data shape lives in the web layer.**
+> **Push validation, side effects, and data writes into services.
+> Routes should mostly read form fields, call a service method, and
+> render the result.**
 
-Concretely:
+Current state of the code:
 
-- ✅ A route reads form fields, calls a service method, renders the result.
-- ✅ A route translates a service error into an HTTP status code.
-- ❌ A route doing schema validation that the service doesn't already do.
-- ❌ A route reaching into Mongoose models directly.
-- ❌ A route making Discord API calls that aren't going through a service.
+- `src/web/write-routes.ts` still owns some input coercion
+  (`coerceConfigValue`, `normalizeCron`, `validCron`) and reads/writes
+  to Mongoose models directly. Same for `read-only-routes.ts`, which
+  imports several models for page data.
+- These are *not* prohibited today, but new write paths should prefer
+  pushing logic into a service so the slash-command surface and the
+  Web UI surface share one validation path. If you're tempted to add a
+  `if (input.length > 200)` check inside a write-route handler, add it
+  to the service instead.
 
-The reason: the slash-command surface (`src/commands/`) and the Web UI
-surface (`src/web/`) **must share one validation path**, one permission
-check, and one source of truth. If a setting is valid in one place but
-rejected in the other, that's a bug — and it's a bug we structurally
-prevent by keeping the logic in services and giving both surfaces the
-same client view.
-
-If you find yourself wanting to add a `if (input.length > 200)` check
-inside a write-route handler, stop. Add it to the service. The web
-layer should just call the service and react to its return value.
+The reason: when both surfaces share one validation path, a setting
+accepted in one place can never be silently rejected in the other.
 
 ### Adding a write route
+
+`createWebRouter` mounts the router at `/admin`, so routes declared
+inside `write-routes.ts` use **relative** paths — Express composes the
+final `/admin/<your-path>` URL for you.
 
 ```typescript
 // src/web/write-routes.ts (example)
 router.post(
-  "/admin/myfeature/save",
+  "/myfeature/save",            // becomes /admin/myfeature/save
   requireCsrf,
   requireSession,
   async (req: AuthenticatedRequest, res: Response) => {
@@ -542,21 +551,37 @@ await myService.initialize();
 
 Configuration uses a two-tier system:
 
-| Tier                | Stored in | Who edits it           | Reload          |
-| ------------------- | --------- | ---------------------- | --------------- |
-| Bootstrap / secrets | `.env`    | Operator (host shell)  | Restart process |
-| Feature settings    | MongoDB   | Admin via Web UI       | Live            |
+| Tier                | Stored in | Who edits it          | Picked up                                                  |
+| ------------------- | --------- | --------------------- | ---------------------------------------------------------- |
+| Bootstrap / secrets | `.env`    | Operator (host shell) | Process restart                                            |
+| Feature settings    | MongoDB   | Admin via Web UI      | Saved immediately to the `ConfigService` cache (see below) |
+
+Some services (cron-driven schedules, channel managers) cache derived
+state that does not refresh automatically when their config changes —
+those have a per-page reload button on the Web UI. Plain feature
+toggles take effect on the next read.
 
 **Rule:** if a value is read at startup (Discord token, Mongo URI,
 `WEBUI_*` secrets), it goes in `.env`. Anything else lives in MongoDB
-and is edited through the Web UI's Settings page. `src/services/config-service.ts`
-is the only thing that reads MongoDB-backed settings; only
-`src/index.ts`, `src/web/`, and `src/services/web-session-service.ts`
-read `process.env`.
+and is edited through the Web UI's Settings page.
+
+`process.env` is read at boot by a known set of modules — `src/index.ts`,
+`src/web/index.ts`, `src/web/session.ts`, `src/web/csrf.ts`,
+`src/web/admin-layout.ts`, `src/web/read-only-routes.ts` (bootstrap
+page), `src/services/config-service.ts` (for the env→bootstrap-key
+mappings), `src/services/web-session-service.ts`,
+`src/services/discord-logger.ts`, `src/services/startup-migrator.ts`,
+and `src/utils/logger.ts`. New service code should prefer reading
+through `ConfigService` so the same lookup path serves both surfaces;
+add new direct `process.env` reads only when the value is genuinely a
+startup-only secret.
 
 The protected-keys list lives at the top of `src/web/write-routes.ts`
-(`PROTECTED_KEYS`). It is hand-maintained — when you add a new env var,
-add it there too so YAML import can't overwrite it.
+(`PROTECTED_KEYS`). It is hand-maintained — when you add a new
+**bootstrap** env var (something whose value should never round-trip
+through YAML import/export), add it to that set so imports can't
+overwrite it. Operational tuning vars like `WEBUI_TRUST_PROXY` don't
+need to be there since they aren't represented as DB-backed keys.
 
 #### Adding New Config Keys
 
@@ -592,9 +617,12 @@ discovers settings from `defaultConfig` automatically.
 - Use dot notation: `feature.subsetting`
 - Group by domain: `voicechannels.*`, `quotes.*`, etc.
 - Always provide defaults
-- **Never access `process.env` directly outside `src/index.ts`,
-  `src/web/`, and `src/services/web-session-service.ts`.** Every other
-  caller goes through `ConfigService`.
+- **Prefer `ConfigService` for runtime feature settings.** Direct
+  `process.env` reads are expected at boot in `src/index.ts`,
+  `src/web/`, and a small allowlist of services (see the
+  "Configuration Management" section above for the current list). New
+  runtime feature code should go through `ConfigService` so the slash
+  command and Web UI surfaces see the same value.
 - Use appropriate type methods: `getBoolean()`, `getString()`, `getNumber()`
 
 ---

--- a/DOCS_SUMMARY.md
+++ b/DOCS_SUMMARY.md
@@ -126,16 +126,16 @@ This file provides an overview of the complete documentation structure.
 
 ## 📊 Documentation Map (where to go for what)
 
-| You want to…                       | Read                       |
-| ---------------------------------- | -------------------------- |
-| Stand up the bot in 5 minutes      | README.md                  |
-| Understand the magic-link flow     | WEBUI.md                   |
-| Put the Web UI behind HTTPS        | WEBUI.md → Reverse-proxy   |
-| Run `/config` and find a setting   | SETTINGS.md                |
-| Look up a slash command            | COMMANDS.md                |
-| Contribute code                    | DEVELOPER_GUIDE.md, CONTRIBUTING.md |
-| Debug a problem                    | TROUBLESHOOTING.md         |
-| See the visual diagram             | QUICK_START_VISUAL.md      |
+| You want to…                     | Read                                |
+| -------------------------------- | ----------------------------------- |
+| Stand up the bot in 5 minutes    | README.md                           |
+| Understand the magic-link flow   | WEBUI.md                            |
+| Put the Web UI behind HTTPS      | WEBUI.md → Reverse-proxy            |
+| Run `/config` and find a setting | SETTINGS.md                         |
+| Look up a slash command          | COMMANDS.md                         |
+| Contribute code                  | DEVELOPER_GUIDE.md, CONTRIBUTING.md |
+| Debug a problem                  | TROUBLESHOOTING.md                  |
+| See the visual diagram           | QUICK_START_VISUAL.md               |
 
 ## 🔗 Cross-References
 

--- a/DOCS_SUMMARY.md
+++ b/DOCS_SUMMARY.md
@@ -6,54 +6,75 @@ This file provides an overview of the complete documentation structure.
 
 ### Core Documentation
 
-1. **README.md** (605 lines)
-   - Quick start guide (3 steps: clone, configure .env, docker-compose up)
-   - Feature overview with examples
-   - Voice channel management examples
-   - Discord logging setup
-   - Docker management commands
-   - Developer section
+1. **README.md**
+   - Quick start guide (3 steps: download files, edit `.env` with Web UI vars, `docker compose up -d`)
+   - Feature overview
+   - Web UI launcher walkthrough
+   - Docker management (incl. direct port publish, localhost-only, Caddy reverse proxy)
+   - Backup & restore (Settings page Export/Import + `mongodump`)
+   - Troubleshooting
 
-2. **DEVELOPER_GUIDE.md** (NEW)
-   - Architecture overview and patterns
+2. **WEBUI.md** (NEW)
+   - Magic-link flow diagram and lifecycle
+   - Env-vs-DB configuration boundary
+   - Bootstrap env vars (`WEBUI_*` + secrets)
+   - Enabling the Web UI
+   - Docker Compose recipes (direct publish, localhost-only, Caddy)
+   - Reverse-proxy guidance (Caddy / nginx / Traefik / tunnels)
+   - Public-internet exposure caveats
+   - DM-closed fallback
+   - Session lifecycle and revocation
+   - Web UI page → legacy slash command mapping
+   - Troubleshooting
+
+3. **DEVELOPER_GUIDE.md**
+   - Architecture overview including `src/web/`
+   - The "no business logic outside services" rule
+   - Magic-link auth flow
+   - CSRF and rate-limiting patterns
    - Bot-controlled channel header posts (reusable pattern)
    - Service singleton pattern
-   - Configuration management
+   - Configuration management (two-tier model)
    - Feature development checklist
    - Testing guidelines
    - Code style standards
 
-3. **COMMANDS.md** (934 lines)
-   - Complete command reference
-   - User commands with examples
-   - Admin commands with detailed subcommands
+4. **COMMANDS.md**
+   - User-facing slash commands (`/ping`, `/help`, `/voicestats`, `/seen`, `/achievements`, `/quote`, `/amikool`)
+   - Admin launcher (`/config`) — the only admin slash command, opens the Web UI
+   - Voice channel control panel
    - Permission requirements
-   - Common workflows
-   - Troubleshooting command issues
+   - Quick reference
+   - Page → legacy slash command mapping
 
-4. **SETTINGS.md** (481 lines)
-   - Environment variables guide
-   - All configuration options
-   - Category-organized settings
-   - Practical examples for each feature
+5. **SETTINGS.md**
+   - Environment variables (bootstrap, read-only in Web UI)
+   - WebUI env vars (`WEBUI_*`)
+   - All DB-backed configuration options (edited in the Web UI)
    - Quick reference table
-   - Configuration management guide
 
-5. **TROUBLESHOOTING.md** (668 lines)
+6. **QUICK_START_VISUAL.md**
+   - Visual / ASCII flow of the 3-step quick start
+   - Magic-link flow diagram
+   - Docker exposure options
+   - Updated architecture diagram (includes Web UI)
+
+7. **TROUBLESHOOTING.md**
    - Initial setup issues
    - Docker problems
    - Discord connection issues
    - Command troubleshooting
+   - Web UI / magic-link troubleshooting (see also WEBUI.md)
    - Voice channel issues
    - Database problems
    - Configuration issues
    - Performance optimization
    - Emergency procedures
 
-6. **RELEASE_NOTES.md** (existing, 150 lines)
+8. **RELEASE_NOTES.md**
    - Version history
    - Feature changes
-   - Migration notes
+   - Migration notes (v1.0 admin commands → Web UI)
 
 ### Configuration Files
 
@@ -61,12 +82,16 @@ This file provides an overview of the complete documentation structure.
    - Clear, commented template
    - Discord credentials instructions
    - Docker-optimized MongoDB URI
+   - Web UI bootstrap env vars (`WEBUI_ENABLED`, `WEBUI_BASE_URL`,
+     `WEBUI_SESSION_SECRET`, optional `WEBUI_SESSION_TTL_MINUTES`,
+     `WEBUI_INACTIVITY_TIMEOUT_MINUTES`, `WEBUI_TRUST_PROXY`)
    - Debug mode options
 
 2. **docker-compose.yml**
    - Production deployment
    - MongoDB with persistent volume
-   - Proper networking
+   - Operators choose how to expose port 3000 (see README + WEBUI.md
+     for direct-publish, localhost-only, and Caddy recipes)
 
 3. **docker-compose.dev.yml**
    - Development setup
@@ -78,137 +103,117 @@ This file provides an overview of the complete documentation structure.
 ### User-First Deployment
 
 - **Only 2 files needed:** `.env` and `docker-compose.yml`
-- **3-step quick start:** clone, configure, deploy
+- **3-step quick start:** download, configure, deploy
 - **No manual builds** required for users
 
-### Comprehensive Examples
+### Web UI as the only admin surface
 
-- Every feature has real configuration examples
-- Copy-paste ready commands
+- All admin configuration is browser-based, magic-link gated
+- Slash command surface stays focused on member-facing actions
+- One source of truth (`src/services/`) — the Web UI is a thin client
+
+### Bootstrap-vs-DB boundary
+
+- `.env` holds secrets and startup config only
+- MongoDB holds feature settings, edited via the Web UI
+- YAML import/export covers the MongoDB tier only
+
+### Comprehensive examples
+
+- Every feature has Web UI navigation breadcrumbs
+- Real docker-compose snippets including Caddy
 - Expected outputs shown
 
-### Troubleshooting Focus
+## 📊 Documentation Map (where to go for what)
 
-- Common issues identified
-- Step-by-step solutions
-- Emergency procedures included
-
-### Progressive Disclosure
-
-- Quick start → Features → Deep dive
-- Beginners can start immediately
-- Advanced users have detailed references
-
-## 📊 Documentation Statistics
-
-Total Lines: 2,688 (main documentation)
-
-- README.md: 605 lines
-- COMMANDS.md: 934 lines  
-- SETTINGS.md: 481 lines
-- TROUBLESHOOTING.md: 668 lines
-
-## ✅ Documentation Completeness
-
-### ✓ Covered Topics
-
-- [x] Quick start with Docker Compose
-- [x] Getting Discord credentials
-- [x] Environment variable configuration
-- [x] All command documentation
-- [x] All settings documentation
-- [x] Voice channel features
-- [x] Activity tracking
-- [x] Automated announcements
-- [x] Data cleanup
-- [x] Discord logging
-- [x] Quote system
-- [x] Permission requirements
-- [x] Troubleshooting guides
-- [x] Docker management
-- [x] Configuration backup/restore
-- [x] Emergency procedures
-
-### Example Coverage
-
-- [x] .env file setup
-- [x] Docker commands
-- [x] Voice channel configuration
-- [x] Tracking setup
-- [x] Announcement scheduling
-- [x] Data cleanup configuration
-- [x] Logging setup
-- [x] Quote system setup
-- [x] All admin commands
-- [x] All user commands
+| You want to…                       | Read                       |
+| ---------------------------------- | -------------------------- |
+| Stand up the bot in 5 minutes      | README.md                  |
+| Understand the magic-link flow     | WEBUI.md                   |
+| Put the Web UI behind HTTPS        | WEBUI.md → Reverse-proxy   |
+| Run `/config` and find a setting   | SETTINGS.md                |
+| Look up a slash command            | COMMANDS.md                |
+| Contribute code                    | DEVELOPER_GUIDE.md, CONTRIBUTING.md |
+| Debug a problem                    | TROUBLESHOOTING.md         |
+| See the visual diagram             | QUICK_START_VISUAL.md      |
 
 ## 🔗 Cross-References
 
 All documentation files cross-reference each other:
 
-- README → COMMANDS, SETTINGS, TROUBLESHOOTING
-- COMMANDS → README, SETTINGS, TROUBLESHOOTING
-- SETTINGS → README, COMMANDS, TROUBLESHOOTING
-- TROUBLESHOOTING → README, COMMANDS, SETTINGS
+- README → WEBUI, COMMANDS, SETTINGS, TROUBLESHOOTING, DEVELOPER_GUIDE
+- WEBUI → README, COMMANDS, SETTINGS, DEVELOPER_GUIDE, TROUBLESHOOTING
+- COMMANDS → README, WEBUI, SETTINGS, TROUBLESHOOTING
+- SETTINGS → README, WEBUI, COMMANDS, TROUBLESHOOTING
+- DEVELOPER_GUIDE → CONTRIBUTING, SETTINGS, COMMANDS, TESTING
+- TROUBLESHOOTING → README, WEBUI, COMMANDS, SETTINGS
 
 ## 🎨 Formatting Standards
 
 - **Headers:** Emoji + title for easy scanning
-- **Code blocks:** Syntax highlighting with bash/env/yaml
+- **Code blocks:** Syntax highlighting with `bash`, `env`, `yaml`, `text`
 - **Examples:** Real, copy-paste ready
 - **Warnings:** Clearly marked with ⚠️
 - **Navigation:** Table of contents in long docs
-- **Visual aids:** Tables for settings and commands
+- **Visual aids:** Tables for settings and command-to-page mappings
 
 ## 🚀 User Journey
 
-### First-Time User
+### First-time user
 
 1. Read README Quick Start
-2. Copy .env.example → .env
-3. Run docker-compose up -d
-4. Configure features via Discord commands
-5. Reference COMMANDS.md as needed
+2. Copy `.env.example` → `.env`, fill in Discord credentials and WebUI vars
+3. `docker compose up -d`
+4. Run `/config` in Discord → click DM link → configure in browser
+5. Reference WEBUI.md if they need HTTPS / a real domain
 
-### Troubleshooting User
+### Troubleshooting user
 
 1. Check TROUBLESHOOTING.md index
-2. Find issue category
+2. For Web UI / magic-link issues → WEBUI.md → Troubleshooting
 3. Follow step-by-step solutions
-4. Reference SETTINGS.md for configuration
+4. Reference SETTINGS.md for what each key does
 5. Check logs as directed
 
-### Advanced User
+### Advanced user / operator
 
 1. Review SETTINGS.md for all options
-2. Use COMMANDS.md for admin features
-3. Set up logging, cleanup, tracking
-4. Export/import configurations
-5. Optimize performance
+2. Read WEBUI.md for reverse-proxy / threat-model details
+3. Use the Web UI Bootstrap page to verify env values
+4. Export / import YAML for migrations and backups
+
+### Contributor
+
+1. Read DEVELOPER_GUIDE.md for architecture and `src/web/` layout
+2. Note the "no business logic outside services" rule before adding routes
+3. Run `npm run check:all` before opening a PR
+4. Update the relevant docs for any user-visible change
 
 ## 📝 Notes for Maintainers
 
 ### When Adding Features
 
 - [ ] Update README.md (features section)
-- [ ] Add command to COMMANDS.md (if user-facing)
+- [ ] Add command to COMMANDS.md (only if user-facing slash command — admin features go in the Web UI)
 - [ ] Add settings to SETTINGS.md
-- [ ] Add to DEVELOPER_GUIDE.md (if reusable pattern)
+- [ ] Add Web UI page/section to WEBUI.md if applicable
+- [ ] Add to DEVELOPER_GUIDE.md if you established a reusable pattern
 - [ ] Add troubleshooting to TROUBLESHOOTING.md
 - [ ] Update examples
-- [ ] Update RELEASE_NOTES.md
+- [ ] Add a Conventional Commits footer that release-please understands
 
 ### When Changing Configuration
 
 - [ ] Update SETTINGS.md
-- [ ] Update .env.example if env var
+- [ ] Update `.env.example` if it's an env var
+- [ ] Update `PROTECTED_KEYS` in `src/web/write-routes.ts` if it's a new env var
 - [ ] Update examples in README.md
 - [ ] Add migration notes if breaking
 
 ### Documentation Review Checklist
 
 - [ ] All links work
-- [ ] Examples are current
+- [ ] Examples are current (no references to removed slash commands)
 - [ ] Code blocks have syntax highlighting
 - [ ] Cross-references are accurate
 - [ ] No outdated information

--- a/DOCS_SUMMARY.md
+++ b/DOCS_SUMMARY.md
@@ -110,7 +110,10 @@ This file provides an overview of the complete documentation structure.
 
 - All admin configuration is browser-based, magic-link gated
 - Slash command surface stays focused on member-facing actions
-- One source of truth (`src/services/`) — the Web UI is a thin client
+- Goal: `src/services/` holds the business logic; `src/web/` is a thin
+  HTTP layer over it. The current code is on that path but not all the
+  way there (some input coercion and direct model reads still live in
+  the web layer) — new code should push toward the goal
 
 ### Bootstrap-vs-DB boundary
 

--- a/QUICK_START_VISUAL.md
+++ b/QUICK_START_VISUAL.md
@@ -37,7 +37,15 @@ STEP 2: Configure
 │ Enable the admin Web UI (recommended):                                  │
 │   WEBUI_ENABLED=true                                                    │
 │   WEBUI_BASE_URL=http://localhost:3000                                  │
-│   WEBUI_SESSION_SECRET=$(openssl rand -base64 32)                       │
+│   WEBUI_SESSION_SECRET=<paste output of: openssl rand -base64 32>       │
+│                                                                         │
+│ Note: dotenv does not run shell substitutions — run                     │
+│   openssl rand -base64 32                                               │
+│ separately on your host, then paste the output into the value.          │
+│                                                                         │
+│ For plain-HTTP localhost testing, also set NODE_ENV=development         │
+│ (the Web UI cookie is Secure-flagged whenever NODE_ENV=production,      │
+│ and browsers refuse Secure cookies over http://...).                    │
 └─────────────────────────────────────────────────────────────────────────┘
 
 Where to get credentials:

--- a/QUICK_START_VISUAL.md
+++ b/QUICK_START_VISUAL.md
@@ -2,42 +2,47 @@
 
 ```text
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                          KOOLBOT QUICK START                             │
+│                          KOOLBOT QUICK START                            │
 │                    (3 Steps - 5 Minutes to Deploy)                      │
 └─────────────────────────────────────────────────────────────────────────┘
 
 STEP 1: Get the Files
 ════════════════════════════════════════════════════════════════════════════
 ┌─────────────────────────────────────────────────────────────────────────┐
-│ $ mkdir koolbot && cd koolbot                                            │
-│                                                                           │
-│ Download docker-compose.yml:                                             │
+│ $ mkdir koolbot && cd koolbot                                           │
+│                                                                         │
+│ Download docker-compose.yml:                                            │
 │ $ curl -O https://raw.githubusercontent.com/lonix/koolbot/main/\        │
-│   docker-compose.yml                                                     │
-│                                                                           │
-│ Download .env.example:                                                   │
+│   docker-compose.yml                                                    │
+│                                                                         │
+│ Download .env.example:                                                  │
 │ $ curl -O https://raw.githubusercontent.com/lonix/koolbot/main/\        │
-│   .env.example                                                           │
-│                                                                           │
-│ Or download manually from GitHub                                         │
+│   .env.example                                                          │
+│                                                                         │
+│ Or download manually from GitHub.                                       │
 └─────────────────────────────────────────────────────────────────────────┘
 
 STEP 2: Configure
 ════════════════════════════════════════════════════════════════════════════
 ┌─────────────────────────────────────────────────────────────────────────┐
-│ $ cp .env.example .env                                                   │
+│ $ cp .env.example .env                                                  │
 │ $ nano .env  # or use your favorite editor                              │
-│                                                                           │
-│ Edit these 4 values:                                                     │
-│   DISCORD_TOKEN=your_bot_token_here     ← From Discord Developer Portal │
+│                                                                         │
+│ Edit these required values:                                             │
+│   DISCORD_TOKEN=your_bot_token_here     ← Discord Developer Portal      │
 │   CLIENT_ID=your_application_id_here    ← Application ID                │
 │   GUILD_ID=your_server_id_here          ← Your Discord Server ID        │
-│   MONGODB_URI=mongodb://mongodb:27017/koolbot  ← Leave as-is for Docker │
+│   MONGODB_URI=mongodb://mongodb:27017/koolbot  ← leave as-is for Docker │
+│                                                                         │
+│ Enable the admin Web UI (recommended):                                  │
+│   WEBUI_ENABLED=true                                                    │
+│   WEBUI_BASE_URL=http://localhost:3000                                  │
+│   WEBUI_SESSION_SECRET=$(openssl rand -base64 32)                       │
 └─────────────────────────────────────────────────────────────────────────┘
 
 Where to get credentials:
 ┌─────────────────────────────────────────────────────────────────────────┐
-│ 1. Go to: https://discord.com/developers/applications                   │
+│ 1. https://discord.com/developers/applications                          │
 │ 2. Create/Select Application                                            │
 │ 3. Bot tab → Copy Token                                                 │
 │ 4. General Info → Copy Application ID                                   │
@@ -47,100 +52,168 @@ Where to get credentials:
 STEP 3: Start with Docker
 ════════════════════════════════════════════════════════════════════════════
 ┌─────────────────────────────────────────────────────────────────────────┐
-│ $ docker-compose up -d                                                   │
-│                                                                           │
+│ $ docker compose up -d                                                  │
+│                                                                         │
 │ ✓ Bot starts automatically                                              │
 │ ✓ MongoDB configured automatically                                      │
 │ ✓ Commands registered with Discord                                      │
+│ ✓ Web UI mounted at /admin (only when WEBUI_ENABLED=true)               │
 └─────────────────────────────────────────────────────────────────────────┘
 
 THAT'S IT! 🎉
 ════════════════════════════════════════════════════════════════════════════
 
-Your bot is now online! Next steps in Discord:
+Your bot is now online! Configure it from a browser:
 
 ┌─────────────────────────────────────────────────────────────────────────┐
-│ CONFIGURE IN DISCORD (All commands are disabled by default)             │
+│ FROM DISCORD                                                            │
 ├─────────────────────────────────────────────────────────────────────────┤
-│                                                                           │
-│ Quick Start - Interactive Wizard (Recommended):                         │
-│   /setup wizard                                                          │
-│   # Guided setup for voice channels, tracking, quotes, and more         │
-│                                                                           │
-│ -- OR Manual Configuration --                                            │
-│                                                                           │
-│ Basic Commands:                                                          │
-│   /config set key:ping.enabled value:true                               │
-│   /config reload                                                         │
-│                                                                           │
-│ Voice Channels (Dynamic Creation):                                      │
-│   /setup wizard feature:voicechannels                                    │
-│   /config reload                                                         │
-│                                                                           │
-│ Activity Tracking:                                                       │
-│   /config set key:voicetracking.enabled value:true                      │
-│   /config set key:voicetracking.seen.enabled value:true                 │
-│   /config reload                                                         │
-│                                                                           │
-│ Weekly Stats Announcements:                                             │
-│   /config set key:voicetracking.announcements.enabled value:true        │
-│   /config set key:voicetracking.announcements.channel value:"stats"     │
-│   /config reload                                                         │
+│                                                                         │
+│   /config                                                               │
+│                                                                         │
+│ The bot DMs you a single-use sign-in link. Click it.                    │
+│                                                                         │
+│ FROM THE WEB UI (browser, after clicking the link)                      │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│ • Dashboard       — Live counts and status                              │
+│ • Settings        — Edit every DB-backed setting (Export/Import YAML)   │
+│ • Permissions     — Per-command role gating                             │
+│ • Setup Wizard    — Guided multi-feature configuration                  │
+│ • Announcements   — Schedule posts; run weekly stats now                │
+│ • Polls           — Schedules + question library                        │
+│ • Reaction Roles  — Create / archive / unarchive / delete               │
+│ • Notices         — Server rules / info / help / game-server posts      │
+│ • Voice Channels  — Cleanup, currently-managed channels                 │
+│ • Database        — Cleanup status, run now                             │
+│ • Bootstrap       — Read-only .env diagnostics                          │
+│                                                                         │
+│ Click [Finish] when done. The link is dead after that.                  │
+└─────────────────────────────────────────────────────────────────────────┘
+
+MAGIC-LINK FLOW (under the hood)
+════════════════════════════════════════════════════════════════════════════
+┌─────────────────────────────────────────────────────────────────────────┐
+│                                                                         │
+│   You (Discord)                                                         │
+│        │                                                                │
+│        │  /config                                                       │
+│        ▼                                                                │
+│   KoolBot ───► MongoDB (insert web_session: tokenHash, expires_at, ...) │
+│        │                                                                │
+│        │  DM single-use URL                                             │
+│        ▼                                                                │
+│   You (DM tab)                                                          │
+│        │                                                                │
+│        │  click the link in browser                                     │
+│        ▼                                                                │
+│   GET /admin/s/<token>                                                  │
+│        │   ✓ token unused, not expired, not revoked                     │
+│        │   → mark used, issue signed cookie, 302 → /admin/              │
+│        ▼                                                                │
+│   /admin/* pages (re-check permissions every request)                   │
+│        │                                                                │
+│        │  click [Finish]                                                │
+│        ▼                                                                │
+│   session revoked, cookie cleared, /admin/* → 401                       │
+│                                                                         │
 └─────────────────────────────────────────────────────────────────────────┘
 
 DOCKER COMMANDS
 ════════════════════════════════════════════════════════════════════════════
 ┌─────────────────────────────────────────────────────────────────────────┐
-│ View logs:     docker-compose logs -f bot                               │
-│ Restart:       docker-compose restart bot                               │
-│ Stop:          docker-compose down                                       │
-│ Update:        docker-compose pull && docker-compose up -d              │
+│ View logs:     docker compose logs -f bot                               │
+│ Restart:       docker compose restart bot                               │
+│ Stop:          docker compose down                                      │
+│ Update:        docker compose pull && docker compose up -d              │
+│ Force-recreate after .env edits:                                        │
+│                docker compose up -d --force-recreate                    │
+└─────────────────────────────────────────────────────────────────────────┘
+
+EXPOSING THE WEB UI
+════════════════════════════════════════════════════════════════════════════
+┌─────────────────────────────────────────────────────────────────────────┐
+│ The default docker-compose.yml does NOT publish port 3000.              │
+│ Pick one of:                                                            │
+│                                                                         │
+│  Direct port publish (LAN/VPN-only, no HTTPS):                          │
+│    ports:                                                               │
+│      - "3000:3000"                                                      │
+│                                                                         │
+│  Localhost only (SSH tunnel in):                                        │
+│    ports:                                                               │
+│      - "127.0.0.1:3000:3000"                                            │
+│                                                                         │
+│  Caddy reverse proxy (recommended, gets HTTPS for free):                │
+│    See WEBUI.md → Docker Compose recipes                                │
+│                                                                         │
+│  Tailscale / Cloudflare Tunnel:                                         │
+│    Don't publish 3000. Point WEBUI_BASE_URL at your tunnel URL.         │
 └─────────────────────────────────────────────────────────────────────────┘
 
 TROUBLESHOOTING
 ════════════════════════════════════════════════════════════════════════════
 ┌─────────────────────────────────────────────────────────────────────────┐
-│ Bot not starting?                                                        │
-│   → Check logs: docker-compose logs bot                                 │
-│   → Verify .env file has all 4 required values                          │
-│   → Ensure Discord token is valid                                       │
-│                                                                           │
-│ Commands not appearing?                                                  │
-│   → Enable command: /config set key:commandname.enabled value:true      │
-│   → MUST reload: /config reload                                         │
-│   → Wait 2-5 minutes for Discord to sync                                │
-│                                                                           │
-│ Need help?                                                               │
-│   → See TROUBLESHOOTING.md                                              │
+│ Bot not starting?                                                       │
+│   → Check logs:        docker compose logs bot                          │
+│   → Verify .env has DISCORD_TOKEN, CLIENT_ID, GUILD_ID, MONGODB_URI     │
+│                                                                         │
+│ /config says "the web UI is disabled"?                                  │
+│   → Set WEBUI_ENABLED=true and restart                                  │
+│                                                                         │
+│ /config says "missing env vars"?                                        │
+│   → Set WEBUI_BASE_URL and WEBUI_SESSION_SECRET in .env, restart        │
+│                                                                         │
+│ DM link 404s when clicked?                                              │
+│   → Already used, expired, or superseded by a newer /config call        │
+│   → Run /config again                                                   │
+│                                                                         │
+│ Commands not appearing?                                                 │
+│   → Web UI → Settings → set <command>.enabled = true                    │
+│   → Click "Reload commands to Discord"                                  │
+│   → Wait 2-5 minutes                                                    │
+│                                                                         │
+│ Need help?                                                              │
+│   → See WEBUI.md, TROUBLESHOOTING.md                                    │
 │   → https://github.com/lonix/koolbot/issues                             │
 └─────────────────────────────────────────────────────────────────────────┘
 
 ARCHITECTURE (What Gets Deployed)
 ════════════════════════════════════════════════════════════════════════════
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                                                                           │
-│    ┌───────────────┐         ┌──────────────┐        ┌──────────────┐  │
-│    │   Discord     │◄────────│   KoolBot    │───────►│   MongoDB    │  │
-│    │   Server      │         │  Container   │        │  Container   │  │
-│    └───────────────┘         └──────────────┘        └──────────────┘  │
-│          ▲                          │                        │           │
-│          │                          │                        │           │
-│          └──────────────────────────┘                        │           │
-│               Slash Commands                    Persistent Storage       │
-│                                                                           │
-│    You only need:                                                        │
-│    • 2 files: docker-compose.yml and .env                               │
-│    • Docker installed on your system                                    │
-│                                                                           │
+│                                                                         │
+│    ┌───────────────┐    ┌────────────────┐    ┌──────────────┐          │
+│    │   Discord     │◄──►│   KoolBot      │◄──►│   MongoDB    │          │
+│    │   Server      │    │  Container     │    │  Container   │          │
+│    │               │    │  • Bot         │    └──────────────┘          │
+│    │  Slash cmds   │    │  • /health     │            ▲                 │
+│    │  +DM messages │    │  • /admin (UI) │            │                 │
+│    └──────┬────────┘    └────────┬───────┘            │                 │
+│           │                      │                    │                 │
+│           │                      │ port 3000          │ persistent      │
+│           │                      ▼                    │ volume          │
+│           │             ┌────────────────┐            │                 │
+│           │             │ Your Browser   │            │                 │
+│           │             │ (admin Web UI) │            │                 │
+│           │             └────────────────┘            │                 │
+│           │                                           │                 │
+│           └────── DM with sign-in link ───────────────┘                 │
+│                                                                         │
+│    Files you need:                                                      │
+│    • docker-compose.yml and .env                                        │
+│    • Docker (and optionally a reverse proxy for HTTPS)                  │
+│                                                                         │
 └─────────────────────────────────────────────────────────────────────────┘
 
 DOCUMENTATION
 ════════════════════════════════════════════════════════════════════════════
 ┌─────────────────────────────────────────────────────────────────────────┐
-│ README.md           → Overview, quick start, examples                    │
-│ COMMANDS.md         → All commands with usage examples                   │
-│ SETTINGS.md         → All configuration options explained                │
-│ TROUBLESHOOTING.md  → Common issues and solutions                        │
-│ .env.example        → Environment variable template                      │
+│ README.md           → Overview, quick start, examples                   │
+│ WEBUI.md            → Web UI setup, magic-link flow, reverse proxies    │
+│ COMMANDS.md         → All slash commands with usage examples            │
+│ SETTINGS.md         → All configuration options explained               │
+│ DEVELOPER_GUIDE.md  → Architecture, src/web/, services pattern          │
+│ TROUBLESHOOTING.md  → Common issues and solutions                       │
+│ .env.example        → Environment variable template                     │
 └─────────────────────────────────────────────────────────────────────────┘
 ```

--- a/QUICK_START_VISUAL.md
+++ b/QUICK_START_VISUAL.md
@@ -141,10 +141,11 @@ DOCKER COMMANDS
 EXPOSING THE WEB UI
 ════════════════════════════════════════════════════════════════════════════
 ┌─────────────────────────────────────────────────────────────────────────┐
-│ The default docker-compose.yml does NOT publish port 3000.              │
-│ Pick one of:                                                            │
+│ The default docker-compose.yml publishes port 3000 to the host         │
+│ already (LAN/VPN-only, no HTTPS). To change that, edit the bot         │
+│ service's ports: block:                                                │
 │                                                                         │
-│  Direct port publish (LAN/VPN-only, no HTTPS):                          │
+│  Direct port publish (shipped default):                                 │
 │    ports:                                                               │
 │      - "3000:3000"                                                      │
 │                                                                         │
@@ -152,11 +153,12 @@ EXPOSING THE WEB UI
 │    ports:                                                               │
 │      - "127.0.0.1:3000:3000"                                            │
 │                                                                         │
-│  Caddy reverse proxy (recommended, gets HTTPS for free):                │
-│    See WEBUI.md → Docker Compose recipes                                │
+│  Caddy reverse proxy (recommended for internet-facing, HTTPS free):    │
+│    Remove the ports: block; let Caddy forward to bot:3000.             │
+│    See WEBUI.md → Docker Compose recipes for a full example.           │
 │                                                                         │
 │  Tailscale / Cloudflare Tunnel:                                         │
-│    Don't publish 3000. Point WEBUI_BASE_URL at your tunnel URL.         │
+│    Remove the ports: block. Point WEBUI_BASE_URL at your tunnel URL.   │
 └─────────────────────────────────────────────────────────────────────────┘
 
 TROUBLESHOOTING

--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ admin launcher.
 
 KoolBot has a **two-tier** configuration model:
 
-| Tier                | Stored in | Edited via                                | Reload          |
-| ------------------- | --------- | ----------------------------------------- | --------------- |
-| Bootstrap / secrets | `.env`    | Edit the file on the host                 | Restart bot     |
-| Feature settings    | MongoDB   | Web UI **Settings**, **Permissions**, etc. | Live            |
+| Tier                | Stored in | Edited via                                 | Reload      |
+| ------------------- | --------- | ------------------------------------------ | ----------- |
+| Bootstrap / secrets | `.env`    | Edit the file on the host                  | Restart bot |
+| Feature settings    | MongoDB   | Web UI **Settings**, **Permissions**, etc. | Live        |
 
 All features ship **disabled by default** for safety. Turn them on from the
 Web UI's Settings page once the bot is running.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
 # KoolBot
 
 A powerful and modular Discord bot built with TypeScript, featuring dynamic voice channel
-management, activity tracking, automated announcements, and comprehensive configuration
-management.
+management, activity tracking, automated announcements, and a browser-based admin Web UI.
 
 ![Discord.js](https://img.shields.io/badge/Discord.js-14.25.1-blue)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.9.3-blue)
 ![MongoDB](https://img.shields.io/badge/MongoDB-Latest-green)
 ![Docker](https://img.shields.io/badge/Docker-Ready-blue)
-![Tests](https://img.shields.io/badge/Tests-51%20passing-brightgreen)
-![Coverage](https://img.shields.io/badge/Coverage-In%20Progress-yellow)
 
 ---
 
@@ -39,11 +36,10 @@ Or manually download from GitHub and save to your `koolbot` directory.
 ### 2. **Create Your `.env` File**
 
 ```bash
-# Copy the example file
 cp .env.example .env
 ```
 
-Edit `.env` with your Discord bot credentials:
+Edit `.env` with your Discord credentials and turn the Web UI on:
 
 ```env
 # Required: Get these from Discord Developer Portal
@@ -54,37 +50,64 @@ GUILD_ID=your_guild_id_here
 # MongoDB connection (leave as-is for Docker)
 MONGODB_URI=mongodb://mongodb:27017/koolbot
 
-# Optional settings
+# Web UI — the admin surface. Recommended.
+WEBUI_ENABLED=true
+WEBUI_BASE_URL=http://localhost:3000
+WEBUI_SESSION_SECRET=replace-with-openssl-rand-base64-32
+
+# Optional
 DEBUG=false
 NODE_ENV=production
 ```
 
-**Where to get your credentials:**
+Generate a strong `WEBUI_SESSION_SECRET`:
+
+```bash
+openssl rand -base64 32
+```
+
+**Where to get your Discord credentials:**
 
 - Go to [Discord Developer Portal](https://discord.com/developers/applications)
 - Create a new application (or select existing)
 - **DISCORD_TOKEN**: Bot tab → Reset Token → Copy
 - **CLIENT_ID**: General Information → Application ID
-- **GUILD_ID**: Your Discord Server → Right-click server icon → Copy ID (Enable Developer Mode in Discord settings)
+- **GUILD_ID**: Right-click your server icon in Discord → Copy ID (enable Developer Mode under User Settings → Advanced)
 
 ### 3. **Start with Docker Compose**
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
-**That's it!** Your bot is now running. The Docker container will:
+Then in Discord, run:
+
+```text
+/config
+```
+
+The bot DMs you a single-use sign-in link. Click it, configure everything in the
+browser, click **Finish**.
+
+**That's it.** Your bot is now running and configurable from a real UI. The Docker
+container will:
 
 - ✅ Automatically install dependencies
 - ✅ Set up MongoDB database
-- ✅ Register commands with Discord
+- ✅ Register `/config` and the user-facing slash commands with Discord
+- ✅ Mount the Web UI at `/admin` (only when `WEBUI_ENABLED=true`)
 - ✅ Start the bot and keep it running
 
 Check the logs:
 
 ```bash
-docker-compose logs -f bot
+docker compose logs -f bot
 ```
+
+Look for `WebUI mounted at /admin` to confirm the Web UI is live.
+
+> Need HTTPS or a real domain? See **[WEBUI.md](WEBUI.md)** for Caddy, nginx,
+> Traefik, and Tailscale recipes.
 
 ---
 
@@ -92,117 +115,114 @@ docker-compose logs -f bot
 
 ### Core Features
 
-- **🎙 Dynamic Voice Channels** - Users create their own voice channels from a lobby
-- **📊 Activity Tracking** - Track voice channel usage with leaderboards and statistics
-- **⏰ Automated Announcements** - Weekly stats announcements
-- **🧹 Smart Data Cleanup** - Automatic cleanup with data preservation
-- **⚙ Flexible Configuration** - Configure everything through Discord commands
-- **📝 Discord Logging** - Bot events logged to Discord channels
-- **🎭 Quote System** - Save and retrieve memorable quotes
-- **🤖 Bot Status** - Dynamic status showing bot state and user count
-- **🔒 Rate Limiting** - Protect against command spam with configurable limits
+- **🎙 Dynamic Voice Channels** — Users create their own voice channels from a lobby
+- **📊 Activity Tracking** — Voice channel usage with leaderboards and statistics
+- **🏆 Achievements** — Persistent accolades for milestones and participation
+- **⏰ Automated Announcements** — Scheduled posts on a cron schedule
+- **🗳️ Polls** — Native Discord polls posted from a question library
+- **🎭 Reaction Roles** — Self-assignable roles via emoji reactions
+- **📝 Notices** — Bot-managed rules / info / help / game-server channel
+- **🧹 Smart Data Cleanup** — Automatic cleanup with data preservation
+- **🌐 Web UI Admin** — Magic-link sign-in, no persistent OAuth setup
+- **📝 Discord Logging** — Bot events logged to Discord channels
+- **🎭 Quote System** — Save and retrieve memorable quotes
+- **🤖 Bot Status** — Dynamic status showing bot state and user count
+- **🔒 Rate Limiting** — Protect against command spam with configurable limits
 
 ### Available Commands
 
-**User Commands:**
+KoolBot ships **two** kinds of commands: user-facing chat commands, and one
+admin launcher.
 
-- `/ping` - Check bot responsiveness
-- `/vctop` - View voice channel leaderboards
-- `/vcstats` - View your personal voice statistics
-- `/transfer-ownership` - Transfer ownership of your voice channel
-- `/quote` - Add or retrieve quotes
-- `/seen` - Check when a user was last seen
-- `/amikool` - Role verification command
+**User commands** (always in Discord):
 
-**Admin Commands:**
+- `/ping` — Check bot responsiveness
+- `/help` — Discover commands
+- `/voicestats top` / `/voicestats user` — Leaderboards and personal stats
+- `/seen` — Last-seen lookup
+- `/achievements` — View earned accolades
+- `/quote add` / `/quote edit` — Manage memorable quotes
+- `/amikool` — Role verification
 
-- `/setup` - Interactive setup wizard (recommended for first-time configuration)
-- `/config` - Manage all bot settings
-- `/permissions` - Manage role-based command access
-- `/vc` - Voice channel management
-- `/dbtrunk` - Database cleanup management
-- `/exclude-channel` - Exclude channels from tracking
-- `/botstats` - View bot performance metrics
-- `/announce-vc-stats` - Manually trigger voice channel stats announcements
-- `/announce` - Manage scheduled announcements
-- `/reactrole` - Manage reaction roles
+**Admin launcher** (Discord → Web UI):
+
+- `/config` — DMs you a single-use sign-in link for the admin Web UI.
+  Everything formerly behind `/permissions`, `/setup`, `/announce`,
+  `/announce-vc-stats`, `/poll`, `/reactrole`, `/notice`, `/dbtrunk`,
+  `/vc`, `/botstats`, and the `/config` subcommand tree now lives in
+  the Web UI.
 
 📖 **[Complete Command Reference →](COMMANDS.md)**
+📖 **[Web UI Guide →](WEBUI.md)**
 
 ---
 
 ## ⚙ Configuration
 
-All bot features are **disabled by default** for security. You enable and configure them using Discord commands after the bot starts.
+KoolBot has a **two-tier** configuration model:
 
-### Initial Setup
+| Tier                | Stored in | Edited via                                | Reload          |
+| ------------------- | --------- | ----------------------------------------- | --------------- |
+| Bootstrap / secrets | `.env`    | Edit the file on the host                 | Restart bot     |
+| Feature settings    | MongoDB   | Web UI **Settings**, **Permissions**, etc. | Live            |
 
-Once your bot is running, configure it from Discord:
+All features ship **disabled by default** for safety. Turn them on from the
+Web UI's Settings page once the bot is running.
 
-#### Option 1: Interactive Setup Wizard (Recommended for beginners)
+### Initial setup, two ways
 
-```bash
-# Use the guided setup wizard for easy configuration
-/setup wizard
+#### Option 1: Setup wizard (recommended)
 
-# The wizard will:
-# - Auto-detect your existing channels
-# - Guide you through each feature
-# - Help you configure voice channels, tracking, quotes, and more
-# - Apply all settings for you
-```
+1. Run `/config` in Discord.
+2. Open the DM'd link.
+3. Click **Setup Wizard** in the navigation.
+4. Pick the features you want (voice channels, voice tracking, quotes,
+   achievements, logging, etc.) and the wizard fills in the relevant
+   settings for you.
 
-#### Option 2: Manual Configuration (Advanced users)
+#### Option 2: Manual configuration
 
-```bash
-# Enable the ping command
-/config set key:ping.enabled value:true
-/config reload
+1. Run `/config` in Discord.
+2. Open the DM'd link.
+3. Open **Settings**, find the keys you care about, edit them, save.
+4. If you changed which commands are enabled, hit **Reload commands to
+   Discord** on the Settings page so Discord re-syncs the registration.
 
-# Enable voice channel management
-/config set key:voicechannels.enabled value:true
-/config set key:voicechannels.category.name value:"Voice Channels"
-/config reload
-
-# Enable voice tracking
-/config set key:voicetracking.enabled value:true
-/config reload
-```
-
-### View All Settings
-
-```bash
-# List all configuration options
-/config list
-
-# Get a specific setting
-/config get key:ping.enabled
-
-# Reset a setting to default
-/config reset key:ping.enabled
-```
-
-### Configuration Categories
+### Configuration categories
 
 | Category | Description |
 | --- | --- |
 | **Commands** | Enable/disable individual commands (`ping.enabled`, `quotes.enabled`, etc.) |
 | **Voice Channels** | Dynamic channel creation, lobby settings, naming patterns |
 | **Voice Tracking** | Activity tracking, excluded channels, admin roles |
-| **Announcements** | Weekly stats announcements, schedule, target channel |
+| **Announcements** | Scheduled posts and weekly stats |
+| **Polls** | Scheduled native Discord polls from a question library |
 | **Data Cleanup** | Retention periods, cleanup schedule, aggregation |
 | **Discord Logging** | Log bot events to Discord channels (`core.*` settings) |
 | **Quote System** | Cooldowns, permissions, max length |
+| **Notices** | Server rules / game-server info / help posts |
+| **Reaction Roles** | Self-assignable role categories |
+| **Leaderboard Roles** | Auto-assign Discord roles from voice leaderboard |
+| **Achievements** | Persistent accolades and milestone badges |
 | **Fun Features** | Easter eggs and passive listeners |
 | **Rate Limiting** | Command spam protection with admin bypass |
+| **Permissions** | Per-command role gating |
 
 📖 **[Complete Settings Reference →](SETTINGS.md)**
+
+### YAML import / export
+
+The Web UI's Settings page has **Export** and **Import** buttons. Exports
+are YAML files covering DB-backed settings only — bootstrap env vars are
+never included. Imports are previewed as a diff before you apply them,
+and any payload that tries to set a protected key (`DISCORD_TOKEN`,
+`WEBUI_SESSION_SECRET`, etc.) is rejected outright.
 
 ---
 
 ## 🎙 Voice Channel Features (Examples)
 
-### Dynamic Voice Channel Creation
+### Dynamic voice channel creation
 
 When enabled, KoolBot creates private voice channels on-demand:
 
@@ -211,152 +231,82 @@ When enabled, KoolBot creates private voice channels on-demand:
 3. **User is moved to their new channel** automatically
 4. **Channel is deleted** when everyone leaves
 
-**Setup:**
+Configure from the Web UI's **Settings** page (or use **Setup Wizard →
+Voice Channels** to be walked through it):
 
-```bash
-# Enable voice channel management
-/config set key:voicechannels.enabled value:true
+| Setting | Example value |
+| --- | --- |
+| `voicechannels.enabled` | `true` |
+| `voicechannels.category.name` | `Voice Channels` |
+| `voicechannels.lobby.name` | `🟢 Lobby` |
+| `voicechannels.lobby.offlinename` | `🔴 Lobby` |
+| `voicechannels.channel.prefix` | `🎮` |
 
-# Set the category name (create this category in Discord first)
-/config set key:voicechannels.category.name value:"Voice Channels"
+The lobby automatically renames based on bot status:
 
-# Configure lobby channel names
-/config set key:voicechannels.lobby.name value:"🟢 Lobby"
-/config set key:voicechannels.lobby.offlinename value:"🔴 Lobby"
+- **"🟢 Lobby"** — Bot online and ready
+- **"🔴 Lobby"** — Bot offline
 
-# Optional: Customize channel naming
-/config set key:voicechannels.channel.prefix value:"🎮"
-
-# Apply changes
-/config reload
-```
-
-The lobby will automatically rename based on bot status:
-
-- **"🟢 Lobby"** - Bot online and ready
-- **"🔴 Lobby"** - Bot offline
-
-### Voice Activity Tracking
+### Voice activity tracking
 
 Track how much time users spend in voice channels:
 
-**Setup:**
+| Setting | Example value |
+| --- | --- |
+| `voicetracking.enabled` | `true` |
+| `voicetracking.stats.top.enabled` | `true` |
+| `voicetracking.stats.user.enabled` | `true` |
+| `voicetracking.seen.enabled` | `true` |
+| `voicetracking.excluded_channels` | `123456789,987654321` |
 
-```bash
-# Enable tracking
-/config set key:voicetracking.enabled value:true
+Usage from Discord:
 
-# Exclude specific channels (e.g., AFK channels)
-/config set key:voicetracking.excluded_channels value:"123456789,987654321"
+```text
+/voicestats top                     # This week's top users
+/voicestats top period:month        # This month's top users
+/voicestats top period:alltime limit:20
 
-# Enable /seen command
-/config set key:voicetracking.seen.enabled value:true
+/voicestats user                    # Your stats for this week
+/voicestats user period:alltime
 
-/config reload
+/seen user:@JohnDoe                 # Last-seen lookup
 ```
 
-**Usage:**
+### Automated stats announcements
 
-```bash
-# View leaderboards
-/vctop              # This week's top users
-/vctop period:month # This month's top users
-/vctop period:alltime limit:20  # Top 20 all-time
+The weekly voice channel stats post is configured on the **Announcements**
+page or via **Setup Wizard → Voice Tracking**:
 
-# Check personal stats
-/vcstats            # Your stats for this week
-/vcstats period:alltime  # Your all-time stats
+| Setting | Example value |
+| --- | --- |
+| `voicetracking.announcements.enabled` | `true` |
+| `voicetracking.announcements.channel` | `voice-stats` (name or ID) |
+| `voicetracking.announcements.schedule` | `0 16 * * 5` (Fridays at 4 PM) |
 
-# Check when someone was last online
-/seen user:@JohnDoe
-```
+Trigger one on demand from the Web UI's Announcements page — click
+**Post weekly stats now**.
 
-### Automated Stats Announcements
+### Data cleanup & retention
 
-Post weekly voice channel statistics automatically:
+Automatically clean old session data while preserving aggregated
+statistics. Configure on the Settings page:
 
-**Setup:**
+| Setting | Default |
+| --- | --- |
+| `voicetracking.cleanup.enabled` | `false` (turn on) |
+| `voicetracking.cleanup.schedule` | `0 0 * * *` (daily at midnight) |
+| `voicetracking.cleanup.retention.detailed_sessions_days` | `30` |
+| `voicetracking.cleanup.retention.monthly_summaries_months` | `6` |
+| `voicetracking.cleanup.retention.yearly_summaries_years` | `1` |
 
-```bash
-# Enable announcements
-/config set key:voicetracking.announcements.enabled value:true
-
-# Set the channel (by name or ID)
-/config set key:voicetracking.announcements.channel value:"voice-stats"
-
-# Set schedule (cron format) - Default: Every Friday at 4 PM
-/config set key:voicetracking.announcements.schedule value:"0 16 * * 5"
-
-/config reload
-```
-
-**Manual trigger:**
-
-```bash
-/announce-vc-stats
-```
-
-### Data Cleanup & Retention
-
-Automatically clean old session data while preserving aggregated statistics:
-
-**Setup:**
-
-```bash
-# Enable automatic cleanup
-/config set key:voicetracking.cleanup.enabled value:true
-
-# Set retention periods
-/config set key:voicetracking.cleanup.retention.detailed_sessions_days value:30
-/config set key:voicetracking.cleanup.retention.monthly_summaries_months value:6
-/config set key:voicetracking.cleanup.retention.yearly_summaries_years value:1
-
-# Set cleanup schedule (default: daily at midnight)
-/config set key:voicetracking.cleanup.schedule value:"0 0 * * *"
-
-/config reload
-```
-
-**Manual cleanup:**
-
-```bash
-/dbtrunk status     # Check cleanup status
-/dbtrunk run        # Run cleanup now
-```
+Run an out-of-schedule cleanup from the **Database** page.
 
 ---
 
 ## 📝 Discord Logging (Examples)
 
-Configure the bot to send event logs to Discord channels:
-
-### Setup Logging Channels
-
-```bash
-# Log startup/shutdown events to #bot-status
-/config set key:core.startup.enabled value:true
-/config set key:core.startup.channel_id value:123456789
-
-# Log errors to #admin-alerts
-/config set key:core.errors.enabled value:true
-/config set key:core.errors.channel_id value:987654321
-
-# Log cleanup reports to #bot-logs
-/config set key:core.cleanup.enabled value:true
-/config set key:core.cleanup.channel_id value:555666777
-
-# Log configuration changes
-/config set key:core.config.enabled value:true
-/config set key:core.config.channel_id value:111222333
-
-# Log cron job execution
-/config set key:core.cron.enabled value:true
-/config set key:core.cron.channel_id value:444555666
-```
-
-**Tip:** You can use the same channel for multiple log types, or separate them for better organization.
-
-### Available Log Types
+Configure the bot to send event logs to Discord channels via the
+Settings page. Available log categories:
 
 | Log Type | Description | Example Events |
 | --- | --- | --- |
@@ -366,271 +316,246 @@ Configure the bot to send event logs to Discord channels:
 | `core.config.*` | Settings changes | Configuration reloads, value updates |
 | `core.cron.*` | Scheduled tasks | Announcement triggers, cleanup runs |
 
+You can point each category at the same channel for one consolidated log,
+or split them between `#bot-status`, `#admin-alerts`, `#bot-logs`, etc.
+
 ---
 
 ## 🐳 Docker Management
 
-### Useful Docker Commands
+### Useful Docker commands
 
 ```bash
 # Start the bot
-docker-compose up -d
+docker compose up -d
 
 # View live logs
-docker-compose logs -f bot
+docker compose logs -f bot
 
 # Stop the bot
-docker-compose down
+docker compose down
 
 # Restart the bot
-docker-compose restart bot
+docker compose restart bot
 
 # Update to latest version
-docker-compose pull
-docker-compose up -d
+docker compose pull
+docker compose up -d
 
-# Access the bot container
-docker-compose exec bot sh
+# Shell into the bot container
+docker compose exec bot sh
 
 # View MongoDB logs
-docker-compose logs -f mongodb
+docker compose logs -f mongodb
 ```
 
-### Development Mode
+### Exposing the Web UI
+
+The default `docker-compose.yml` does **not** publish the bot's port —
+operators should make a deliberate choice about how to expose `/admin`.
+Pick one:
+
+- **Direct port publish** (simplest, no HTTPS — fine for LAN/VPN-only):
+
+  ```yaml
+  services:
+    bot:
+      # ...
+      ports:
+        - "3000:3000"     # /health and /admin
+  ```
+
+- **Bind to localhost only** (then SSH-tunnel or VPN in):
+
+  ```yaml
+  services:
+    bot:
+      # ...
+      ports:
+        - "127.0.0.1:3000:3000"
+  ```
+
+- **Reverse proxy with Caddy** (recommended for any internet-facing
+  deployment — gets you HTTPS for free):
+
+  See [WEBUI.md → Docker Compose recipes](WEBUI.md#docker-compose-recipes)
+  for a complete `docker-compose.yml` + `Caddyfile` you can copy.
+
+After changing the compose file, run `docker compose up -d --force-recreate`.
+
+### Development mode
 
 For local development with hot reloading:
 
 ```bash
-# Start in development mode
-docker-compose -f docker-compose.dev.yml up
-
-# Or in detached mode
-docker-compose -f docker-compose.dev.yml up -d
+docker compose -f docker-compose.dev.yml up
+# or in detached mode:
+docker compose -f docker-compose.dev.yml up -d
 ```
 
-This will:
+This mounts your local code into the container and reloads on file
+changes.
 
-- Mount your local code into the container
-- Automatically reload on file changes
-- Show detailed debug output
+### Configuration & data backup
 
-### Configuration Backup & Restore
+**Configuration backup (DB-backed settings):**
 
-**Configuration (Settings) Backup:**
+From the Web UI's Settings page, click **Export** to download a YAML
+file containing every DB-backed setting. To restore on the same or a
+different bot, use the **Import** button — the diff is previewed before
+apply. Bootstrap env vars (`DISCORD_TOKEN`, etc.) are never included
+in either direction.
 
-```bash
-# Export configuration to YAML
-/config export
+**Database backup (all data):**
 
-# Import configuration from YAML (attach file to Discord)
-/config import
-```
-
-**Database (Data) Backup:**
-
-To backup all your data (voice tracking stats, quotes, etc.), backup the MongoDB database:
+To back up everything — voice tracking stats, quotes, notices,
+announcements, reaction roles, achievements — back up MongoDB:
 
 ```bash
-# Create a backup of the MongoDB database
-docker-compose exec mongodb mongodump --archive=/data/db/backup.archive --db=koolbot
+# Create a backup
+docker compose exec mongodb mongodump \
+  --archive=/data/db/backup.archive --db=koolbot
 
 # Copy backup file to your local machine
-docker cp koolbot-mongodb:/data/db/backup.archive ./koolbot-backup-$(date +%Y%m%d).archive
+docker cp koolbot-mongodb:/data/db/backup.archive \
+  ./koolbot-backup-$(date +%Y%m%d).archive
 ```
 
-**Database Restore:**
+**Database restore:**
 
 ```bash
-# Copy backup file to container (replace YYYYMMDD with your backup date, e.g., 20240115)
-docker cp ./koolbot-backup-YYYYMMDD.archive koolbot-mongodb:/data/db/restore.archive
+# Copy backup file into the container
+docker cp ./koolbot-backup-YYYYMMDD.archive \
+  koolbot-mongodb:/data/db/restore.archive
 
-# Restore the database (--drop removes existing collections before restoring)
-docker-compose exec mongodb mongorestore --archive=/data/db/restore.archive --db=koolbot --drop
+# Restore (--drop removes existing collections before restoring)
+docker compose exec mongodb mongorestore \
+  --archive=/data/db/restore.archive --db=koolbot --drop
 
 # Restart the bot to refresh connections
-docker-compose restart bot
+docker compose restart bot
 ```
 
-> **Note:** The `--drop` flag removes existing collections before restoring. This ensures a clean restore but will delete any data created after
-> the backup was made.
+> **Note:** The `--drop` flag removes existing collections before
+> restoring. This ensures a clean restore but will delete any data
+> created after the backup was made.
 
-**Complete Backup (Recommended):**
-
-For a complete backup, save both configuration and database:
-
-```bash
-# 1. Export configuration from Discord
-/config export
-# (Download the YAML file Discord sends you)
-
-# 2. Backup database
-docker-compose exec mongodb mongodump --archive=/data/db/backup.archive --db=koolbot
-docker cp koolbot-mongodb:/data/db/backup.archive ./koolbot-backup-$(date +%Y%m%d).archive
-```
-
----
-
-## 🔧 Advanced Configuration Examples
-
-### Quote System
+**Complete backup (recommended):**
 
 ```bash
-# Enable quotes
-/config set key:quotes.enabled value:true
-
-# Set cooldown (seconds between adding quotes)
-/config set key:quotes.cooldown value:120
-
-# Set max quote length
-/config set key:quotes.max_length value:500
-
-# Restrict who can add quotes (role IDs, comma-separated)
-/config set key:quotes.add_roles value:"123456789,987654321"
-
-# Restrict who can delete quotes
-/config set key:quotes.delete_roles value:"123456789"
-
-/config reload
-```
-
-### Role-Based Commands
-
-```bash
-# Enable amikool command
-/config set key:amikool.enabled value:true
-
-# Set the role name to check
-/config set key:amikool.role.name value:"Kool Members"
-
-/config reload
-```
-
-### Fun Features
-
-```bash
-# Enable friendship listener (responds to "best ship" mentions)
-/config set key:fun.friendship value:true
-```
-
-### Voice Channel Customization
-
-```bash
-# Customize channel naming
-/config set key:voicechannels.channel.prefix value:"🎮"
-/config set key:voicechannels.channel.suffix value:"'s Gaming Room"
-
-# Set specific admin roles for tracking
-/config set key:voicetracking.admin_roles value:"Admin,Moderator"
+# 1. Export settings from the Web UI's Settings page (Export button)
+# 2. Backup the database
+docker compose exec mongodb mongodump \
+  --archive=/data/db/backup.archive --db=koolbot
+docker cp koolbot-mongodb:/data/db/backup.archive \
+  ./koolbot-backup-$(date +%Y%m%d).archive
 ```
 
 ---
 
 ## 🚨 Troubleshooting
 
-### Bot Not Starting
-
-**Check the logs:**
+### Bot not starting
 
 ```bash
-docker-compose logs -f bot
+docker compose logs -f bot
 ```
 
-**Common issues:**
+Common issues:
 
 - ❌ Invalid `DISCORD_TOKEN` → Check Discord Developer Portal
 - ❌ Missing `MONGODB_URI` → Ensure it's set to `mongodb://mongodb:27017/koolbot`
-- ❌ Docker not running → Start Docker Desktop
+- ❌ Docker not running → Start Docker Desktop / `systemctl start docker`
 
-### Commands Not Appearing
+### `/config` says "the web UI is disabled"
+
+You didn't set `WEBUI_ENABLED=true` (or didn't restart after editing
+`.env`). Fix `.env`, then:
 
 ```bash
-# Reload commands to Discord
-/config reload
+docker compose up -d --force-recreate
 ```
 
-**If still not working:**
+### `/config` says "missing env vars: WEBUI_BASE_URL, WEBUI_SESSION_SECRET"
 
-- Ensure the command is enabled (`/config list`)
-- Check bot has proper Discord permissions
-- Wait a few minutes for Discord to sync
+Both must be set in `.env` when `WEBUI_ENABLED=true`. Generate a secret
+with `openssl rand -base64 32` and restart.
 
-### Voice Channels Not Creating
+### The DM link 404s when I click it
 
-**Check configuration:**
+One of:
+
+- It was already used (single-use).
+- It expired (default 10 minutes).
+- You ran `/config` again and got a newer link, which revoked this one.
+
+Run `/config` again to mint a fresh one.
+
+See [WEBUI.md → Troubleshooting](WEBUI.md#troubleshooting) for more.
+
+### Commands not appearing in Discord
+
+From the Web UI Settings page:
+
+1. Verify the command is enabled (e.g. `ping.enabled` = `true`).
+2. Click **Reload commands to Discord**.
+3. Wait up to a few minutes for Discord to sync.
+
+### Voice channels not creating
+
+Verify `voicechannels.enabled` is `true` on the Settings page, then
+check:
+
+- The category named in `voicechannels.category.name` exists in Discord.
+- The bot has `Manage Channels` and `Move Members` permissions.
+- The lobby channel exists inside that category.
+
+### Database connection issues
 
 ```bash
-/config get key:voicechannels.enabled
-/config get key:voicechannels.category.name
-```
-
-**Ensure:**
-
-- The category exists in Discord
-- Bot has permissions: `Manage Channels`, `Move Members`
-- The lobby channel exists
-
-### Database Connection Issues
-
-```bash
-# Check MongoDB container
-docker-compose ps
-
-# View MongoDB logs
-docker-compose logs -f mongodb
-
-# Restart MongoDB
-docker-compose restart mongodb
-```
-
-### Reset Configuration
-
-```bash
-# Reset a specific setting
-/config reset key:ping.enabled
-
-# Or re-import from backup
-/config import
+docker compose ps                # Is mongodb running?
+docker compose logs -f mongodb   # Why isn't it?
+docker compose restart mongodb
 ```
 
 📖 **[Detailed Troubleshooting Guide →](TROUBLESHOOTING.md)**
+📖 **[Web UI Troubleshooting →](WEBUI.md#troubleshooting)**
 
 ---
 
 ## 📚 Documentation
 
-- **[COMMANDS.md](COMMANDS.md)** - Complete command reference with examples
-- **[SETTINGS.md](SETTINGS.md)** - All configuration options explained
-- **[TESTING.md](TESTING.md)** - Testing guide and best practices
-- **[TROUBLESHOOTING.md](TROUBLESHOOTING.md)** - Common issues and solutions
-- **[RELEASE_NOTES.md](RELEASE_NOTES.md)** - Version history and changelog
-- **[CONTRIBUTING.md](CONTRIBUTING.md)** - Contribution guidelines for developers
-- **[SECURITY.md](SECURITY.md)** - Security policy and vulnerability reporting
+- **[WEBUI.md](WEBUI.md)** — Web UI setup, reverse-proxy guidance, magic-link flow
+- **[COMMANDS.md](COMMANDS.md)** — Complete command reference with examples
+- **[SETTINGS.md](SETTINGS.md)** — All configuration options explained
+- **[DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md)** — Architecture and contribution patterns
+- **[QUICK_START_VISUAL.md](QUICK_START_VISUAL.md)** — Visual quick start
+- **[TESTING.md](TESTING.md)** — Testing guide and best practices
+- **[TROUBLESHOOTING.md](TROUBLESHOOTING.md)** — Common issues and solutions
+- **[RELEASE_NOTES.md](RELEASE_NOTES.md)** — Version history and changelog
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** — Contribution guidelines for developers
+- **[SECURITY.md](SECURITY.md)** — Security policy and vulnerability reporting
 
 ---
 
 ## 🔧 For Developers
 
 > **Note:** The Quick Start guide above is for **users** who just want to run the bot.
-> If you want to **develop** or **contribute** to KoolBot, you'll need to clone the full repository.
+> If you want to **develop** or **contribute** to KoolBot, you'll need to clone the
+> full repository.
 
-### Cloning for Development
+### Cloning for development
 
 ```bash
-# Clone the repository
 git clone https://github.com/lonix/koolbot.git
 cd koolbot
-
-# Install dependencies
 npm install
 ```
 
-### Local Development (Without Docker)
-
-If you want to develop locally without Docker:
+### Local development (without Docker)
 
 ```bash
-# Start MongoDB separately
-# (Use Docker, local install, or cloud MongoDB)
+# Start MongoDB separately (Docker, local install, or cloud MongoDB)
 
 # Update .env with your MongoDB URI
 MONGODB_URI=mongodb://localhost:27017/koolbot
@@ -642,7 +567,7 @@ npm run build
 npm run dev
 ```
 
-### Code Quality Tools
+### Code quality tools
 
 ```bash
 npm run lint           # Check code quality
@@ -664,7 +589,7 @@ npm run test:ci        # Run tests in CI mode
 
 📖 **[Complete Testing Guide →](TESTING.md)**
 
-### Available Scripts
+### Available scripts
 
 ```bash
 npm run build                     # Compile TypeScript
@@ -675,24 +600,40 @@ npm run migrate-config            # Migrate old settings
 npm run cleanup-global-commands   # Clean up Discord commands
 ```
 
-### Architecture Overview
+### Architecture overview
 
 ```text
 src/
-├── commands/           # Discord slash commands
-├── services/          # Core business logic
+├── commands/             # Discord slash commands (/ping, /config, etc.)
+├── services/             # Core business logic (single source of truth)
 │   ├── config-service.ts
+│   ├── permissions-service.ts
 │   ├── voice-channel-manager.ts
 │   ├── voice-channel-tracker.ts
+│   ├── web-session-service.ts
 │   └── ...
-├── models/            # MongoDB schemas
-├── utils/             # Helper functions
-└── index.ts           # Application entry point
+├── web/                  # Web UI router (thin wrappers over services)
+│   ├── index.ts          # Express router mounted at /admin
+│   ├── session.ts        # Cookie session middleware
+│   ├── read-only-routes.ts
+│   ├── write-routes.ts
+│   ├── csrf.ts
+│   └── ...
+├── models/               # MongoDB schemas
+├── handlers/             # Discord event handlers
+├── utils/                # Helper functions
+└── index.ts              # Application entry point
 ```
+
+The hard rule for `src/web/`: **no business logic lives outside
+`src/services/`.** The Web UI is a new client on top of existing
+services, not a fork of the data model. See
+[DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md) for details.
 
 ### Contributing
 
-Contributions are welcome! Please see our [Contributing Guide](CONTRIBUTING.md) for detailed information on:
+Contributions are welcome! Please see our [Contributing Guide](CONTRIBUTING.md)
+for detailed information on:
 
 - Development setup and workflow
 - Coding standards and best practices
@@ -716,16 +657,17 @@ For security vulnerabilities, please see our [Security Policy](SECURITY.md).
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the LICENSE file for details.
+This project is licensed under the MIT License — see the LICENSE file for details.
 
 ---
 
 ## 🙏 Acknowledgments
 
-- **Discord.js** - Powerful Discord API library
-- **MongoDB** - Flexible NoSQL database
-- **Docker** - Containerization platform
-- **TypeScript** - Type-safe JavaScript
+- **Discord.js** — Powerful Discord API library
+- **Express** — HTTP server backbone for the Web UI and healthcheck
+- **MongoDB** — Flexible NoSQL database
+- **Docker** — Containerization platform
+- **TypeScript** — Type-safe JavaScript
 
 ---
 
@@ -738,7 +680,7 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 <div align="center">
 
-**KoolBot v1.0.0** - Making Discord servers more engaging! 🚀
+**KoolBot v1.0** — Making Discord servers more engaging! 🚀
 
 Built with ❤️ using TypeScript and Discord.js
 

--- a/README.md
+++ b/README.md
@@ -375,11 +375,14 @@ docker compose logs -f mongodb
 
 ### Exposing the Web UI
 
-The default `docker-compose.yml` does **not** publish the bot's port —
-operators should make a deliberate choice about how to expose `/admin`.
-Pick one:
+The default `docker-compose.yml` **publishes port 3000 to the host**
+already — that's what makes the quick-start magic link reachable at
+`http://your-host:3000` out of the box. There is no HTTPS. The compose
+file's `bot.ports` block is the spot to change if you want something
+else:
 
-- **Direct port publish** (simplest, no HTTPS — fine for LAN/VPN-only):
+- **Direct port publish (shipped default)** — fine for LAN-only or
+  VPN-only deployments:
 
   ```yaml
   services:
@@ -389,7 +392,8 @@ Pick one:
         - "3000:3000"     # /health and /admin
   ```
 
-- **Bind to localhost only** (then SSH-tunnel or VPN in):
+- **Bind to localhost only** (then SSH-tunnel or VPN in) — replace the
+  publish above with:
 
   ```yaml
   services:
@@ -400,7 +404,9 @@ Pick one:
   ```
 
 - **Reverse proxy with Caddy** (recommended for any internet-facing
-  deployment — gets you HTTPS for free):
+  deployment — gets you HTTPS for free). Remove the `ports:` block on
+  the bot service entirely and let the proxy forward to `bot:3000` on
+  the internal Docker network:
 
   See [WEBUI.md → Docker Compose recipes](WEBUI.md#docker-compose-recipes)
   for a complete `docker-compose.yml` + `Caddyfile` you can copy.

--- a/README.md
+++ b/README.md
@@ -53,14 +53,19 @@ MONGODB_URI=mongodb://mongodb:27017/koolbot
 # Web UI — the admin surface. Recommended.
 WEBUI_ENABLED=true
 WEBUI_BASE_URL=http://localhost:3000
-WEBUI_SESSION_SECRET=replace-with-openssl-rand-base64-32
+WEBUI_SESSION_SECRET=replace-with-output-from-openssl-rand-base64-32
 
 # Optional
 DEBUG=false
-NODE_ENV=production
+# For local testing over plain HTTP, use NODE_ENV=development. The Web UI
+# session cookie is flagged `Secure` whenever NODE_ENV=production, which
+# browsers refuse over a `http://localhost` URL.
+NODE_ENV=development
 ```
 
-Generate a strong `WEBUI_SESSION_SECRET`:
+Generate a strong `WEBUI_SESSION_SECRET` by running this on your host
+**before** editing the file (paste the output in as the value above —
+dotenv files do not execute shell substitutions):
 
 ```bash
 openssl rand -base64 32
@@ -94,8 +99,11 @@ container will:
 
 - ✅ Automatically install dependencies
 - ✅ Set up MongoDB database
-- ✅ Register `/config` and the user-facing slash commands with Discord
+- ✅ Register `/config` and `/help` with Discord (other user commands
+  register only after you enable them on the Web UI's Settings page and
+  click **Reload commands to Discord**)
 - ✅ Mount the Web UI at `/admin` (only when `WEBUI_ENABLED=true`)
+- ✅ Publish port 3000 to the host so the sign-in link is reachable
 - ✅ Start the bot and keep it running
 
 Check the logs:
@@ -134,15 +142,21 @@ Look for `WebUI mounted at /admin` to confirm the Web UI is live.
 KoolBot ships **two** kinds of commands: user-facing chat commands, and one
 admin launcher.
 
-**User commands** (always in Discord):
+**User commands** (registered on demand — each one is gated by a
+`*.enabled` setting in the Web UI; `/help` and `/config` are the only
+commands always registered):
 
-- `/ping` — Check bot responsiveness
-- `/help` — Discover commands
-- `/voicestats top` / `/voicestats user` — Leaderboards and personal stats
-- `/seen` — Last-seen lookup
-- `/achievements` — View earned accolades
-- `/quote add` / `/quote edit` — Manage memorable quotes
-- `/amikool` — Role verification
+- `/ping` — Check bot responsiveness (`ping.enabled`)
+- `/help` — Discover commands (always on)
+- `/voicestats top` / `/voicestats user` — Leaderboards and personal stats (`voicetracking.enabled` + per-subcommand flag)
+- `/seen` — Last-seen lookup (`voicetracking.seen.enabled`)
+- `/achievements` — View earned accolades (`achievements.enabled`)
+- `/quote add` / `/quote edit` — Manage memorable quotes (`quotes.enabled`)
+- `/amikool` — Role verification (`amikool.enabled`)
+
+A fresh install only sees `/help` and `/config` in Discord until you
+enable the others on the Settings page and click **Reload commands to
+Discord**.
 
 **Admin launcher** (Discord → Web UI):
 
@@ -161,10 +175,14 @@ admin launcher.
 
 KoolBot has a **two-tier** configuration model:
 
-| Tier                | Stored in | Edited via                                 | Reload      |
-| ------------------- | --------- | ------------------------------------------ | ----------- |
-| Bootstrap / secrets | `.env`    | Edit the file on the host                  | Restart bot |
-| Feature settings    | MongoDB   | Web UI **Settings**, **Permissions**, etc. | Live        |
+| Tier                | Stored in | Edited via                                 | Picked up                  |
+| ------------------- | --------- | ------------------------------------------ | -------------------------- |
+| Bootstrap / secrets | `.env`    | Edit the file on the host                  | Bot restart                |
+| Feature settings    | MongoDB   | Web UI **Settings**, **Permissions**, etc. | Saved immediately (note ↓) |
+
+> ↓ Plain feature toggles take effect on the next read. A few
+> services (cron schedules, channel managers) cache derived state and
+> need a manual reload via their per-page button to fully apply.
 
 All features ship **disabled by default** for safety. Turn them on from the
 Web UI's Settings page once the bot is running.
@@ -214,9 +232,15 @@ Web UI's Settings page once the bot is running.
 
 The Web UI's Settings page has **Export** and **Import** buttons. Exports
 are YAML files covering DB-backed settings only — bootstrap env vars are
-never included. Imports are previewed as a diff before you apply them,
-and any payload that tries to set a protected key (`DISCORD_TOKEN`,
-`WEBUI_SESSION_SECRET`, etc.) is rejected outright.
+never included.
+
+Imports are previewed as a diff before you apply them. Apply is
+**per-key**: rows that target protected bootstrap keys
+(`DISCORD_TOKEN`, `WEBUI_SESSION_SECRET`, etc.) are skipped with a
+`rejected: protected key` status, and the remaining valid rows still
+apply. The result page reports per-key `applied` / `rejected` outcomes
+and a top-level `ok` / `partial` / `failed` summary, so a mixed YAML
+file produces a partial import rather than an all-or-nothing failure.
 
 ---
 
@@ -612,7 +636,7 @@ src/
 │   ├── voice-channel-tracker.ts
 │   ├── web-session-service.ts
 │   └── ...
-├── web/                  # Web UI router (thin wrappers over services)
+├── web/                  # Web UI router (HTTP layer over services)
 │   ├── index.ts          # Express router mounted at /admin
 │   ├── session.ts        # Cookie session middleware
 │   ├── read-only-routes.ts
@@ -625,10 +649,14 @@ src/
 └── index.ts              # Application entry point
 ```
 
-The hard rule for `src/web/`: **no business logic lives outside
-`src/services/`.** The Web UI is a new client on top of existing
-services, not a fork of the data model. See
-[DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md) for details.
+The target for `src/web/` is to be a thin HTTP layer over the
+services — the routes today do still hold some input coercion
+(`coerceConfigValue`, `normalizeCron`) and direct model reads for page
+data, but new write paths should prefer pushing that into a service
+method. The goal is one validation path shared between the slash-command
+surface and the Web UI surface, not two. See
+[DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md) for the current state and
+conventions.
 
 ### Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -90,11 +90,10 @@ Please include the following information in your report to help us better unders
 
 ### Rate Limiting
 
-KoolBot includes built-in rate limiting to prevent command spam. Ensure rate limiting is enabled in production:
-
-```bash
-/config set key:ratelimit.enabled value:true
-```
+KoolBot includes built-in rate limiting to prevent command spam. Ensure
+rate limiting is enabled in production: in the Web UI's Settings page,
+set `ratelimit.enabled = true` (run `/config` in Discord to receive a
+sign-in link to the Web UI).
 
 ### Input Validation
 

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -130,7 +130,10 @@ shell into the container.
 ## 🎮 Command Enablement
 
 Enable or disable individual commands from the Web UI's **Settings**
-page. **All commands are disabled by default.**
+page. **Every command listed below is disabled by default.** `/help`
+and `/config` are the exceptions — both are always registered (no
+`*.enabled` flag) so a fresh install always has access to the Web UI
+launcher and help discovery.
 
 | Setting | Default | Description |
 | --- | --- | --- |
@@ -684,8 +687,13 @@ These commands are **admin-only** by default:
 
 - `/config` — opens the Web UI
 
-The Web UI itself also requires that the user can run `config` (admin
-by default, overridable via the Permissions page).
+`/config` is registered with Discord's `setDefaultMemberPermissions(Administrator)`,
+so Discord enforces the admin gate before the bot's `PermissionsService`
+ever runs. To grant `/config` to non-admin roles, an operator must
+override the command in Discord (**Server Settings → Integrations →
+KoolBot → /config**). The Web UI's Permissions page only **narrows**
+who is allowed once Discord has admitted the interaction; it does not
+widen Discord's default member-permission gate.
 
 All other commands default to accessible by everyone unless you add
 permissions.
@@ -697,19 +705,26 @@ permissions.
 ### Editing settings
 
 All DB-backed settings are edited on the Web UI's **Settings** page.
-The Settings page groups settings by feature, validates input per
-schema, and shows inline help. After changing any `*.enabled` value,
-click **Reload commands to Discord** so Discord re-syncs the
-registration.
+The Settings page groups settings by feature, coerces inputs to the
+declared primitive type (boolean / number / string), and shows inline
+help. It does **not** enforce schema-level constraints like numeric
+ranges or enum allow-lists — invalid-but-well-typed values are
+accepted, so double-check inputs against the docs for keys with valid
+ranges (cron expressions, retention days, etc.). After changing any
+`*.enabled` value, click **Reload commands to Discord** so Discord
+re-syncs the registration.
 
 ### YAML export / import
 
 - **Export** — Settings page → click **Export** → download YAML. Covers
   DB-backed settings only; bootstrap env vars are excluded.
 - **Import** — Settings page → click **Import** → upload YAML → review
-  the diff → apply. Imports that try to set a protected key
-  (`DISCORD_TOKEN`, `WEBUI_SESSION_SECRET`, any other `.env` value) are
-  rejected outright.
+  the diff → apply. Imports are **per-key**: any row targeting a
+  protected key (`DISCORD_TOKEN`, `WEBUI_SESSION_SECRET`, any other
+  `.env` value) is flagged `rejected: protected key`, and the remaining
+  rows still apply. The result page surfaces per-key outcomes plus a
+  top-level `ok` / `partial` / `failed` summary, so a mixed YAML
+  produces a partial import rather than an all-or-nothing failure.
 
 ### Reset to default
 
@@ -720,7 +735,9 @@ For any setting, click **Reset to default** on the Settings page.
 The Web UI form controls map to the underlying schema types:
 
 - **Booleans** — checkbox
-- **Numbers** — number input with min/max validation
+- **Numbers** — number input; the form coerces strings to numbers but
+  does not enforce per-setting min/max (see [Editing settings](#editing-settings)
+  above)
 - **Strings** — text input
 - **Comma-separated lists** — text input; you handle the commas
 
@@ -735,7 +752,15 @@ The Web UI form controls map to the underlying schema types:
 
 ## 📖 Quick Settings Reference
 
-### All available settings (DB-backed)
+### Commonly used settings (DB-backed)
+
+This is a selected subset — the authoritative list of every key (with
+defaults and metadata) lives in `src/services/config-schema.ts`. Notable
+keys that may be missing from this summary include the `help.*` toggle,
+`voicechannels.presets.*`, `quotes.cleanup_interval`, the
+`*.header_message_id` storage slots managed by the bot, and the
+`leaderboard_roles.*` family (covered in [its own section](#-leaderboard-role-rewards)
+above).
 
 #### Commands
 

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -15,7 +15,7 @@ Complete configuration reference for all KoolBot settings.
 > Legacy `/config set` / `/permissions add` / `/setup wizard` etc. slash
 > commands have been removed — the Web UI is the only admin surface.
 > See [WEBUI.md](WEBUI.md).
-
+>
 > **Important:** Most features are **disabled by default** for safety.
 > Turn them on from the Web UI's Settings page once the bot is running.
 

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -131,9 +131,12 @@ shell into the container.
 
 Enable or disable individual commands from the Web UI's **Settings**
 page. **Every command listed below is disabled by default.** `/help`
-and `/config` are the exceptions — both are always registered (no
-`*.enabled` flag) so a fresh install always has access to the Web UI
-launcher and help discovery.
+and `/config` are the exceptions — both are always registered by
+`CommandManager` regardless of any config flag, so a fresh install
+always has access to the Web UI launcher and help discovery. (The
+schema does contain a `help.enabled` flag with `default: true`, but it
+is **not** consulted when registering `/help` — toggling it has no
+effect on whether the command appears in Discord.)
 
 | Setting | Default | Description |
 | --- | --- | --- |

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -1,40 +1,58 @@
 # KoolBot Settings Reference
 
-Complete configuration reference for all KoolBot settings. All settings can be managed through the `/config` command in Discord.
+Complete configuration reference for all KoolBot settings.
 
-> **Important:** Most features are **disabled by default** for security. You must enable features you want to use.
+> **Important:** KoolBot has a **two-tier** configuration model.
+>
+> - **Bootstrap settings** live in `.env`. Edit the file on the host and
+>   restart the bot to apply. The Web UI surfaces these read-only on its
+>   **Bootstrap** page; they are never editable from the browser.
+> - **Feature settings** live in MongoDB and are edited exclusively
+>   through the **Web UI**'s Settings, Permissions, Setup Wizard, and
+>   per-feature pages. Run `/config` in Discord to get a single-use
+>   sign-in link.
+>
+> Legacy `/config set` / `/permissions add` / `/setup wizard` etc. slash
+> commands have been removed — the Web UI is the only admin surface.
+> See [WEBUI.md](WEBUI.md).
+
+> **Important:** Most features are **disabled by default** for safety.
+> Turn them on from the Web UI's Settings page once the bot is running.
 
 ---
 
 ## 📋 Table of Contents
 
-- [Environment Variables](#-environment-variables) - Required `.env` file settings
-- [Command Enablement](#-command-enablement) - Enable/disable commands
-- [Setup Wizard](#-setup-wizard) - Interactive configuration system
-- [Quote System](#-quote-system) - Quote management settings
-- [Notices System](#-notices-system) - Protected notices channel settings
-- [Poll System](#️-poll-system) - Periodic poll settings
-- [Voice Channel Management](#-voice-channel-management) - Dynamic channel settings
-- [Voice Activity Tracking](#-voice-activity-tracking) - Track user activity
-- [Voice Channel Cleanup](#-voice-channel-cleanup) - Data retention
-- [Announcements](#-announcements) - Automated stats posting
-- [Achievements System](#-achievements-system) - Badges and achievements
-- [Reaction Roles](#-reaction-roles) - Self-assignable roles via reactions
-- [Leaderboard Role Rewards](#-leaderboard-role-rewards) - Auto-assign roles from voice leaderboard
-- [Discord Logging](#-discord-logging) - Event logging to channels
-- [Fun Features](#-fun-features) - Easter eggs and extras
-- [Rate Limiting](#-rate-limiting) - Command spam protection
-- [Permissions & Access Control](#-permissions--access-control) - Role-based command access
-- [Configuration Management](#-configuration-management) - Using `/config` commands
-- [Quick Reference](#-quick-settings-reference) - All settings table
+- [Environment Variables](#-environment-variables) — `.env` (bootstrap, read-only in Web UI)
+- [Command Enablement](#-command-enablement) — Enable/disable commands
+- [Setup Wizard](#-setup-wizard)
+- [Quote System](#-quote-system)
+- [Notices System](#-notices-system)
+- [Poll System](#️-poll-system)
+- [Voice Channel Management](#-voice-channel-management)
+- [Voice Activity Tracking](#-voice-activity-tracking)
+- [Voice Channel Cleanup](#-voice-channel-cleanup)
+- [Announcements](#-announcements)
+- [Achievements System](#-achievements-system)
+- [Reaction Roles](#-reaction-roles)
+- [Leaderboard Role Rewards](#-leaderboard-role-rewards)
+- [Discord Logging](#-discord-logging)
+- [Fun Features](#-fun-features)
+- [Rate Limiting](#-rate-limiting)
+- [Permissions & Access Control](#-permissions--access-control)
+- [Configuration Management](#-configuration-management) — Using the Web UI
+- [Quick Reference](#-quick-settings-reference) — All settings table
 
 ---
 
 ## 🔐 Environment Variables
 
-These settings **must** be configured in your `.env` file before starting the bot.
+These settings live in `.env` only. Editing them requires editing the
+file on the host and restarting the bot. The Web UI's **Bootstrap** page
+surfaces them read-only for diagnostics, with secrets masked to the last
+4 characters.
 
-### Required Variables
+### Required for the bot itself
 
 ```env
 # Discord Bot Credentials (Required)
@@ -50,19 +68,41 @@ DEBUG=false
 NODE_ENV=production
 ```
 
-### How to Get Discord Credentials
+### Required when the Web UI is enabled
 
-1. **Go to [Discord Developer Portal](https://discord.com/developers/applications)**
-2. **Create or select your application**
-3. **Get your credentials:**
+```env
+# Master switch — when true, /admin/* is mounted
+WEBUI_ENABLED=true
+
+# Public URL the DM'd sign-in link points at (no trailing slash needed)
+WEBUI_BASE_URL=https://bot.example.com
+
+# HMAC key for tokens and cookies — generate with `openssl rand -base64 32`
+WEBUI_SESSION_SECRET=replace-me
+
+# Optional tuning (defaults shown)
+WEBUI_SESSION_TTL_MINUTES=10
+WEBUI_INACTIVITY_TIMEOUT_MINUTES=30
+
+# Reverse proxy hop count (set to 1 when running behind Caddy/nginx/Traefik)
+# WEBUI_TRUST_PROXY=1
+```
+
+See [WEBUI.md → Bootstrap environment variables](WEBUI.md#bootstrap-environment-variables)
+for full descriptions and threat-model notes.
+
+### How to get Discord credentials
+
+1. Go to [Discord Developer Portal](https://discord.com/developers/applications)
+2. Create or select your application
+3. Get your credentials:
    - `DISCORD_TOKEN`: Bot tab → Reset Token → Copy
    - `CLIENT_ID`: General Information → Application ID
-   - `GUILD_ID`: Your Discord Server → Right-click server icon → Copy ID
+   - `GUILD_ID`: Right-click your server icon in Discord → Copy ID
 
-**Enable Developer Mode in Discord:**
-User Settings → Advanced → Developer Mode (toggle on)
+**Enable Developer Mode in Discord:** User Settings → Advanced → Developer Mode (toggle on)
 
-### MongoDB URI Examples
+### MongoDB URI examples
 
 ```env
 # Docker Compose (default)
@@ -78,11 +118,19 @@ MONGODB_URI=mongodb://username:password@host:27017/koolbot
 MONGODB_URI=mongodb+srv://username:password@cluster.mongodb.net/koolbot
 ```
 
+### Bootstrap diagnostics
+
+Inside the Web UI, the **Bootstrap** page shows whether each env var is
+configured. Secrets are masked (e.g. `DISCORD_TOKEN ✓ ...x9F2`). You
+can verify the process picked up the values you set without having to
+shell into the container.
+
 ---
 
 ## 🎮 Command Enablement
 
-Enable or disable individual commands. **All commands are disabled by default.**
+Enable or disable individual commands from the Web UI's **Settings**
+page. **All commands are disabled by default.**
 
 | Setting | Default | Description |
 | --- | --- | --- |
@@ -91,58 +139,30 @@ Enable or disable individual commands. **All commands are disabled by default.**
 | `amikool.role.name` | `""` | Role name to check for `/amikool` verification |
 | `quotes.enabled` | `false` | Enable/disable the quote system |
 
-### Example
-
-```bash
-# Enable ping command
-/config set key:ping.enabled value:true
-/config reload  # Required!
-
-# Enable amikool with role
-/config set key:amikool.enabled value:true
-/config set key:amikool.role.name value:"Kool Members"
-/config reload
-```
+After changing any `*.enabled` value, click **Reload commands to
+Discord** on the Settings page so Discord picks up the change.
 
 ---
 
 ## 🧙 Setup Wizard
 
-Interactive configuration wizard for guided server setup.
+Interactive guided configuration for new operators.
 
 | Setting | Default | Description |
 | --- | --- | --- |
-| `wizard.enabled` | `true` | Enable/disable the interactive setup wizard |
+| `wizard.enabled` | `true` | Enable/disable the Setup Wizard page |
 
-### About the Setup Wizard
+The wizard is the **Setup Wizard** page inside the Web UI. It:
 
-The setup wizard (`/setup wizard`) provides an interactive, step-by-step configuration experience for new users. It:
+- Auto-detects existing Discord resources (categories, channels)
+- Walks you through each feature step by step
+- Validates settings (channels must exist, etc.) before applying
+- Sets multiple related settings in one click
 
-- **Auto-detects resources** - Finds existing categories and channels
-- **Validates settings** - Ensures channels exist before applying configuration
-- **Guides users** - Provides explanations and suggestions for each setting
-- **Bulk configuration** - Sets multiple related settings at once
-- **Feature-specific** - Can configure individual features or all at once
-
-**When to disable:**
-
-- If you prefer manual configuration only
-- To prevent accidental reconfiguration by admins
-- For servers with complex custom setups
-
-### Example
-
-```bash
-# Disable the wizard (not recommended for new users)
-/config set key:wizard.enabled value:false
-/config reload
-
-# Re-enable the wizard
-/config set key:wizard.enabled value:true
-/config reload
-```
-
-**Note:** The wizard is **enabled by default** and is the recommended way to configure KoolBot for first-time users.
+**When to disable:** if you prefer to edit settings directly on the
+Settings page, or want to keep the wizard out of the navigation for an
+already-configured deployment. The wizard is on by default for new
+installs.
 
 ---
 
@@ -163,35 +183,25 @@ Configure the quote management system.
 | `quotes.header_pin_enabled` | `true` | Pin the header post for easy access |
 | `quotes.header_message_id` | `""` | Stores header message ID (managed automatically) |
 
-### Example
-
-```bash
-# Enable quotes with restrictions
-/config set key:quotes.enabled value:true
-/config set key:quotes.cooldown value:120
-/config set key:quotes.max_length value:500
-/config set key:quotes.add_roles value:"123456789,987654321"
-/config reload
-
-# Optionally set a dedicated quote channel
-/config set key:quotes.channel_id value:"1234567890"
-/config reload
-```
-
 **Notes:**
 
-- `quotes.channel_id` - If set, all quotes will be posted to this channel. If empty, quotes post in the channel where the command was used.
-- `quotes.cleanup_interval` - Controls how often unauthorized quote messages are cleaned up (messages from non-command sources in the quote channel).
-- `quotes.header_enabled` - When enabled, displays an informational header post explaining how the quote channel works.
-  The header is automatically recreated if deleted.
-- `quotes.header_pin_enabled` - Controls whether the header post is pinned for easy visibility.
-- `quotes.header_message_id` - Automatically managed by the bot; stores the message ID of the header post.
+- `quotes.channel_id` — If set, all quotes are posted to this channel.
+  If empty, quotes post in the channel where the command was used.
+- `quotes.cleanup_interval` — Controls how often unauthorized messages
+  in the quote channel are removed.
+- `quotes.header_enabled` — Displays a pinned informational header.
+  Auto-recreated if deleted.
+- `quotes.header_pin_enabled` — Controls whether the header is pinned.
+- `quotes.header_message_id` — Managed by the bot.
 
 ---
 
 ## 📋 Notices System
 
-Bot-managed protected channel for server notices, rules, and help information.
+Bot-managed protected channel for server notices, rules, and help
+information. Notice content (titles, bodies, categories, order) is
+managed on the Web UI's **Notices** page; the settings below control
+the channel itself.
 
 | Setting | Default | Description |
 | --- | --- | --- |
@@ -202,97 +212,50 @@ Bot-managed protected channel for server notices, rules, and help information.
 | `notices.header_pin_enabled` | `true` | Pin the header post for easy access |
 | `notices.header_message_id` | `""` | Stores header message ID (managed automatically) |
 
-### Example
-
-```bash
-# Enable notices
-/config set key:notices.enabled value:true
-/config set key:notices.channel_id value:"1234567890"
-/config reload
-
-# Add your first notice
-/notice add title:"Server Rules" content:"1. Be respectful..." category:"Rules"
-```
-
 **Features:**
 
-- **Bot-Only Channel**: Only bot can post, users can only read
-- **Auto-Cleanup**: Removes unauthorized messages every 5 minutes
-- **Persistent**: Notices stored in MongoDB, survive bot restarts
-- **Organized**: Sort by category (Rules, Info, Help, Game Servers, General)
-- **Custom Order**: Control display order with order parameter
-- **Rich Embeds**: Each notice displayed as a formatted embed with color-coded categories
+- **Bot-only channel** — Only bot can post; users can only read
+- **Auto-cleanup** — Removes unauthorized messages every 5 minutes
+- **Persistent** — Notices stored in MongoDB, survive bot restarts
+- **Organized** — Sort by category (Rules, Info, Help, Game Servers, General)
+- **Custom order** — Control display order with the `order` field on each notice
+- **Rich embeds** — Each notice displayed as a formatted embed with color-coded category
 
-**Notice Categories:**
+**Notice categories:**
 
-- **General** (📋) - General server information
-- **Rules** (📜) - Server rules and guidelines
-- **Information** (ℹ️) - Important server info
-- **Help** (❓) - Bot feature help and guides
-- **Game Servers** (🎮) - Game server connection information
+- **General** (📋) — General server information
+- **Rules** (📜) — Server rules and guidelines
+- **Information** (ℹ️) — Important server info
+- **Help** (❓) — Bot feature help and guides
+- **Game Servers** (🎮) — Game server connection info
 
-**Commands:**
-
-- `/notice add` - Create a new notice
-- `/notice edit` - Update existing notice (ID visible in notice footer)
-- `/notice delete` - Remove a notice (ID visible in notice footer)
-- `/notice sync` - Recreate all notices in channel
-
-**Notes:**
-
-- The channel is automatically configured with strict permissions
-- Bot automatically creates a "Features" notice listing enabled bot features
-- Header post explains the channel purpose and is auto-recreated if deleted
-- Notices persist in the database and are automatically reposted on bot restart
-- Notice IDs are displayed in each notice's footer for editing/deletion
-- Perfect for rules, game server info, bot help, and important announcements
+CRUD operations (add, edit, delete, sync) happen on the Web UI's
+**Notices** page.
 
 ---
 
 ## 🗳️ Poll System
 
-Periodic polls for icebreaker discussions and community engagement using Discord's native poll feature.
+Periodic Discord native polls. Poll questions and schedules are managed
+on the Web UI's **Polls** page; the settings below are global defaults.
 
 | Setting | Default | Description |
 | --- | --- | --- |
 | `polls.enabled` | `false` | Enable/disable the poll system |
-| `polls.default_duration_hours` | `24` | Default poll duration in hours (1-768, max 32 days) |
+| `polls.default_duration_hours` | `24` | Default poll duration (1-768, max 32 days) |
 | `polls.cooldown_days` | `7` | Minimum days before reusing the same poll question |
-
-### Example
-
-```bash
-# Enable polls
-/config set key:polls.enabled value:true
-/config set key:polls.default_duration_hours value:24
-/config set key:polls.cooldown_days value:7
-/config reload
-
-# Import poll questions from a URL
-/poll import-url url:https://example.com/polls.yaml
-
-# Create a schedule
-/poll create channel:#daily-questions schedule:"0 12 * * *" duration:24 ping_role:@Community
-```
 
 **Features:**
 
-- **Native Polls**: Uses Discord's built-in poll feature for a polished experience
-- **Scheduled Posting**: Automatic polls based on cron schedules  
-- **URL Import**: Fetch poll questions from YAML or JSON files (and save to database)
-- **Smart Rotation**: Intelligently avoids repeating polls within the cooldown period
-- **Database Storage**: Store and manage poll questions locally
-- **Role Pinging**: Optional role mentions when posting polls
-- **Multi-Select Support**: Polls can allow multiple answer selections
+- **Native polls** — Discord's built-in poll feature
+- **Scheduled posting** — Cron-driven automatic polls
+- **URL import** — Fetch poll questions from YAML or JSON files
+- **Smart rotation** — Avoids repeating polls within the cooldown
+- **Database storage** — Local library of poll questions
+- **Role pinging** — Optional role mention when posting
+- **Multi-select support** — Polls can accept multiple selections
 
-**Poll Sources:**
-
-The bot stores all poll questions in the database. You can populate the database by:
-
-1. **URL Import** - Fetch polls from a remote YAML/JSON file (copies to database)
-2. **Manual Entry** - Add individual poll questions via `/poll add-item`
-
-**URL Format (YAML):**
+**URL formats:**
 
 ```yaml
 polls:
@@ -300,14 +263,7 @@ polls:
     answers: ["JavaScript", "Python", "Go", "Rust"]
     multiselect: false
     tags: ["tech", "icebreaker"]
-  
-  - question: "Would you rather fight 100 duck-sized horses or 1 horse-sized duck?"
-    answers: ["100 duck-sized horses", "1 horse-sized duck", "Neither!"]
-    multiselect: false
-    tags: ["funny", "absurd"]
 ```
-
-**URL Format (JSON):**
 
 ```json
 {
@@ -322,35 +278,21 @@ polls:
 }
 ```
 
-**Commands:**
+Schedule CRUD and question CRUD live on the Polls page.
 
-- `/poll create` - Schedule periodic polls
-- `/poll list` - View all poll schedules
-- `/poll delete` - Remove a poll schedule
-- `/poll test` - Post a test poll immediately
-- `/poll add-item` - Add a poll question to the database
-- `/poll list-items` - View all stored poll questions
-- `/poll delete-item` - Remove a poll question
-- `/poll import-url` - Import polls from YAML/JSON URL
+**Smart poll selection:**
 
-**Smart Poll Selection:**
-
-The bot intelligently selects which poll to post:
-
-1. **Cooldown Filter** - Excludes polls used within the cooldown period
-2. **Usage Priority** - Prioritizes polls with lower usage counts
-3. **Random Selection** - Randomly picks from top 20% least-used eligible polls
-4. **Fallback** - If all polls are within cooldown, uses the oldest one
+1. Excludes polls used within the cooldown
+2. Prioritizes lower usage counts
+3. Random selection from the top 20% least-used eligible polls
+4. Fallback to the oldest-used poll if all are within cooldown
 
 **Notes:**
 
 - Poll questions must have 2-10 answer options (Discord limitation)
 - Questions limited to 300 characters (Discord limitation)
 - Polls can run for 1 hour to 32 days (768 hours)
-- Import from URL copies all polls to the database for local management
-- Usage statistics track how often each poll is used
-- Tags help organize polls but don't affect selection logic
-- Perfect for daily icebreakers, team building, and community engagement
+- URL import copies all polls to the database for local management
 
 ---
 
@@ -367,36 +309,24 @@ Dynamic voice channel creation and management.
 | `voicechannels.channel.prefix` | `"🎮"` | Prefix for user-created channels |
 | `voicechannels.channel.suffix` | `""` | Suffix for user-created channels |
 | `voicechannels.controlpanel.enabled` | `true` | Show interactive control panel in channel text chat |
-| `voicechannels.ownership.grace_period_seconds` | `30` | Grace period (seconds) before transferring ownership when owner disconnects |
+| `voicechannels.ownership.grace_period_seconds` | `30` | Grace period before transferring ownership when owner disconnects |
 
-### Ownership Grace Period
+### Ownership grace period
 
-When a channel owner disconnects (e.g., network issue, client restart), the bot waits for the grace period before transferring ownership.
-If the owner rejoins within this time, they retain ownership. This prevents accidental ownership transfers during brief disconnects.
+When a channel owner disconnects (e.g., network issue, client restart),
+the bot waits for the grace period before transferring ownership. If
+the owner rejoins within this time, they retain ownership.
 
 **Recommended values:**
 
-- `30` (default) - Good balance for most servers
-- `60` - For servers with frequent connection issues
-- `10` - For faster ownership transfers
+- `30` (default) — Good balance for most servers
+- `60` — Servers with frequent connection issues
+- `10` — For faster ownership transfers
 
-### Example
+### Manual cleanup
 
-```bash
-# Setup voice channels
-/config set key:voicechannels.enabled value:true
-/config set key:voicechannels.category.name value:"Voice Channels"
-/config set key:voicechannels.lobby.name value:"🟢 Join Here"
-/config set key:voicechannels.channel.prefix value:"🎮"
-/config set key:voicechannels.channel.suffix value:"'s Room"
-
-# Set ownership grace period to 60 seconds
-/config set key:voicechannels.ownership.grace_period_seconds value:60
-
-/config reload
-```
-
-**Result:** User "Alice" joining creates: **🎮 Alice's Room**
+Out-of-schedule channel cleanup runs from the Web UI's **Voice Channels**
+page (replaces the old `/vc reload` and `/vc force-reload`).
 
 ---
 
@@ -413,71 +343,33 @@ Track user voice channel activity and generate statistics.
 | `voicetracking.excluded_channels` | `""` | Channel IDs to exclude from tracking (comma-separated) |
 | `voicetracking.admin_roles` | `""` | Role names with tracking admin powers (comma-separated) |
 
-### Example
+### Managing excluded channels
 
-```bash
-# Enable tracking and voicestats command
-/config set key:voicetracking.enabled value:true
-/config set key:voicetracking.stats.top.enabled value:true
-/config set key:voicetracking.stats.user.enabled value:true
-/config set key:voicetracking.seen.enabled value:true
+Right-click each channel in Discord and **Copy ID** (with Developer Mode
+enabled), then set `voicetracking.excluded_channels` on the Web UI's
+Settings page as a comma-separated list:
 
-# Exclude AFK channels
-/config set key:voicetracking.excluded_channels value:"123456789,987654321"
-
-# Set admin roles
-/config set key:voicetracking.admin_roles value:"Admin,Moderator"
-
-/config reload
+```text
+123456789012345678,987654321098765432
 ```
 
-### Managing Excluded Channels
-
-**View currently excluded channels:**
-
-```bash
-/config get key:voicetracking.excluded_channels
-```
-
-**Add channels to exclusion list:**
-
-To exclude channels, get their IDs (right-click channel → Copy ID with Developer Mode enabled) and set them as a comma-separated list:
-
-```bash
-# Exclude a single channel
-/config set key:voicetracking.excluded_channels value:"123456789"
-
-# Exclude multiple channels
-/config set key:voicetracking.excluded_channels value:"123456789,987654321,555555555"
-```
-
-**Remove channels from exclusion:**
-
-```bash
-# Remove all exclusions (empty value)
-/config set key:voicetracking.excluded_channels value:""
-
-# Or manually edit the list to remove specific channels
-/config set key:voicetracking.excluded_channels value:"123456789,987654321"
-```
-
-**Common channels to exclude:**
+**Common candidates to exclude:**
 
 - AFK channels
 - Music bot channels
 - Waiting rooms
-- Private/admin channels
+- Private / admin channels
 - Temporary meeting rooms
 
-**Excluded channels** won't count toward leaderboards or statistics.
+Excluded channels won't count toward leaderboards or statistics.
 
 ---
 
 ## ⏰ Announcements
 
-### Voice Channel Statistics Announcements
+### Voice channel statistics announcements
 
-Automated voice channel statistics announcements.
+Automated weekly voice channel statistics post.
 
 | Setting | Default | Description |
 | --- | --- | --- |
@@ -485,57 +377,35 @@ Automated voice channel statistics announcements.
 | `voicetracking.announcements.channel` | `"voice-stats"` | Channel name or ID for announcements |
 | `voicetracking.announcements.schedule` | `"0 16 * * 5"` | Cron schedule (default: Fridays 4 PM) |
 
-**Example:**
+To trigger one out of schedule, use the **Post weekly stats now** button
+on the Web UI's Announcements page (replaces the old
+`/announce-vc-stats`).
 
-```bash
-# Enable weekly announcements
-/config set key:voicetracking.announcements.enabled value:true
-/config set key:voicetracking.announcements.channel value:"voice-stats"
-/config set key:voicetracking.announcements.schedule value:"0 16 * * 5"
-/config reload
-```
+### Scheduled announcements
 
-### Scheduled Announcements
-
-Custom scheduled announcements system for automated messages.
+Custom scheduled announcements (managed on the Web UI's **Announcements**
+page).
 
 | Setting | Default | Description |
 | --- | --- | --- |
 | `announcements.enabled` | `false` | Enable scheduled announcements system |
 
-**Example:**
-
-```bash
-# Enable scheduled announcements
-/config set key:announcements.enabled value:true
-/config reload
-
-# Create announcements using /announce command
-/announce create cron:"0 9 * * *" channel:#general message:"Good morning!"
-```
-
 **Features:**
 
 - Schedule custom messages to any channel
-- Support for cron expressions
+- Cron expressions for the schedule
 - Embed support with customizable colors
-- Dynamic placeholders ({server_name}, {member_count}, {date}, {time}, etc.)
+- Dynamic placeholders (`{server_name}`, `{member_count}`, `{date}`,
+  `{time}`, `{day}`, `{month}`, `{year}`)
 - Persistent across bot restarts
-- Manage via `/announce` commands
 
-**Commands:**
-
-- `/announce create` - Create a new scheduled announcement
-- `/announce list` - View all scheduled announcements
-- `/announce delete` - Remove an announcement
-
-See [Commands Documentation](COMMANDS.md#announce) for detailed usage.
+CRUD operations happen on the Announcements page.
 
 ---
 
 ## 🏆 Achievements System
 
-Badge and achievement system to encourage voice channel participation.
+Persistent accolade system to encourage voice channel participation.
 
 | Setting | Default | Description |
 | --- | --- | --- |
@@ -543,81 +413,38 @@ Badge and achievement system to encourage voice channel participation.
 | `achievements.announcements.enabled` | `true` | Include new accolades in weekly announcements |
 | `achievements.dm_notifications.enabled` | `true` | Send DM to users when they earn accolades |
 
-**Example:**
-
-```bash
-# Enable achievements
-/config set key:achievements.enabled value:true
-/config reload
-
-# Disable DM notifications (keep announcements)
-/config set key:achievements.dm_notifications.enabled value:false
-/config reload
-```
-
 **Features:**
 
-- **Persistent Accolades** - Permanent badges earned once and kept forever
-- **16 Different Accolades** - Milestone-based, time-based, behavior-based, and streak-based
-- **Automatic Tracking** - Earned automatically based on voice activity
-- **DM Notifications** - Users notified immediately when earning badges
-- **Weekly Announcements** - New accolades announced in voice stats channel
-- **View Command** - Use `/achievements` to see earned badges
+- **Persistent accolades** — Permanent badges earned once and kept forever
+- **22+ different accolades** — Time milestones, session length, social,
+  time-of-day, day-of-week, streak, quote-related
+- **Automatic tracking** — Earned automatically based on voice activity
+- **DM notifications** — Users notified immediately when earning badges
+- **Weekly announcements** — New accolades announced in voice stats channel
+- **View command** — Use `/achievements` to see earned badges
 
-**Available Accolades:**
+**Notes:**
 
-Time Milestones:
-
-- First Steps (1 hour)
-- Voice Veteran (100 hours)
-- Voice Elite (500 hours)
-- Voice Master (1000 hours)
-- Voice Legend (8765 hours / 1 year)
-
-Session Length:
-
-- Marathon Runner (4+ hour session)
-- Ultra Marathoner (8+ hour session)
-
-Social Activity:
-
-- Social Butterfly (10+ unique users)
-- Connector (25+ unique users)
-
-Time of Day:
-
-- Night Owl (50+ late-night hours, 10 PM - 6 AM UTC)
-- Early Bird (50+ early-morning hours, 6 AM - 10 AM UTC)
-
-Day of Week:
-
-- Weekend Warrior (100+ weekend hours)
-- Weekday Warrior (100+ weekday hours)
-
-Consecutive Days (NEW):
-
-- 🔥 On a Roll (7 consecutive days, 5+ min/day)
-- ⚡ Dedicated AF (14 consecutive days, 5+ min/day)
-- 💀 No-Lifer (30 consecutive days, 5+ min/day)
-
-**Important Notes:**
-
-- **Time-based accolades** (Night Owl, Early Bird, Weekend Warrior, Weekday Warrior) use **UTC timezone**
-- Time of day calculations are based on the bot's server time (UTC), not user's local time
-- Weekend/weekday determination uses UTC day of week
+- Time-based accolades (Night Owl, Early Bird, Weekend Warrior, Weekday
+  Warrior) use **UTC** timezone, not the user's local time.
+- Weekend / weekday determination uses UTC day of week.
 
 **Requirements:**
 
-- Requires `voicetracking.enabled` to be `true`
+- Requires `voicetracking.enabled = true`
 - Accolades are checked after each voice session ends
-- DMs require user to have DMs enabled for the bot
-- **For consecutive days accolades:** Ensure `voicetracking.cleanup.retention.detailed_sessions_days` is at least **60 days** to preserve streak history
+- DMs require the user to have DMs enabled for the bot
+- **For consecutive-days accolades:** keep
+  `voicetracking.cleanup.retention.detailed_sessions_days` at **60 days
+  or higher** to preserve enough streak history for the 30-day
+  "No-Lifer" badge.
 
-See [Achievements Command](COMMANDS.md#achievements) for usage details.
+See [COMMANDS.md → /achievements](COMMANDS.md#achievements) for the full
+accolade list and usage.
 
 ---
 
-### Cron Schedule Format
+### Cron schedule format
 
 ```text
 * * * * *
@@ -631,98 +458,60 @@ See [Achievements Command](COMMANDS.md#achievements) for usage details.
 
 **Examples:**
 
-- `0 16 * * 5` - Every Friday at 4 PM
-- `0 0 * * 1` - Every Monday at midnight
-- `0 12 * * *` - Every day at noon
+- `0 16 * * 5` — Every Friday at 4 PM
+- `0 0 * * 1` — Every Monday at midnight
+- `0 12 * * *` — Every day at noon
+- `*/30 * * * *` — Every 30 minutes
 
 ---
 
 ## 🎭 Reaction Roles
 
-Self-assignable roles via message reactions. Users react to get a role and access to dedicated channels.
+Self-assignable roles via message reactions. Users react to a message
+to get a role and access to a dedicated category. Role CRUD happens on
+the Web UI's **Reaction Roles** page.
 
 | Setting | Default | Description |
 | --- | --- | --- |
 | `reactionroles.enabled` | `false` | Enable reaction role system |
-| `reactionroles.message_channel_id` | `""` | Channel ID for reaction role messages |
+| `reactionroles.message_channel_id` | `""` | Channel ID where reaction-role messages are posted |
 
-### Setup
+### How it works
 
-```bash
-# Enable reaction roles
-/config set key:reactionroles.enabled value:true
-
-# Set message channel (users react here)
-/config set key:reactionroles.message_channel_id value:"1234567890"
-
-/config reload
-```
-
-### How it Works
-
-1. **Create a reaction role:**
-
-```bash
-/reactrole create name:"Gaming" emoji:🎮
-```
-
-1. **Bot automatically creates:**
-   - A Discord role named "Gaming"
-   - A category channel (visible only to role members)
+1. Create a reaction role on the Web UI's Reaction Roles page (specify a
+   name and emoji).
+2. The bot creates:
+   - A Discord role with the specified name
+   - A category visible only to role members
    - A text channel inside the category
-   - A reaction message in the configured message channel
+   - A reaction message in `reactionroles.message_channel_id`
+3. Users react with the emoji to get the role; remove the reaction to
+   lose it.
+4. The Web UI lets you **Archive** (disable reactions but keep the role
+   and channels), **Unarchive** (re-enable), or **Delete** (remove
+   everything).
 
-1. **Users can:**
-   - React with 🎮 to get the Gaming role
-   - Gain access to the Gaming category and channels
-   - Remove reaction to lose the role and access
+### Use cases
 
-1. **Lifecycle management:**
-   - **Archive:** Disable reactions but keep role/channels (`/reactrole archive`)
-   - **Unarchive:** Re-enable reactions for an archived role (`/reactrole unarchive`)
-   - **Delete:** Remove everything permanently (`/reactrole delete`)
+- Interest groups (Gaming, Movies, Music)
+- Event participation (tournament sign-ups)
+- Opt-in announcements (news, updates)
+- Activity organization (separate channels per game/activity)
 
-### Features
+### Best practices
 
-- **Automatic role assignment** - React to get the role instantly
-- **Private channels** - Category visible only to role members
-- **Permission management** - Bot maintains category permissions
-- **Flexible lifecycle** - Archive, unarchive, or delete as needed
-- **Status tracking** - List and check status of all reaction roles
-
-### Use Cases
-
-- **Interest groups** - Gaming, movies, music communities
-- **Event participation** - Tournament sign-ups, event attendance
-- **Opt-in announcements** - News, updates for specific topics
-- **Activity organization** - Separate channels for different games/activities
-
-### Commands
-
-- `/reactrole create` - Create a new reaction role
-- `/reactrole archive` - Archive a role (disable reactions)
-- `/reactrole unarchive` - Unarchive a role (re-enable reactions)
-- `/reactrole delete` - Delete a role and all resources
-- `/reactrole list` - List all configured reaction roles
-- `/reactrole status` - Check status of a specific role
-
-See [Commands Documentation](COMMANDS.md#reactrole) for detailed usage.
-
-### Best Practices
-
-- Use a dedicated channel for reaction role messages (e.g., #get-roles)
-- Pin reaction messages for easy access
+- Use a dedicated channel for reaction-role messages (e.g. `#get-roles`)
+- Pin the reaction messages for easy access
 - Choose clear, recognizable emojis
-- Archive seasonal roles instead of deleting them (use unarchive to reactivate)
-- Use descriptive names for roles and channels
+- Archive seasonal roles instead of deleting them
 
 ---
 
 ## 🏅 Leaderboard Role Rewards
 
-Auto-assign Discord roles based on each user's position on the voice-channel leaderboard.
-A cron job recalculates assignments on a schedule; users who fall out of a tier lose
-the role automatically.
+Auto-assign Discord roles based on each user's position on the
+voice-channel leaderboard. A cron job recalculates assignments on a
+schedule; users who fall out of a tier lose the role automatically.
 
 | Setting | Default | Description |
 | --- | --- | --- |
@@ -732,40 +521,33 @@ the role automatically.
 | `leaderboard_roles.tiers` | `""` | Comma-separated `topN:roleId` pairs (e.g. `1:111,3:222,10:333`) |
 | `leaderboard_roles.announcement_channel_id` | `""` | Optional channel ID for role-change announcements (empty disables) |
 
-### Tier Configuration
+### Tier configuration
 
-Tiers are admin-defined — there is no built-in "top 1 / top 3 / top 10". You pick any
-positions you want to reward and which role each one grants. The format is a
-comma-separated list of `topN:roleId` pairs:
+Tiers are admin-defined — there is no built-in "top 1 / top 3 / top 10".
+You pick any positions you want to reward and which role each one
+grants. The format is a comma-separated list of `topN:roleId` pairs:
 
 ```text
 leaderboard_roles.tiers = "1:111111111111111111,3:222222222222222222,10:333333333333333333"
 ```
 
-In this example a user at rank #1 receives all three roles, a user at rank #2 or #3
-receives the latter two, and a user at rank #4–#10 receives only the third. Each tier
-is independent.
+A user at rank #1 receives all three roles; rank #2 or #3 receives the
+latter two; rank #4–#10 receives only the third. Each tier is
+independent.
 
-Invalid entries (non-numeric `topN`, non-snowflake role ID, malformed syntax) are
-logged and skipped — they don't stop the rest of the configuration from applying.
-
-### Example
-
-```bash
-# Enable and configure
-/config set key:leaderboard_roles.enabled value:true
-/config set key:leaderboard_roles.period value:week
-/config set key:leaderboard_roles.update_cron value:"0 0 * * 1"
-/config set key:leaderboard_roles.tiers value:"1:111111111111111111,3:222222222222222222"
-/config set key:leaderboard_roles.announcement_channel_id value:"123456789012345678"
-/config reload
-```
+Invalid entries (non-numeric `topN`, non-snowflake role ID, malformed
+syntax) are logged and skipped — they don't stop the rest of the
+configuration from applying.
 
 **Notes:**
 
-- The bot must have the **Manage Roles** permission and its highest role must sit above the reward roles in the role hierarchy, otherwise role add/remove will fail.
-- Role assignments are tracked in MongoDB so the bot can revoke a role from a user even after a restart, without requiring the privileged `GuildMembers` intent.
-- The announcement embed is only posted when there is at least one add/remove in a run.
+- The bot must have **Manage Roles** permission and its highest role
+  must sit above the reward roles in the hierarchy.
+- Role assignments are tracked in MongoDB so the bot can revoke a role
+  from a user even after a restart, without requiring the privileged
+  `GuildMembers` intent.
+- The announcement embed only posts when there's at least one add or
+  remove in a run.
 
 ---
 
@@ -781,39 +563,24 @@ Automatic cleanup of old tracking data with data aggregation.
 | `voicetracking.cleanup.retention.monthly_summaries_months` | `6` | Months to keep monthly summaries |
 | `voicetracking.cleanup.retention.yearly_summaries_years` | `1` | Years to keep yearly summaries |
 
-### Example
-
-```bash
-# Enable cleanup with custom retention
-/config set key:voicetracking.cleanup.enabled value:true
-/config set key:voicetracking.cleanup.schedule value:"0 2 * * *"
-/config set key:voicetracking.cleanup.retention.detailed_sessions_days value:60
-/config set key:voicetracking.cleanup.retention.monthly_summaries_months value:12
-/config set key:voicetracking.cleanup.retention.yearly_summaries_years value:2
-/config reload
-```
-
 **How it works:**
 
-1. Old detailed sessions are removed after retention period
-2. Data is aggregated into monthly/yearly summaries before deletion
+1. Old detailed sessions are removed after the retention period
+2. Data is aggregated into monthly / yearly summaries before deletion
 3. Statistics are preserved even after detailed data is removed
-4. Manual cleanup available with `/dbtrunk run`
+4. Manual cleanup runs from the Web UI's **Database** page (replaces
+   the old `/dbtrunk run`)
 
-⚠️ **Important for Consecutive Days Accolades:**
+⚠️ **Important for consecutive-days accolades:**
 
-The cleanup job deletes session history older than `detailed_sessions_days`. This affects consecutive day streak calculations:
+The cleanup job deletes session history older than
+`detailed_sessions_days`. This affects consecutive-day streak
+calculations:
 
-- **Default retention (30 days):** Supports streaks up to ~25 days (some buffer needed)
-- **For 30-day "No-Lifer" accolade:** Increase retention to at least **60 days** (30-day streak + 30-day buffer for safety)
-- **Formula:** Set retention to (longest streak × 2) for safe operation
-
-**Recommended configuration for accolades:**
-
-```bash
-# Recommended: 60 days to safely support all default accolades
-/config set key:voicetracking.cleanup.retention.detailed_sessions_days value:60
-```
+- **Default retention (30 days):** supports streaks up to ~25 days
+- **For 30-day "No-Lifer" accolade:** raise retention to at least **60
+  days**
+- **Formula:** retention ≥ longest streak × 2
 
 ---
 
@@ -821,74 +588,43 @@ The cleanup job deletes session history older than `detailed_sessions_days`. Thi
 
 Send bot events and logs to Discord channels.
 
-### Startup/Shutdown Logging
+### Startup / shutdown logging
 
 | Setting | Default | Description |
 | --- | --- | --- |
 | `core.startup.enabled` | `false` | Enable startup/shutdown event logging |
 | `core.startup.channel_id` | `""` | Channel ID for startup/shutdown logs |
 
-### Error Logging
+### Error logging
 
 | Setting | Default | Description |
 | --- | --- | --- |
 | `core.errors.enabled` | `false` | Enable error logging |
 | `core.errors.channel_id` | `""` | Channel ID for error logs |
 
-### Cleanup Logging
+### Cleanup logging
 
 | Setting | Default | Description |
 | --- | --- | --- |
 | `core.cleanup.enabled` | `false` | Enable cleanup operation logging |
 | `core.cleanup.channel_id` | `""` | Channel ID for cleanup logs |
 
-### Configuration Logging
+### Configuration logging
 
 | Setting | Default | Description |
 | --- | --- | --- |
 | `core.config.enabled` | `false` | Enable configuration change logging |
 | `core.config.channel_id` | `""` | Channel ID for config logs |
 
-### Cron Job Logging
+### Cron job logging
 
 | Setting | Default | Description |
 | --- | --- | --- |
 | `core.cron.enabled` | `false` | Enable scheduled task logging |
 | `core.cron.channel_id` | `""` | Channel ID for cron logs |
 
-### Example
-
-```bash
-# Enable all logging to same channel
-/config set key:core.startup.enabled value:true
-/config set key:core.startup.channel_id value:123456789
-
-/config set key:core.errors.enabled value:true
-/config set key:core.errors.channel_id value:123456789
-
-/config set key:core.cleanup.enabled value:true
-/config set key:core.cleanup.channel_id value:123456789
-
-/config set key:core.config.enabled value:true
-/config set key:core.config.channel_id value:123456789
-
-/config set key:core.cron.enabled value:true
-/config set key:core.cron.channel_id value:123456789
-```
-
-**Or use separate channels for organization:**
-
-```bash
-# Different channels for different log types
-/config set key:core.startup.enabled value:true
-/config set key:core.startup.channel_id value:111111111  # #bot-status
-
-/config set key:core.errors.enabled value:true
-/config set key:core.errors.channel_id value:222222222   # #admin-alerts
-
-/config set key:core.cleanup.enabled value:true
-/config set key:core.cleanup.channel_id value:333333333  # #bot-logs
-```
+You can point every category at the same channel for a consolidated log,
+or split them across `#bot-status`, `#admin-alerts`, `#bot-logs`, etc.
 
 ---
 
@@ -899,15 +635,6 @@ Easter eggs and passive listeners.
 | Setting | Default | Description |
 | --- | --- | --- |
 | `fun.friendship` | `false` | Respond to "best ship" and "worst ship" mentions |
-
-### Example
-
-```bash
-# Enable friendship listener
-/config set key:fun.friendship value:true
-```
-
-This enables passive responses when users mention "best ship" or "worst ship" in messages.
 
 ---
 
@@ -922,248 +649,93 @@ Protect your bot from command spam with global rate limiting.
 | `ratelimit.window_seconds` | `10` | Time window in seconds for rate limit tracking |
 | `ratelimit.bypass_admin` | `true` | Allow administrators to bypass rate limits |
 
-### How Rate Limiting Works
-
-Rate limiting uses a **sliding window** approach to prevent command spam:
-
-- Tracks the number of commands executed by each user within a time window
-- When a user exceeds the limit, they receive a rate limit message
-- The window slides continuously, so limits reset as old commands expire
-- Administrators can bypass rate limiting (configurable)
-
-### Example
-
-```bash
-# Enable rate limiting with default settings (5 commands per 10 seconds)
-/config set key:ratelimit.enabled value:true
-
-# Custom configuration (3 commands per 5 seconds)
-/config set key:ratelimit.enabled value:true
-/config set key:ratelimit.max_commands value:3
-/config set key:ratelimit.window_seconds value:5
-
-# Disable admin bypass (rate limit applies to everyone)
-/config set key:ratelimit.bypass_admin value:false
-```
-
-### Rate Limit Messages
-
-When a user is rate limited, they receive an ephemeral message like:
+Rate limiting uses a sliding window. When a user exceeds the limit, they
+receive an ephemeral message like:
 
 ```text
 ⏱️ You're using commands too quickly! Please wait 7 seconds before trying again.
 ```
 
-### Use Cases
-
-- **Public servers**: Prevent users from spamming commands
-- **Bot testing**: Disable bypass for admins to test rate limiting behavior
-- **Custom limits**: Adjust based on your server size and activity
-- **Security**: Protect against abuse and reduce server load
-
 ---
 
 ## 🔐 Permissions & Access Control
 
-**Role-Based Command Access** allows you to control which Discord roles can use specific commands. This is a **core feature** that is
-always enabled.
+Per-command role gating. Manage permissions on the Web UI's
+**Permissions** page (replaces the old `/permissions set/add/remove/clear/list/view`).
 
-### Key Concepts
+### Key concepts
 
-**Command Name Format:** Command names are used directly (e.g., `quote`, `voicestats`)
+- **Multi-role support** — Commands can be assigned to multiple roles
+- **OR logic** — Users need ANY of the assigned roles to execute a command
+- **Admin bypass** — Administrators always have access to all commands
+- **Default open** — Commands without permissions are accessible to everyone
+- **Cached** — Permissions are cached in memory for performance
 
-**Access Logic:**
+### How it works
 
-- **Multi-role support** - Commands can be assigned to multiple roles
-- **OR logic** - Users need ANY of the assigned roles to execute a command
-- **Admin bypass** - Administrators always have access to all commands
-- **Default open** - Commands without permissions are accessible to everyone
-- **Cached** - Permissions are cached in memory for performance
+1. **No permissions set** → Everyone can use the command (except
+   admin-only commands like `/config`).
+2. **Permissions set** → Only users with the specified roles can use it.
+3. **Admins** → Always bypass permission checks.
 
-### How It Works
+### Default behavior
 
-1. **No permissions set** → Everyone can use the command (except admin-only commands)
-2. **Permissions set** → Only users with the specified roles can use the command
-3. **Admins** → Always bypass permission checks
+These commands are **admin-only** by default:
 
-### Managing Permissions
+- `/config` — opens the Web UI
 
-Use the `/permissions` command to manage role-based access:
+The Web UI itself also requires that the user can run `config` (admin
+by default, overridable via the Permissions page).
 
-> **Note:** In the examples below, `command:` and `role:` represent Discord slash command option names.
-> When using the command in Discord, you'll select values from dropdowns or type them in the option fields.
-
-```bash
-# Set permissions (replaces existing)
-/permissions set command:quote role:@Moderator role:@VIP
-
-# Add roles to existing permissions
-/permissions add command:quote role:@Contributor
-
-# Remove specific roles
-/permissions remove command:quote role:@VIP
-
-# View all permissions
-/permissions list
-
-# Check what a user can access
-/permissions view user:@username
-
-# Check what a role can access
-/permissions view role:@Moderator
-
-# Clear all permissions (make accessible to everyone)
-/permissions clear command:quote
-```
-
-### Use Cases
-
-**Restrict powerful commands:**
-
-```bash
-/permissions set command:dbtrunk role:@ServerAdmin
-/permissions set command:vc role:@Moderator
-```
-
-**Limit resource-intensive commands:**
-
-```bash
-/permissions set command:voicestats role:@Member
-```
-
-**Create tiered access:**
-
-```bash
-# Moderators and VIPs can use quote
-/permissions set command:quote role:@Moderator role:@VIP
-
-# Anyone can see stats
-# (no permissions set, default open)
-```
-
-**Audit permissions:**
-
-```bash
-/permissions list
-/permissions view user:@newmember
-```
-
-### Default Behavior
-
-The following commands are **admin-only by default** (require Administrator permission):
-
-- `/config` - Bot configuration
-- `/vc` - Voice channel management
-- `/dbtrunk` - Database cleanup
-- `/permissions` - Permission management
-- `/setup` - Setup wizard
-
-All other commands default to accessible by everyone unless you set permissions.
-
-### Important Notes
-
-- **Database storage** - Permissions are stored in MongoDB
-- **Single guild** - Permissions are per-guild (designed for self-hosted bots)
-- **Immediate effect** - Permission changes take effect immediately
-- **Role IDs** - Uses Discord role IDs internally for consistency
-- **Autocomplete** - Command names have autocomplete in `/permissions` commands
-
-### Examples
-
-#### Example 1: Member-only commands
-
-```bash
-# Restrict voice tracking commands to Members role
-/permissions set command:voicestats role:@Member
-/permissions set command:seen role:@Member
-```
-
-#### Example 2: Tiered moderation
-
-```bash
-# Moderators can manage quotes
-/permissions set command:quote role:@Moderator role:@Admin
-
-# Only admins can manage voice channels
-# (already admin-only by default, no action needed)
-```
-
-#### Example 3: Troubleshooting access
-
-```bash
-# User reports they can't use /voicestats
-/permissions view user:@user123
-# Shows: Can access 10 command(s): /ping, /help, /quote, ...
-# (voicestats not in list)
-
-# Check role permissions
-/permissions view role:@Member
-# Shows: Can access 15 command(s): /ping, /help, /voicestats, ...
-
-# Solution: User needs @Member role
-```
+All other commands default to accessible by everyone unless you add
+permissions.
 
 ---
 
 ## ⚙ Configuration Management
 
-### Using `/config` Commands
+### Editing settings
 
-```bash
-# List all settings
-/config list
+All DB-backed settings are edited on the Web UI's **Settings** page.
+The Settings page groups settings by feature, validates input per
+schema, and shows inline help. After changing any `*.enabled` value,
+click **Reload commands to Discord** so Discord re-syncs the
+registration.
 
-# Get specific setting
-/config get key:ping.enabled
+### YAML export / import
 
-# Set a value
-/config set key:ping.enabled value:true
+- **Export** — Settings page → click **Export** → download YAML. Covers
+  DB-backed settings only; bootstrap env vars are excluded.
+- **Import** — Settings page → click **Import** → upload YAML → review
+  the diff → apply. Imports that try to set a protected key
+  (`DISCORD_TOKEN`, `WEBUI_SESSION_SECRET`, any other `.env` value) are
+  rejected outright.
 
-# Reset to default
-/config reset key:ping.enabled
+### Reset to default
 
-# Reload commands (required after enabling/disabling commands)
-/config reload
+For any setting, click **Reset to default** on the Settings page.
 
-# Export configuration
-/config export
+### Value types
 
-# Import configuration (attach YAML file)
-/config import
-```
+The Web UI form controls map to the underlying schema types:
 
-### Value Types
+- **Booleans** — checkbox
+- **Numbers** — number input with min/max validation
+- **Strings** — text input
+- **Comma-separated lists** — text input; you handle the commas
 
-The config system automatically converts values:
+### Best practices
 
-```bash
-# Booleans
-/config set key:ping.enabled value:true
-/config set key:ping.enabled value:false
-
-# Numbers
-/config set key:quotes.cooldown value:120
-
-# Strings
-/config set key:voicechannels.lobby.name value:"🟢 Join Here"
-
-# Comma-separated lists
-/config set key:voicetracking.excluded_channels value:"123,456,789"
-```
-
-### Best Practices
-
-1. **Always run `/config reload`** after enabling/disabling commands
-2. **Use exact key names** - they're case-sensitive
-3. **Export regularly** for backups
-4. **Test changes** in development first
-5. **Document custom settings** for your team
+1. Always **Reload commands to Discord** after enabling/disabling commands.
+2. Export regularly for backups.
+3. Test changes in a development setup first when in doubt.
+4. Document custom settings for your team if multiple people admin the bot.
 
 ---
 
 ## 📖 Quick Settings Reference
 
-### All Available Settings
+### All available settings (DB-backed)
 
 #### Commands
 
@@ -1197,6 +769,22 @@ The config system automatically converts values:
 - `quotes.max_length` (number, default: 1000)
 - `quotes.add_roles` (string, default: "")
 - `quotes.delete_roles` (string, default: "")
+- `quotes.header_enabled` (bool, default: true)
+- `quotes.header_pin_enabled` (bool, default: true)
+
+#### Notices
+
+- `notices.enabled` (bool, default: false)
+- `notices.channel_id` (string, default: "")
+- `notices.cleanup_interval` (number, default: 5)
+- `notices.header_enabled` (bool, default: true)
+- `notices.header_pin_enabled` (bool, default: true)
+
+#### Polls
+
+- `polls.enabled` (bool, default: false)
+- `polls.default_duration_hours` (number, default: 24)
+- `polls.cooldown_days` (number, default: 7)
 
 #### Voice Channels
 
@@ -1207,10 +795,13 @@ The config system automatically converts values:
 - `voicechannels.channel.prefix` (string, default: "🎮")
 - `voicechannels.channel.suffix` (string, default: "")
 - `voicechannels.controlpanel.enabled` (bool, default: true)
+- `voicechannels.ownership.grace_period_seconds` (number, default: 30)
 
 #### Voice Tracking
 
 - `voicetracking.enabled` (bool, default: false)
+- `voicetracking.stats.top.enabled` (bool, default: false)
+- `voicetracking.stats.user.enabled` (bool, default: false)
 - `voicetracking.seen.enabled` (bool, default: false)
 - `voicetracking.excluded_channels` (string, default: "")
 - `voicetracking.admin_roles` (string, default: "")
@@ -1219,10 +810,10 @@ The config system automatically converts values:
 
 - `voicetracking.announcements.enabled` (bool, default: false)
 - `voicetracking.announcements.channel` (string, default: "voice-stats")
-- `voicetracking.announcements.schedule` (string, default: "0 16 ** 5")
+- `voicetracking.announcements.schedule` (string, default: `"0 16 * * 5"`)
 - `announcements.enabled` (bool, default: false)
 
-#### Gamification
+#### Achievements
 
 - `achievements.enabled` (bool, default: false)
 - `achievements.announcements.enabled` (bool, default: true)
@@ -1231,7 +822,7 @@ The config system automatically converts values:
 #### Cleanup
 
 - `voicetracking.cleanup.enabled` (bool, default: false)
-- `voicetracking.cleanup.schedule` (string, default: "0 0 ** *")
+- `voicetracking.cleanup.schedule` (string, default: `"0 0 * * *"`)
 - `voicetracking.cleanup.retention.detailed_sessions_days` (number, default: 30)
 - `voicetracking.cleanup.retention.monthly_summaries_months` (number, default: 6)
 - `voicetracking.cleanup.retention.yearly_summaries_years` (number, default: 1)
@@ -1260,13 +851,25 @@ The config system automatically converts values:
 - `ratelimit.window_seconds` (number, default: 10)
 - `ratelimit.bypass_admin` (bool, default: true)
 
+### Bootstrap env vars (read-only in Web UI)
+
+- `DISCORD_TOKEN`, `CLIENT_ID`, `GUILD_ID`, `MONGODB_URI`
+- `NODE_ENV`, `DEBUG`
+- `WEBUI_ENABLED`, `WEBUI_BASE_URL`, `WEBUI_SESSION_SECRET`
+- `WEBUI_SESSION_TTL_MINUTES`, `WEBUI_INACTIVITY_TIMEOUT_MINUTES`
+- `WEBUI_TRUST_PROXY`
+
+These are visible on the Web UI's **Bootstrap** page (secrets masked).
+Edit them in `.env` and restart the bot to change them.
+
 ---
 
 ## 📚 Related Documentation
 
-- **[README.md](README.md)** - Bot overview and quick start
-- **[COMMANDS.md](COMMANDS.md)** - Complete command reference
-- **[TROUBLESHOOTING.md](TROUBLESHOOTING.md)** - Common issues and solutions
+- **[README.md](README.md)** — Bot overview and quick start
+- **[WEBUI.md](WEBUI.md)** — Web UI setup, magic-link flow, reverse-proxy guidance
+- **[COMMANDS.md](COMMANDS.md)** — Complete command reference
+- **[TROUBLESHOOTING.md](TROUBLESHOOTING.md)** — Common issues and solutions
 
 ---
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -280,11 +280,18 @@ docker compose up -d --force-recreate
 
 ### `/config` says "missing env vars: WEBUI_BASE_URL, WEBUI_SESSION_SECRET"
 
-Both must be set in `.env` when `WEBUI_ENABLED=true`:
+Both must be set in `.env` when `WEBUI_ENABLED=true`. Generate the
+secret on your host first (dotenv does not run shell substitutions):
+
+```bash
+openssl rand -base64 32
+```
+
+Then paste the output into `.env`:
 
 ```env
 WEBUI_BASE_URL=https://bot.example.com   # or http://localhost:3000 for local
-WEBUI_SESSION_SECRET=$(openssl rand -base64 32)
+WEBUI_SESSION_SECRET=<paste-the-output-here>
 ```
 
 Restart the bot.
@@ -318,16 +325,33 @@ One of:
 
 ### "Sign in required" on every page
 
-Your cookie is stale or your IP changed. Run `/config` again to mint a
-fresh link.
+Possible causes:
+
+- Cookie expired (idle past `WEBUI_INACTIVITY_TIMEOUT_MINUTES`).
+- DB session row passed its hard TTL.
+- You ran `/config` again, which server-side-revoked this session.
+- Permission re-check failed (Web UI Permissions → `config` was
+  configured and your roles no longer match).
+- The bot restarted with a new `WEBUI_SESSION_SECRET`.
+
+The cookie is **not** bound to your client IP — switching networks
+does not by itself end a session.
+
+Run `/config` again to mint a fresh link.
 
 ### Web UI URL loads but won't accept my cookie
 
-Browsers refuse `Secure`-flagged cookies over plain HTTP. Either:
+Browsers refuse `Secure`-flagged cookies over plain HTTP. The Web UI
+flags its session cookie `Secure` whenever `NODE_ENV=production`
+(`shouldUseSecureCookies()` in `src/web/csrf.ts`). Pick one:
 
-- Run behind HTTPS (recommended) — see [WEBUI.md → Reverse-proxy guidance](WEBUI.md#reverse-proxy-guidance).
-- Set `WEBUI_BASE_URL=http://...` so the bot doesn't mark the cookie as
-  `Secure`. **Local testing only.**
+- Run behind HTTPS via a reverse proxy (recommended) — see
+  [WEBUI.md → Reverse-proxy guidance](WEBUI.md#reverse-proxy-guidance).
+- Set `NODE_ENV=development` in `.env` and restart. The cookie loses
+  the `Secure` flag and plain HTTP works again. **Local testing only.**
+
+Changing `WEBUI_BASE_URL` to `http://...` alone does **not** fix this —
+the URL scheme is not what flips the `Secure` flag.
 
 ### Behind a reverse proxy, rate limits trigger on the proxy's IP
 
@@ -410,8 +434,13 @@ For more, see [WEBUI.md → Troubleshooting](WEBUI.md#troubleshooting).
 
 **Solutions:**
 
-1. **Verify you have Administrator permission** in Discord (or a role
-   that the Web UI's Permissions page allows for `config`).
+1. **Verify you have Administrator permission** in Discord. `/config`
+   is registered with `setDefaultMemberPermissions(Administrator)`, so
+   Discord blocks non-admins from even invoking it. If you need to
+   allow a non-admin role, an operator must override the command in
+   Discord under **Server Settings → Integrations → KoolBot → /config**.
+   The Web UI's Permissions page can only narrow access further, it
+   cannot grant Discord-level access on its own.
 2. **Verify `WEBUI_ENABLED=true`** in `.env` and that you've restarted
    the bot since the change.
 3. **Check bot logs for the mount confirmation:**

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -2,6 +2,11 @@
 
 Common issues and solutions for KoolBot deployment and operation.
 
+> **From v1.0:** Configuration is edited from the **Web UI** (run
+> `/config` in Discord to receive a single-use sign-in link). Steps
+> below say "Web UI → Settings" when they mean the Settings page in
+> that UI. For Web-UI-specific issues, see [WEBUI.md → Troubleshooting](WEBUI.md#troubleshooting).
+
 ---
 
 ## 📋 Table of Contents
@@ -9,11 +14,13 @@ Common issues and solutions for KoolBot deployment and operation.
 - [Initial Setup Issues](#-initial-setup-issues)
 - [Docker Issues](#-docker-issues)
 - [Discord Connection Issues](#-discord-connection-issues)
+- [Web UI Issues](#-web-ui-issues)
 - [Command Issues](#-command-issues)
 - [Voice Channel Issues](#-voice-channel-issues)
 - [Database Issues](#-database-issues)
 - [Configuration Issues](#-configuration-issues)
 - [Performance Issues](#-performance-issues)
+- [Emergency Procedures](#-emergency-procedures)
 
 ---
 
@@ -50,6 +57,14 @@ Common issues and solutions for KoolBot deployment and operation.
    MONGODB_URI=mongodb://mongodb:27017/koolbot
    ```
 
+   And, when the Web UI is enabled:
+
+   ```env
+   WEBUI_ENABLED=true
+   WEBUI_BASE_URL=https://bot.example.com
+   WEBUI_SESSION_SECRET=...
+   ```
+
 3. **Verify Discord token is valid:**
    - Go to [Discord Developer Portal](https://discord.com/developers/applications)
    - Select your application
@@ -61,7 +76,7 @@ Common issues and solutions for KoolBot deployment and operation.
    ```env
    # ❌ Wrong
    DISCORD_TOKEN = "your_token_here"
-   
+
    # ✅ Correct
    DISCORD_TOKEN=your_token_here
    ```
@@ -87,14 +102,14 @@ sudo chmod 666 /var/run/docker.sock
 **Check logs:**
 
 ```bash
-docker-compose logs -f bot
+docker compose logs -f bot
 ```
 
 **Common causes:**
 
 1. **Database not ready:**
    - Wait 30 seconds for MongoDB to initialize
-   - Check MongoDB status: `docker-compose ps`
+   - Check MongoDB status: `docker compose ps`
 
 2. **Invalid configuration:**
    - Review error messages in logs
@@ -105,7 +120,7 @@ docker-compose logs -f bot
    ```bash
    # Check if port 27017 is in use
    netstat -an | grep 27017
-   
+
    # Or use a different port on the host
    # In docker-compose.yml: "27018:27017"
    # In .env (for bot container): MONGODB_URI=mongodb://mongodb:27017/koolbot
@@ -113,26 +128,26 @@ docker-compose logs -f bot
    #       Containers still connect to MongoDB on its internal port 27017.
    ```
 
-### "docker-compose: command not found"
+### "docker compose: command not found"
 
 **Solutions:**
 
-1. **Install Docker Compose:**
+1. **Install Docker Compose v2:**
 
    ```bash
    # Linux
-   sudo apt-get install docker-compose
-   
+   sudo apt-get install docker-compose-plugin
+
    # macOS (via Homebrew)
-   brew install docker-compose
-   
-   # Or use Docker Desktop (includes compose)
+   brew install docker
+
+   # Or use Docker Desktop (includes compose v2)
    ```
 
-2. **Use `docker compose` (without dash):**
+2. **Use the legacy `docker-compose` (with dash) if you have it:**
 
    ```bash
-   docker compose up -d
+   docker-compose up -d
    ```
 
 ### MongoDB Container Won't Start
@@ -140,7 +155,7 @@ docker-compose logs -f bot
 **Check logs:**
 
 ```bash
-docker-compose logs -f mongodb
+docker compose logs -f mongodb
 ```
 
 **Solutions:**
@@ -148,9 +163,11 @@ docker-compose logs -f mongodb
 1. **Remove corrupted volume:**
 
    ```bash
-   docker-compose down -v
-   docker-compose up -d
+   docker compose down -v
+   docker compose up -d
    ```
+
+   ⚠️ This deletes all data. Back up first if possible.
 
 2. **Check disk space:**
 
@@ -162,7 +179,7 @@ docker-compose logs -f mongodb
 
    ```bash
    docker pull mongo:latest
-   docker-compose up -d --force-recreate
+   docker compose up -d --force-recreate
    ```
 
 ---
@@ -176,18 +193,17 @@ docker-compose logs -f mongodb
 1. **Check bot is running:**
 
    ```bash
-   docker-compose ps
+   docker compose ps
    ```
 
 2. **Check logs for connection errors:**
 
    ```bash
-   docker-compose logs -f bot | grep -i "error\|discord"
+   docker compose logs -f bot | grep -i "error\|discord"
    ```
 
 3. **Verify Discord token:**
    - Token must be from the "Bot" section, not "OAuth2"
-   - Token should start with your bot's user ID
 
 4. **Check Discord API status:**
    - Visit [Discord Status](https://discordstatus.com)
@@ -196,7 +212,7 @@ docker-compose logs -f mongodb
 
 **Symptoms:**
 
-```json
+```text
 Error: An invalid token was provided
 ```
 
@@ -206,7 +222,7 @@ Error: An invalid token was provided
    - Discord Developer Portal → Your App → Bot
    - Reset Token → Copy new token
    - Update `.env` file
-   - Restart bot: `docker-compose restart bot`
+   - Restart bot: `docker compose restart bot`
 
 2. **Check for extra characters:**
    - No spaces before/after token
@@ -225,22 +241,125 @@ Error: An invalid token was provided
 
 1. **Re-invite bot with correct permissions:**
 
-```json
+   ```text
    https://discord.com/api/oauth2/authorize?client_id=YOUR_CLIENT_ID&permissions=8&scope=bot%20applications.commands
    ```
 
    Replace `YOUR_CLIENT_ID` with your actual Client ID.
 
-1. **Check role hierarchy:**
+2. **Check role hierarchy:**
    - Bot's role must be ABOVE roles it needs to manage
    - Move bot's role higher in Server Settings → Roles
 
-2. **Verify required permissions:**
-   - Administrator (easiest, or:)
+3. **Verify required permissions:**
+   - Administrator (easiest), or:
    - Manage Channels
+   - Manage Roles (for reaction roles, leaderboard role rewards)
    - Move Members
    - Send Messages
    - Use Slash Commands
+   - Embed Links
+
+---
+
+## 🌐 Web UI Issues
+
+### `/config` says "the web UI is disabled"
+
+`WEBUI_ENABLED` is not `true` (case-insensitive). Update `.env`:
+
+```env
+WEBUI_ENABLED=true
+```
+
+Then restart the bot:
+
+```bash
+docker compose up -d --force-recreate
+```
+
+### `/config` says "missing env vars: WEBUI_BASE_URL, WEBUI_SESSION_SECRET"
+
+Both must be set in `.env` when `WEBUI_ENABLED=true`:
+
+```env
+WEBUI_BASE_URL=https://bot.example.com   # or http://localhost:3000 for local
+WEBUI_SESSION_SECRET=$(openssl rand -base64 32)
+```
+
+Restart the bot.
+
+### `/config` ran but I didn't get a DM
+
+The bot tries to DM, then falls back to an **ephemeral reply** in the
+channel where you ran `/config` (visible only to you). Check there for
+the sign-in link.
+
+If you'd rather receive DMs:
+
+- Discord Settings → Privacy & Safety → Allow direct messages from
+  server members (for the server where the bot runs).
+
+The bot logs a warning when it falls back:
+
+```text
+Could not DM web sign-in link to <user-id>; falling back to ephemeral reply
+```
+
+### Magic link 404s when clicked
+
+One of:
+
+- It was already redeemed (single-use). Run `/config` again.
+- It expired (default 10 minutes). Run `/config` again.
+- You ran `/config` again later and got a *newer* link, which revoked
+  this one. Use the most recent DM.
+- `WEBUI_SESSION_SECRET` was changed between issuance and redemption.
+
+### "Sign in required" on every page
+
+Your cookie is stale or your IP changed. Run `/config` again to mint a
+fresh link.
+
+### Web UI URL loads but won't accept my cookie
+
+Browsers refuse `Secure`-flagged cookies over plain HTTP. Either:
+
+- Run behind HTTPS (recommended) — see [WEBUI.md → Reverse-proxy guidance](WEBUI.md#reverse-proxy-guidance).
+- Set `WEBUI_BASE_URL=http://...` so the bot doesn't mark the cookie as
+  `Secure`. **Local testing only.**
+
+### Behind a reverse proxy, rate limits trigger on the proxy's IP
+
+Set `WEBUI_TRUST_PROXY` to your hop count (usually `1`) and restart:
+
+```env
+WEBUI_TRUST_PROXY=1
+```
+
+For Caddy / nginx / Traefik recipes, see [WEBUI.md → Docker Compose recipes](WEBUI.md#docker-compose-recipes).
+
+### Want to disable the Web UI entirely
+
+Set `WEBUI_ENABLED=false` (or remove the line) and restart. All
+`/admin/*` paths 404 again. The `/health` endpoint is unaffected.
+
+### I locked myself out
+
+The bootstrap path is "if you can run `/config` in Discord, you can
+configure the bot." There is no forgotten-password flow because there
+is no password.
+
+To recover:
+
+1. Edit `.env` on the host. Set a fresh `WEBUI_SESSION_SECRET`
+   (`openssl rand -base64 32`) — this invalidates every existing session
+   and outstanding link.
+2. Restart the bot.
+3. Run `/config` in Discord from an account that holds the Administrator
+   permission.
+
+For more, see [WEBUI.md → Troubleshooting](WEBUI.md#troubleshooting).
 
 ---
 
@@ -252,28 +371,12 @@ Error: An invalid token was provided
 
 **Solutions:**
 
-1. **Enable the command:**
-
-   ```bash
-   /config set key:ping.enabled value:true
-   ```
-
-2. **Reload commands (REQUIRED!):**
-
-   ```bash
-   /config reload
-   ```
-
-3. **Wait for Discord to sync:**
-   - Can take 2-5 minutes
-   - Try in a different channel
-   - Restart Discord client
-
-4. **Check if commands are enabled:**
-
-   ```bash
-   /config list
-   ```
+1. **Run `/config` → Web UI → Settings**, set `<command>.enabled` to
+   `true`, save.
+2. Click **Reload commands to Discord** on the Settings page (required
+   after enabling/disabling a command).
+3. Wait 2-5 minutes for Discord to sync. Try a different channel or
+   restart the Discord client if needed.
 
 ### "Application did not respond" Error
 
@@ -288,37 +391,43 @@ Error: An invalid token was provided
 1. **Check bot logs:**
 
    ```bash
-   docker-compose logs -f bot | tail -50
+   docker compose logs -f bot | tail -50
    ```
 
 2. **Restart bot:**
 
    ```bash
-   docker-compose restart bot
+   docker compose restart bot
    ```
 
 3. **Check MongoDB connection:**
 
    ```bash
-   docker-compose logs mongodb | grep -i error
+   docker compose logs mongodb | grep -i error
    ```
 
 ### `/config` Command Not Working
 
 **Solutions:**
 
-1. **Verify you have Administrator permission** in Discord
-
-2. **Check bot logs for errors:**
+1. **Verify you have Administrator permission** in Discord (or a role
+   that the Web UI's Permissions page allows for `config`).
+2. **Verify `WEBUI_ENABLED=true`** in `.env` and that you've restarted
+   the bot since the change.
+3. **Check bot logs for the mount confirmation:**
 
    ```bash
-   docker-compose logs -f bot | grep -i config
+   docker compose logs -f bot | grep -i webui
    ```
 
-3. **Verify MongoDB is connected:**
+   You should see `WebUI mounted at /admin`.
+
+4. **Verify MongoDB is connected** — the Bootstrap page in the Web UI
+   shows this, but if you can't even reach the UI:
 
    ```bash
-   /dbtrunk status
+   docker compose ps mongodb
+   docker compose logs mongodb
    ```
 
 ---
@@ -327,32 +436,24 @@ Error: An invalid token was provided
 
 ### Lobby Channel Not Creating Users' Rooms
 
-**Check configuration:**
+**Check configuration** in the Web UI's Settings page:
 
-```bash
-/config get key:voicechannels.enabled
-/config get key:voicechannels.category.name
-```
+- `voicechannels.enabled` = `true`
+- `voicechannels.category.name` = the exact category name in Discord
 
 **Solutions:**
 
 1. **Enable voice channels:**
+   - Web UI → Settings → set `voicechannels.enabled` = `true`.
+   - Save and reload commands.
 
-   ```bash
-   /config set key:voicechannels.enabled value:true
-   /config reload
-   ```
-
-2. **Run setup wizard:**
-
-   ```bash
-   /setup wizard feature:voicechannels
-   ```
+2. **Run the Setup Wizard:**
+   - Web UI → Setup Wizard → Voice Channels.
+   - The wizard auto-detects categories.
 
 3. **Verify category exists:**
-   - Create category in Discord: "Voice Channels"
-   - Match exact name in config
-   - Bot role must have permissions in category
+   - Create the category in Discord with the exact name configured
+   - Bot role must have permissions in that category
 
 4. **Check bot permissions:**
    - Manage Channels
@@ -369,86 +470,60 @@ Error: An invalid token was provided
 
 **Solutions:**
 
-1. **Manual cleanup:**
+1. **Manual cleanup** — Web UI → Voice Channels → **Reload empty
+   channels**.
 
-   ```bash
-   /vc reload
-   ```
+2. **Force cleanup** — Web UI → Voice Channels → **Force cleanup**.
 
-2. **Force cleanup:**
-
-   ```bash
-   /vc force-reload
-   ```
-
-   ⚠️ **Warning:** Removes ALL unmanaged channels!
+   ⚠️ **Warning:** Force cleanup removes ALL unmanaged channels in the
+   category, including ones with users in them.
 
 3. **Check bot logs:**
 
    ```bash
-   docker-compose logs -f bot | grep -i "voice"
+   docker compose logs -f bot | grep -i voice
    ```
 
 ### Voice Tracking Not Working
 
-**Check configuration:**
+**Check configuration** in the Web UI's Settings page:
 
-```bash
-/config get key:voicetracking.enabled
-```
+- `voicetracking.enabled` = `true`
 
 **Solutions:**
 
-1. **Enable tracking:**
+1. **Enable tracking** — Web UI → Settings → set
+   `voicetracking.enabled` = `true`, save.
 
-   ```bash
-   /config set key:voicetracking.enabled value:true
-   /config reload
-   ```
+2. **Check excluded channels** — Web UI → Settings →
+   `voicetracking.excluded_channels`. If your test channel is in this
+   list, sessions there won't be tracked.
 
-2. **Check excluded channels:**
+3. **Verify users are in voice channels** — stats only update while
+   users are active. The bot doesn't backfill data from before tracking
+   was enabled.
 
-   ```bash
-   /config get key:voicetracking.excluded_channels
-   ```
+4. **Check database** — Web UI → Database → see counts and last cleanup
+   run.
 
-3. **Verify users are in voice channels:**
-   - Stats only update while users are active
-   - Check if channel is excluded
-
-4. **Check database:**
-
-   ```bash
-   /dbtrunk status
-   ```
-
-### `/vctop` Shows "No data"
+### `/voicestats top` shows "No data"
 
 **Causes:**
 
 - Tracking recently enabled (no data yet)
-- All channels are excluded
+- All target channels are excluded
 - Users haven't been in voice yet
 
 **Solutions:**
 
-1. **Wait for data to accumulate:**
-   - Join a voice channel for a few minutes
-   - Run `/vcstats` to verify tracking
+1. **Wait for data to accumulate** — join a voice channel for a few
+   minutes, then re-run.
 
-2. **Check excluded channels:**
+2. **Check excluded channels** — Web UI → Settings →
+   `voicetracking.excluded_channels`.
 
-   ```bash
-   /config get key:voicetracking.excluded_channels
-   ```
-
-3. **Verify tracking is enabled:**
-
-   ```bash
-   /config list
-   ```
-
-   Check `voicetracking.enabled: true`
+3. **Verify tracking is enabled** — Web UI → Settings → confirm
+   `voicetracking.enabled` is `true`.
 
 ---
 
@@ -461,25 +536,25 @@ Error: An invalid token was provided
 1. **Check MongoDB container:**
 
    ```bash
-   docker-compose ps mongodb
+   docker compose ps mongodb
    ```
 
 2. **Restart MongoDB:**
 
    ```bash
-   docker-compose restart mongodb
+   docker compose restart mongodb
    ```
 
 3. **Check MongoDB logs:**
 
    ```bash
-   docker-compose logs -f mongodb
+   docker compose logs -f mongodb
    ```
 
-4. **Verify MONGODB_URI:**
+4. **Verify `MONGODB_URI`:**
 
    ```bash
-   cat .env | grep MONGODB_URI
+   grep MONGODB_URI .env
    ```
 
    Should be: `mongodb://mongodb:27017/koolbot`
@@ -491,81 +566,75 @@ Error: An invalid token was provided
 1. **Ensure MongoDB container is running:**
 
    ```bash
-   docker-compose up -d mongodb
+   docker compose up -d mongodb
    ```
 
 2. **Check network connectivity:**
 
    ```bash
-   docker-compose exec bot ping mongodb
+   docker compose exec bot ping mongodb
    ```
 
 3. **Recreate containers:**
 
    ```bash
-   docker-compose down
-   docker-compose up -d
+   docker compose down
+   docker compose up -d
    ```
 
 ### Data Loss / Cleanup Too Aggressive
 
-**Check retention settings:**
+**Check retention settings** — Web UI → Settings:
 
-```bash
-/config get key:voicetracking.cleanup.retention.detailed_sessions_days
-```
+- `voicetracking.cleanup.retention.detailed_sessions_days`
+- `voicetracking.cleanup.retention.monthly_summaries_months`
+- `voicetracking.cleanup.retention.yearly_summaries_years`
 
 **Adjust retention:**
 
-```bash
-# Keep detailed sessions for 90 days instead of 30
-/config set key:voicetracking.cleanup.retention.detailed_sessions_days value:90
-
-# Keep monthly summaries for 12 months
-/config set key:voicetracking.cleanup.retention.monthly_summaries_months value:12
-
-# Disable automatic cleanup
-/config set key:voicetracking.cleanup.enabled value:false
-```
+- Web UI → Settings → bump
+  `voicetracking.cleanup.retention.detailed_sessions_days` to `60` or
+  `90` (60+ days is required for the 30-day "No-Lifer" accolade).
+- Or set `voicetracking.cleanup.enabled` to `false` to pause cleanup
+  entirely.
 
 ### Database Backup and Restore
 
 **Create a backup:**
 
 ```bash
-# Backup MongoDB database to archive file
-docker-compose exec mongodb mongodump --archive=/data/db/backup.archive --db=koolbot
+docker compose exec mongodb mongodump \
+  --archive=/data/db/backup.archive --db=koolbot
 
-# Copy backup to your local machine
-docker cp koolbot-mongodb:/data/db/backup.archive ./koolbot-backup-$(date +%Y%m%d).archive
+docker cp koolbot-mongodb:/data/db/backup.archive \
+  ./koolbot-backup-$(date +%Y%m%d).archive
 ```
 
 **Restore from backup:**
 
 ```bash
-# Copy backup file to container (replace YYYYMMDD with your backup date, e.g., 20240115)
-docker cp ./koolbot-backup-YYYYMMDD.archive koolbot-mongodb:/data/db/restore.archive
+docker cp ./koolbot-backup-YYYYMMDD.archive \
+  koolbot-mongodb:/data/db/restore.archive
 
-# Restore the database (--drop removes existing collections before restoring)
-docker-compose exec mongodb mongorestore --archive=/data/db/restore.archive --db=koolbot --drop
+docker compose exec mongodb mongorestore \
+  --archive=/data/db/restore.archive --db=koolbot --drop
 
-# Restart bot to refresh connections
-docker-compose restart bot
+docker compose restart bot
 ```
 
-> **Note:** The `--drop` flag removes existing collections before restoring to avoid data conflicts.
+> **Note:** The `--drop` flag removes existing collections before
+> restoring to avoid data conflicts.
 
 **Automated backups (recommended):**
 
-Create a cron job or scheduled task to backup regularly:
-
 ```bash
-# Example: Daily backup script
 #!/bin/bash
 BACKUP_DIR="/path/to/backups"
 DATE=$(date +%Y%m%d)
-docker-compose exec mongodb mongodump --archive=/data/db/backup.archive --db=koolbot
-docker cp koolbot-mongodb:/data/db/backup.archive "$BACKUP_DIR/koolbot-backup-$DATE.archive"
+docker compose exec mongodb mongodump \
+  --archive=/data/db/backup.archive --db=koolbot
+docker cp koolbot-mongodb:/data/db/backup.archive \
+  "$BACKUP_DIR/koolbot-backup-$DATE.archive"
 
 # Keep only last 7 days of backups
 find "$BACKUP_DIR" -name "koolbot-backup-*.archive" -mtime +7 -delete
@@ -577,19 +646,14 @@ find "$BACKUP_DIR" -name "koolbot-backup-*.archive" -mtime +7 -delete
 
 ### "Invalid key" Error
 
-**Cause:** Typo in configuration key
+**Cause:** Typo in configuration key when importing YAML.
 
 **Solution:**
 
-1. **Check exact key name:**
-
-   ```bash
-   /config list
-   ```
-
-2. **Copy exact key from list**
-
-3. **Use tab completion in Discord**
+- The Web UI's Settings page lists every valid key. Compare your
+  imported YAML against what the Settings page shows.
+- The YAML import preview surfaces keys that don't match the schema —
+  it will not let you apply an invalid key.
 
 ### Settings Not Persisting
 
@@ -597,41 +661,39 @@ find "$BACKUP_DIR" -name "koolbot-backup-*.archive" -mtime +7 -delete
 
 ```bash
 # Verify database is running
-docker-compose ps mongodb
+docker compose ps mongodb
 
-# Check bot can write to database
-/config set key:ping.enabled value:true
-/config get key:ping.enabled
+# In the Web UI's Settings page, change a value, save, refresh — does it stick?
 ```
 
-**Solution:**
-
-If database is corrupted:
+If the database is corrupted:
 
 ```bash
-# Backup first!
-# 1. Backup configuration
-/config export
+# 1. Back up configuration via Web UI → Settings → Export
+#    (download the YAML file the Web UI returns)
 
-# 2. Backup database (if possible)
-docker-compose exec mongodb mongodump --archive=/data/db/backup.archive --db=koolbot
-docker cp koolbot-mongodb:/data/db/backup.archive ./koolbot-backup-$(date +%Y%m%d).archive
+# 2. Back up database
+docker compose exec mongodb mongodump \
+  --archive=/data/db/backup.archive --db=koolbot
+docker cp koolbot-mongodb:/data/db/backup.archive \
+  ./koolbot-backup-$(date +%Y%m%d).archive
 
-# Reset database
-docker-compose down -v
-docker-compose up -d
+# 3. Reset database
+docker compose down -v
+docker compose up -d
 
-# Restore config
-/config import
+# 4. After bot is back, re-issue /config in Discord and import the
+#    YAML from step 1 via the Web UI's Settings → Import.
 
-# Restore database (if backup was successful)
-# Replace YYYYMMDD with your actual backup file date (e.g., 20240115)
-docker cp ./koolbot-backup-YYYYMMDD.archive koolbot-mongodb:/data/db/restore.archive
-docker-compose exec mongodb mongorestore --archive=/data/db/restore.archive --db=koolbot --drop
-docker-compose restart bot
+# 5. (Optional) Restore raw MongoDB if you'd rather skip YAML import
+docker cp ./koolbot-backup-YYYYMMDD.archive \
+  koolbot-mongodb:/data/db/restore.archive
+docker compose exec mongodb mongorestore \
+  --archive=/data/db/restore.archive --db=koolbot --drop
+docker compose restart bot
 ```
 
-### Can't Import Configuration
+### Can't Import YAML Configuration
 
 **Verify YAML format:**
 
@@ -650,6 +712,10 @@ voicechannels:
 - Incorrect indentation (use 2 spaces)
 - Missing quotes on strings with special characters
 - Invalid YAML syntax
+- Attempting to set a protected key (`DISCORD_TOKEN`,
+  `WEBUI_SESSION_SECRET`, etc.) — these are bootstrap env vars and the
+  Web UI rejects imports that touch them. Remove those keys from the
+  YAML and try again.
 
 ---
 
@@ -663,8 +729,8 @@ voicechannels:
 # View container stats
 docker stats
 
-# Check system resources
-docker-compose exec bot top
+# Check system resources inside the container
+docker compose exec bot top
 ```
 
 **Solutions:**
@@ -673,24 +739,12 @@ docker-compose exec bot top
    - Docker Desktop → Settings → Resources
    - Increase CPU and memory allocation
 
-2. **Check database size:**
+2. **Check database size** via Web UI → Database. If it's large, click
+   **Run cleanup now**.
 
-   ```bash
-   /dbtrunk status
-   ```
-
-   Run cleanup if database is large:
-
-   ```bash
-   /dbtrunk run
-   ```
-
-3. **Optimize retention:**
-
-   ```bash
-   # Reduce retention periods to save space
-   /config set key:voicetracking.cleanup.retention.detailed_sessions_days value:14
-   ```
+3. **Optimize retention** via Web UI → Settings:
+   - Reduce `voicetracking.cleanup.retention.detailed_sessions_days`
+   - Keep it at 60+ if you use consecutive-day accolades
 
 ### High Memory Usage
 
@@ -701,20 +755,20 @@ docker-compose exec bot top
 1. **Restart bot:**
 
    ```bash
-   docker-compose restart bot
+   docker compose restart bot
    ```
 
 2. **Check for memory leaks in logs:**
 
    ```bash
-   docker-compose logs -f bot | grep -i "memory\|heap"
+   docker compose logs -f bot | grep -i "memory\|heap"
    ```
 
 3. **Update to latest version:**
 
    ```bash
-   docker-compose pull
-   docker-compose up -d
+   docker compose pull
+   docker compose up -d
    ```
 
 ---
@@ -726,36 +780,35 @@ docker-compose exec bot top
 If everything is broken:
 
 ```bash
-# 1. Backup configuration
-/config export
+# 1. Back up configuration (YAML) from Web UI → Settings → Export
 
-# 2. Backup database
-docker-compose exec mongodb mongodump --archive=/data/db/backup.archive --db=koolbot
-docker cp koolbot-mongodb:/data/db/backup.archive ./koolbot-backup-$(date +%Y%m%d).archive
+# 2. Back up database
+docker compose exec mongodb mongodump \
+  --archive=/data/db/backup.archive --db=koolbot
+docker cp koolbot-mongodb:/data/db/backup.archive \
+  ./koolbot-backup-$(date +%Y%m%d).archive
 
 # 3. Stop everything
-docker-compose down -v
+docker compose down -v
 
 # 4. Verify .env file
 cat .env
 
 # 5. Start fresh
-docker-compose up -d
+docker compose up -d
 
-# 6. Wait for startup
-sleep 30
+# 6. Wait for startup, check logs
+docker compose logs -f bot
 
-# 7. Check logs
-docker-compose logs -f bot
+# 7. In Discord, run /config → open the Web UI → Settings → Import
+#    Upload your saved YAML file from step 1.
 
-# 8. Restore configuration
-/config import
-
-# 9. Restore database
-# Replace YYYYMMDD with your actual backup file date (e.g., 20240115)
-docker cp ./koolbot-backup-YYYYMMDD.archive koolbot-mongodb:/data/db/restore.archive
-docker-compose exec mongodb mongorestore --archive=/data/db/restore.archive --db=koolbot --drop
-docker-compose restart bot
+# 8. (Optional) Restore raw MongoDB if you'd rather skip YAML import
+docker cp ./koolbot-backup-YYYYMMDD.archive \
+  koolbot-mongodb:/data/db/restore.archive
+docker compose exec mongodb mongorestore \
+  --archive=/data/db/restore.archive --db=koolbot --drop
+docker compose restart bot
 ```
 
 ### Get Support
@@ -763,26 +816,28 @@ docker-compose restart bot
 1. **Check logs first:**
 
    ```bash
-   docker-compose logs bot > bot-logs.txt
+   docker compose logs bot > bot-logs.txt
    ```
 
 2. **Gather information:**
-   - KoolBot version: `docker-compose exec bot cat package.json | grep version`
+   - KoolBot version: `docker compose exec bot cat package.json | grep version`
    - Docker version: `docker --version`
    - OS: `uname -a`
    - Error messages from logs
 
 3. **Open an issue:**
    - [GitHub Issues](https://github.com/lonix/koolbot/issues)
-   - Include logs and configuration (remove sensitive data!)
+   - Include logs and configuration (remove sensitive data — `DISCORD_TOKEN`,
+     `WEBUI_SESSION_SECRET`, etc.)
 
 ---
 
 ## 📖 Related Documentation
 
-- **[README.md](README.md)** - Bot overview and quick start
-- **[COMMANDS.md](COMMANDS.md)** - Complete command reference
-- **[SETTINGS.md](SETTINGS.md)** - Configuration guide
+- **[README.md](README.md)** — Bot overview and quick start
+- **[WEBUI.md](WEBUI.md)** — Web UI setup, magic-link flow, troubleshooting
+- **[COMMANDS.md](COMMANDS.md)** — Complete command reference
+- **[SETTINGS.md](SETTINGS.md)** — Configuration guide
 
 ---
 

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -210,8 +210,10 @@ WEBUI_SESSION_SECRET=replace-with-openssl-rand-base64-32-output
 
 Pick **one** of:
 
-- **Publish the port directly** (simplest, but no HTTPS). See the
-  [Direct port publish](#direct-port-publish) recipe below.
+- **Publish the port directly** (simplest, but no HTTPS — this is what
+  the shipped compose does). See the
+  [Direct port publish (the shipped default)](#direct-port-publish-the-shipped-default)
+  recipe below.
 - **Reverse-proxy it** (recommended for any deployment users will visit
   from a real browser). See [Reverse-proxy guidance](#reverse-proxy-guidance).
 - **Tunnel it** (Tailscale, WireGuard, Cloudflare Tunnel, etc.). Same
@@ -246,14 +248,18 @@ Open the DM, click the link, and you're in.
 
 ## Docker Compose recipes
 
-The production `docker-compose.yml` shipped in the repo does **not**
-publish port `3000` by default — operators should make a deliberate
-choice about how to expose the Web UI. The recipes below are starting
-points; pick one and drop it into your own `docker-compose.yml`.
+The production `docker-compose.yml` shipped in the repo **publishes
+port 3000 by default** so the quick-start magic link is reachable on
+`http://your-host:3000` out of the box. That's the right default for a
+local or LAN install but it has no HTTPS — for anything reachable from
+the public internet, swap the direct publish for a reverse proxy. The
+recipes below are starting points; pick one and drop it into your own
+`docker-compose.yml`.
 
-### Direct port publish
+### Direct port publish (the shipped default)
 
-Simplest setup. The bot listens on port `3000`; you map it to the host.
+The simplest setup, and what the repo's `docker-compose.yml` does
+already. The bot listens on port `3000`; you map it to the host.
 
 ```yaml
 services:

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -76,13 +76,15 @@ port to learn. It is dark unless `WEBUI_ENABLED=true`.
                             │ checked each req │
                             └──────────────────┘
                                  │
-                                 │ click "Finish" (or idle out)
-                                 ▼
-                            ┌──────────────────┐
-                            │ session revoked  │
-                            │ cookie cleared   │
-                            │ /admin/* → 401   │
-                            └──────────────────┘
+                                 ├─ click "Finish" or re-run /config
+                                 │  → session revoked server-side,
+                                 │    cookie cleared, /admin/* → 401
+                                 │
+                                 └─ idle past the inactivity window,
+                                    or reach the hard expiresAt
+                                    → cookie rejected on the next request;
+                                      the DB row stays until TTL or
+                                      explicit revoke
 ```
 
 Key properties:
@@ -99,8 +101,12 @@ Key properties:
   sessions are untouched.
 - **Permissions re-checked every request.** The cookie-session middleware
   re-runs `PermissionsService.checkCommandPermission(uid, gid, "config")`
-  on every hit. Demote an admin in Discord and their next click logs
-  them out.
+  on every hit. That check returns `false` (and the middleware logs the
+  user out) when the user has lost Administrator **and** the bot's
+  Permissions page has explicit role gating configured for `config` that
+  no longer matches the user's roles. With no explicit gating configured,
+  a re-check after demotion still passes — the magic-link gate at
+  `/admin/s/<token>` is the primary defense, not this revalidation.
 - **No persistent OAuth.** The bot is the trust anchor. If you can run
   `/config` in Discord, you can configure the bot — no separate login.
 
@@ -111,20 +117,30 @@ Key properties:
 KoolBot has a hard rule: **bootstrap settings live in `.env`, everything
 else lives in MongoDB and is edited via the Web UI.**
 
-| Setting tier         | Where it lives | How it's edited                                  | Reload           |
-| -------------------- | -------------- | ------------------------------------------------ | ---------------- |
-| Bootstrap / secrets  | `.env`         | Edit the file on the host                        | Restart bot      |
-| Feature config       | MongoDB        | Web UI **Settings**, **Permissions**, etc.       | Live             |
-| Discord command list | MongoDB        | Web UI Settings → **Reload commands to Discord** | Click the button |
+| Setting tier         | Where it lives | How it's edited                                  | Picked up                  |
+| -------------------- | -------------- | ------------------------------------------------ | -------------------------- |
+| Bootstrap / secrets  | `.env`         | Edit the file on the host                        | Bot restart                |
+| Feature config       | MongoDB        | Web UI **Settings**, **Permissions**, etc.       | Saved immediately (note ↓) |
+| Discord command list | MongoDB        | Web UI Settings → **Reload commands to Discord** | Click the button           |
 
-The Web UI's **Bootstrap** page surfaces every `.env` value the bot reads,
+> ↓ Plain feature toggles take effect on the next read. Cron-scheduled
+> services (announcements, polls, cleanup) and channel managers cache
+> derived state and need a manual reload via their per-page button to
+> fully apply.
+
+The Web UI's **Bootstrap** page surfaces every `.env` value the bot
+reads (see `BOOTSTRAP_VARS` in `src/web/read-only-routes.ts`),
 read-only, with secrets masked (last 4 characters only). You can verify
 what the process saw at startup, but you cannot change it from the
 browser.
 
-YAML import/export covers the MongoDB tier only. The protected-keys list
-(`src/web/write-routes.ts`) refuses any import that tries to set a
-bootstrap key, even if you handcraft the YAML. Defense in depth.
+YAML import/export covers the MongoDB tier only. Imports apply
+**per-key**: the protected-keys list (`PROTECTED_KEYS` in
+`src/web/write-routes.ts`) flags any row that targets a bootstrap key
+as `rejected: protected key`, but other valid rows in the same file
+still apply. The result page shows per-key outcomes plus a top-level
+`ok` / `partial` / `failed` status — a mixed YAML produces a partial
+import, not an atomic failure.
 
 ---
 
@@ -259,8 +275,12 @@ services:
     restart: unless-stopped
     volumes:
       - mongodb_data:/data/db
-    ports:
-      - "27017:27017"
+    # Intentionally no `ports:` — the bot reaches MongoDB over the
+    # internal Docker network. The default mongo image has NO auth, so
+    # do not publish 27017 to a public interface. If you need host
+    # access for mongosh, bind explicitly to loopback:
+    #   ports:
+    #     - "127.0.0.1:27017:27017"
     stop_grace_period: 30s
     stop_signal: SIGTERM
 
@@ -270,9 +290,25 @@ volumes:
 
 With this, `WEBUI_BASE_URL=http://your-host:3000`.
 
-⚠️ **No HTTPS.** The session cookie is `Secure`-flagged automatically
-when `WEBUI_BASE_URL` is HTTPS; over plain HTTP, anyone on the network
-path can lift it. Don't do this on the public internet.
+⚠️ **No HTTPS — read this before using this recipe in production.**
+
+The Web UI sets the session cookie's `Secure` flag whenever
+`NODE_ENV=production` (see `shouldUseSecureCookies()` in
+`src/web/csrf.ts`). Browsers refuse to send `Secure` cookies over plain
+HTTP, so a production-mode bot reached at `http://your-host:3000`
+**will not maintain a session** — every page click logs you back out.
+
+Pick one:
+
+- Set `NODE_ENV=development` while you accept plain HTTP (the cookie
+  drops the `Secure` flag), **or**
+- Put a reverse proxy in front of the bot and terminate TLS there
+  (recommended — see [Caddy reverse proxy](#caddy-reverse-proxy-recommended)
+  below).
+
+Either way, plain HTTP exposes the magic-link bearer token in transit
+and the session cookie in subsequent requests. Don't run plain HTTP on
+the public internet.
 
 ### Bind to localhost only
 
@@ -369,8 +405,16 @@ WEBUI_TRUST_PROXY=1
 Caddy provisions the TLS certificate automatically via Let's Encrypt and
 forwards `X-Forwarded-For` to the bot. `WEBUI_TRUST_PROXY=1` tells the
 bot's rate limiter to trust exactly one hop (Caddy) when reading client
-IPs — without it, an attacker who can reach `/admin/s/...` directly
-could spoof their IP and bypass rate limits.
+IPs.
+
+⚠️ **Trust-proxy is a footgun if the bot is *also* directly reachable.**
+By default the bot ignores `X-Forwarded-*` headers, so a direct client
+cannot spoof its IP. Setting `WEBUI_TRUST_PROXY=1` flips that: any
+request reaching the bot — including a direct one that bypasses Caddy
+— can now set `X-Forwarded-For` to anything it wants. **Block direct
+access to `bot:3000` from outside the Docker network** (the recipe
+above does this by not declaring a `ports:` on the bot service) before
+trusting forwarded headers.
 
 > **We do not bundle Caddy.** The recipe above is the easy path; your
 > existing nginx, Traefik, or HAProxy works equally well as long as it
@@ -389,15 +433,21 @@ reachable from the tunnel sidecar's network namespace.
 The Web UI is a plain HTTP server. Any reverse proxy works. The
 requirements are:
 
-1. **Forward `Host`** so URL generation inside the app matches
+1. **Terminate TLS at the proxy.** The bot itself does not speak HTTPS.
+2. **Forward `Host`** so URL generation inside the app matches
    `WEBUI_BASE_URL`. Most proxies do this by default.
-2. **Forward `X-Forwarded-Proto`** so the bot knows whether the original
-   request was HTTPS. The `Secure` cookie flag depends on this.
-3. **Set `WEBUI_TRUST_PROXY`** to the hop count of trusted proxies in
+3. **Run the bot with `NODE_ENV=production`.** That's what flips the
+   session cookie's `Secure` flag on (`shouldUseSecureCookies()` in
+   `src/web/csrf.ts`). The bot does not look at `X-Forwarded-Proto` —
+   the decision is `NODE_ENV`-only. You can still forward
+   `X-Forwarded-Proto` for your own logging, it just doesn't affect
+   cookie flagging.
+4. **Set `WEBUI_TRUST_PROXY`** to the hop count of trusted proxies in
    front of the bot. `1` for "one Caddy/nginx", larger for chained
-   setups. Without this, the bot ignores `X-Forwarded-*` headers and
-   treats every request as coming from the proxy's IP.
-4. **Terminate TLS at the proxy.** The bot itself does not speak HTTPS.
+   setups. Without this, the bot ignores `X-Forwarded-*` headers
+   entirely; with this, **make sure the bot is not also directly
+   reachable** so attackers can't bypass the proxy and spoof
+   `X-Forwarded-For` against the rate limiter.
 
 The Caddy config above is intentionally minimal. nginx equivalent:
 
@@ -486,16 +536,24 @@ Could not DM web sign-in link to <user-id>; falling back to ephemeral reply
 
 ## Session lifecycle and revocation
 
-| Trigger                            | Effect                                                   |
-| ---------------------------------- | -------------------------------------------------------- |
-| Run `/config`                      | Revokes all your prior unrevoked sessions; mints new     |
-| Click DM link                      | Marks token `usedAt`; sets signed session cookie         |
-| Idle longer than inactivity window | Cookie expires; next click → 401                         |
-| Reach session's hard `expiresAt`   | Session revoked server-side; next click → 401            |
-| Click **Finish** in the UI         | Session revoked server-side; cookie cleared              |
-| Admin role removed in Discord      | Next request re-checks permissions → 401, cookie cleared |
-| Bot restart                        | Sessions survive (stored in MongoDB)                     |
-| `WEBUI_SESSION_SECRET` rotated     | All existing sessions and outstanding tokens invalid     |
+| Trigger                            | Effect                                                                                  |
+| ---------------------------------- | --------------------------------------------------------------------------------------- |
+| Run `/config`                      | Revokes all your prior unrevoked sessions server-side; mints new                        |
+| Click DM link                      | Marks token `usedAt`; sets signed session cookie                                        |
+| Idle longer than inactivity window | Cookie is rejected on the next request; the DB row remains until TTL or explicit revoke |
+| Reach session's hard `expiresAt`   | Cookie is rejected on the next request; the DB row is past its TTL                      |
+| Click **Finish** in the UI         | Session revoked server-side; cookie cleared                                             |
+| Admin role removed in Discord      | Next request re-runs the permission check — caveat ↓                                    |
+| Bot restart                        | Sessions survive (stored in MongoDB)                                                    |
+| `WEBUI_SESSION_SECRET` rotated     | All existing sessions and outstanding tokens invalid                                    |
+
+> **Caveat on the "admin role removed" row.** The permission re-check
+> only returns `false` when there's explicit role gating configured for
+> `config` on the Web UI's Permissions page that no longer matches the
+> user's roles. With no explicit gating, the check returns `true` and
+> the session continues. If you want demotions to log existing sessions
+> out, configure Permissions → `config` to an admin-only role, then
+> the role removal will kick the session on the next request.
 
 Two admins can be in the Web UI at the same time. Re-running `/config`
 only invalidates **your own** sessions.
@@ -565,16 +623,34 @@ One of:
 
 ### "Sign in required" on every page
 
-Your cookie is stale or your IP changed in a way that broke session
-binding. Run `/config` again to mint a fresh link.
+Possible causes (in roughly decreasing likelihood):
+
+- Your cookie expired (idle past `WEBUI_INACTIVITY_TIMEOUT_MINUTES`).
+- The DB session row passed its hard TTL (`WEBUI_SESSION_TTL_MINUTES`
+  from issuance).
+- You ran `/config` again and revoked this session server-side.
+- Permission re-check failed: someone configured Web UI Permissions →
+  `config` to restrict the command, and your roles no longer match.
+- The bot was restarted with a new `WEBUI_SESSION_SECRET`, invalidating
+  the cookie signature.
+
+Run `/config` again to mint a fresh link.
+
+The cookie is **not** bound to your client IP — switching networks does
+not by itself end a session.
 
 ### The Web UI URL loads but won't accept my cookie
 
-Browsers refuse `Secure`-flagged cookies over plain HTTP. Either:
+Browsers refuse `Secure`-flagged cookies over plain HTTP. The Web UI
+flags its session cookie `Secure` whenever `NODE_ENV=production`
+(see `shouldUseSecureCookies()` in `src/web/csrf.ts`). Pick one:
 
-- Run behind HTTPS (recommended), **or**
-- Set `WEBUI_BASE_URL=http://...` so the bot doesn't set the `Secure`
-  flag in the first place. Only do this for local testing.
+- Run behind HTTPS via a reverse proxy (recommended), **or**
+- Set `NODE_ENV=development` in `.env` and restart, so the cookie is
+  not flagged `Secure`. Only do this for local testing.
+
+Changing only `WEBUI_BASE_URL` to `http://...` is **not** enough — the
+URL scheme does not influence cookie flagging.
 
 ### Behind a proxy, rate limits trigger on the proxy's IP
 

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -1,0 +1,615 @@
+# KoolBot Web UI
+
+The Web UI is the **only** admin surface for KoolBot from v1.0 onward.
+Everything that used to live behind `/config set`, `/permissions`, `/setup`,
+`/announce`, `/poll`, `/reactrole`, `/notice`, `/dbtrunk`, `/vc`, and
+`/botstats` is now reached by running a single Discord slash command,
+`/config`, which DMs you a one-time sign-in link.
+
+This document explains how to enable it, expose it, and operate it.
+
+---
+
+## 📋 Table of Contents
+
+- [TL;DR](#tldr)
+- [How the magic-link flow works](#how-the-magic-link-flow-works)
+- [Configuration boundary: env vs. database](#configuration-boundary-env-vs-database)
+- [Bootstrap environment variables](#bootstrap-environment-variables)
+- [Enabling the Web UI](#enabling-the-web-ui)
+- [Docker Compose recipes](#docker-compose-recipes)
+- [Reverse-proxy guidance](#reverse-proxy-guidance)
+- [Public-internet exposure](#public-internet-exposure)
+- [DM-closed fallback](#dm-closed-fallback)
+- [Session lifecycle and revocation](#session-lifecycle-and-revocation)
+- [What the Web UI lets you do](#what-the-web-ui-lets-you-do)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## TL;DR
+
+1. Set `WEBUI_ENABLED=true` plus the four other `WEBUI_*` bootstrap env vars
+   in `.env` (see [Bootstrap environment variables](#bootstrap-environment-variables)).
+2. Publish or reverse-proxy port `3000` so the URL in `WEBUI_BASE_URL`
+   actually reaches the container.
+3. Restart the bot.
+4. In Discord, run `/config`. The bot DMs you a single-use link.
+5. Click the link, configure the bot, click **Finish** when you're done.
+
+The Web UI mounts on the **same Express server** that already serves
+`/health` (port `3000` inside the container) — no new container, no new
+port to learn. It is dark unless `WEBUI_ENABLED=true`.
+
+---
+
+## How the magic-link flow works
+
+```text
+┌──────────┐                ┌──────────┐               ┌──────────┐
+│  Admin   │ /config        │  KoolBot │ create        │ MongoDB  │
+│ (Discord)│ ─────────────► │ (bot)    │ ────────────► │ (session)│
+└──────────┘                └──────────┘               └──────────┘
+                                 │
+                                 │ DM single-use URL
+                                 ▼
+                            ┌──────────┐
+                            │   Admin  │
+                            │ (DM)     │
+                            └──────────┘
+                                 │
+                                 │ open link in browser
+                                 ▼
+                            ┌──────────────────┐
+                            │ GET /admin/s/    │
+                            │ - validate token │
+                            │ - mark used      │
+                            │ - issue cookie   │
+                            │ - 302 → /admin/  │
+                            └──────────────────┘
+                                 │
+                                 │ authenticated by signed cookie
+                                 ▼
+                            ┌──────────────────┐
+                            │ /admin/* pages   │
+                            │ permissions re-  │
+                            │ checked each req │
+                            └──────────────────┘
+                                 │
+                                 │ click "Finish" (or idle out)
+                                 ▼
+                            ┌──────────────────┐
+                            │ session revoked  │
+                            │ cookie cleared   │
+                            │ /admin/* → 401   │
+                            └──────────────────┘
+```
+
+Key properties:
+
+- **Single-use.** Each link is bound to one Discord user ID and one token
+  hash. Redeeming it marks `usedAt` server-side. A second click 404s.
+- **Short TTL.** Default `WEBUI_SESSION_TTL_MINUTES=10`. Tokens expire
+  whether or not they're used.
+- **Sliding inactivity.** Once redeemed, the cookie has a sliding
+  inactivity window (default `WEBUI_INACTIVITY_TIMEOUT_MINUTES=30`)
+  hard-capped at the session's server-side `expiresAt`.
+- **Re-issuing kills the prior session.** Running `/config` again revokes
+  all of *your* unrevoked sessions and mints a new one. Other admins'
+  sessions are untouched.
+- **Permissions re-checked every request.** The cookie-session middleware
+  re-runs `PermissionsService.checkCommandPermission(uid, gid, "config")`
+  on every hit. Demote an admin in Discord and their next click logs
+  them out.
+- **No persistent OAuth.** The bot is the trust anchor. If you can run
+  `/config` in Discord, you can configure the bot — no separate login.
+
+---
+
+## Configuration boundary: env vs. database
+
+KoolBot has a hard rule: **bootstrap settings live in `.env`, everything
+else lives in MongoDB and is edited via the Web UI.**
+
+| Setting tier         | Where it lives | How it's edited                                    | Reload          |
+| -------------------- | -------------- | -------------------------------------------------- | --------------- |
+| Bootstrap / secrets  | `.env`         | Edit the file on the host                          | Restart bot     |
+| Feature config       | MongoDB        | Web UI **Settings**, **Permissions**, etc.         | Live            |
+| Discord command list | MongoDB        | Web UI Settings → **Reload commands to Discord**   | Click the button |
+
+The Web UI's **Bootstrap** page surfaces every `.env` value the bot reads,
+read-only, with secrets masked (last 4 characters only). You can verify
+what the process saw at startup, but you cannot change it from the
+browser.
+
+YAML import/export covers the MongoDB tier only. The protected-keys list
+(`src/web/write-routes.ts`) refuses any import that tries to set a
+bootstrap key, even if you handcraft the YAML. Defense in depth.
+
+---
+
+## Bootstrap environment variables
+
+These are read at startup and never edited from the Web UI. Change them
+by editing `.env` and restarting the container.
+
+### Required for the bot itself
+
+| Variable        | Required | Example                                  |
+| --------------- | -------- | ---------------------------------------- |
+| `DISCORD_TOKEN` | yes      | `MTIzNDU2Nzg5MDEy...`                    |
+| `CLIENT_ID`     | yes      | `1234567890123456789`                    |
+| `GUILD_ID`      | yes      | `9876543210987654321`                    |
+| `MONGODB_URI`   | yes      | `mongodb://mongodb:27017/koolbot`        |
+| `NODE_ENV`      | no       | `production` (default) / `development`   |
+| `DEBUG`         | no       | `false` (default) / `true`               |
+
+### Required when the Web UI is enabled
+
+| Variable                            | Required          | Default | Notes                                                                                            |
+| ----------------------------------- | ----------------- | ------- | ------------------------------------------------------------------------------------------------ |
+| `WEBUI_ENABLED`                     | yes (to turn on)  | `false` | `true` mounts `/admin/*`; anything else leaves it 404.                                           |
+| `WEBUI_BASE_URL`                    | yes when enabled  | —       | Public URL the DM'd link points at, e.g. `https://bot.example.com`. No trailing slash needed.    |
+| `WEBUI_SESSION_SECRET`              | yes when enabled  | —       | HMAC key for token hashes and signed cookies. Use 32+ random bytes (`openssl rand -base64 32`).  |
+| `WEBUI_SESSION_TTL_MINUTES`         | no                | `10`    | TTL of the DM'd link from issuance.                                                              |
+| `WEBUI_INACTIVITY_TIMEOUT_MINUTES`  | no                | `30`    | Sliding cookie window after redemption.                                                          |
+| `WEBUI_TRUST_PROXY`                 | no                | (off)   | Set to a hop count (e.g. `1`) when running behind a reverse proxy that sets `X-Forwarded-*`.     |
+
+> ⚠️ **Treat `WEBUI_SESSION_SECRET` like `DISCORD_TOKEN`.** Anyone who
+> can read it can forge sign-in cookies. Rotating it invalidates every
+> existing session and outstanding magic link.
+
+Generate a strong secret:
+
+```bash
+openssl rand -base64 32
+```
+
+---
+
+## Enabling the Web UI
+
+### 1. Set the env vars
+
+Append to `.env`:
+
+```env
+WEBUI_ENABLED=true
+WEBUI_BASE_URL=https://bot.example.com
+WEBUI_SESSION_SECRET=replace-with-openssl-rand-base64-32-output
+# Optional tuning
+WEBUI_SESSION_TTL_MINUTES=10
+WEBUI_INACTIVITY_TIMEOUT_MINUTES=30
+```
+
+If you don't have a real domain yet and just want to try it locally:
+
+```env
+WEBUI_ENABLED=true
+WEBUI_BASE_URL=http://localhost:3000
+WEBUI_SESSION_SECRET=replace-with-openssl-rand-base64-32-output
+```
+
+### 2. Make port 3000 reachable
+
+Pick **one** of:
+
+- **Publish the port directly** (simplest, but no HTTPS). See the
+  [Direct port publish](#direct-port-publish) recipe below.
+- **Reverse-proxy it** (recommended for any deployment users will visit
+  from a real browser). See [Reverse-proxy guidance](#reverse-proxy-guidance).
+- **Tunnel it** (Tailscale, WireGuard, Cloudflare Tunnel, etc.). Same
+  config as the reverse-proxy case — set `WEBUI_BASE_URL` to the URL
+  your tunnel exposes.
+
+### 3. Restart and verify
+
+```bash
+docker compose up -d --force-recreate
+docker compose logs -f bot | grep -i webui
+```
+
+Look for:
+
+```text
+WebUI mounted at /admin
+```
+
+If you see `WEBUI_ENABLED=true but missing required env vars: ...`, the
+bot started without the Web UI mounted — fix the env vars and restart.
+
+### 4. Run `/config`
+
+Run `/config` in Discord. The bot replies ephemerally:
+
+> ✅ I've DMed you a single-use sign-in link. Check your direct messages.
+
+Open the DM, click the link, and you're in.
+
+---
+
+## Docker Compose recipes
+
+The production `docker-compose.yml` shipped in the repo does **not**
+publish port `3000` by default — operators should make a deliberate
+choice about how to expose the Web UI. The recipes below are starting
+points; pick one and drop it into your own `docker-compose.yml`.
+
+### Direct port publish
+
+Simplest setup. The bot listens on port `3000`; you map it to the host.
+
+```yaml
+services:
+  bot:
+    image: ghcr.io/lonix/koolbot:latest
+    container_name: koolbot
+    restart: unless-stopped
+    env_file: .env
+    depends_on:
+      - mongodb
+    stop_grace_period: 30s
+    stop_signal: SIGTERM
+    ports:
+      - "3000:3000"   # /health and /admin (when WEBUI_ENABLED=true)
+
+  mongodb:
+    image: mongo:latest
+    container_name: koolbot-mongodb
+    restart: unless-stopped
+    volumes:
+      - mongodb_data:/data/db
+    ports:
+      - "27017:27017"
+    stop_grace_period: 30s
+    stop_signal: SIGTERM
+
+volumes:
+  mongodb_data:
+```
+
+With this, `WEBUI_BASE_URL=http://your-host:3000`.
+
+⚠️ **No HTTPS.** The session cookie is `Secure`-flagged automatically
+when `WEBUI_BASE_URL` is HTTPS; over plain HTTP, anyone on the network
+path can lift it. Don't do this on the public internet.
+
+### Bind to localhost only
+
+If you only want to reach the Web UI from the host machine (and SSH-tunnel
+or VPN in), bind to the loopback:
+
+```yaml
+services:
+  bot:
+    # ...other fields...
+    ports:
+      - "127.0.0.1:3000:3000"
+```
+
+`WEBUI_BASE_URL=http://localhost:3000`, then open it locally or via
+`ssh -L 3000:localhost:3000 host`.
+
+### Caddy reverse proxy (recommended)
+
+Caddy gives you HTTPS with a one-line config and a public-domain DNS
+record. The bot stays on a private Docker network and is not directly
+exposed.
+
+```yaml
+services:
+  bot:
+    image: ghcr.io/lonix/koolbot:latest
+    container_name: koolbot
+    restart: unless-stopped
+    env_file: .env
+    depends_on:
+      - mongodb
+    stop_grace_period: 30s
+    stop_signal: SIGTERM
+    networks:
+      - koolbot-net
+    # No `ports:` — Caddy is the only public surface.
+
+  mongodb:
+    image: mongo:latest
+    container_name: koolbot-mongodb
+    restart: unless-stopped
+    volumes:
+      - mongodb_data:/data/db
+    stop_grace_period: 30s
+    stop_signal: SIGTERM
+    networks:
+      - koolbot-net
+
+  caddy:
+    image: caddy:2-alpine
+    container_name: koolbot-caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    networks:
+      - koolbot-net
+    depends_on:
+      - bot
+
+volumes:
+  mongodb_data:
+  caddy_data:
+  caddy_config:
+
+networks:
+  koolbot-net:
+    driver: bridge
+```
+
+`Caddyfile`:
+
+```text
+bot.example.com {
+    encode zstd gzip
+    reverse_proxy bot:3000
+}
+```
+
+In `.env`:
+
+```env
+WEBUI_ENABLED=true
+WEBUI_BASE_URL=https://bot.example.com
+WEBUI_SESSION_SECRET=...
+WEBUI_TRUST_PROXY=1
+```
+
+Caddy provisions the TLS certificate automatically via Let's Encrypt and
+forwards `X-Forwarded-For` to the bot. `WEBUI_TRUST_PROXY=1` tells the
+bot's rate limiter to trust exactly one hop (Caddy) when reading client
+IPs — without it, an attacker who can reach `/admin/s/...` directly
+could spoof their IP and bypass rate limits.
+
+> **We do not bundle Caddy.** The recipe above is the easy path; your
+> existing nginx, Traefik, or HAProxy works equally well as long as it
+> terminates TLS and forwards `Host` and `X-Forwarded-*` faithfully.
+
+### Tailscale / Cloudflare Tunnel
+
+Set `WEBUI_BASE_URL` to whatever URL your tunnel hands out and *don't*
+publish port `3000` to the public internet. The bot only needs to be
+reachable from the tunnel sidecar's network namespace.
+
+---
+
+## Reverse-proxy guidance
+
+The Web UI is a plain HTTP server. Any reverse proxy works. The
+requirements are:
+
+1. **Forward `Host`** so URL generation inside the app matches
+   `WEBUI_BASE_URL`. Most proxies do this by default.
+2. **Forward `X-Forwarded-Proto`** so the bot knows whether the original
+   request was HTTPS. The `Secure` cookie flag depends on this.
+3. **Set `WEBUI_TRUST_PROXY`** to the hop count of trusted proxies in
+   front of the bot. `1` for "one Caddy/nginx", larger for chained
+   setups. Without this, the bot ignores `X-Forwarded-*` headers and
+   treats every request as coming from the proxy's IP.
+4. **Terminate TLS at the proxy.** The bot itself does not speak HTTPS.
+
+The Caddy config above is intentionally minimal. nginx equivalent:
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name bot.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/bot.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/bot.example.com/privkey.pem;
+
+    location / {
+        proxy_pass         http://bot:3000;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+Traefik (compose labels):
+
+```yaml
+labels:
+  - "traefik.enable=true"
+  - "traefik.http.routers.koolbot.rule=Host(`bot.example.com`)"
+  - "traefik.http.routers.koolbot.entrypoints=websecure"
+  - "traefik.http.routers.koolbot.tls.certresolver=letsencrypt"
+  - "traefik.http.services.koolbot.loadbalancer.server.port=3000"
+```
+
+---
+
+## Public-internet exposure
+
+Because every `/admin/*` route returns 401 (or 404 for the redemption
+endpoint) without a valid token or cookie, **putting the Web UI on the
+open internet is acceptable** — there is no login form to brute-force.
+
+That said:
+
+- **Always run behind HTTPS.** The session cookie is HMAC-signed but
+  cleartext, and the magic link itself is a bearer token. TLS is
+  non-negotiable on the public internet.
+- **The healthcheck endpoint (`/health`) is unauthenticated.** It is
+  intentionally minimal (returns `OK` or `Service Unavailable`) but it
+  *does* report whether MongoDB and Discord are reachable. Restrict it
+  to your monitoring system if you'd rather not advertise that.
+- **Mind the magic-link TTL.** A leaked link is useless after redemption
+  or expiry, but if the admin who ran `/config` shares the URL before
+  redeeming it, anyone with the URL becomes that admin until the TTL
+  fires. The default 10-minute window is short enough that this rarely
+  bites in practice.
+- **`/admin/s/<token>` is rate-limited** to 10 attempts per minute per
+  IP. Set `WEBUI_TRUST_PROXY` correctly so this rate-limiting actually
+  applies per real client and not per proxy.
+- **No analytics, no third-party assets.** Every page is rendered
+  server-side from `src/web/` with inline CSS. There is no JS bundle to
+  pin or CDN to allowlist.
+
+---
+
+## DM-closed fallback
+
+If you've disabled DMs from server members, the bot can't deliver the
+link via direct message. The current behavior:
+
+1. `/config` first tries to DM you.
+2. On failure, the bot falls back to **posting the link as the ephemeral
+   reply to the slash command itself** — visible only to you, not to
+   other users in the channel.
+3. The reply text is identical to the DM body.
+
+This means an admin with DMs closed can still configure the bot — they
+just see the link inline in Discord instead of in their DM tab. Re-enable
+DMs at any time to switch back to the cleaner experience.
+
+You'll see this warning in the logs whenever the fallback fires:
+
+```text
+Could not DM web sign-in link to <user-id>; falling back to ephemeral reply
+```
+
+---
+
+## Session lifecycle and revocation
+
+| Trigger                                | Effect                                                 |
+| -------------------------------------- | ------------------------------------------------------ |
+| Run `/config`                          | Revokes all your prior unrevoked sessions; mints new   |
+| Click DM link                          | Marks token `usedAt`; sets signed session cookie       |
+| Idle longer than inactivity window     | Cookie expires; next click → 401                       |
+| Reach session's hard `expiresAt`       | Session revoked server-side; next click → 401          |
+| Click **Finish** in the UI             | Session revoked server-side; cookie cleared            |
+| Admin role removed in Discord          | Next request re-checks permissions → 401, cookie cleared |
+| Bot restart                            | Sessions survive (stored in MongoDB)                   |
+| `WEBUI_SESSION_SECRET` rotated         | All existing sessions and outstanding tokens invalid   |
+
+Two admins can be in the Web UI at the same time. Re-running `/config`
+only invalidates **your own** sessions.
+
+To hard-revoke every session right now without restarting:
+
+```bash
+# Drop just the active sessions; existing rows have revokedAt set.
+docker compose exec mongodb mongosh koolbot --eval '
+  db.websessions.updateMany(
+    { revokedAt: null },
+    { $set: { revokedAt: new Date() } }
+  )
+'
+```
+
+Or rotate `WEBUI_SESSION_SECRET` in `.env` and restart — that
+invalidates every signed cookie and every outstanding magic link as a
+side effect, since the HMAC key changes.
+
+---
+
+## What the Web UI lets you do
+
+| Page              | Replaces                                                |
+| ----------------- | ------------------------------------------------------- |
+| **Dashboard**     | `/botstats`                                             |
+| **Settings**      | `/config list`, `/config get`, `/config set`, `/config reset`, `/config import`, `/config export`, `/config reload` |
+| **Permissions**   | `/permissions set`, `add`, `remove`, `clear`, `list`, `view` |
+| **Setup Wizard**  | `/setup wizard`                                         |
+| **Announcements** | `/announce create`, `list`, `delete`                    |
+| **Polls**         | `/poll create`, `list`, `add-item`, `import-url`, `delete`, `delete-item`, `test`, `list-items` |
+| **Reaction Roles**| `/reactrole create`, `archive`, `unarchive`, `delete`, `list`, `status` |
+| **Notices**       | `/notice add`, `edit`, `delete`, `sync`                 |
+| **Voice Channels**| `/vc reload`, `/vc force-reload`                        |
+| **Database**      | `/dbtrunk status`, `/dbtrunk run`                       |
+| **Bootstrap**     | (new — read-only env diagnostics)                       |
+
+User-facing commands (`/ping`, `/voicestats`, `/seen`, `/quote`,
+`/achievements`, `/amikool`, `/help`) are **not** affected and stay in
+Discord exactly as before. The per-voice-channel control panel (rename,
+privacy, invite, transfer, live, waiting room) also stays in Discord —
+it's a member-facing feature, not an admin tool.
+
+---
+
+## Troubleshooting
+
+### `/config` says "The web UI is disabled"
+
+`WEBUI_ENABLED` is not `true` (case-insensitive). Update `.env` and
+restart the bot.
+
+### `/config` says "missing env vars: WEBUI_BASE_URL, WEBUI_SESSION_SECRET"
+
+Exactly what it says. Set both in `.env` and restart.
+
+### The DM link 404s when I click it
+
+One of:
+
+- It was already redeemed (single-use). Run `/config` again.
+- It expired (default 10 minutes). Run `/config` again.
+- You ran `/config` a second time and got a *newer* link, which revoked
+  this one. Use the most recent DM.
+- `WEBUI_SESSION_SECRET` changed between issuance and redemption.
+
+### "Sign in required" on every page
+
+Your cookie is stale or your IP changed in a way that broke session
+binding. Run `/config` again to mint a fresh link.
+
+### The Web UI URL loads but won't accept my cookie
+
+Browsers refuse `Secure`-flagged cookies over plain HTTP. Either:
+
+- Run behind HTTPS (recommended), **or**
+- Set `WEBUI_BASE_URL=http://...` so the bot doesn't set the `Secure`
+  flag in the first place. Only do this for local testing.
+
+### Behind a proxy, rate limits trigger on the proxy's IP
+
+Set `WEBUI_TRUST_PROXY` to your hop count (usually `1`) and restart.
+Without it, every request appears to come from the proxy and they all
+share one rate-limit bucket.
+
+### I want to disable the Web UI entirely
+
+Set `WEBUI_ENABLED=false` (or remove the line) and restart. All
+`/admin/*` paths 404 again. The `/health` endpoint is unaffected.
+
+### I locked myself out
+
+Edit `.env` on the host: set a fresh `WEBUI_SESSION_SECRET` and restart.
+Then run `/config` in Discord with an account that has the
+Administrator permission. The bootstrap path is "if you can run
+`/config` in Discord, you can configure the bot" — there is no
+forgotten-password flow because there is no password.
+
+---
+
+## 📚 Related documentation
+
+- [README.md](README.md) — Quick start
+- [SETTINGS.md](SETTINGS.md) — DB-backed setting catalog (what each
+  Web UI form field actually does)
+- [COMMANDS.md](COMMANDS.md) — User-facing slash commands
+- [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md) — `src/web/` architecture
+- [TROUBLESHOOTING.md](TROUBLESHOOTING.md) — General troubleshooting
+
+---
+
+<div align="center">
+
+**Questions?** [Open an issue](https://github.com/lonix/koolbot/issues)
+
+</div>

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -111,11 +111,11 @@ Key properties:
 KoolBot has a hard rule: **bootstrap settings live in `.env`, everything
 else lives in MongoDB and is edited via the Web UI.**
 
-| Setting tier         | Where it lives | How it's edited                                    | Reload          |
-| -------------------- | -------------- | -------------------------------------------------- | --------------- |
-| Bootstrap / secrets  | `.env`         | Edit the file on the host                          | Restart bot     |
-| Feature config       | MongoDB        | Web UI **Settings**, **Permissions**, etc.         | Live            |
-| Discord command list | MongoDB        | Web UI Settings → **Reload commands to Discord**   | Click the button |
+| Setting tier         | Where it lives | How it's edited                                  | Reload           |
+| -------------------- | -------------- | ------------------------------------------------ | ---------------- |
+| Bootstrap / secrets  | `.env`         | Edit the file on the host                        | Restart bot      |
+| Feature config       | MongoDB        | Web UI **Settings**, **Permissions**, etc.       | Live             |
+| Discord command list | MongoDB        | Web UI Settings → **Reload commands to Discord** | Click the button |
 
 The Web UI's **Bootstrap** page surfaces every `.env` value the bot reads,
 read-only, with secrets masked (last 4 characters only). You can verify
@@ -486,16 +486,16 @@ Could not DM web sign-in link to <user-id>; falling back to ephemeral reply
 
 ## Session lifecycle and revocation
 
-| Trigger                                | Effect                                                 |
-| -------------------------------------- | ------------------------------------------------------ |
-| Run `/config`                          | Revokes all your prior unrevoked sessions; mints new   |
-| Click DM link                          | Marks token `usedAt`; sets signed session cookie       |
-| Idle longer than inactivity window     | Cookie expires; next click → 401                       |
-| Reach session's hard `expiresAt`       | Session revoked server-side; next click → 401          |
-| Click **Finish** in the UI             | Session revoked server-side; cookie cleared            |
-| Admin role removed in Discord          | Next request re-checks permissions → 401, cookie cleared |
-| Bot restart                            | Sessions survive (stored in MongoDB)                   |
-| `WEBUI_SESSION_SECRET` rotated         | All existing sessions and outstanding tokens invalid   |
+| Trigger                            | Effect                                                   |
+| ---------------------------------- | -------------------------------------------------------- |
+| Run `/config`                      | Revokes all your prior unrevoked sessions; mints new     |
+| Click DM link                      | Marks token `usedAt`; sets signed session cookie         |
+| Idle longer than inactivity window | Cookie expires; next click → 401                         |
+| Reach session's hard `expiresAt`   | Session revoked server-side; next click → 401            |
+| Click **Finish** in the UI         | Session revoked server-side; cookie cleared              |
+| Admin role removed in Discord      | Next request re-checks permissions → 401, cookie cleared |
+| Bot restart                        | Sessions survive (stored in MongoDB)                     |
+| `WEBUI_SESSION_SECRET` rotated     | All existing sessions and outstanding tokens invalid     |
 
 Two admins can be in the Web UI at the same time. Re-running `/config`
 only invalidates **your own** sessions.
@@ -520,19 +520,19 @@ side effect, since the HMAC key changes.
 
 ## What the Web UI lets you do
 
-| Page              | Replaces                                                |
-| ----------------- | ------------------------------------------------------- |
-| **Dashboard**     | `/botstats`                                             |
-| **Settings**      | `/config list`, `/config get`, `/config set`, `/config reset`, `/config import`, `/config export`, `/config reload` |
-| **Permissions**   | `/permissions set`, `add`, `remove`, `clear`, `list`, `view` |
-| **Setup Wizard**  | `/setup wizard`                                         |
-| **Announcements** | `/announce create`, `list`, `delete`                    |
-| **Polls**         | `/poll create`, `list`, `add-item`, `import-url`, `delete`, `delete-item`, `test`, `list-items` |
-| **Reaction Roles**| `/reactrole create`, `archive`, `unarchive`, `delete`, `list`, `status` |
-| **Notices**       | `/notice add`, `edit`, `delete`, `sync`                 |
-| **Voice Channels**| `/vc reload`, `/vc force-reload`                        |
-| **Database**      | `/dbtrunk status`, `/dbtrunk run`                       |
-| **Bootstrap**     | (new — read-only env diagnostics)                       |
+| Page               | Replaces                                                                                            |
+| ------------------ | --------------------------------------------------------------------------------------------------- |
+| **Dashboard**      | `/botstats`                                                                                         |
+| **Settings**       | `/config list`, `get`, `set`, `reset`, `import`, `export`, `reload`                                 |
+| **Permissions**    | `/permissions set`, `add`, `remove`, `clear`, `list`, `view`                                        |
+| **Setup Wizard**   | `/setup wizard`                                                                                     |
+| **Announcements**  | `/announce create`, `list`, `delete`                                                                |
+| **Polls**          | `/poll create`, `list`, `add-item`, `import-url`, `delete`, `delete-item`, `test`, `list-items`     |
+| **Reaction Roles** | `/reactrole create`, `archive`, `unarchive`, `delete`, `list`, `status`                             |
+| **Notices**        | `/notice add`, `edit`, `delete`, `sync`                                                             |
+| **Voice Channels** | `/vc reload`, `/vc force-reload`                                                                    |
+| **Database**       | `/dbtrunk status`, `/dbtrunk run`                                                                   |
+| **Bootstrap**      | (new — read-only env diagnostics)                                                                   |
 
 User-facing commands (`/ping`, `/voicestats`, `/seen`, `/quote`,
 `/achievements`, `/amikool`, `/help`) are **not** affected and stay in

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,6 +15,11 @@ services:
       - mongodb
     stop_grace_period: 30s
     stop_signal: SIGTERM
+    # Publish port 3000 in dev so you can hit /health and the admin Web UI
+    # (when WEBUI_ENABLED=true in .env) from your host browser at
+    # http://localhost:3000. Set WEBUI_BASE_URL=http://localhost:3000.
+    ports:
+      - "3000:3000"
 
   mongodb:
     image: mongo:latest
@@ -34,4 +39,4 @@ volumes:
 
 networks:
   koolbot-network:
-    driver: bridge 
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,24 @@ services:
       - mongodb
     stop_grace_period: 30s
     stop_signal: SIGTERM
-
+    # The bot listens on port 3000 inside the container for /health and the
+    # admin Web UI (/admin/*, only when WEBUI_ENABLED=true in .env).
+    #
+    # Pick one of the options below to make the Web UI reachable from your
+    # browser. See WEBUI.md for HTTPS / reverse-proxy setups.
+    #
+    # Option A — Publish directly (LAN/VPN-only, no HTTPS):
+    # ports:
+    #   - "3000:3000"
+    #
+    # Option B — Bind to localhost only (use an SSH tunnel to reach it):
+    # ports:
+    #   - "127.0.0.1:3000:3000"
+    #
+    # Option C — Caddy / nginx / Traefik reverse proxy (recommended for any
+    # internet-facing deployment). Leave `ports:` unset on this service and
+    # let the proxy service forward to bot:3000 over the internal Docker
+    # network. See WEBUI.md → "Docker Compose recipes" for a full example.
 
   mongodb:
     image: mongo:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,24 +8,16 @@ services:
       - mongodb
     stop_grace_period: 30s
     stop_signal: SIGTERM
-    # The bot listens on port 3000 inside the container for /health and the
-    # admin Web UI (/admin/*, only when WEBUI_ENABLED=true in .env).
+    # Publish the bot's port 3000 so /health and (when WEBUI_ENABLED=true)
+    # the admin Web UI at /admin/* are reachable from the host. This is the
+    # simplest setup; it is NOT secured for the public internet.
     #
-    # Pick one of the options below to make the Web UI reachable from your
-    # browser. See WEBUI.md for HTTPS / reverse-proxy setups.
-    #
-    # Option A — Publish directly (LAN/VPN-only, no HTTPS):
-    # ports:
-    #   - "3000:3000"
-    #
-    # Option B — Bind to localhost only (use an SSH tunnel to reach it):
-    # ports:
-    #   - "127.0.0.1:3000:3000"
-    #
-    # Option C — Caddy / nginx / Traefik reverse proxy (recommended for any
-    # internet-facing deployment). Leave `ports:` unset on this service and
-    # let the proxy service forward to bot:3000 over the internal Docker
-    # network. See WEBUI.md → "Docker Compose recipes" for a full example.
+    # For internet-facing deployments use a reverse proxy (Caddy, nginx,
+    # Traefik) and remove this publish — let the proxy forward to bot:3000
+    # over the internal Docker network. See WEBUI.md → "Docker Compose
+    # recipes" for a complete Caddy example.
+    ports:
+      - "3000:3000"
 
   mongodb:
     image: mongo:latest
@@ -33,6 +25,12 @@ services:
     restart: unless-stopped
     volumes:
       - mongodb_data:/data/db
+    # ⚠️ The default mongo image has NO authentication. This publish makes
+    # MongoDB reachable on the host's port 27017. If your host is on the
+    # public internet, restrict the bind to localhost only:
+    #   - "127.0.0.1:27017:27017"
+    # or remove the publish entirely (the bot reaches it over the internal
+    # Docker network at mongodb:27017 either way).
     ports:
       - "27017:27017"
     stop_grace_period: 30s

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -79,6 +79,7 @@ const BOOTSTRAP_VARS: BootstrapEnvVar[] = [
     category: "WebUI",
     isSecret: false,
   },
+  { key: "WEBUI_TRUST_PROXY", category: "WebUI", isSecret: false },
 ];
 
 function deriveCategory(key: string): string {


### PR DESCRIPTION
## Summary

Full documentation pass aligning every doc with the v1.0 admin model that landed in #414/#415: slash commands are gone except `/config` (Web UI launcher), all admin configuration lives in `/admin/*` behind a magic-link session, and the env-vs-DB boundary is now explicit everywhere.

Closes #387.

## What changed

- **`WEBUI.md` (new)** — magic-link flow diagram, env-vs-DB boundary, bootstrap env-var catalog (`WEBUI_*` + secrets), enable-the-WebUI walkthrough, Docker Compose recipes (direct publish, localhost-only, Caddy reverse proxy), reverse-proxy guidance for nginx/Traefik/tunnels, public-internet exposure caveats, DM-closed fallback, session lifecycle and revocation, page→legacy-command mapping, troubleshooting.
- **`COMMANDS.md`** — removed every deprecated admin command (`/permissions`, `/setup`, `/announce`, `/announce-vc-stats`, `/poll`, `/reactrole`, `/notice`, `/dbtrunk`, `/vc`, `/botstats`, all `/config` subcommands). `/config` is now documented as the single Web UI launcher. User-facing commands (`/ping`, `/voicestats`, `/seen`, `/quote`, `/achievements`, `/amikool`, `/help`) and the voice channel control panel are unchanged. Added a Web UI page → legacy slash command mapping table.
- **`SETTINGS.md`** — DB-backed settings are now described as Web UI-edited; legacy `/config set` examples removed. Added a `WEBUI_*` bootstrap env-var section pointing at WEBUI.md, with a note that those vars are read-only on the Bootstrap page.
- **`README.md`** — quick start rewritten around `WEBUI_ENABLED=true` and the `/config` magic-link launcher; docker-compose snippets updated; backup/restore now uses Web UI Export/Import for settings plus `mongodump` for data.
- **`DEVELOPER_GUIDE.md`** — added `src/web/` architecture section, the "no business logic outside services" rule, magic-link auth flow, CSRF/rate-limit patterns, refreshed feature-development checklist.
- **`QUICK_START_VISUAL.md`** — refreshed ASCII flows and architecture diagram to include the Web UI and the magic-link sequence.
- **`DOCS_SUMMARY.md`, `TROUBLESHOOTING.md`, `SECURITY.md`** — aligned with the Web UI as the only admin surface; added a Web UI troubleshooting section that links to WEBUI.md.
- **`.env.example`** — added the `WEBUI_*` env vars with comments and an `openssl rand` hint.
- **`docker-compose.yml`** — added inline comments for the three port-exposure options (direct publish, localhost-only, Caddy reverse proxy via WEBUI.md).
- **`docker-compose.dev.yml`** — publishes port 3000 for dev so the Web UI is reachable on `http://localhost:3000`.

## Acceptance criteria from #387

- [x] A new operator can stand up the bot and reach the WebUI using only README + WEBUI.md.
- [x] Every removed slash command is gone from `COMMANDS.md`.
- [x] No doc still references `/config set` / `/permissions add` / etc. as the way to do something (the only mentions left are historical mapping tables describing what the Web UI replaces, plus untouched entries in `RELEASE_NOTES.md` / `CHANGELOG.md`).
- [x] New `WEBUI.md` covers magic-link flow + diagram, env-vs-DB boundary with the bootstrap env-var list, reverse-proxy guidance (Caddy as the recommended easy path; not bundled), public-internet caveats, DM-closed fallback.
- [x] `SETTINGS.md` notes DB-backed settings are Web UI-edited; bootstrap env vars are read-only.
- [x] `README.md` quick-start mentions `WEBUI_ENABLED` and the magic-link launcher.
- [x] `DEVELOPER_GUIDE.md` documents `src/web/` and the "no business logic outside services" rule.
- [x] `QUICK_START_VISUAL.md` updated for the new flow.

## Test plan

- [ ] Skim `WEBUI.md` end-to-end and confirm the recipes match the current `src/index.ts` mount and `src/web/index.ts` env-var requirements.
- [ ] Confirm `README.md` quick-start steps stand on their own without needing the old `/config set ...` flow.
- [ ] Verify `COMMANDS.md` no longer documents any removed slash command as if it still exists.
- [ ] Spot-check `SETTINGS.md` against `src/services/config-schema.ts` defaults.
- [ ] Confirm Caddy recipe in `WEBUI.md` matches what `WEBUI_TRUST_PROXY` actually does in `src/index.ts`.

https://claude.ai/code/session_01PiRA4Yd1cN2bBZTJMD8Uw1


---
_Generated by [Claude Code](https://claude.ai/code/session_01PiRA4Yd1cN2bBZTJMD8Uw1)_