### PR TITLE
fix(config): log /config invocations and web-session redeem outcomes

### DIFF
--- a/__tests__/services/web-session-service.test.ts
+++ b/__tests__/services/web-session-service.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@jest/globals";
 import { WebSessionService } from "../../src/services/web-session-service.js";
 import { WebSession } from "../../src/models/web-session.js";
+import logger from "../../src/utils/logger.js";
 
 jest.mock("../../src/models/web-session.js");
 jest.mock("../../src/utils/logger.js");
@@ -125,5 +126,105 @@ describe("WebSessionService", () => {
     const svc = WebSessionService.getInstance();
     expect(await svc.revokeSession("")).toBe(false);
     expect(updateOne).not.toHaveBeenCalled();
+  });
+
+  describe("redeem failure classification", () => {
+    let infoMock: jest.Mock;
+
+    beforeEach(() => {
+      // ts-jest's ESM auto-mock for the logger module produces a default
+      // export whose method shape isn't a jest.fn() we can introspect, so
+      // patch `info` directly with a known mock for these assertions.
+      infoMock = jest.fn();
+      (logger as unknown as { info: unknown }).info = infoMock;
+    });
+
+    function mockClassifierState(existing: unknown): void {
+      (
+        WebSession as unknown as { findOneAndUpdate: unknown }
+      ).findOneAndUpdate = jest.fn().mockResolvedValue(null);
+      (WebSession as unknown as { findOne: unknown }).findOne = jest
+        .fn()
+        .mockResolvedValue(existing);
+    }
+
+    function reasonsLogged(): string[] {
+      return infoMock.mock.calls.map((c) => String(c[0]));
+    }
+
+    it("logs 'not_found' when no row matches the tokenHash", async () => {
+      mockClassifierState(null);
+      const svc = WebSessionService.getInstance();
+      expect(await svc.redeem("anything")).toBeNull();
+      expect(reasonsLogged()).toEqual(
+        expect.arrayContaining([expect.stringContaining("not_found")]),
+      );
+    });
+
+    it("logs 'revoked' when revokedAt is set (takes precedence over used/expired)", async () => {
+      mockClassifierState({
+        revokedAt: new Date(),
+        usedAt: new Date(),
+        expiresAt: new Date(Date.now() - 1000),
+      });
+      const svc = WebSessionService.getInstance();
+      expect(await svc.redeem("anything")).toBeNull();
+      expect(reasonsLogged()).toEqual(
+        expect.arrayContaining([expect.stringContaining("revoked")]),
+      );
+    });
+
+    it("logs 'already_used' when usedAt is set and not revoked", async () => {
+      mockClassifierState({
+        revokedAt: null,
+        usedAt: new Date(),
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+      const svc = WebSessionService.getInstance();
+      expect(await svc.redeem("anything")).toBeNull();
+      expect(reasonsLogged()).toEqual(
+        expect.arrayContaining([expect.stringContaining("already_used")]),
+      );
+    });
+
+    it("logs 'expired' when expiresAt is in the past, not used or revoked", async () => {
+      mockClassifierState({
+        revokedAt: null,
+        usedAt: null,
+        expiresAt: new Date(Date.now() - 1000),
+      });
+      const svc = WebSessionService.getInstance();
+      expect(await svc.redeem("anything")).toBeNull();
+      expect(reasonsLogged()).toEqual(
+        expect.arrayContaining([expect.stringContaining("expired")]),
+      );
+    });
+
+    it("logs 'unknown' when the row is otherwise live (lookup raced with state change)", async () => {
+      mockClassifierState({
+        revokedAt: null,
+        usedAt: null,
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+      const svc = WebSessionService.getInstance();
+      expect(await svc.redeem("anything")).toBeNull();
+      expect(reasonsLogged()).toEqual(
+        expect.arrayContaining([expect.stringContaining("unknown")]),
+      );
+    });
+
+    it("collapses to 'unknown' if the diagnostic findOne throws", async () => {
+      (
+        WebSession as unknown as { findOneAndUpdate: unknown }
+      ).findOneAndUpdate = jest.fn().mockResolvedValue(null);
+      (WebSession as unknown as { findOne: unknown }).findOne = jest
+        .fn()
+        .mockRejectedValue(new Error("mongo down"));
+      const svc = WebSessionService.getInstance();
+      expect(await svc.redeem("anything")).toBeNull();
+      expect(reasonsLogged()).toEqual(
+        expect.arrayContaining([expect.stringContaining("unknown")]),
+      );
+    });
   });
 });

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -17,9 +17,7 @@ export async function execute(
 ): Promise<void> {
   const userId = interaction.user.id;
   const guildId = interaction.guildId;
-  logger.info(
-    `/config invoked by user=${userId} guild=${guildId ?? "<none>"}`,
-  );
+  logger.info(`/config invoked by user=${userId} guild=${guildId ?? "<none>"}`);
 
   // Defer immediately so the DB revoke/create + DM round-trip can't blow
   // Discord's 3-second interaction-ack deadline.
@@ -89,10 +87,7 @@ export async function execute(
       });
     }
   } catch (error) {
-    logger.error(
-      `Error issuing web sign-in link for user=${userId}:`,
-      error,
-    );
+    logger.error(`Error issuing web sign-in link for user=${userId}:`, error);
     await interaction.editReply({
       content: "An error occurred while issuing your sign-in link.",
     });

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -15,11 +15,20 @@ export const data = new SlashCommandBuilder()
 export async function execute(
   interaction: ChatInputCommandInteraction,
 ): Promise<void> {
+  const userId = interaction.user.id;
+  const guildId = interaction.guildId;
+  logger.info(
+    `/config invoked by user=${userId} guild=${guildId ?? "<none>"}`,
+  );
+
   // Defer immediately so the DB revoke/create + DM round-trip can't blow
   // Discord's 3-second interaction-ack deadline.
   await interaction.deferReply({ ephemeral: true });
 
   if (!isWebUIEnabled()) {
+    logger.info(
+      `/config rejected for user=${userId}: WebUI disabled (WEBUI_ENABLED!=true)`,
+    );
     await interaction.editReply({
       content:
         "The web UI is disabled. Ask an operator to set `WEBUI_ENABLED=true` and restart the bot.",
@@ -29,13 +38,17 @@ export async function execute(
 
   const missing = getMissingWebUIEnvVars();
   if (missing.length > 0) {
+    logger.warn(
+      `/config rejected for user=${userId}: missing env vars: ${missing.join(", ")}`,
+    );
     await interaction.editReply({
       content: `❌ Web UI is enabled but missing env vars: ${missing.join(", ")}`,
     });
     return;
   }
 
-  if (!interaction.guildId) {
+  if (!guildId) {
+    logger.info(`/config rejected for user=${userId}: not invoked in a guild`);
     await interaction.editReply({
       content: "This command must be run inside a guild.",
     });
@@ -44,8 +57,8 @@ export async function execute(
 
   try {
     const session = await WebSessionService.getInstance().create(
-      interaction.user.id,
-      interaction.guildId,
+      userId,
+      guildId,
     );
     const ttlMinutes = Math.max(
       1,
@@ -59,13 +72,16 @@ export async function execute(
 
     try {
       await interaction.user.send(dmBody);
+      logger.info(
+        `/config: sign-in link DMed to user=${userId} (expires ${session.expiresAt.toISOString()})`,
+      );
       await interaction.editReply({
         content:
           "✅ I've DMed you a single-use sign-in link. Check your direct messages.",
       });
     } catch (dmError) {
       logger.warn(
-        `Could not DM web sign-in link to ${interaction.user.id}; falling back to ephemeral reply`,
+        `Could not DM web sign-in link to ${userId}; falling back to ephemeral reply`,
         dmError,
       );
       await interaction.editReply({
@@ -73,7 +89,10 @@ export async function execute(
       });
     }
   } catch (error) {
-    logger.error("Error issuing web sign-in link:", error);
+    logger.error(
+      `Error issuing web sign-in link for user=${userId}:`,
+      error,
+    );
     await interaction.editReply({
       content: "An error occurred while issuing your sign-in link.",
     });

--- a/src/services/web-session-service.ts
+++ b/src/services/web-session-service.ts
@@ -86,6 +86,10 @@ export class WebSessionService {
       revokedAt: null,
     });
 
+    logger.info(
+      `Web session created for user=${discordUserId} guild=${guildId} expires=${expiresAt.toISOString()}`,
+    );
+
     const url = `${this.getBaseUrl()}/admin/s/${token}`;
     return { token, url, expiresAt };
   }
@@ -95,7 +99,10 @@ export class WebSessionService {
    * already used, expired, or revoked. Marks the session used on success.
    */
   public async redeem(token: string): Promise<RedeemedSession | null> {
-    if (!token) return null;
+    if (!token) {
+      logger.info("Web session redeem rejected: empty token");
+      return null;
+    }
     let tokenHash: string;
     try {
       tokenHash = this.hashToken(token);
@@ -116,7 +123,15 @@ export class WebSessionService {
       { new: true },
     );
 
-    if (!session) return null;
+    if (!session) {
+      const reason = await this.classifyRedeemFailure(tokenHash, now);
+      logger.info(`Web session redeem rejected: ${reason}`);
+      return null;
+    }
+
+    logger.info(
+      `Web session redeemed for user=${session.discordUserId} guild=${session.guildId} session=${String(session._id)}`,
+    );
 
     return {
       sessionId: String(session._id),
@@ -124,6 +139,27 @@ export class WebSessionService {
       guildId: session.guildId,
       scopes: session.scopes,
     };
+  }
+
+  /**
+   * Diagnose why a redeem() lookup missed: token not found, already used,
+   * expired, revoked, or a more obscure state. Best-effort — any error
+   * collapses to "unknown" so a logging path never breaks the request.
+   */
+  private async classifyRedeemFailure(
+    tokenHash: string,
+    now: Date,
+  ): Promise<string> {
+    try {
+      const existing = await WebSession.findOne({ tokenHash });
+      if (!existing) return "not_found";
+      if (existing.revokedAt) return "revoked";
+      if (existing.usedAt) return "already_used";
+      if (existing.expiresAt <= now) return "expired";
+      return "unknown";
+    } catch {
+      return "unknown";
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Admins running `/config` produced **zero** log entries: the command's happy path had no `logger.info` calls, and the `/admin/s/:token` redeem path silently returned 404 with `renderInvalidLink()` regardless of which check rejected the token. Operators could not tell from logs whether the request even reached the bot, let alone why the link was rejected.

- `src/commands/config.ts` — log invocations with user and guild, plus a reason on every early-rejection branch (WebUI disabled, missing env vars, not in a guild), and log a confirmation when the DM is sent.
- `src/services/web-session-service.ts` — log session creation in `create()` (user, guild, expiry); log successful redemption in `redeem()`; on failed redemption, run a follow-up `findOne` to classify the reason (`not_found` / `already_used` / `expired` / `revoked` / `unknown`) and emit it at info level.

The classifier is best-effort and wrapped in `try/catch` so a logging path can never break a redeem request.

## Test plan

- [x] `npm test` — 716 passed, 1 skipped, 0 failed (existing `redeem returns null` test now also exercises the new classifier path via auto-mocked `findOne`, producing `Web session redeem rejected: not_found`).
- [x] `npm run lint` — 0 errors (107 pre-existing warnings unchanged).
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: redeploy on test server, run `/config`, expect log lines:
  - `/config invoked by user=… guild=…`
  - `Web session created for user=… guild=… expires=…`
  - `/config: sign-in link DMed to user=… (expires …)`
- [ ] Manual: click the link a second time (or after expiry) and expect `Web session redeem rejected: already_used` / `expired` in logs while the user still sees the existing "invalid or expired" page.


---
_Generated by [Claude Code](https://claude.ai/code/session_0172FyeqTEg2beBJPrig8rRX)_