### PR TITLE
security(docker): run production container as non-root node user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,19 +21,22 @@ FROM node:22-alpine
 WORKDIR /app
 
 # Copy only necessary files from builder
-COPY --from=builder /app/package*.json ./
-COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder --chown=node:node /app/package*.json ./
+COPY --from=builder --chown=node:node /app/dist ./dist
+COPY --from=builder --chown=node:node /app/node_modules ./node_modules
 
 # Copy migration scripts for production use
-COPY --from=builder /app/src/scripts ./src/scripts
-COPY --from=builder /app/src/loader.js ./src/loader.js
+COPY --from=builder --chown=node:node /app/src/scripts ./src/scripts
+COPY --from=builder --chown=node:node /app/src/loader.js ./src/loader.js
 
 # Set environment variables
 ENV NODE_ENV=production
 
 # Expose health check port
 EXPOSE 3000
+
+# Drop root privileges — run as the built-in node user (uid 1000)
+USER node
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \


### PR DESCRIPTION
Closes #409.

## Summary

Running the production container as `root` violates least-privilege: any RCE in the bot, Discord.js, Express, or a transitive dep would land with root inside the container, making escape easier. Container security scanners (Trivy, Snyk, Docker Scout) flag this.

## Change

In the **production stage** of `Dockerfile`:

- Add `--chown=node:node` to every `COPY --from=builder ...` instruction so `/app` and its contents are owned by the built-in `node` user (uid 1000, already present in `node:22-alpine`).
- Add `USER node` before the `HEALTHCHECK` / `CMD` so the container drops root before running `npm start`.

The builder stage is left as root — it only runs `npm install` + `tsc` and is discarded.

`Dockerfile.dev` is intentionally untouched: dev compose bind-mounts the host workspace, which would create uid-mismatch friction.

## Test plan

- [ ] `docker build -t koolbot-test .` succeeds.
- [ ] `docker run --rm koolbot-test id` reports `uid=1000(node)`.
- [ ] Container starts cleanly with the production env and the `/health` endpoint responds (healthcheck passes).
- [ ] `trivy image koolbot-test` (or `docker scout cves`) no longer reports "running as root".

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGuTzTho9SpvpniJnb9MGp)_