### PR TITLE
refactor(web): derive PROTECTED_KEYS from shared BOOTSTRAP_VARS (closes #457)

### DIFF
--- a/__tests__/web/write-routes.test.ts
+++ b/__tests__/web/write-routes.test.ts
@@ -5,12 +5,23 @@
  */
 
 import { describe, it, expect } from "@jest/globals";
+import { coerceConfigValue } from "../../src/web/write-routes.js";
 import {
+  BOOTSTRAP_VARS,
   PROTECTED_KEYS,
-  coerceConfigValue,
-} from "../../src/web/write-routes.js";
+} from "../../src/web/bootstrap-vars.js";
 
 describe("PROTECTED_KEYS", () => {
+  it("covers every bootstrap env variable (derived from BOOTSTRAP_VARS)", () => {
+    // PROTECTED_KEYS is derived from BOOTSTRAP_VARS so they cannot drift.
+    // This assertion guards against an accidental refactor that re-introduces
+    // a hand-maintained copy.
+    for (const v of BOOTSTRAP_VARS) {
+      expect(PROTECTED_KEYS.has(v.key)).toBe(true);
+    }
+    expect(PROTECTED_KEYS.size).toBe(BOOTSTRAP_VARS.length);
+  });
+
   it("covers every bootstrap and WebUI env variable", () => {
     // Locked snapshot — adding a new env var must force an intentional
     // update of this list, otherwise YAML import could overwrite it.
@@ -27,6 +38,7 @@ describe("PROTECTED_KEYS", () => {
         "WEBUI_INACTIVITY_TIMEOUT_MINUTES",
         "WEBUI_SESSION_SECRET",
         "WEBUI_SESSION_TTL_MINUTES",
+        "WEBUI_TRUST_PROXY",
       ].sort(),
     );
   });

--- a/src/web/bootstrap-vars.ts
+++ b/src/web/bootstrap-vars.ts
@@ -1,0 +1,41 @@
+/**
+ * Single source of truth for the environment / bootstrap variables consumed
+ * at process start (not via the `Config` DB collection).
+ *
+ * Two consumers share this list:
+ *   - `read-only-routes.ts` renders the admin Bootstrap page from it.
+ *   - `write-routes.ts` rejects these keys in YAML import/export (see
+ *     `PROTECTED_KEYS`), since the DB row would have no effect and could
+ *     mask the real value held in `process.env`.
+ *
+ * Adding a new env var here automatically protects it from YAML import.
+ */
+
+export interface BootstrapEnvVar {
+  key: string;
+  category: "Discord" | "Database" | "Process" | "WebUI";
+  isSecret: boolean;
+}
+
+export const BOOTSTRAP_VARS: readonly BootstrapEnvVar[] = [
+  { key: "DISCORD_TOKEN", category: "Discord", isSecret: true },
+  { key: "CLIENT_ID", category: "Discord", isSecret: false },
+  { key: "GUILD_ID", category: "Discord", isSecret: false },
+  { key: "MONGODB_URI", category: "Database", isSecret: true },
+  { key: "NODE_ENV", category: "Process", isSecret: false },
+  { key: "DEBUG", category: "Process", isSecret: false },
+  { key: "WEBUI_ENABLED", category: "WebUI", isSecret: false },
+  { key: "WEBUI_BASE_URL", category: "WebUI", isSecret: false },
+  { key: "WEBUI_SESSION_SECRET", category: "WebUI", isSecret: true },
+  { key: "WEBUI_SESSION_TTL_MINUTES", category: "WebUI", isSecret: false },
+  {
+    key: "WEBUI_INACTIVITY_TIMEOUT_MINUTES",
+    category: "WebUI",
+    isSecret: false,
+  },
+  { key: "WEBUI_TRUST_PROXY", category: "WebUI", isSecret: false },
+];
+
+export const PROTECTED_KEYS: ReadonlySet<string> = new Set(
+  BOOTSTRAP_VARS.map((v) => v.key),
+);

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -35,6 +35,7 @@ import { NOTICE_CATEGORIES } from "../content/notice-categories.js";
 import { VoiceChannelTruncationService } from "../services/voice-channel-truncation.js";
 import { VoiceChannelManager } from "../services/voice-channel-manager.js";
 import { WebAuditLog } from "../models/web-audit-log.js";
+import { BOOTSTRAP_VARS } from "./bootstrap-vars.js";
 import type { AuthenticatedRequest } from "./session.js";
 import {
   getDisplayedRemainingMs,
@@ -60,31 +61,6 @@ import {
   type RoleOption,
   type SettingRow,
 } from "./admin-views.js";
-
-interface BootstrapEnvVar {
-  key: string;
-  category: "Discord" | "Database" | "Process" | "WebUI";
-  isSecret: boolean;
-}
-
-const BOOTSTRAP_VARS: BootstrapEnvVar[] = [
-  { key: "DISCORD_TOKEN", category: "Discord", isSecret: true },
-  { key: "CLIENT_ID", category: "Discord", isSecret: false },
-  { key: "GUILD_ID", category: "Discord", isSecret: false },
-  { key: "MONGODB_URI", category: "Database", isSecret: true },
-  { key: "NODE_ENV", category: "Process", isSecret: false },
-  { key: "DEBUG", category: "Process", isSecret: false },
-  { key: "WEBUI_ENABLED", category: "WebUI", isSecret: false },
-  { key: "WEBUI_BASE_URL", category: "WebUI", isSecret: false },
-  { key: "WEBUI_SESSION_SECRET", category: "WebUI", isSecret: true },
-  { key: "WEBUI_SESSION_TTL_MINUTES", category: "WebUI", isSecret: false },
-  {
-    key: "WEBUI_INACTIVITY_TIMEOUT_MINUTES",
-    category: "WebUI",
-    isSecret: false,
-  },
-  { key: "WEBUI_TRUST_PROXY", category: "WebUI", isSecret: false },
-];
 
 function deriveCategory(key: string): string {
   const dot = key.indexOf(".");

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -36,6 +36,7 @@ import type { IPollItem } from "../models/poll-item.js";
 import Notice from "../models/notice.js";
 import { NOTICE_CATEGORIES } from "../content/notice-categories.js";
 import { requireCsrf } from "./csrf.js";
+import { PROTECTED_KEYS } from "./bootstrap-vars.js";
 import type { AuthenticatedRequest } from "./session.js";
 import { recordAudit } from "./audit.js";
 import {
@@ -131,29 +132,6 @@ function asyncHandler(
     fn(req as AuthenticatedRequest, res).catch(next);
   };
 }
-
-/**
- * Environment / bootstrap keys that must never appear in YAML import payloads
- * or YAML export output. Defense in depth — they're never put into the export
- * dictionary in the first place, and import/apply refuses them again.
- *
- * Hand-maintained: keep in lock-step with the `WEBUI_*` and bootstrap env
- * vars consumed in src/index.ts and src/web/index.ts. Adding a new env var
- * without updating this list will silently let admins overwrite it via YAML.
- */
-export const PROTECTED_KEYS: ReadonlySet<string> = new Set([
-  "DISCORD_TOKEN",
-  "CLIENT_ID",
-  "GUILD_ID",
-  "MONGODB_URI",
-  "NODE_ENV",
-  "DEBUG",
-  "WEBUI_ENABLED",
-  "WEBUI_BASE_URL",
-  "WEBUI_SESSION_SECRET",
-  "WEBUI_SESSION_TTL_MINUTES",
-  "WEBUI_INACTIVITY_TIMEOUT_MINUTES",
-]);
 
 /**
  * Settings shown per wizard feature. Key order determines form order.


### PR DESCRIPTION
## Summary

Fixes #457.

The YAML import/export gate in `src/web/write-routes.ts` maintained a hand-edited `PROTECTED_KEYS` list that mirrored the bootstrap env-var list already kept in `src/web/read-only-routes.ts` as `BOOTSTRAP_VARS`. The two had already drifted: `WEBUI_TRUST_PROXY` was in `BOOTSTRAP_VARS` (rendered on the admin Bootstrap page) but missing from `PROTECTED_KEYS`, so admins could set it via YAML import as if it were a regular DB-backed config key — exactly the drift the issue warns about.

## Changes

- New shared module `src/web/bootstrap-vars.ts` owns the `BootstrapEnvVar` type, the `BOOTSTRAP_VARS` array, and a derived `PROTECTED_KEYS = new Set(BOOTSTRAP_VARS.map(v => v.key))`.
- `read-only-routes.ts` imports `BOOTSTRAP_VARS` from the new module; the local copy is removed.
- `write-routes.ts` imports `PROTECTED_KEYS` from the new module; the hand-maintained copy (and its drift warning) is removed.
- The locked snapshot test is updated to include `WEBUI_TRUST_PROXY`, and a new assertion guards that `PROTECTED_KEYS` stays equivalent to `BOOTSTRAP_VARS` so a future refactor can't silently re-introduce the drift.

Note: `criticalSettings` in `src/services/config-service.ts` is intentionally left alone — it's the env vars *not* to migrate from legacy `.env` into the DB during a one-time migration, a different concern than runtime YAML-import protection.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 757 passed, 1 skipped (was 757/1 before)
- [x] `npm run lint` — no new errors (warning count unchanged)
- [x] `npm run format:check` — clean
- [x] `__tests__/web/write-routes.test.ts` PROTECTED_KEYS suite covers the new derivation assertion and the updated snapshot.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EYQWLY2pn3aeEh2mbzofRn)_