### PR TITLE
services: guard singleton getInstance against client mismatch (closes #458)

### DIFF
--- a/__tests__/services/command-manager.test.ts
+++ b/__tests__/services/command-manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { CommandManager } from '../../src/services/command-manager.js';
+import { PermissionsService } from '../../src/services/permissions-service.js';
 
 // Mock dependencies
 jest.mock('../../src/services/config-service.js');
@@ -14,7 +15,9 @@ describe('CommandManager', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockClient = { 
+    CommandManager.reset();
+    PermissionsService.reset();
+    mockClient = {
       user: { id: '123' },
       application: { id: '456' },
     };

--- a/__tests__/services/leaderboard-role-service.test.ts
+++ b/__tests__/services/leaderboard-role-service.test.ts
@@ -139,9 +139,17 @@ describe("LeaderboardRoleService", () => {
 
   describe("singleton", () => {
     it("returns the same instance", () => {
-      const a = LeaderboardRoleService.getInstance(makeClient());
-      const b = LeaderboardRoleService.getInstance(makeClient());
+      const client = makeClient();
+      const a = LeaderboardRoleService.getInstance(client);
+      const b = LeaderboardRoleService.getInstance(client);
       expect(a).toBe(b);
+    });
+
+    it("throws when called with a different client", () => {
+      LeaderboardRoleService.getInstance(makeClient());
+      expect(() => LeaderboardRoleService.getInstance(makeClient())).toThrow(
+        /already initialised with a different client/,
+      );
     });
 
     it("registers a config reload callback on construction", () => {

--- a/__tests__/services/notices-channel-manager.test.ts
+++ b/__tests__/services/notices-channel-manager.test.ts
@@ -12,6 +12,7 @@ describe("NoticesChannelManager", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    NoticesChannelManager.reset();
 
     // Mock Discord client
     mockClient = {

--- a/__tests__/services/voice-channel-announcer.test.ts
+++ b/__tests__/services/voice-channel-announcer.test.ts
@@ -12,7 +12,8 @@ describe('VoiceChannelAnnouncer', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockClient = { 
+    VoiceChannelAnnouncer.reset();
+    mockClient = {
       user: { id: '123' },
       channels: { fetch: jest.fn() },
     };

--- a/src/services/command-manager.ts
+++ b/src/services/command-manager.ts
@@ -44,8 +44,16 @@ export class CommandManager {
   public static getInstance(client: Client): CommandManager {
     if (!CommandManager.instance) {
       CommandManager.instance = new CommandManager(client);
+    } else if (CommandManager.instance.client !== client) {
+      throw new Error(
+        "CommandManager already initialised with a different client",
+      );
     }
     return CommandManager.instance;
+  }
+
+  public static reset(): void {
+    CommandManager.instance = undefined as unknown as CommandManager;
   }
 
   async initialize(): Promise<unknown[]> {

--- a/src/services/leaderboard-role-service.ts
+++ b/src/services/leaderboard-role-service.ts
@@ -86,6 +86,9 @@ export class LeaderboardRoleService {
   }
 
   public static reset(): void {
+    if (LeaderboardRoleService.instance) {
+      LeaderboardRoleService.instance.destroy();
+    }
     LeaderboardRoleService.instance =
       undefined as unknown as LeaderboardRoleService;
   }

--- a/src/services/leaderboard-role-service.ts
+++ b/src/services/leaderboard-role-service.ts
@@ -77,8 +77,17 @@ export class LeaderboardRoleService {
   public static getInstance(client: Client): LeaderboardRoleService {
     if (!LeaderboardRoleService.instance) {
       LeaderboardRoleService.instance = new LeaderboardRoleService(client);
+    } else if (LeaderboardRoleService.instance.client !== client) {
+      throw new Error(
+        "LeaderboardRoleService already initialised with a different client",
+      );
     }
     return LeaderboardRoleService.instance;
+  }
+
+  public static reset(): void {
+    LeaderboardRoleService.instance =
+      undefined as unknown as LeaderboardRoleService;
   }
 
   private validateCronExpression(expression: string): boolean {

--- a/src/services/notices-channel-manager.ts
+++ b/src/services/notices-channel-manager.ts
@@ -35,6 +35,9 @@ export class NoticesChannelManager {
   }
 
   public static reset(): void {
+    if (NoticesChannelManager.instance) {
+      void NoticesChannelManager.instance.stop();
+    }
     NoticesChannelManager.instance =
       undefined as unknown as NoticesChannelManager;
   }

--- a/src/services/notices-channel-manager.ts
+++ b/src/services/notices-channel-manager.ts
@@ -26,8 +26,17 @@ export class NoticesChannelManager {
   public static getInstance(client: Client): NoticesChannelManager {
     if (!NoticesChannelManager.instance) {
       NoticesChannelManager.instance = new NoticesChannelManager(client);
+    } else if (NoticesChannelManager.instance.client !== client) {
+      throw new Error(
+        "NoticesChannelManager already initialised with a different client",
+      );
     }
     return NoticesChannelManager.instance;
+  }
+
+  public static reset(): void {
+    NoticesChannelManager.instance =
+      undefined as unknown as NoticesChannelManager;
   }
 
   private async waitForClientReady(): Promise<void> {

--- a/src/services/permissions-service.ts
+++ b/src/services/permissions-service.ts
@@ -22,8 +22,16 @@ export class PermissionsService {
   public static getInstance(client: Client): PermissionsService {
     if (!PermissionsService.instance) {
       PermissionsService.instance = new PermissionsService(client);
+    } else if (PermissionsService.instance.client !== client) {
+      throw new Error(
+        "PermissionsService already initialised with a different client",
+      );
     }
     return PermissionsService.instance;
+  }
+
+  public static reset(): void {
+    PermissionsService.instance = undefined as unknown as PermissionsService;
   }
 
   /**

--- a/src/services/poll-service.ts
+++ b/src/services/poll-service.ts
@@ -144,8 +144,16 @@ export class PollService {
   public static getInstance(client: Client): PollService {
     if (!PollService.instance) {
       PollService.instance = new PollService(client);
+    } else if (PollService.instance.client !== client) {
+      throw new Error(
+        "PollService already initialised with a different client",
+      );
     }
     return PollService.instance;
+  }
+
+  public static reset(): void {
+    PollService.instance = undefined as unknown as PollService;
   }
 
   private validateCronExpression(expression: string): boolean {

--- a/src/services/poll-service.ts
+++ b/src/services/poll-service.ts
@@ -153,6 +153,9 @@ export class PollService {
   }
 
   public static reset(): void {
+    if (PollService.instance) {
+      PollService.instance.destroy();
+    }
     PollService.instance = undefined as unknown as PollService;
   }
 

--- a/src/services/scheduled-announcement-service.ts
+++ b/src/services/scheduled-announcement-service.ts
@@ -59,8 +59,17 @@ export class ScheduledAnnouncementService {
       ScheduledAnnouncementService.instance = new ScheduledAnnouncementService(
         client,
       );
+    } else if (ScheduledAnnouncementService.instance.client !== client) {
+      throw new Error(
+        "ScheduledAnnouncementService already initialised with a different client",
+      );
     }
     return ScheduledAnnouncementService.instance;
+  }
+
+  public static reset(): void {
+    ScheduledAnnouncementService.instance =
+      undefined as unknown as ScheduledAnnouncementService;
   }
 
   private validateCronExpression(expression: string): boolean {

--- a/src/services/scheduled-announcement-service.ts
+++ b/src/services/scheduled-announcement-service.ts
@@ -68,6 +68,9 @@ export class ScheduledAnnouncementService {
   }
 
   public static reset(): void {
+    if (ScheduledAnnouncementService.instance) {
+      ScheduledAnnouncementService.instance.destroy();
+    }
     ScheduledAnnouncementService.instance =
       undefined as unknown as ScheduledAnnouncementService;
   }

--- a/src/services/voice-channel-announcer.ts
+++ b/src/services/voice-channel-announcer.ts
@@ -20,8 +20,17 @@ export class VoiceChannelAnnouncer {
   public static getInstance(client: Client): VoiceChannelAnnouncer {
     if (!VoiceChannelAnnouncer.instance) {
       VoiceChannelAnnouncer.instance = new VoiceChannelAnnouncer(client);
+    } else if (VoiceChannelAnnouncer.instance.client !== client) {
+      throw new Error(
+        "VoiceChannelAnnouncer already initialised with a different client",
+      );
     }
     return VoiceChannelAnnouncer.instance;
+  }
+
+  public static reset(): void {
+    VoiceChannelAnnouncer.instance =
+      undefined as unknown as VoiceChannelAnnouncer;
   }
 
   private validateCronExpression(expression: string): boolean {

--- a/src/services/voice-channel-announcer.ts
+++ b/src/services/voice-channel-announcer.ts
@@ -29,6 +29,9 @@ export class VoiceChannelAnnouncer {
   }
 
   public static reset(): void {
+    if (VoiceChannelAnnouncer.instance) {
+      VoiceChannelAnnouncer.instance.destroy();
+    }
     VoiceChannelAnnouncer.instance =
       undefined as unknown as VoiceChannelAnnouncer;
   }

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -69,8 +69,16 @@ export class VoiceChannelManager {
   public static getInstance(client: Client): VoiceChannelManager {
     if (!VoiceChannelManager.instance) {
       VoiceChannelManager.instance = new VoiceChannelManager(client);
+    } else if (VoiceChannelManager.instance.client !== client) {
+      throw new Error(
+        "VoiceChannelManager already initialised with a different client",
+      );
     }
     return VoiceChannelManager.instance;
+  }
+
+  public static reset(): void {
+    VoiceChannelManager.instance = undefined as unknown as VoiceChannelManager;
   }
 
   /**

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -78,6 +78,9 @@ export class VoiceChannelManager {
   }
 
   public static reset(): void {
+    if (VoiceChannelManager.instance) {
+      VoiceChannelManager.instance.destroy();
+    }
     VoiceChannelManager.instance = undefined as unknown as VoiceChannelManager;
   }
 


### PR DESCRIPTION
## Summary

Fixes #458. Eight services exposed `getInstance(client)` that silently discarded the `client` argument on every call after the first — a misleading API that masked reconnect bugs and let test state leak between cases.

Applies options **B + C** from the issue:

- **Option B (guard):** `getInstance(client)` now throws when called with a client different from the one used to construct the singleton. Reconnect bugs and cross-test pollution surface immediately instead of silently returning a stale binding.
- **Option C (reset):** each service gains a `public static reset(): void` so tests can clear the singleton cleanly. This replaces the widespread `(Service as unknown as { instance: unknown }).instance = undefined` pattern at use sites that needed updates.

Services touched: `VoiceChannelManager`, `PermissionsService`, `PollService`, `NoticesChannelManager`, `ScheduledAnnouncementService`, `VoiceChannelAnnouncer`, `LeaderboardRoleService`, `CommandManager`.

## Test plan

- [x] `npm run build`
- [x] `npm test` — 76 suites, 757 passing (1 pre-existing skip)
- [x] `npm run lint` — no new errors
- [x] `npm run format:check`
- [x] Added a test asserting the new throw on client mismatch (`leaderboard-role-service.test.ts`)
- [x] Updated three tests (`command-manager`, `voice-channel-announcer`, `notices-channel-manager`) that constructed a fresh mock client each `beforeEach` to call `reset()` first

https://claude.ai/code/session_01Cd6Jo4tTArCWHzzWYMzrZH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cd6Jo4tTArCWHzzWYMzrZH)_