### PR TITLE
config: audit defaultConfig enabled-true defaults (closes #445, closes #434)

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -148,23 +148,13 @@ Discord** on the Settings page so Discord picks up the change.
 
 ## 🧙 Setup Wizard
 
-Interactive guided configuration for new operators.
-
-| Setting | Default | Description |
-| --- | --- | --- |
-| `wizard.enabled` | `true` | Enable/disable the Setup Wizard page |
-
-The wizard is the **Setup Wizard** page inside the Web UI. It:
+Interactive guided configuration for new operators. Always accessible
+from the admin nav — no config key gates it. The wizard:
 
 - Auto-detects existing Discord resources (categories, channels)
 - Walks you through each feature step by step
 - Validates settings (channels must exist, etc.) before applying
 - Sets multiple related settings in one click
-
-**When to disable:** if you prefer to edit settings directly on the
-Settings page, or want to keep the wizard out of the navigation for an
-already-configured deployment. The wizard is on by default for new
-installs.
 
 ---
 
@@ -694,10 +684,6 @@ above).
 
 - `ping.enabled` (bool, default: false)
 - `quotes.enabled` (bool, default: false)
-
-#### Setup Wizard
-
-- `wizard.enabled` (bool, default: true)
 
 #### Reaction Roles
 

--- a/__tests__/services/config-schema.test.ts
+++ b/__tests__/services/config-schema.test.ts
@@ -145,50 +145,87 @@ describe('Config Schema', () => {
     //   2. Sub-feature toggles may default to true if they're inert
     //      until the parent feature is enabled and the operator who
     //      turns the parent on almost certainly wants them.
-    // These tests pin the matrix so a future contributor can't quietly
-    // flip a top-level gate to true (rule 1) or add a new sub-feature
-    // toggle without an explicit audit entry (rule 2).
+    //
+    // The matrix below is the *complete* set of `*enabled` keys in
+    // defaultConfig at this PR. The first test below derives the actual
+    // set from defaultConfig and fails when it drifts, forcing a future
+    // contributor to deliberately audit any new toggle they add.
 
-    it('keeps every top-level feature gate `enabled: false`', () => {
-      const topLevelGates = [
-        'voicechannels.enabled',
-        'voicetracking.enabled',
-        'voicetracking.announcements.enabled',
-        'voicetracking.cleanup.enabled',
-        'voicetracking.stats.top.enabled',
-        'voicetracking.stats.user.enabled',
-        'voicetracking.seen.enabled',
-        'ping.enabled',
-        'quotes.enabled',
-        'ratelimit.enabled',
-        'announcements.enabled',
-        'achievements.enabled',
-        'reactionroles.enabled',
-        'notices.enabled',
-        'polls.enabled',
-        'leaderboard_roles.enabled',
-      ];
-      for (const key of topLevelGates) {
-        expect(defaultConfig[key as keyof typeof defaultConfig]).toBe(false);
+    const EXPECTED_ENABLED_DEFAULTS: Record<string, boolean> = {
+      // ─── Top-level feature gates (rule 1: must be false) ────────────
+      'voicechannels.enabled': false,
+      'voicetracking.enabled': false,
+      'ping.enabled': false,
+      'quotes.enabled': false,
+      'ratelimit.enabled': false,
+      'announcements.enabled': false,
+      'achievements.enabled': false,
+      'reactionroles.enabled': false,
+      'notices.enabled': false,
+      'polls.enabled': false,
+      'leaderboard_roles.enabled': false,
+
+      // ─── Sub-features that default off (auxiliary opt-ins) ──────────
+      'voicechannels.presets.enabled': false,
+      'voicetracking.stats.top.enabled': false,
+      'voicetracking.stats.user.enabled': false,
+      'voicetracking.seen.enabled': false,
+      'voicetracking.announcements.enabled': false,
+      'voicetracking.cleanup.enabled': false,
+
+      // ─── Sub-features that default on (rule 2: parent-gated) ────────
+      'voicechannels.controlpanel.enabled': true,
+      'quotes.header_enabled': true,
+      'quotes.header_pin_enabled': true,
+      'achievements.announcements.enabled': true,
+      'achievements.dm_notifications.enabled': true,
+      'notices.header_enabled': true,
+      'notices.header_pin_enabled': true,
+    };
+
+    // Parent feature each rule-2 (default-true) sub-feature is gated by.
+    // Used to prove the sub-feature is inert on a fresh install.
+    const PARENT_OF_DEFAULT_TRUE: Record<string, string> = {
+      'voicechannels.controlpanel.enabled': 'voicechannels.enabled',
+      'quotes.header_enabled': 'quotes.enabled',
+      'quotes.header_pin_enabled': 'quotes.enabled',
+      'achievements.announcements.enabled': 'achievements.enabled',
+      'achievements.dm_notifications.enabled': 'achievements.enabled',
+      'notices.header_enabled': 'notices.enabled',
+      'notices.header_pin_enabled': 'notices.enabled',
+    };
+
+    it('audits every `*enabled` key in defaultConfig (no drift)', () => {
+      // Derive the live set so a new toggle added to defaultConfig
+      // without an entry above immediately fails this test.
+      const liveEnabledKeys = Object.keys(defaultConfig).filter((k) =>
+        /enabled$/.test(k),
+      );
+      const audited = new Set(Object.keys(EXPECTED_ENABLED_DEFAULTS));
+      const unaudited = liveEnabledKeys.filter((k) => !audited.has(k));
+      const stale = Object.keys(EXPECTED_ENABLED_DEFAULTS).filter(
+        (k) => !(k in defaultConfig),
+      );
+      expect(unaudited).toEqual([]);
+      expect(stale).toEqual([]);
+    });
+
+    it('every audited `*enabled` key matches its expected default value', () => {
+      for (const [key, expected] of Object.entries(
+        EXPECTED_ENABLED_DEFAULTS,
+      )) {
+        expect(defaultConfig[key as keyof typeof defaultConfig]).toBe(
+          expected,
+        );
       }
     });
 
-    it('keeps the parent-gated sub-feature toggles `true`', () => {
-      // Each is inert when its parent feature is off; defaulting on
-      // matches operator expectations when the parent is enabled.
-      const enabledByDefault: Record<string, string> = {
-        'voicechannels.controlpanel.enabled': 'voicechannels.enabled',
-        'quotes.header_enabled': 'quotes.enabled',
-        'quotes.header_pin_enabled': 'quotes.enabled',
-        'achievements.announcements.enabled': 'achievements.enabled',
-        'achievements.dm_notifications.enabled': 'achievements.enabled',
-        'notices.header_enabled': 'notices.enabled',
-        'notices.header_pin_enabled': 'notices.enabled',
-      };
-      for (const [key, parent] of Object.entries(enabledByDefault)) {
+    it('every default-true sub-feature has a parent gate that defaults to false', () => {
+      for (const [key, parent] of Object.entries(PARENT_OF_DEFAULT_TRUE)) {
         expect(defaultConfig[key as keyof typeof defaultConfig]).toBe(true);
-        // Parent is off, so the sub-feature is inert on a fresh install.
-        expect(defaultConfig[parent as keyof typeof defaultConfig]).toBe(false);
+        expect(defaultConfig[parent as keyof typeof defaultConfig]).toBe(
+          false,
+        );
       }
     });
 

--- a/__tests__/services/config-schema.test.ts
+++ b/__tests__/services/config-schema.test.ts
@@ -138,4 +138,62 @@ describe('Config Schema', () => {
       expect(missing).toEqual([]);
     });
   });
+
+  describe('enabled-default audit (#445)', () => {
+    // The audit's principle (documented in defaultConfig's leading comment):
+    //   1. Top-level feature gates default to false (opt-in).
+    //   2. Sub-feature toggles may default to true if they're inert
+    //      until the parent feature is enabled and the operator who
+    //      turns the parent on almost certainly wants them.
+    // These tests pin the matrix so a future contributor can't quietly
+    // flip a top-level gate to true (rule 1) or add a new sub-feature
+    // toggle without an explicit audit entry (rule 2).
+
+    it('keeps every top-level feature gate `enabled: false`', () => {
+      const topLevelGates = [
+        'voicechannels.enabled',
+        'voicetracking.enabled',
+        'voicetracking.announcements.enabled',
+        'voicetracking.cleanup.enabled',
+        'voicetracking.stats.top.enabled',
+        'voicetracking.stats.user.enabled',
+        'voicetracking.seen.enabled',
+        'ping.enabled',
+        'quotes.enabled',
+        'ratelimit.enabled',
+        'announcements.enabled',
+        'achievements.enabled',
+        'reactionroles.enabled',
+        'notices.enabled',
+        'polls.enabled',
+        'leaderboard_roles.enabled',
+      ];
+      for (const key of topLevelGates) {
+        expect(defaultConfig[key as keyof typeof defaultConfig]).toBe(false);
+      }
+    });
+
+    it('keeps the parent-gated sub-feature toggles `true`', () => {
+      // Each is inert when its parent feature is off; defaulting on
+      // matches operator expectations when the parent is enabled.
+      const enabledByDefault: Record<string, string> = {
+        'voicechannels.controlpanel.enabled': 'voicechannels.enabled',
+        'quotes.header_enabled': 'quotes.enabled',
+        'quotes.header_pin_enabled': 'quotes.enabled',
+        'achievements.announcements.enabled': 'achievements.enabled',
+        'achievements.dm_notifications.enabled': 'achievements.enabled',
+        'notices.header_enabled': 'notices.enabled',
+        'notices.header_pin_enabled': 'notices.enabled',
+      };
+      for (const [key, parent] of Object.entries(enabledByDefault)) {
+        expect(defaultConfig[key as keyof typeof defaultConfig]).toBe(true);
+        // Parent is off, so the sub-feature is inert on a fresh install.
+        expect(defaultConfig[parent as keyof typeof defaultConfig]).toBe(false);
+      }
+    });
+
+    it('does not declare wizard.enabled (#434 / #445 — wizard is always on)', () => {
+      expect('wizard.enabled' in defaultConfig).toBe(false);
+    });
+  });
 });

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -44,7 +44,7 @@ const ConfigSchema = new Schema<IConfig>(
         "reactionroles",
         "voicechannels",
         "voicetracking",
-        "wizard",
+        "wizard", // Kept for backward compatibility; key removed but legacy rows may exist
       ],
     },
     updatedAt: {

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -57,9 +57,6 @@ export interface ConfigSchema {
   "reactionroles.enabled": boolean;
   "reactionroles.message_channel_id": string; // Channel for reaction role messages
 
-  // Setup Wizard
-  "wizard.enabled": boolean;
-
   // Notices System
   "notices.enabled": boolean;
   "notices.channel_id": string; // Channel ID for notice messages
@@ -80,6 +77,36 @@ export interface ConfigSchema {
   "leaderboard_roles.announcement_channel_id": string; // Optional channel ID for role-change announcements
 }
 
+/**
+ * Defaults applied to a fresh deployment. Two rules govern booleans:
+ *
+ *   1. **Top-level feature gates default to `false`.** Every
+ *      `<feature>.enabled` key that controls whether a feature runs at
+ *      all (voicechannels, voicetracking, quotes, polls, notices,
+ *      announcements, achievements, reactionroles, leaderboard_roles,
+ *      ratelimit, ping) ships off. Operators opt in via the Setup
+ *      Wizard or Settings page — consistent with #438's "wizard starts
+ *      blank" semantics and #445's broader audit.
+ *
+ *   2. **Sub-feature defaults may be `true` if they're inert until the
+ *      parent feature is enabled and the operator who turns the parent
+ *      on almost certainly wants them.** Examples:
+ *      - `voicechannels.controlpanel.enabled` — the in-channel control
+ *        panel is the headline UX of voice channels; nobody enabling
+ *        voicechannels wants it hidden.
+ *      - `quotes.header_enabled` / `notices.header_enabled` /
+ *        `*.header_pin_enabled` — pinned informational headers in the
+ *        managed channels; helpful by default, harmless when the
+ *        parent feature is off.
+ *      - `achievements.announcements.enabled` /
+ *        `achievements.dm_notifications.enabled` — silent achievements
+ *        are pointless; enabling achievements implies wanting at least
+ *        one notification path.
+ *
+ * If you add a new `<feature>.enabled` key, default it to `false`. If
+ * you add a sub-feature toggle, apply rule 2 deliberately and add a
+ * brief comment so the next reader can audit the choice.
+ */
 export const defaultConfig: ConfigSchema = {
   // Voice Channel Management
   "voicechannels.enabled": false,
@@ -138,9 +165,6 @@ export const defaultConfig: ConfigSchema = {
   // Reaction Roles defaults
   "reactionroles.enabled": false,
   "reactionroles.message_channel_id": "",
-
-  // Setup Wizard defaults
-  "wizard.enabled": true,
 
   // Notices System defaults
   "notices.enabled": false,
@@ -250,11 +274,6 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
     title: "Reaction Roles",
     description:
       "Let users self-assign roles by reacting to a configured message.",
-  },
-  wizard: {
-    title: "Setup Wizard",
-    description:
-      "The /setup slash command that walks new admins through feature configuration.",
   },
   notices: {
     title: "Notices",
@@ -554,14 +573,6 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
     description: "Channel ID where reaction-role messages are posted.",
     category: "reactionroles",
     type: "channel",
-  },
-
-  // Setup Wizard
-  "wizard.enabled": {
-    label: "/setup wizard command enabled",
-    description: "Enable the /setup wizard command.",
-    category: "wizard",
-    type: "boolean",
   },
 
   // Notices System


### PR DESCRIPTION
Closes #445, closes #434.

`#434` falls naturally inside `#445`'s scope: the only top-level `enabled: true` default in `defaultConfig` was `wizard.enabled`, and the answer the audit demands is to delete it.

## Audit

Walked every boolean default. Two rules, codified in `defaultConfig`'s new header comment and pinned by tests:

1. **Top-level feature gates default to `false`** (opt-in). Consistent with #438's "wizard starts blank" — operators reach for the Setup Wizard or Settings page to turn features on.
2. **Sub-feature toggles may default to `true`** if they're inert until the parent feature is enabled AND the operator who turns the parent on almost certainly wants them.

### Findings

**KEEP `true`** (rule 2 — parent-gated):

| Key | Parent gate | Why default-on makes sense |
|---|---|---|
| `voicechannels.controlpanel.enabled` | `voicechannels.enabled` | The in-channel control panel is the headline UX of voice channels. |
| `quotes.header_enabled` | `quotes.enabled` | Pinned informational header in the quote channel. |
| `quotes.header_pin_enabled` | `quotes.enabled` | Pin the above header. |
| `achievements.announcements.enabled` | `achievements.enabled` | Silent achievements are pointless. |
| `achievements.dm_notifications.enabled` | `achievements.enabled` | At least one notification path. |
| `notices.header_enabled` | `notices.enabled` | Same pattern as quotes. |
| `notices.header_pin_enabled` | `notices.enabled` | Same. |

**DELETE `wizard.enabled`** (closes #434). The only top-level `enabled: true` default. Verified via grep — no runtime reader anywhere in `src/`. The wizard at `/admin/wizard` is rendered unconditionally; this key gates nothing.

**KEEP `false`** (rule 1 — all top-level gates already correct):

`voicechannels`, `voicetracking`, `voicetracking.{announcements,cleanup,stats.top,stats.user,seen}`, `ping`, `quotes`, `ratelimit`, `announcements`, `achievements`, `reactionroles`, `notices`, `polls`, `leaderboard_roles`.

## Changes

### `src/services/config-schema.ts`

- `ConfigSchema`, `defaultConfig`, `settingsMetadata`, `categoryMetadata` — drop the `wizard.enabled` / `wizard` entries.
- New leading docstring on `defaultConfig` codifying the two rules.

### `src/models/config.ts`

- `"wizard"` stays in the category enum with a backward-compat comment (same pattern as the retired `amikool` / `fun` / `core` slots) so existing DB rows pass Mongoose validation until cleanup deletes them.

### `src/services/config-service.ts`

- `"wizard"` stays in `validCategories`; cleanup's first pass (key-not-in-`defaultConfig`) deletes the orphan row before the category check runs.

### `SETTINGS.md`

- Removed the `wizard.enabled` table row, the bullet describing it, and the quick-reference entry. Section copy updated to "Always accessible from the admin nav — no config key gates it".

### Tests

New `enabled-default audit (#445)` describe block in `__tests__/services/config-schema.test.ts` with three pinning tests:

1. Every top-level feature gate is `false`.
2. The seven parent-gated sub-feature toggles are `true`, AND their parent is `false` — proving the defaults are inert on a fresh install.
3. `wizard.enabled` is absent from `defaultConfig` (#434 / #445).

## Verification

- [x] `npm test` — 755 passed, 1 skipped, 0 failed (+3 new tests).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — 0 errors.
- [x] `npm run format:check` — clean.
- [x] `grep -rn 'wizard\\.enabled' src` returns nothing.
- [ ] Manual on a deployment that had `wizard.enabled` stored: on next start expect `cleanupUnknownSettings()` log entry deleting it. The wizard page itself still loads.


---
_Generated by [Claude Code](https://claude.ai/code/session_0172FyeqTEg2beBJPrig8rRX)_