### PR TITLE
security: stop publishing MongoDB port 27017 in production compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,14 +426,16 @@ If you need host-side access for `mongosh`, Compass, or backups from
 the host, bind to localhost only — never `0.0.0.0`:
 
 ```yaml
-mongodb:
-  # ...
-  ports:
-    - "127.0.0.1:27017:27017"
+services:
+  mongodb:
+    # ...
+    ports:
+      - "127.0.0.1:27017:27017"
 ```
 
 For backups and exec'd-in tools, you don't need to publish at all —
-`docker compose exec mongodb mongodump …` runs inside the container.
+`docker compose exec mongodb mongodump <args>` runs inside the
+container.
 
 `docker-compose.dev.yml` does publish 27017 (bound to 127.0.0.1) for
 developer convenience. Do not use the dev compose file in production.

--- a/README.md
+++ b/README.md
@@ -413,6 +413,31 @@ else:
 
 After changing the compose file, run `docker compose up -d --force-recreate`.
 
+### MongoDB exposure
+
+The production `docker-compose.yml` deliberately does **not** publish
+MongoDB's port 27017 to the host — the bot reaches MongoDB over the
+internal Docker network at `mongodb:27017`. The default `mongo` image
+ships with no authentication, so publishing 27017 would mean any
+process on the host (and, on hosts with no firewall, anyone on the
+public internet) could read and write the bot's entire database.
+
+If you need host-side access for `mongosh`, Compass, or backups from
+the host, bind to localhost only — never `0.0.0.0`:
+
+```yaml
+mongodb:
+  # ...
+  ports:
+    - "127.0.0.1:27017:27017"
+```
+
+For backups and exec'd-in tools, you don't need to publish at all —
+`docker compose exec mongodb mongodump …` runs inside the container.
+
+`docker-compose.dev.yml` does publish 27017 (bound to 127.0.0.1) for
+developer convenience. Do not use the dev compose file in production.
+
 ### Development mode
 
 For local development with hot reloading:

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -117,15 +117,26 @@ docker compose logs -f bot
 
 3. **Port conflicts:**
 
+   The production `docker-compose.yml` does not publish MongoDB's port
+   27017 to the host (the bot reaches it on the internal Docker
+   network), so port-27017 conflicts only apply if you've added a
+   publish yourself or you're using `docker-compose.dev.yml`.
+
    ```bash
-   # Check if port 27017 is in use
+   # Check if port 27017 is in use on the host
    netstat -an | grep 27017
 
-   # Or use a different port on the host
-   # In docker-compose.yml: "27018:27017"
-   # In .env (for bot container): MONGODB_URI=mongodb://mongodb:27017/koolbot
-   # Note: The host port (27018) only affects connections from your host machine.
-   #       Containers still connect to MongoDB on its internal port 27017.
+   # If you've added a host publish for debugging, bind it to localhost
+   # only and pick a free host port — never bind 0.0.0.0:
+   # In docker-compose.yml (or the dev file):
+   #   ports:
+   #     - "127.0.0.1:27018:27017"
+   # In .env (the bot container always connects internally):
+   #   MONGODB_URI=mongodb://mongodb:27017/koolbot
+   # The host port only affects connections from your host machine;
+   # containers still talk to MongoDB on its internal port 27017.
+   # Exposing 27017 to 0.0.0.0 with the default mongo image (no auth)
+   # makes the database world-readable — don't do it.
    ```
 
 ### "docker compose: command not found"

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -136,7 +136,8 @@ docker compose logs -f bot
    # The host port only affects connections from your host machine;
    # containers still talk to MongoDB on its internal port 27017.
    # Exposing 27017 to 0.0.0.0 with the default mongo image (no auth)
-   # makes the database world-readable — don't do it.
+   # makes the database publicly accessible for both reads and writes
+   # — don't do it.
    ```
 
 ### "docker compose: command not found"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -28,11 +28,13 @@ services:
     volumes:
       - mongodb_data_dev:/data/db
     # ⚠️ DEV ONLY — publishes MongoDB to the host so you can connect with
-    # Compass / mongosh from your workstation. The default mongo image has
-    # NO authentication, so this is effectively an open database for
-    # anyone who can reach this host. Do NOT use docker-compose.dev.yml in
-    # production. The production docker-compose.yml deliberately does not
-    # publish 27017.
+    # Compass / mongosh from your workstation. The bind below is
+    # localhost-only (127.0.0.1), so it's reachable from the host itself
+    # but not from the LAN or the public internet. The default mongo
+    # image has NO authentication, so anyone with local access to the
+    # host can still read and write the entire database. Do NOT use
+    # docker-compose.dev.yml in production. The production
+    # docker-compose.yml deliberately does not publish 27017.
     ports:
       - "127.0.0.1:27017:27017"
     networks:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -27,8 +27,14 @@ services:
     restart: unless-stopped
     volumes:
       - mongodb_data_dev:/data/db
+    # ⚠️ DEV ONLY — publishes MongoDB to the host so you can connect with
+    # Compass / mongosh from your workstation. The default mongo image has
+    # NO authentication, so this is effectively an open database for
+    # anyone who can reach this host. Do NOT use docker-compose.dev.yml in
+    # production. The production docker-compose.yml deliberately does not
+    # publish 27017.
     ports:
-      - "27017:27017"
+      - "127.0.0.1:27017:27017"
     networks:
       - koolbot-network
     stop_grace_period: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,14 +25,16 @@ services:
     restart: unless-stopped
     volumes:
       - mongodb_data:/data/db
-    # ⚠️ The default mongo image has NO authentication. This publish makes
-    # MongoDB reachable on the host's port 27017. If your host is on the
-    # public internet, restrict the bind to localhost only:
-    #   - "127.0.0.1:27017:27017"
-    # or remove the publish entirely (the bot reaches it over the internal
-    # Docker network at mongodb:27017 either way).
-    ports:
-      - "27017:27017"
+    # MongoDB is NOT published to the host. The bot reaches it over the
+    # internal Docker network at mongodb:27017. The default mongo image
+    # ships with NO authentication, so exposing 27017 to the host (and
+    # potentially the public internet) would mean an unauthenticated
+    # database open to anyone who can reach the host.
+    #
+    # If you need host-side access for debugging, add a localhost-only
+    # publish — never bind 0.0.0.0:
+    #   ports:
+    #     - "127.0.0.1:27017:27017"
     stop_grace_period: 30s
     stop_signal: SIGTERM
 


### PR DESCRIPTION
## Summary

Closes #408.

The default `mongo:latest` image ships with **no authentication**, so the
`27017:27017` publish in `docker-compose.yml` exposed an unauthenticated
database to anything that could reach the host — on cloud VMs without a
host-level firewall, that's the public internet. The bot already talks
to MongoDB over the internal Docker network at `mongodb:27017`, so the
host publish was unnecessary.

## Changes

- **`docker-compose.yml`** — removed the `ports: - "27017:27017"`
  binding. Replaced with a comment explaining why and a
  localhost-only snippet (`127.0.0.1:27017:27017`) for users who
  genuinely need host-side access for debugging.
- **`docker-compose.dev.yml`** — tightened the dev binding from
  `0.0.0.0` to `127.0.0.1` and added a prominent warning that the
  dev compose file must not be used in production.
- **`README.md`** — new "MongoDB exposure" subsection under the
  "Exposing the Web UI" section, explaining the default, how to add
  a localhost-only publish if needed, and that `docker compose exec
  mongodb …` works without any publish at all.
- **`TROUBLESHOOTING.md`** — updated the port-conflict troubleshooting
  block so it matches the new default (no host publish) and steers
  readers toward `127.0.0.1` if they add one.

## Acceptance criteria

- [x] Production `docker-compose.yml` no longer binds port 27017 to
      `0.0.0.0`.
- [x] `docker-compose.dev.yml` retains a port binding for dev (now
      bound to `127.0.0.1` only) and has a comment warning against
      production use.
- [x] `README.md` / `TROUBLESHOOTING.md` note that MongoDB should not
      be publicly accessible.

## Test plan

- [ ] `docker compose up -d` brings up bot + mongodb; bot connects to
      MongoDB on the internal network.
- [ ] `ss -tlnp | grep 27017` on the host shows no listener after
      `docker compose up -d` against the production file.
- [ ] `docker compose -f docker-compose.dev.yml up -d` exposes 27017
      on `127.0.0.1` only — verify with `ss -tlnp | grep 27017`
      (should show `127.0.0.1:27017`, not `0.0.0.0:27017`).
- [ ] `docker compose exec mongodb mongosh` still works for ops tasks
      without any host publish.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ri1pE912pYsyVg745e6w6g)_