### PR TITLE
fix(config): treat empty-string env vars as absent (closes #455)

### DIFF
--- a/__tests__/services/config-service-methods.test.ts
+++ b/__tests__/services/config-service-methods.test.ts
@@ -122,6 +122,22 @@ describe('ConfigService - Methods', () => {
       expect(result).toBe('hello world');
     });
 
+    it('should treat empty-string env var as absent (not numeric 0)', async () => {
+      process.env['TEST_EMPTY_KEY'] = '';
+      mockFindOne.mockResolvedValue(null);
+
+      const result = await service.get('TEST_EMPTY_KEY');
+      expect(result).toBeNull();
+    });
+
+    it('should treat whitespace-only env var as absent', async () => {
+      process.env['TEST_WHITESPACE_KEY'] = '   ';
+      mockFindOne.mockResolvedValue(null);
+
+      const result = await service.get('TEST_WHITESPACE_KEY');
+      expect(result).toBeNull();
+    });
+
     it('should handle database errors gracefully', async () => {
       mockFindOne.mockRejectedValue(new Error('DB error'));
 
@@ -273,6 +289,14 @@ describe('ConfigService - Methods', () => {
 
       const result = await service.getNumber('nonexistent.key');
       expect(result).toBe(0);
+    });
+
+    it('should honor defaultValue when env var is set to empty string', async () => {
+      process.env['EMPTY_NUM_KEY'] = '';
+      mockFindOne.mockResolvedValue(null);
+
+      const result = await service.getNumber('EMPTY_NUM_KEY', 60);
+      expect(result).toBe(60);
     });
   });
 

--- a/src/services/config-service.ts
+++ b/src/services/config-service.ts
@@ -335,15 +335,15 @@ export class ConfigService {
 
       // If not found, try to get from environment variables (for backward compatibility)
       const envValue = process.env[key];
-      if (envValue !== undefined) {
+      if (envValue !== undefined && envValue.trim() !== "") {
         // Convert string values to appropriate types
         if (envValue === "true" || envValue === "false") {
           const boolValue = envValue === "true";
           this.cache.set(key, boolValue);
           return boolValue;
         }
-        if (!isNaN(Number(envValue))) {
-          const numValue = Number(envValue);
+        const numValue = Number(envValue);
+        if (!isNaN(numValue)) {
           this.cache.set(key, numValue);
           return numValue;
         }


### PR DESCRIPTION
## Summary

Fixes #455.

`Number("")` evaluates to `0` and `isNaN(0)` is `false`, so the env-var fallback in `ConfigService.get()` was caching any env var set to an empty string as the numeric value `0`, silently overriding `defaultValue` arguments passed to `getNumber()` / `getBoolean()`.

The fix guards the env fallback with an explicit emptiness check (`envValue.trim() !== ""`), so a blank env var is treated as if the key were absent and callers' default values are honoured.

## Changes

- `src/services/config-service.ts`: skip the env-var branch when the value is empty or whitespace-only.
- `__tests__/services/config-service-methods.test.ts`: add coverage for empty / whitespace env vars and verify `getNumber()` honours its default when the env var is empty.

## Test plan

- [x] `npm test -- __tests__/services/config-service-methods.test.ts` — 43 tests pass (including 3 new cases)
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — succeeds

---
_Generated by [Claude Code](https://claude.ai/code/session_012EPtHgEQ952fUpjiwu48a2)_