### PR TITLE
fix(config): consent screen on magic-link redeem so unfurlers don't burn tokens

### DIFF
--- a/__tests__/services/web-session-service.test.ts
+++ b/__tests__/services/web-session-service.test.ts
@@ -227,4 +227,113 @@ describe("WebSessionService", () => {
       );
     });
   });
+
+  describe("peek (validate without consuming)", () => {
+    let infoMock: jest.Mock;
+
+    beforeEach(() => {
+      infoMock = jest.fn();
+      (logger as unknown as { info: unknown }).info = infoMock;
+    });
+
+    function mockFindOne(existing: unknown): jest.Mock {
+      const fn = jest.fn().mockResolvedValue(existing);
+      (WebSession as unknown as { findOne: unknown }).findOne = fn;
+      // No findOneAndUpdate stub — peek must not call it.
+      (WebSession as unknown as { findOneAndUpdate: unknown }).findOneAndUpdate =
+        jest.fn(() => {
+          throw new Error("peek() must not consume the token");
+        });
+      return fn;
+    }
+
+    it("returns session context without marking the token used", async () => {
+      const findOne = mockFindOne({
+        _id: { toString: () => "session-id" },
+        discordUserId: "user-1",
+        guildId: "guild-1",
+        scopes: ["scope:a"],
+        usedAt: null,
+        revokedAt: null,
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+      const svc = WebSessionService.getInstance();
+      const result = await svc.peek("any-token");
+      expect(result).toEqual({
+        sessionId: "session-id",
+        discordUserId: "user-1",
+        guildId: "guild-1",
+        scopes: ["scope:a"],
+      });
+      expect(findOne).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns null and logs 'empty token' for an empty token", async () => {
+      const svc = WebSessionService.getInstance();
+      expect(await svc.peek("")).toBeNull();
+      expect(infoMock).toHaveBeenCalledWith(
+        expect.stringContaining("empty token"),
+      );
+    });
+
+    it("returns null and logs 'not_found' when no row matches", async () => {
+      mockFindOne(null);
+      const svc = WebSessionService.getInstance();
+      expect(await svc.peek("anything")).toBeNull();
+      expect(infoMock).toHaveBeenCalledWith(
+        expect.stringContaining("not_found"),
+      );
+    });
+
+    it("returns null and logs 'revoked' when revokedAt is set", async () => {
+      mockFindOne({
+        _id: { toString: () => "x" },
+        discordUserId: "u",
+        guildId: "g",
+        scopes: [],
+        usedAt: null,
+        revokedAt: new Date(),
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+      const svc = WebSessionService.getInstance();
+      expect(await svc.peek("anything")).toBeNull();
+      expect(infoMock).toHaveBeenCalledWith(
+        expect.stringContaining("revoked"),
+      );
+    });
+
+    it("returns null and logs 'already_used' when usedAt is set", async () => {
+      mockFindOne({
+        _id: { toString: () => "x" },
+        discordUserId: "u",
+        guildId: "g",
+        scopes: [],
+        usedAt: new Date(),
+        revokedAt: null,
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+      const svc = WebSessionService.getInstance();
+      expect(await svc.peek("anything")).toBeNull();
+      expect(infoMock).toHaveBeenCalledWith(
+        expect.stringContaining("already_used"),
+      );
+    });
+
+    it("returns null and logs 'expired' when expiresAt is in the past", async () => {
+      mockFindOne({
+        _id: { toString: () => "x" },
+        discordUserId: "u",
+        guildId: "g",
+        scopes: [],
+        usedAt: null,
+        revokedAt: null,
+        expiresAt: new Date(Date.now() - 1000),
+      });
+      const svc = WebSessionService.getInstance();
+      expect(await svc.peek("anything")).toBeNull();
+      expect(infoMock).toHaveBeenCalledWith(
+        expect.stringContaining("expired"),
+      );
+    });
+  });
 });

--- a/src/services/web-session-service.ts
+++ b/src/services/web-session-service.ts
@@ -142,6 +142,60 @@ export class WebSessionService {
   }
 
   /**
+   * Validate a magic-link token *without* consuming it. Returns the same
+   * shape as redeem() on success. Used by the consent screen so that
+   * server-side link previewers (Discordbot, Slackbot, etc.) doing a GET
+   * on the magic link don't burn the single-use token before the admin
+   * has a chance to click "Continue".
+   */
+  public async peek(token: string): Promise<RedeemedSession | null> {
+    if (!token) {
+      logger.info("Web session peek rejected: empty token");
+      return null;
+    }
+    let tokenHash: string;
+    try {
+      tokenHash = this.hashToken(token);
+    } catch (err) {
+      logger.error("Failed to hash token for peek", err);
+      return null;
+    }
+
+    const now = new Date();
+    let existing: IWebSession | null;
+    try {
+      existing = await WebSession.findOne({ tokenHash });
+    } catch (err) {
+      logger.error("Failed to look up session for peek", err);
+      return null;
+    }
+
+    if (!existing) {
+      logger.info("Web session peek rejected: not_found");
+      return null;
+    }
+    if (existing.revokedAt) {
+      logger.info("Web session peek rejected: revoked");
+      return null;
+    }
+    if (existing.usedAt) {
+      logger.info("Web session peek rejected: already_used");
+      return null;
+    }
+    if (existing.expiresAt <= now) {
+      logger.info("Web session peek rejected: expired");
+      return null;
+    }
+
+    return {
+      sessionId: String(existing._id),
+      discordUserId: existing.discordUserId,
+      guildId: existing.guildId,
+      scopes: existing.scopes,
+    };
+  }
+
+  /**
    * Diagnose why a redeem() lookup missed: token not found, already used,
    * expired, revoked, or a more obscure state. Best-effort — any error
    * collapses to "unknown" so a logging path never breaks the request.

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -10,7 +10,7 @@ import {
   createSessionMiddleware,
   writeSessionCookie,
 } from "./session.js";
-import { renderInvalidLink, renderSignedOut } from "./views.js";
+import { renderConsent, renderInvalidLink, renderSignedOut } from "./views.js";
 import { createReadOnlyRouter } from "./read-only-routes.js";
 import { createWriteRouter } from "./write-routes.js";
 
@@ -43,9 +43,40 @@ export function createWebRouter(client: Client): Router {
 
   const requireSession = createSessionMiddleware(client);
 
+  // GET only validates the token (peek) so server-side link previewers
+  // like Discordbot/Slackbot can't burn the single-use token before the
+  // admin clicks. The actual consume happens on POST below.
   router.get(
     "/s/:token",
     redeemLimiter,
+    async (req: Request, res: Response): Promise<void> => {
+      try {
+        const token = String(req.params.token || "");
+        const peeked = await sessionService.peek(token);
+        if (!peeked) {
+          res.status(404).type("text/html").send(renderInvalidLink());
+          return;
+        }
+        const csrfToken =
+          (req as Request & { csrfToken?: string }).csrfToken || "";
+        res
+          .status(200)
+          .type("text/html")
+          .send(renderConsent({ token, csrfToken }));
+      } catch (err) {
+        logger.error("Error peeking web session token", err);
+        res.status(500).type("text/plain").send("Internal Server Error");
+      }
+    },
+  );
+
+  // POST consumes the token, marks it used, writes the session cookie,
+  // and redirects into the admin app. Requires the CSRF cookie set by
+  // ensureCsrfCookie on the preceding GET.
+  router.post(
+    "/s/:token",
+    redeemLimiter,
+    requireCsrf,
     async (req: Request, res: Response): Promise<void> => {
       try {
         const token = String(req.params.token || "");

--- a/src/web/views.ts
+++ b/src/web/views.ts
@@ -87,6 +87,22 @@ export function renderSignedOut(): string {
   );
 }
 
+export function renderConsent(opts: {
+  token: string;
+  csrfToken: string;
+}): string {
+  const action = `/admin/s/${encodeURIComponent(opts.token)}`;
+  const body = [
+    "<h1>Sign in to Koolbot Admin</h1>",
+    "<p>Click <strong>Continue</strong> to start your admin session in this browser. Your single-use sign-in link will be consumed when you do.</p>",
+    `<form method="POST" action="${escapeHtml(action)}">`,
+    `<input type="hidden" name="_csrf" value="${escapeHtml(opts.csrfToken)}">`,
+    '<button type="submit">Continue</button>',
+    "</form>",
+  ].join("");
+  return pageShell("Sign in", body);
+}
+
 export function renderInvalidLink(): string {
   return pageShell(
     "Invalid link",


### PR DESCRIPTION
## Summary

After #429 shipped the diagnostic logging, real-world logs proved the original "link invalid or expired" report was caused by **Discord's link unfurler burning the single-use token before the admin clicked**:

```
08:29:56.914  /config: sign-in link DMed
08:29:57.089  Web session redeemed for user=… session=6a0c1f84…   ← Discordbot/2.0
08:30:01.378  Web session redeem rejected: already_used            ← admin's real click
```

The fix follows the standard OAuth pattern: don't consume the token on a server-side GET. The magic-link URL now serves a tiny consent page; the actual consume happens on a CSRF-protected POST when the admin clicks **Continue**. Unfurlers do GETs only and don't follow forms, so the token survives any number of preview fetches.

### Changes

- `src/services/web-session-service.ts` — new `peek(token)` method that validates without marking used. Same reason-classification logging as `redeem()` (`not_found` / `revoked` / `already_used` / `expired`), so failure modes stay observable.
- `src/web/index.ts` — split `/admin/s/:token`:
  - `GET` → peek + render consent page (no DB write).
  - `POST` → existing `redeem()` + write session cookie + 302 to `/admin/`. Protected by `requireCsrf` (double-submit cookie is set by `ensureCsrfCookie` on the preceding GET).
- `src/web/views.ts` — `renderConsent({ token, csrfToken })`, minimal form with a hidden `_csrf` field.
- Tests — 6 new tests for `peek()`: happy path (asserts `findOneAndUpdate` is not called) and each rejection reason.

### Why this is safe

- **No new attack surface.** Token still consumable exactly once. Previously an attacker who could trigger a single GET on the URL could burn it; now they need CSRF token + form POST, which the double-submit cookie already prevents.
- **No UX regression.** Admin clicks the DM link, sees a single "Continue" button, ends up on `/admin/` — one extra click but it survives unfurling.
- **Auto-revoke on `/config` re-run unchanged.** `create()` still calls `revokeForUser()` first, so reissuing a link still invalidates prior ones.

## Test plan

- [x] `npm test` — 728 passed, 1 skipped, 0 failed (6 new `peek()` tests).
- [x] `npm run lint` — 0 errors.
- [x] `npm run format:check` — clean.
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual on test server: run `/config`, expect logs to show `peek rejected: not_found`-style entries only from real botspeak, the original click renders the consent page, the **Continue** button lands the admin on `/admin/` with `Web session redeemed for user=…` in logs.
- [ ] Manual: rapid double-click the **Continue** button on the consent page — first POST should redirect, second should show "Invalid link" with `Web session redeem rejected: already_used` in logs (intended behavior).


---
_Generated by [Claude Code](https://claude.ai/code/session_0172FyeqTEg2beBJPrig8rRX)_