### PR TITLE
webui: operator-friendly schedule editor for cron-typed settings (closes #444)

### DIFF
--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -1214,6 +1214,25 @@ describe("parseCronToPickerState", () => {
     const raw = "*/5 * * * MON-FRI";
     expect(parseCronToPickerState(raw).raw).toBe(raw);
   });
+
+  it("strips surrounding quotes before parsing, matching runtime services", () => {
+    // voice-channel-truncation, voice-channel-announcer, and
+    // scheduled-announcement-service all apply `.replace(/^["']|["']$/g, "")`
+    // before handing the cron to CronJob. The picker must agree, or a
+    // stored value like `"0 16 * * 5"` would round-trip as custom even
+    // though the bot itself treats it as the unquoted form.
+    expect(parseCronToPickerState('"0 16 * * 5"')).toMatchObject({
+      mode: "weekly",
+      minute: 0,
+      hour: 16,
+      dayOfWeek: 5,
+    });
+    expect(parseCronToPickerState("'0 0 * * *'")).toMatchObject({
+      mode: "daily",
+      minute: 0,
+      hour: 0,
+    });
+  });
 });
 
 describe("renderSettingsPage cron picker", () => {

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "@jest/globals";
 import {
+  parseCronToPickerState,
   renderAnnouncementsPage,
   renderBootstrapPage,
   renderDashboardPage,
@@ -481,33 +482,6 @@ describe("renderSettingsPage", () => {
     );
   });
 
-  it("falls back to a text input for cron-type settings (placeholder until #444)", () => {
-    const html = renderSettingsPage({
-      ...COMMON,
-      textChannels: [],
-      categoryChannels: [],
-      roles: [],
-      groups: [
-        {
-          category: "voicetracking",
-          rows: [
-            {
-              key: "voicetracking.announcements.schedule",
-              label: "Schedule",
-              current: "0 16 * * 5",
-              defaultValue: "0 16 * * 5",
-              type: "cron",
-              description: "",
-              category: "voicetracking",
-            },
-          ],
-        },
-      ],
-    });
-    expect(html).toMatch(
-      /<input type="text" name="value" value="0 16 \* \* 5"/,
-    );
-  });
 });
 
 describe("renderPermissionsPage", () => {
@@ -1171,5 +1145,145 @@ describe("renderWizardConfirmPage", () => {
     });
     expect(html).toMatch(/<button[^>]*disabled[^>]*>Apply<\/button>/);
     expect(html).toContain("No settings configured");
+  });
+});
+
+describe("parseCronToPickerState", () => {
+  it("recognises a daily schedule", () => {
+    expect(parseCronToPickerState("0 0 * * *")).toMatchObject({
+      mode: "daily",
+      minute: 0,
+      hour: 0,
+    });
+    expect(parseCronToPickerState("30 8 * * *")).toMatchObject({
+      mode: "daily",
+      minute: 30,
+      hour: 8,
+    });
+  });
+
+  it("recognises a weekly schedule and normalises Sunday-7 to Sunday-0", () => {
+    expect(parseCronToPickerState("0 16 * * 5")).toMatchObject({
+      mode: "weekly",
+      minute: 0,
+      hour: 16,
+      dayOfWeek: 5,
+    });
+    expect(parseCronToPickerState("0 0 * * 7")).toMatchObject({
+      mode: "weekly",
+      dayOfWeek: 0,
+    });
+  });
+
+  it("recognises a monthly schedule", () => {
+    expect(parseCronToPickerState("0 0 1 * *")).toMatchObject({
+      mode: "monthly",
+      minute: 0,
+      hour: 0,
+      dayOfMonth: 1,
+    });
+    expect(parseCronToPickerState("45 9 15 * *")).toMatchObject({
+      mode: "monthly",
+      minute: 45,
+      hour: 9,
+      dayOfMonth: 15,
+    });
+  });
+
+  it("falls back to custom for patterns the picker can't represent", () => {
+    // Step values, ranges, lists, named months, and anything that doesn't
+    // fit the three supported shapes must round-trip verbatim so the
+    // operator's intent isn't lost.
+    for (const raw of [
+      "*/15 * * * *", // every 15 minutes
+      "0 9-17 * * 1-5", // ranges in hours and days
+      "0 0 1,15 * *", // first and 15th of month
+      "0 12 * JAN *", // named month
+      "garbage", // not a cron at all
+      "0 0 * *", // 4 fields
+      "0 0 32 * *", // dom out of range
+    ]) {
+      expect(parseCronToPickerState(raw)).toMatchObject({
+        mode: "custom",
+        raw,
+      });
+    }
+  });
+
+  it("preserves the raw cron verbatim on custom-mode fallback", () => {
+    const raw = "*/5 * * * MON-FRI";
+    expect(parseCronToPickerState(raw).raw).toBe(raw);
+  });
+});
+
+describe("renderSettingsPage cron picker", () => {
+  const cronCommon = {
+    ...COMMON,
+    textChannels: [],
+    categoryChannels: [],
+    roles: [],
+  };
+
+  function withCron(current: string) {
+    return renderSettingsPage({
+      ...cronCommon,
+      groups: [
+        {
+          category: "voicetracking",
+          rows: [
+            {
+              key: "voicetracking.announcements.schedule",
+              label: "Announcement schedule",
+              current,
+              defaultValue: "0 16 * * 5",
+              type: "cron",
+              description: "",
+              category: "voicetracking",
+            },
+          ],
+        },
+      ],
+    });
+  }
+
+  it("renders the cron picker with mode selector and a hidden value field", () => {
+    const html = withCron("0 16 * * 5");
+    expect(html).toContain('<div class="cron-picker" data-mode="weekly">');
+    expect(html).toContain('<input type="hidden" name="value" value="0 16 * * 5">');
+    expect(html).toContain('<select class="cron-mode"');
+    expect(html).toContain('<option value="weekly" selected>Weekly</option>');
+    // Weekly mode reveals the day-of-week control with the right day picked.
+    expect(html).toMatch(/<option value="5" selected>Friday<\/option>/);
+    // Other mode-specific wrappers are present but hidden.
+    expect(html).toMatch(/<span class="cron-dom-wrap" hidden>/);
+    expect(html).toMatch(/<span class="cron-custom-wrap" hidden>/);
+  });
+
+  it("falls back to custom mode with the raw cron preserved for unrecognised patterns", () => {
+    const html = withCron("*/15 * * * *");
+    expect(html).toContain('<div class="cron-picker" data-mode="custom">');
+    expect(html).toContain(
+      '<option value="custom" selected>Custom (cron)</option>',
+    );
+    // The custom text input is visible (no `hidden` attr on its wrapper)
+    // and pre-populated with the raw value.
+    expect(html).toMatch(
+      /<span class="cron-custom-wrap"[^h]*>.*<input[^>]*class="cron-custom"[^>]*value="\*\/15 \* \* \* \*"/,
+    );
+  });
+
+  it("renders a daily schedule with the time pre-populated", () => {
+    const html = withCron("30 8 * * *");
+    expect(html).toContain('<div class="cron-picker" data-mode="daily">');
+    expect(html).toContain('<option value="daily" selected>Daily</option>');
+    expect(html).toContain('<input type="time" class="cron-time" value="08:30">');
+  });
+
+  it("renders a monthly schedule with the day-of-month pre-populated", () => {
+    const html = withCron("0 0 15 * *");
+    expect(html).toContain('<div class="cron-picker" data-mode="monthly">');
+    expect(html).toMatch(
+      /<input type="number" class="cron-dom"[^>]*value="15"/,
+    );
   });
 });

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -246,7 +246,8 @@ const SCRIPT =
 // text input verbatim, which is what server-side coercion expects for
 // a `cron`-typed key today.
 const CRON_PICKER_SCRIPT =
-  "(function(){function pad(n){return String(n).padStart(2,'0')}" +
+  "(function(){" +
+  "function clamp(n,lo,hi){return Math.max(lo,Math.min(hi,n))}" +
   "function wire(p){var hidden=p.querySelector('input[name=value]');" +
   "var mode=p.querySelector('.cron-mode');" +
   "var time=p.querySelector('.cron-time');" +
@@ -260,11 +261,18 @@ const CRON_PICKER_SCRIPT =
   "function show(el,on){if(el)el.hidden=!on}" +
   "function compute(){var m=mode.value;" +
   "if(m==='custom'){return custom.value}" +
+  // Clamp every numeric field defensively. The day-of-month <input>
+  // carries min/max but browsers only enforce that on form-submit
+  // (and unevenly across vendors), so an operator typing 32 or 0 can
+  // still end up with an invalid cron string here. Time inputs are
+  // browser-constrained but we clamp anyway in case parseInt yields
+  // something silly.
   "var parts=(time.value||'00:00').split(':');" +
-  "var h=parseInt(parts[0],10)||0;var mi=parseInt(parts[1],10)||0;" +
+  "var h=clamp(parseInt(parts[0],10)||0,0,23);" +
+  "var mi=clamp(parseInt(parts[1],10)||0,0,59);" +
   "if(m==='daily')return mi+' '+h+' * * *';" +
-  "if(m==='weekly')return mi+' '+h+' * * '+dow.value;" +
-  "if(m==='monthly')return mi+' '+h+' '+(dom.value||'1')+' * *';" +
+  "if(m==='weekly')return mi+' '+h+' * * '+clamp(parseInt(dow.value,10)||0,0,6);" +
+  "if(m==='monthly')return mi+' '+h+' '+clamp(parseInt(dom.value,10)||1,1,31)+' * *';" +
   "return hidden.value}" +
   "function refresh(){var m=mode.value;" +
   "show(timeWrap,m==='daily'||m==='weekly'||m==='monthly');" +
@@ -272,8 +280,13 @@ const CRON_PICKER_SCRIPT =
   "show(domWrap,m==='monthly');" +
   "show(customWrap,m==='custom');" +
   "hidden.value=compute();p.setAttribute('data-mode',m)}" +
+  "function update(){hidden.value=compute()}" +
   "mode.addEventListener('change',refresh);" +
-  "[time,dow,dom,custom].forEach(function(el){if(el)el.addEventListener('input',function(){hidden.value=compute()})});" +
+  // Listen for both `input` and `change`. Text/number inputs fire
+  // `input` continuously; <select> elements only reliably fire
+  // `change` (some browsers don't fire `input` for selects at all).
+  "[time,dow,dom,custom].forEach(function(el){if(!el)return;" +
+  "el.addEventListener('input',update);el.addEventListener('change',update)});" +
   "refresh()}" +
   "document.querySelectorAll('.cron-picker').forEach(wire)})();";
 

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -220,6 +220,10 @@ const STYLE = [
   ".edit-details{flex:0 0 100%;margin-bottom:.35rem}",
   ".edit-details form.stack{margin-top:.5rem}",
   "button[disabled]{opacity:.5;cursor:not-allowed}",
+  ".cron-picker{display:inline-flex;align-items:center;gap:.4rem;flex-wrap:wrap}",
+  ".cron-picker select,.cron-picker input{font:inherit;font-size:.85rem;padding:.2rem .35rem;background:#0f1115;color:#e4e6eb;border:1px solid #2d3748;border-radius:6px}",
+  ".cron-picker input[type=time]{width:7rem}",
+  ".cron-picker[hidden]{display:none}",
 ].join("");
 
 const SCRIPT =
@@ -232,6 +236,46 @@ const SCRIPT =
   // will reject the now-expired cookie and render the scaffold's 401 page.
   "if(r<=0&&!fired){fired=true;window.location.href='/admin/'}}" +
   "tick();setInterval(tick,1000)})();";
+
+// Cron schedule picker (#444). Each .cron-picker on the page wraps a
+// hidden `name="value"` input that the form actually submits, plus a
+// mode <select> ("daily" / "weekly" / "monthly" / "custom"), a time
+// picker, and day-of-week / day-of-month controls. This script keeps
+// the hidden input in sync as the operator changes the controls so the
+// form posts a canonical cron string. Custom mode just mirrors the raw
+// text input verbatim, which is what server-side coercion expects for
+// a `cron`-typed key today.
+const CRON_PICKER_SCRIPT =
+  "(function(){function pad(n){return String(n).padStart(2,'0')}" +
+  "function wire(p){var hidden=p.querySelector('input[name=value]');" +
+  "var mode=p.querySelector('.cron-mode');" +
+  "var time=p.querySelector('.cron-time');" +
+  "var dow=p.querySelector('.cron-dow');" +
+  "var dom=p.querySelector('.cron-dom');" +
+  "var custom=p.querySelector('.cron-custom');" +
+  "var timeWrap=p.querySelector('.cron-time-wrap');" +
+  "var dowWrap=p.querySelector('.cron-dow-wrap');" +
+  "var domWrap=p.querySelector('.cron-dom-wrap');" +
+  "var customWrap=p.querySelector('.cron-custom-wrap');" +
+  "function show(el,on){if(el)el.hidden=!on}" +
+  "function compute(){var m=mode.value;" +
+  "if(m==='custom'){return custom.value}" +
+  "var parts=(time.value||'00:00').split(':');" +
+  "var h=parseInt(parts[0],10)||0;var mi=parseInt(parts[1],10)||0;" +
+  "if(m==='daily')return mi+' '+h+' * * *';" +
+  "if(m==='weekly')return mi+' '+h+' * * '+dow.value;" +
+  "if(m==='monthly')return mi+' '+h+' '+(dom.value||'1')+' * *';" +
+  "return hidden.value}" +
+  "function refresh(){var m=mode.value;" +
+  "show(timeWrap,m==='daily'||m==='weekly'||m==='monthly');" +
+  "show(dowWrap,m==='weekly');" +
+  "show(domWrap,m==='monthly');" +
+  "show(customWrap,m==='custom');" +
+  "hidden.value=compute();p.setAttribute('data-mode',m)}" +
+  "mode.addEventListener('change',refresh);" +
+  "[time,dow,dom,custom].forEach(function(el){if(el)el.addEventListener('input',function(){hidden.value=compute()})});" +
+  "refresh()}" +
+  "document.querySelectorAll('.cron-picker').forEach(wire)})();";
 
 function renderNav(
   active: string,
@@ -277,6 +321,7 @@ export function renderAdminPage(opts: AdminPageOptions): string {
     `<nav class="side"><ul>${renderNav(opts.active, opts.navFeatureStatus)}</ul></nav>`,
     `<main>${opts.body}</main></div>`,
     `<script>${SCRIPT}</script>`,
+    `<script>${CRON_PICKER_SCRIPT}</script>`,
     "</body></html>",
   ].join("");
 }

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -269,15 +269,22 @@ export interface CronPickerState {
 }
 
 export function parseCronToPickerState(cron: string): CronPickerState {
+  // Strip surrounding quotes the same way the runtime services do
+  // (voice-channel-truncation, voice-channel-announcer,
+  // scheduled-announcement-service all apply this normalisation before
+  // handing the string to CronJob). Without it a stored value like
+  // `"0 16 * * 5"` would silently fall back to custom mode here even
+  // though the bot itself treats it as the unquoted form.
+  const stripped = cron.replace(/^["']|["']$/g, "");
   const fallback: CronPickerState = {
     mode: "custom",
     minute: 0,
     hour: 0,
     dayOfWeek: 0,
     dayOfMonth: 1,
-    raw: cron,
+    raw: stripped,
   };
-  const fields = cron.trim().split(/\s+/);
+  const fields = stripped.trim().split(/\s+/);
   if (fields.length !== 5) return fallback;
   const [mStr, hStr, domStr, monStr, dowStr] = fields;
   const isInt = (s: string) => /^\d+$/.test(s);

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -246,6 +246,123 @@ function buildOptionsHtml(
   return parts.join("");
 }
 
+/**
+ * Parse a 5-field cron string into a "picker" state for the friendly
+ * schedule editor (#444). Returns `mode: "custom"` for anything that
+ * doesn't cleanly match the three supported shapes (daily, weekly,
+ * monthly with single-integer minute/hour and a single weekday or
+ * day-of-month), so the editor falls back to a raw cron input and the
+ * operator's expression round-trips verbatim.
+ *
+ * Supported shapes:
+ *   daily    `M H * * *`         e.g. "0 0 * * *"     midnight every day
+ *   weekly   `M H * * DOW`       e.g. "0 16 * * 5"    Friday 16:00
+ *   monthly  `M H DOM * *`       e.g. "0 0 1 * *"     first of every month
+ */
+export interface CronPickerState {
+  mode: "daily" | "weekly" | "monthly" | "custom";
+  minute: number; // 0–59, only meaningful when mode !== custom
+  hour: number; // 0–23, only meaningful when mode !== custom
+  dayOfWeek: number; // 0–6 (Sun–Sat), only meaningful when mode === weekly
+  dayOfMonth: number; // 1–31, only meaningful when mode === monthly
+  raw: string; // verbatim cron value, used by custom mode
+}
+
+export function parseCronToPickerState(cron: string): CronPickerState {
+  const fallback: CronPickerState = {
+    mode: "custom",
+    minute: 0,
+    hour: 0,
+    dayOfWeek: 0,
+    dayOfMonth: 1,
+    raw: cron,
+  };
+  const fields = cron.trim().split(/\s+/);
+  if (fields.length !== 5) return fallback;
+  const [mStr, hStr, domStr, monStr, dowStr] = fields;
+  const isInt = (s: string) => /^\d+$/.test(s);
+  const inRange = (n: number, lo: number, hi: number) => n >= lo && n <= hi;
+
+  if (!isInt(mStr) || !isInt(hStr)) return fallback;
+  const minute = Number(mStr);
+  const hour = Number(hStr);
+  if (!inRange(minute, 0, 59) || !inRange(hour, 0, 23)) return fallback;
+  // Month must be wildcard for any of the three supported shapes — we
+  // don't expose "every N months" / specific-month patterns.
+  if (monStr !== "*") return fallback;
+
+  // daily: dom=* dow=*
+  if (domStr === "*" && dowStr === "*") {
+    return { ...fallback, mode: "daily", minute, hour };
+  }
+  // weekly: dom=* dow=single integer (sun..sat = 0..6; 7 also means Sun
+  // in some implementations, normalise to 0)
+  if (domStr === "*" && isInt(dowStr)) {
+    let dow = Number(dowStr);
+    if (dow === 7) dow = 0;
+    if (inRange(dow, 0, 6)) {
+      return { ...fallback, mode: "weekly", minute, hour, dayOfWeek: dow };
+    }
+  }
+  // monthly: dom=single integer dow=*
+  if (dowStr === "*" && isInt(domStr)) {
+    const dom = Number(domStr);
+    if (inRange(dom, 1, 31)) {
+      return { ...fallback, mode: "monthly", minute, hour, dayOfMonth: dom };
+    }
+  }
+  return fallback;
+}
+
+const WEEKDAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+
+function renderCronPicker(currentValue: string): string {
+  const state = parseCronToPickerState(currentValue);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const timeAttr = `${pad(state.hour)}:${pad(state.minute)}`;
+  const sel = (cond: boolean) => (cond ? " selected" : "");
+  const hidden = (cond: boolean) => (cond ? " hidden" : "");
+
+  const dowOptions = WEEKDAY_NAMES.map(
+    (name, i) =>
+      `<option value="${i}"${sel(state.dayOfWeek === i)}>${name}</option>`,
+  ).join("");
+
+  // Hidden input is the canonical `name="value"` the form submits. The
+  // bootstrap script in admin-layout keeps it in sync with the controls.
+  return (
+    `<div class="cron-picker" data-mode="${state.mode}">` +
+    `<input type="hidden" name="value" value="${escapeHtml(currentValue)}">` +
+    `<select class="cron-mode" aria-label="Schedule type">` +
+    `<option value="daily"${sel(state.mode === "daily")}>Daily</option>` +
+    `<option value="weekly"${sel(state.mode === "weekly")}>Weekly</option>` +
+    `<option value="monthly"${sel(state.mode === "monthly")}>Monthly</option>` +
+    `<option value="custom"${sel(state.mode === "custom")}>Custom (cron)</option>` +
+    `</select>` +
+    `<span class="cron-time-wrap"${hidden(state.mode === "custom")}>` +
+    ` at <input type="time" class="cron-time" value="${timeAttr}">` +
+    `</span>` +
+    `<span class="cron-dow-wrap"${hidden(state.mode !== "weekly")}>` +
+    ` on <select class="cron-dow" aria-label="Day of week">${dowOptions}</select>` +
+    `</span>` +
+    `<span class="cron-dom-wrap"${hidden(state.mode !== "monthly")}>` +
+    ` on day <input type="number" class="cron-dom" min="1" max="31" value="${state.dayOfMonth}" style="width:5rem">` +
+    `</span>` +
+    `<span class="cron-custom-wrap"${hidden(state.mode !== "custom")}>` +
+    `<input type="text" class="cron-custom" value="${escapeHtml(state.raw)}" placeholder="0 16 * * 5" style="width:12rem">` +
+    `</span>` +
+    `</div>`
+  );
+}
+
 function renderSettingInput(
   r: SettingRow,
   csrfToken: string,
@@ -301,9 +418,10 @@ function renderSettingInput(
       `<select name="value" multiple size="${Math.min(8, Math.max(3, options.length))}">` +
       buildOptionsHtml(options, selected, prefix, false) +
       `</select>`;
+  } else if (r.type === "cron") {
+    control = renderCronPicker(currentStr);
   } else {
-    // string, cron, or any unknown type → plain text. Issue #444 will
-    // replace cron with a friendly picker.
+    // string or unknown type → plain text input.
     control = `<input type="text" name="value" value="${escapeHtml(primitive)}">`;
   }
 


### PR DESCRIPTION
Closes #444. Builds on #439's `cron` type discriminator.

## What changed

Three config keys (`voicetracking.announcements.schedule`, `voicetracking.cleanup.schedule`, `leaderboard_roles.update_cron`) store raw cron strings. Since #439 (PR #452) they've been annotated `type: "cron"` and rendered as plain text inputs awaiting this PR. Raw cron is power-user-only — most operator intents are expressible as **(frequency, time-of-day, day)**.

### Parser (`parseCronToPickerState`)

Recognises three shapes and returns picker state:

| Shape | Cron pattern | Example |
|---|---|---|
| daily | `M H * * *` | `0 0 * * *` → midnight every day |
| weekly | `M H * * DOW` | `0 16 * * 5` → Friday 16:00 |
| monthly | `M H DOM * *` | `0 0 1 * *` → first of every month |

Anything that doesn't cleanly match — step values (`*/15`), ranges (`9-17`), lists (`1,15`), named months (`JAN`), malformed input, out-of-range fields — falls back to `mode: "custom"` with the raw cron preserved verbatim so the operator's expression round-trips on save. `7` for Sunday is normalised to `0`.

### Renderer (`renderCronPicker`)

Emits a `<div class="cron-picker">` containing:

- The canonical hidden `<input name="value">` the form actually submits.
- `<select class="cron-mode">` — Daily / Weekly / Monthly / Custom.
- `<input type="time">`.
- Weekday `<select>` (Sunday–Saturday; shown only for Weekly).
- Day-of-month `<input type="number">` (shown only for Monthly).
- Raw cron `<input type="text">` (shown only for Custom).

Mode-specific wrappers carry the `hidden` attribute server-side; JS toggles them as the operator changes the mode. The `data-mode` attribute on the picker mirrors current state for CSS/tests.

### Client-side JS (`CRON_PICKER_SCRIPT` in `admin-layout.ts`)

Wires up every `.cron-picker` on the page. On any control change it recomputes the cron string and writes it to the hidden `value` field. Form submission therefore posts a canonical cron — **no backend changes**. `coerceConfigValue` already accepts arbitrary strings for cron-typed keys.

### CSS

Small additions for the picker: `inline-flex`, themed inputs, sane defaults.

## Tests

- 4 parser tests: daily / weekly (incl. Sunday-7 → Sunday-0) / monthly / custom-fallback for step values, ranges, lists, named months, malformed input, out-of-range.
- 4 renderer tests: each mode's pre-population from a stored cron, the `data-mode` attribute, and custom-mode raw value preservation.
- Removed the old "placeholder until #444" assertion (replaced by the picker).

## Out of scope

The wizard's per-feature step renderers (`renderWizardStepPage`) also handle cron-valued keys but render them as plain inputs. Flipping that to use the picker is mechanical (the metadata's `type` field is already there); leaving it for a follow-up to keep this PR focused on the Settings page.

## Verification

- [x] `npm test` — 751 passed, 1 skipped, 0 failed (+8 new tests).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — 0 errors.
- [x] `npm run format:check` — clean.
- [ ] Manual: `/admin/settings` shows a picker (not a text input) for each of the three cron-typed keys. Round-trip via Save reproduces the picker state. Picking "Custom" reveals a raw cron field.


---
_Generated by [Claude Code](https://claude.ai/code/session_0172FyeqTEg2beBJPrig8rRX)_