### PR TITLE
cleanup(startup-migrator): remove dead isDefaultValue method (closes #456)

### DIFF
--- a/src/services/startup-migrator.ts
+++ b/src/services/startup-migrator.ts
@@ -44,7 +44,7 @@ const configMigrations: ConfigMigration[] = [
     newKey: "voicechannels.channel.suffix",
     category: "voicechannels",
     description: "Suffix for dynamically created channels",
-    defaultValue: "", // Fixed: match isDefaultValue method
+    defaultValue: "",
   },
 
   // Voice Activity Tracking
@@ -224,32 +224,6 @@ export class StartupMigrator {
    */
   private isFromEnvironment(key: string): boolean {
     return process.env[key] !== undefined;
-  }
-
-  /**
-   * Check if a setting has its default value
-   */
-  private isDefaultValue(key: string, value: any): boolean {
-    // Define default values for each setting
-    const defaultValues: Record<string, any> = {
-      "voicechannels.enabled": true,
-      "voicechannels.lobby.name": "🟢 Lobby",
-      "voicechannels.lobby.offlinename": "🔴 Lobby",
-      "voicechannels.channel.prefix": "🎮",
-      "voicechannels.channel.suffix": "", // Fixed: match migration defaultValue
-      "voicetracking.enabled": true,
-      "voicetracking.seen.enabled": true,
-      "voicetracking.excluded_channels": "",
-      "voicetracking.announcements.enabled": true,
-      "voicetracking.announcements.schedule": "0 16 * * 5",
-      "ping.enabled": true,
-      "quotes.enabled": true,
-      "quotes.delete_roles": "None",
-      "quotes.max_length": 1000,
-      "quotes.cooldown": 60,
-    };
-
-    return defaultValues[key] === value;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Delete the unused `private isDefaultValue(key, value)` method from `src/services/startup-migrator.ts`. It was never called anywhere in the codebase (verified with `grep -rn isDefaultValue`), used the forbidden `any` type, and its inline default-values map duplicated/diverged from `defaultConfig` in `config-schema.ts`.
- Remove the stale `// Fixed: match isDefaultValue method` comment on the `voicechannels.channel.suffix` migration, since it referenced the now-deleted method.

Closes #456.

## Test plan

- [x] `npx tsc --noEmit` — no new errors in `startup-migrator.ts`
- [x] `npx eslint src/services/startup-migrator.ts` — clean
- [x] Confirmed no other references to `isDefaultValue` remain anywhere in `src/` or tests


---
_Generated by [Claude Code](https://claude.ai/code/session_01H6dg48kfmwxvyc46yshNmP)_