### PR TITLE
fix(config): set cookie Secure flag from WEBUI_BASE_URL scheme, not NODE_ENV

### DIFF
--- a/__tests__/web/csrf.test.ts
+++ b/__tests__/web/csrf.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import { shouldUseSecureCookies } from "../../src/web/csrf.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe("shouldUseSecureCookies", () => {
+  beforeEach(() => {
+    delete process.env.WEBUI_BASE_URL;
+    delete process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("returns true when WEBUI_BASE_URL is https", () => {
+    process.env.WEBUI_BASE_URL = "https://admin.example.com";
+    expect(shouldUseSecureCookies()).toBe(true);
+  });
+
+  it("returns false when WEBUI_BASE_URL is http (even in production)", () => {
+    process.env.WEBUI_BASE_URL = "http://192.168.1.10:3000";
+    process.env.NODE_ENV = "production";
+    expect(shouldUseSecureCookies()).toBe(false);
+  });
+
+  it("falls back to NODE_ENV=production when WEBUI_BASE_URL is missing", () => {
+    process.env.NODE_ENV = "production";
+    expect(shouldUseSecureCookies()).toBe(true);
+  });
+
+  it("falls back to false when WEBUI_BASE_URL is missing and NODE_ENV is not production", () => {
+    process.env.NODE_ENV = "development";
+    expect(shouldUseSecureCookies()).toBe(false);
+  });
+
+  it("falls back to NODE_ENV check on malformed WEBUI_BASE_URL", () => {
+    process.env.WEBUI_BASE_URL = "ws://not-a-real-scheme";
+    process.env.NODE_ENV = "production";
+    expect(shouldUseSecureCookies()).toBe(true);
+  });
+});

--- a/src/web/csrf.ts
+++ b/src/web/csrf.ts
@@ -63,6 +63,22 @@ export function requireCsrf(
   next();
 }
 
+/**
+ * Decide whether to set the `Secure` cookie attribute. We key off the
+ * configured access scheme (`WEBUI_BASE_URL`) rather than NODE_ENV
+ * because operators routinely run NODE_ENV=production while exposing
+ * the WebUI over plain HTTP (Docker on a LAN, behind a reverse proxy
+ * that terminates TLS without propagating X-Forwarded-Proto, etc.).
+ * Setting Secure on an HTTP request causes browsers to silently drop
+ * the cookie, which breaks the entire sign-in flow.
+ *
+ * If WEBUI_BASE_URL is missing or malformed we fall back to the
+ * NODE_ENV check so we don't silently disable Secure on a real HTTPS
+ * deployment that just forgot to set the variable.
+ */
 export function shouldUseSecureCookies(): boolean {
+  const baseUrl = process.env.WEBUI_BASE_URL ?? "";
+  if (baseUrl.startsWith("https://")) return true;
+  if (baseUrl.startsWith("http://")) return false;
   return process.env.NODE_ENV === "production";
 }


### PR DESCRIPTION
## Summary

Follow-up to #430 / #431. With #431 in, the consent-screen POST now succeeds, but the next hop fails:

```
09:18:59.919  Web session redeemed for user=…       ← POST consumed the token, cookie set
(browser follows 302 to /admin/)                    ← but Cookie header is empty
              → 401 Sign in required
```

Same underlying issue that caused the earlier `CSRF token missing`: the browser is silently dropping our cookies. Root cause is that `shouldUseSecureCookies()` was keying off `NODE_ENV=production`, but operators routinely run `NODE_ENV=production` while serving the WebUI over plain HTTP — Docker on a LAN, a reverse proxy that terminates TLS without propagating `X-Forwarded-Proto`, etc. Set-Cookie with `Secure` over HTTP → browser discards → no cookie on subsequent requests → 401.

### Fix

Derive the `Secure` flag from `WEBUI_BASE_URL` instead of `NODE_ENV`. The base URL is the actual transport admins use to reach the WebUI (it's the prefix of every magic link), so it's the right source of truth:

- `https://…` → `Secure` on (real HTTPS deployments stay strict).
- `http://…` → `Secure` off (cookies round-trip again).
- Missing/malformed → fall back to `NODE_ENV=production` so a misconfigured-but-real-HTTPS deployment doesn't silently downgrade.

This is purely scoped to the cookie attribute — nothing else changes about how cookies are signed, scoped (`Path=/admin`), or constrained (`HttpOnly`, `SameSite=Lax` unchanged).

### Why this is safe

- HTTPS deployments behave identically to before (`https://` base → `Secure` still set).
- HTTP deployments stop sending broken `Secure` cookies they couldn't use anyway. The cookie was always being dropped silently; setting `Secure=false` doesn't expose anything new because no real HTTPS layer existed to enforce it.
- `HttpOnly`, `SameSite=Lax`, signed session payload, and rate limiting are all unchanged. The session cookie is HMAC-signed (`signValue` / `verifySignedValue` in `src/web/cookies.ts:92-117`), so tamper resistance is unaffected.

### Changes

- `src/web/csrf.ts` — rewrite `shouldUseSecureCookies()` with documented rationale.
- `__tests__/web/csrf.test.ts` (new) — covers each branch: `https`, `http`, missing+prod, missing+dev, malformed scheme.

## Test plan

- [x] `npm test` — 733 passed, 1 skipped, 0 failed (5 new csrf tests).
- [x] `npm run lint` — 0 errors.
- [x] `npm run format:check` — clean.
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual on test server: with `WEBUI_BASE_URL=http://…`, run `/config` → click link → click **Continue** → expect to land on `/admin/` (not the 401 page).


---
_Generated by [Claude Code](https://claude.ai/code/session_0172FyeqTEg2beBJPrig8rRX)_