### PR TITLE
webui: setup wizard starts blank (closes #438)

### DIFF
--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -729,7 +729,7 @@ describe("renderImportDiffPage", () => {
 });
 
 describe("renderWizardPage", () => {
-  it("renders feature cards and reflects current enabled status", () => {
+  it("renders every feature checkbox unchecked regardless of current status", () => {
     const html = renderWizardPage({
       ...COMMON,
       featureOrder: ["voicechannels", "polls"],
@@ -737,11 +737,29 @@ describe("renderWizardPage", () => {
     });
     expect(html).toContain("Voice Channels");
     expect(html).toContain("Polls");
-    expect(html).toMatch(
+    // Neither checkbox should be pre-ticked, even though voicechannels is
+    // currently enabled. The wizard treats each run as a fresh declaration.
+    expect(html).not.toMatch(
       /value="voicechannels" id="feat-voicechannels" checked/,
     );
     expect(html).not.toMatch(/value="polls" id="feat-polls" checked/);
     expect(html).toContain('action="/admin/wizard/start"');
+  });
+
+  it('shows "currently ON/OFF" indicator next to each feature label', () => {
+    const html = renderWizardPage({
+      ...COMMON,
+      featureOrder: ["voicechannels", "polls"],
+      featureStatus: { voicechannels: true, polls: false },
+    });
+    // voicechannels is currently enabled → tag-on.
+    expect(html).toMatch(
+      /Voice Channels\s*<span class="fc-current">currently <span class="tag tag-on">ON<\/span><\/span>/,
+    );
+    // polls is currently disabled → tag-off.
+    expect(html).toMatch(
+      /Polls\s*<span class="fc-current">currently <span class="tag tag-off">OFF<\/span><\/span>/,
+    );
   });
 });
 

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -523,15 +523,21 @@ const WIZARD_FEATURE_LABELS: Record<string, { name: string; desc: string }> = {
 
 export function renderWizardPage(props: WizardPageProps): string {
   const csrf = escapeHtml(props.csrfToken);
+  // Checkboxes always render unchecked, regardless of `featureStatus`. The
+  // wizard treats each run as a fresh declaration of which features should be
+  // on — admins re-tick what they want, untick what they don't. `featureStatus`
+  // only feeds the "currently: ON/OFF" indicator so the admin can see what
+  // state they're about to override.
   const cards = props.featureOrder
     .map((fk) => {
       const info = WIZARD_FEATURE_LABELS[fk] ?? { name: fk, desc: "" };
-      const checked = props.featureStatus[fk] ? " checked" : "";
+      const currentlyOn = Boolean(props.featureStatus[fk]);
+      const indicator = `<span class="fc-current">currently ${tagOnOff(currentlyOn)}</span>`;
       const id = `feat-${fk}`;
       return `<div class="feature-card">
-  <input type="checkbox" name="features" value="${escapeHtml(fk)}" id="${escapeHtml(id)}"${checked}>
+  <input type="checkbox" name="features" value="${escapeHtml(fk)}" id="${escapeHtml(id)}">
   <div class="fc-info">
-    <label for="${escapeHtml(id)}" class="fc-name">${escapeHtml(info.name)}</label>
+    <label for="${escapeHtml(id)}" class="fc-name">${escapeHtml(info.name)} ${indicator}</label>
     <div class="fc-desc">${escapeHtml(info.desc)}</div>
   </div>
 </div>`;

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -986,6 +986,27 @@ export function createWriteRouter(
         return;
       }
 
+      // The wizard treats each run as a complete declaration of which
+      // features should be enabled. Anything the admin didn't tick on the
+      // landing page gets its `.enabled` flag explicitly set to false here,
+      // so re-running the wizard is the supported way to turn things off.
+      // Without this, unchecked features would silently retain their
+      // pre-existing enabled state.
+      const selectedSet = new Set(state.selectedFeatures);
+      for (const fk of WIZARD_FEATURE_ORDER) {
+        if (selectedSet.has(fk)) continue;
+        const enabledKey = (WIZARD_FEATURE_SETTINGS[fk] ?? []).find((k) =>
+          k.endsWith(".enabled"),
+        );
+        if (!enabledKey) continue;
+        wizard.addConfiguration(
+          session.discordUserId,
+          session.guildId,
+          enabledKey,
+          false,
+        );
+      }
+
       const pendingKeys = Object.keys(state.configuration);
       try {
         const applied = await wizard.applyConfiguration(


### PR DESCRIPTION
Closes #438.

## Summary

The wizard previously pre-checked each feature based on its current `<feature>.enabled` value (`src/web/write-routes.ts:828-836` populating `featureStatus`). Combined with several features defaulting to enabled in `defaultConfig`, a first-run admin lands in the wizard with most checkboxes already ticked — which defeats the wizard's purpose of *deciding* what to enable.

## Changes

### `src/web/admin-views.ts` — `renderWizardPage`

- Checkboxes always emit as **unchecked**, regardless of `featureStatus`.
- `featureStatus` still feeds a small **"currently ON/OFF"** indicator next to each feature name (uses the existing `tagOnOff` helper), so the admin sees what state they're about to override before ticking/unticking.

### `src/web/write-routes.ts` — `/wizard/apply`

The wizard now treats each run as a **complete declaration** of feature state. For every entry in `WIZARD_FEATURE_ORDER` that the admin did NOT tick, the corresponding `<feature>.enabled` key is appended to the pending configuration as `false` before `applyConfiguration` runs.

So:
- Tick voicechannels, tick polls, apply → both enabled, everything else explicitly disabled.
- Untick a previously-enabled feature on a subsequent run → that feature is disabled.

This matches the issue's stated semantic ("Saving the wizard *replaces* the prior feature-enabled state") and is the consistent counterpart to the unchecked-by-default UI.

### Tests

- The existing "reflects current enabled status" test was rewritten to assert the opposite — unchecked regardless of status.
- New test covers the "currently ON / OFF" indicator rendering, for both states.

## Verification

- [x] `npm test` — 734 passed, 1 skipped, 0 failed.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — 0 errors.
- [x] `npm run format:check` — clean.
- [ ] Manual: visit `/admin/wizard` on a deployment with several features currently enabled → all checkboxes unchecked, each feature row shows "currently ON" or "currently OFF" indicator.
- [ ] Manual: tick one feature, walk through the wizard, apply → that feature is enabled, every other wizard-tracked feature is disabled.

## Test plan

- [x] Unit: wizard page renders unchecked regardless of `featureStatus`.
- [x] Unit: wizard page renders "currently ON/OFF" indicator.
- [ ] Manual UI flow (above).


---
_Generated by [Claude Code](https://claude.ai/code/session_0172FyeqTEg2beBJPrig8rRX)_