### PR TITLE
web: refresh session banner via /session/ping + local activity reset (closes #435)

### DIFF
--- a/__tests__/web/admin-layout.test.ts
+++ b/__tests__/web/admin-layout.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import {
   escapeHtml,
   getDisplayedRemainingMs,
+  getInactivityWindowMs,
   NAV_ITEMS,
   renderAdminPage,
   resolveNavFeatureStatus,
@@ -59,6 +60,41 @@ describe("renderAdminPage", () => {
     expect(html).toContain('action="/admin/finish"');
     expect(html).toContain('value="csrftoken"');
     expect(html).toContain("<p>hi</p>");
+  });
+
+  it("emits data-inactivity-ms so the banner script knows the sliding window", () => {
+    const saved = process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES;
+    process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES = "20";
+    try {
+      const html = renderAdminPage({
+        title: "Test",
+        active: "/admin/",
+        body: "",
+        csrfToken: "",
+        remainingMs: 0,
+      });
+      expect(html).toContain(`data-inactivity-ms="${20 * 60 * 1000}"`);
+    } finally {
+      if (saved === undefined) {
+        delete process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES;
+      } else {
+        process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES = saved;
+      }
+    }
+  });
+
+  it("ships a banner script that polls /admin/session/ping and handles activity", () => {
+    const html = renderAdminPage({
+      title: "Test",
+      active: "/admin/",
+      body: "",
+      csrfToken: "",
+      remainingMs: 0,
+    });
+    // The polling and activity-listener wiring from #435.
+    expect(html).toContain("/admin/session/ping");
+    expect(html).toContain("mousemove");
+    expect(html).toContain("keydown");
   });
 
   it("escapes the title", () => {
@@ -204,5 +240,36 @@ describe("getDisplayedRemainingMs", () => {
   it("returns 0 when the hard cap has already passed", () => {
     const expiresAt = new Date(Date.now() - 1000);
     expect(getDisplayedRemainingMs({ expiresAt })).toBe(0);
+  });
+});
+
+describe("getInactivityWindowMs", () => {
+  let saved: string | undefined;
+  beforeEach(() => {
+    saved = process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES;
+    delete process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES;
+  });
+  afterEach(() => {
+    if (saved === undefined) {
+      delete process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES;
+    } else {
+      process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES = saved;
+    }
+  });
+
+  it("defaults to 30 minutes when unset", () => {
+    expect(getInactivityWindowMs()).toBe(30 * 60 * 1000);
+  });
+
+  it("reads the env var when set to a positive number", () => {
+    process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES = "5";
+    expect(getInactivityWindowMs()).toBe(5 * 60 * 1000);
+  });
+
+  it("falls back to the default on garbage values", () => {
+    process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES = "nope";
+    expect(getInactivityWindowMs()).toBe(30 * 60 * 1000);
+    process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES = "-5";
+    expect(getInactivityWindowMs()).toBe(30 * 60 * 1000);
   });
 });

--- a/__tests__/web/session-ping.test.ts
+++ b/__tests__/web/session-ping.test.ts
@@ -42,6 +42,7 @@ interface MockResponse {
   status: jest.Mock;
   json: jest.Mock;
   getHeader: jest.Mock;
+  setHeader: jest.Mock;
   headers: Record<string, unknown>;
 }
 
@@ -53,6 +54,7 @@ function makeRes(): MockResponse {
     status: jest.fn(),
     json: jest.fn(),
     getHeader: jest.fn(),
+    setHeader: jest.fn(),
   } as MockResponse;
   res.status.mockImplementation((code: number) => {
     res.statusCode = code;
@@ -65,6 +67,10 @@ function makeRes(): MockResponse {
   res.getHeader.mockImplementation(
     (name: string) => res.headers[name.toLowerCase()],
   );
+  res.setHeader.mockImplementation((name: string, value: unknown) => {
+    res.headers[name.toLowerCase()] = value;
+    return res;
+  });
   return res;
 }
 
@@ -132,6 +138,20 @@ describe("createSessionPingHandler", () => {
     // The crucial property from the issue's acceptance criteria:
     // the ping must NOT rewrite the session cookie / bump `act`.
     expect(res.headers["set-cookie"]).toBeUndefined();
+
+    // Per-session payload — should never be cached by intermediaries.
+    expect(res.headers["cache-control"]).toBe("no-store");
+  });
+
+  it("sets Cache-Control: no-store on the 401 path too", async () => {
+    const res = makeRes();
+    await createSessionPingHandler()(
+      makeReq() as never,
+      res as never,
+      jest.fn() as never,
+    );
+    expect(res.statusCode).toBe(401);
+    expect(res.headers["cache-control"]).toBe("no-store");
   });
 
   it("honours the server's hard cap when it ends before the inactivity window", async () => {

--- a/__tests__/web/session-ping.test.ts
+++ b/__tests__/web/session-ping.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Unit tests for `createSessionPingHandler` (#435).
+ *
+ * Mocks `WebSessionService.findById` so we can drive the handler without
+ * a real Mongo connection, and constructs a real signed cookie via the
+ * same helpers the production code uses so the cookie-parsing path is
+ * exercised end-to-end.
+ */
+
+import { Buffer } from "buffer";
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import { createSessionPingHandler } from "../../src/web/session.js";
+import { signValue } from "../../src/web/cookies.js";
+import { WebSessionService } from "../../src/services/web-session-service.js";
+
+const ORIGINAL_ENV = { ...process.env };
+const SECRET = "test-secret-for-session-ping-tests";
+
+interface CookiePayload {
+  sid: string;
+  uid: string;
+  gid: string;
+  iat: number;
+  act: number;
+}
+
+function buildCookie(payload: CookiePayload): string {
+  const encoded = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return signValue(encoded, SECRET);
+}
+
+interface MockResponse {
+  statusCode: number;
+  body: unknown;
+  status: jest.Mock;
+  json: jest.Mock;
+  getHeader: jest.Mock;
+  headers: Record<string, unknown>;
+}
+
+function makeRes(): MockResponse {
+  const res = {
+    statusCode: 200,
+    body: undefined as unknown,
+    headers: {} as Record<string, unknown>,
+    status: jest.fn(),
+    json: jest.fn(),
+    getHeader: jest.fn(),
+  } as MockResponse;
+  res.status.mockImplementation((code: number) => {
+    res.statusCode = code;
+    return res;
+  });
+  res.json.mockImplementation((data: unknown) => {
+    res.body = data;
+    return res;
+  });
+  res.getHeader.mockImplementation(
+    (name: string) => res.headers[name.toLowerCase()],
+  );
+  return res;
+}
+
+function makeReq(cookie?: string): {
+  headers: { cookie?: string };
+} {
+  return cookie ? { headers: { cookie } } : { headers: {} };
+}
+
+describe("createSessionPingHandler", () => {
+  beforeEach(() => {
+    process.env.WEBUI_SESSION_SECRET = SECRET;
+    process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES = "30";
+    // Reset the singleton so the mocked findById on each test doesn't
+    // leak into the next.
+    (WebSessionService as unknown as { instance: unknown }).instance = null;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    jest.restoreAllMocks();
+  });
+
+  it("returns remainingMs and expiresAt for a live session, without bumping `act`", async () => {
+    const now = Date.now();
+    const act = now - 5 * 60 * 1000; // 5 min ago
+    const expiresAt = new Date(now + 60 * 60 * 1000); // 1h in future
+    const payload: CookiePayload = {
+      sid: "session-id",
+      uid: "user-1",
+      gid: "guild-1",
+      iat: now - 10 * 60 * 1000,
+      act,
+    };
+    const cookie = `koolbot_session=${buildCookie(payload)}`;
+
+    const svc = WebSessionService.getInstance();
+    jest.spyOn(svc, "findById").mockResolvedValue({
+      discordUserId: "user-1",
+      guildId: "guild-1",
+      scopes: [],
+      revokedAt: null,
+      expiresAt,
+    } as unknown as never);
+
+    const req = makeReq(cookie);
+    const res = makeRes();
+    const next = jest.fn();
+    await createSessionPingHandler()(
+      req as never,
+      res as never,
+      next as never,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(next).not.toHaveBeenCalled();
+    const body = res.body as { remainingMs: number; expiresAt: string };
+    expect(typeof body.remainingMs).toBe("number");
+    // Inactivity is 30min; `act` was 5min ago, so ~25min remain there.
+    // The hard cap is 60min, so the inactivity number is the bound.
+    expect(body.remainingMs).toBeGreaterThan(24 * 60 * 1000);
+    expect(body.remainingMs).toBeLessThanOrEqual(25 * 60 * 1000);
+    expect(body.expiresAt).toBe(expiresAt.toISOString());
+
+    // The crucial property from the issue's acceptance criteria:
+    // the ping must NOT rewrite the session cookie / bump `act`.
+    expect(res.headers["set-cookie"]).toBeUndefined();
+  });
+
+  it("honours the server's hard cap when it ends before the inactivity window", async () => {
+    const now = Date.now();
+    const payload: CookiePayload = {
+      sid: "session-id",
+      uid: "user-1",
+      gid: "guild-1",
+      iat: now - 60_000,
+      act: now - 60_000, // 1 min ago
+    };
+    const expiresAt = new Date(now + 3 * 60 * 1000); // 3 min hard cap
+    const cookie = `koolbot_session=${buildCookie(payload)}`;
+
+    const svc = WebSessionService.getInstance();
+    jest.spyOn(svc, "findById").mockResolvedValue({
+      discordUserId: "user-1",
+      guildId: "guild-1",
+      scopes: [],
+      revokedAt: null,
+      expiresAt,
+    } as unknown as never);
+
+    const res = makeRes();
+    await createSessionPingHandler()(
+      makeReq(cookie) as never,
+      res as never,
+      jest.fn() as never,
+    );
+
+    expect(res.statusCode).toBe(200);
+    const body = res.body as { remainingMs: number };
+    // Capped by the 3-min hardCap, NOT the 29-min inactivity remainder.
+    expect(body.remainingMs).toBeLessThanOrEqual(3 * 60 * 1000);
+    expect(body.remainingMs).toBeGreaterThan(2 * 60 * 1000);
+  });
+
+  it("returns 401 when no cookie is present", async () => {
+    const res = makeRes();
+    await createSessionPingHandler()(
+      makeReq() as never,
+      res as never,
+      jest.fn() as never,
+    );
+    expect(res.statusCode).toBe(401);
+    expect(res.headers["set-cookie"]).toBeUndefined();
+  });
+
+  it("returns 401 when the inactivity window has elapsed", async () => {
+    const now = Date.now();
+    const payload: CookiePayload = {
+      sid: "session-id",
+      uid: "user-1",
+      gid: "guild-1",
+      iat: now - 60 * 60 * 1000,
+      act: now - 31 * 60 * 1000, // 31 min ago; default window is 30 min
+    };
+    const cookie = `koolbot_session=${buildCookie(payload)}`;
+
+    const svc = WebSessionService.getInstance();
+    const findById = jest.spyOn(svc, "findById").mockResolvedValue({
+      discordUserId: "user-1",
+      guildId: "guild-1",
+      scopes: [],
+      revokedAt: null,
+      expiresAt: new Date(now + 60 * 60 * 1000),
+    } as unknown as never);
+
+    const res = makeRes();
+    await createSessionPingHandler()(
+      makeReq(cookie) as never,
+      res as never,
+      jest.fn() as never,
+    );
+
+    expect(res.statusCode).toBe(401);
+    expect(res.headers["set-cookie"]).toBeUndefined();
+    // The handler returns 401 from the cookie-level check before reaching
+    // the DB; either way, no Set-Cookie is emitted.
+    findById.mockRestore();
+  });
+
+  it("returns 401 when the DB session is revoked", async () => {
+    const now = Date.now();
+    const payload: CookiePayload = {
+      sid: "session-id",
+      uid: "user-1",
+      gid: "guild-1",
+      iat: now - 60_000,
+      act: now - 60_000,
+    };
+    const cookie = `koolbot_session=${buildCookie(payload)}`;
+
+    const svc = WebSessionService.getInstance();
+    jest.spyOn(svc, "findById").mockResolvedValue({
+      discordUserId: "user-1",
+      guildId: "guild-1",
+      scopes: [],
+      revokedAt: new Date(),
+      expiresAt: new Date(now + 60 * 60 * 1000),
+    } as unknown as never);
+
+    const res = makeRes();
+    await createSessionPingHandler()(
+      makeReq(cookie) as never,
+      res as never,
+      jest.fn() as never,
+    );
+    expect(res.statusCode).toBe(401);
+    expect(res.headers["set-cookie"]).toBeUndefined();
+  });
+
+  it("returns 401 when the DB session has expired (hard cap passed)", async () => {
+    const now = Date.now();
+    const payload: CookiePayload = {
+      sid: "session-id",
+      uid: "user-1",
+      gid: "guild-1",
+      iat: now - 60_000,
+      act: now - 60_000,
+    };
+    const cookie = `koolbot_session=${buildCookie(payload)}`;
+
+    const svc = WebSessionService.getInstance();
+    jest.spyOn(svc, "findById").mockResolvedValue({
+      discordUserId: "user-1",
+      guildId: "guild-1",
+      scopes: [],
+      revokedAt: null,
+      expiresAt: new Date(now - 1000),
+    } as unknown as never);
+
+    const res = makeRes();
+    await createSessionPingHandler()(
+      makeReq(cookie) as never,
+      res as never,
+      jest.fn() as never,
+    );
+    expect(res.statusCode).toBe(401);
+    expect(res.headers["set-cookie"]).toBeUndefined();
+  });
+
+  it("returns 401 when the cookie payload's uid/gid don't match the DB row", async () => {
+    const now = Date.now();
+    const payload: CookiePayload = {
+      sid: "session-id",
+      uid: "user-1",
+      gid: "guild-1",
+      iat: now - 60_000,
+      act: now - 60_000,
+    };
+    const cookie = `koolbot_session=${buildCookie(payload)}`;
+
+    const svc = WebSessionService.getInstance();
+    jest.spyOn(svc, "findById").mockResolvedValue({
+      discordUserId: "user-OTHER",
+      guildId: "guild-1",
+      scopes: [],
+      revokedAt: null,
+      expiresAt: new Date(now + 60 * 60 * 1000),
+    } as unknown as never);
+
+    const res = makeRes();
+    await createSessionPingHandler()(
+      makeReq(cookie) as never,
+      res as never,
+      jest.fn() as never,
+    );
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("forwards unexpected errors to the Express error pipeline", async () => {
+    const now = Date.now();
+    const payload: CookiePayload = {
+      sid: "session-id",
+      uid: "user-1",
+      gid: "guild-1",
+      iat: now - 60_000,
+      act: now - 60_000,
+    };
+    const cookie = `koolbot_session=${buildCookie(payload)}`;
+
+    const svc = WebSessionService.getInstance();
+    jest
+      .spyOn(svc, "findById")
+      .mockRejectedValue(new Error("mongo exploded") as never);
+
+    const next = jest.fn();
+    const res = makeRes();
+    await createSessionPingHandler()(
+      makeReq(cookie) as never,
+      res as never,
+      next as never,
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+  });
+});

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -226,16 +226,47 @@ const STYLE = [
   ".cron-picker[hidden]{display:none}",
 ].join("");
 
+// Session banner script (#367, refreshed in #435).
+//
+// In addition to the per-second local tick from #367, this:
+//   - polls `GET /admin/session/ping` every 30s and re-syncs the local
+//     deadline from the server's authoritative remaining time (the ping
+//     endpoint is read-only and does NOT itself extend the session).
+//   - resets the local deadline on `mousemove` / `keydown` (debounced)
+//     to the inactivity window length so the visible number stays
+//     snappy between polls when the admin is actually interacting.
+//
+// `data-inactivity-ms` is the full sliding window (matches the server's
+// `WEBUI_INACTIVITY_TIMEOUT_MINUTES`); local resets never go beyond
+// that. The ping reconciliation cap (server's hard `expiresAt`) is
+// enforced server-side and surfaces via the ping response.
 const SCRIPT =
   "(function(){var el=document.getElementById('session-countdown');if(!el)return;" +
   "var deadline=Date.now()+parseInt(el.getAttribute('data-remaining-ms'),10);" +
-  "var fired=false;" +
+  "var inactivityMs=parseInt(el.getAttribute('data-inactivity-ms'),10)||0;" +
+  "var fired=false;var lastReset=0;" +
+  "function expire(){if(fired)return;fired=true;window.location.href='/admin/'}" +
   "function tick(){var r=Math.max(0,deadline-Date.now());var s=Math.floor(r/1000);" +
   "var m=Math.floor(s/60);var ss=s%60;el.textContent=m+':'+(ss<10?'0'+ss:ss);" +
   // When the countdown hits 0, navigate to /admin/. The session middleware
   // will reject the now-expired cookie and render the scaffold's 401 page.
-  "if(r<=0&&!fired){fired=true;window.location.href='/admin/'}}" +
-  "tick();setInterval(tick,1000)})();";
+  "if(r<=0)expire()}" +
+  "function applyRemaining(ms){deadline=Date.now()+Math.max(0,ms|0);tick()}" +
+  "function onActivity(){if(inactivityMs<=0||fired)return;" +
+  // Debounce so a stream of mousemove events doesn't reset every frame.
+  // Only nudge the deadline forward (never back) — if the server has
+  // already told us a longer remaining via ping, keep it.
+  "var now=Date.now();if(now-lastReset<5000)return;lastReset=now;" +
+  "if(deadline-now<inactivityMs)applyRemaining(inactivityMs)}" +
+  "function poll(){if(fired)return;" +
+  "fetch('/admin/session/ping',{credentials:'same-origin',headers:{'Accept':'application/json'},cache:'no-store'})" +
+  ".then(function(res){if(res.status===401){expire();return null}" +
+  "if(!res.ok)return null;return res.json()})" +
+  ".then(function(data){if(data&&typeof data.remainingMs==='number')applyRemaining(data.remainingMs)})" +
+  ".catch(function(){})}" +
+  "tick();setInterval(tick,1000);setInterval(poll,30000);" +
+  "document.addEventListener('mousemove',onActivity,{passive:true});" +
+  "document.addEventListener('keydown',onActivity)})();";
 
 // Cron schedule picker (#444). Each .cron-picker on the page wraps a
 // hidden `name="value"` input that the form actually submits, plus a
@@ -313,6 +344,7 @@ function renderNav(
 
 export function renderAdminPage(opts: AdminPageOptions): string {
   const remainingMs = Math.max(0, Math.floor(opts.remainingMs));
+  const inactivityMs = getInactivityWindowMs();
   return [
     "<!doctype html>",
     '<html lang="en"><head>',
@@ -325,7 +357,7 @@ export function renderAdminPage(opts: AdminPageOptions): string {
     '<div class="banner">',
     '<div class="left"><strong>Koolbot Admin</strong></div>',
     '<div class="right">Session expires in ',
-    `<span id="session-countdown" data-remaining-ms="${remainingMs}" class="mono">--:--</span> · `,
+    `<span id="session-countdown" data-remaining-ms="${remainingMs}" data-inactivity-ms="${inactivityMs}" class="mono">--:--</span> · `,
     '<form method="POST" action="/admin/finish">',
     `<input type="hidden" name="_csrf" value="${escapeHtml(opts.csrfToken)}">`,
     '<button type="submit">Finish</button>',
@@ -337,6 +369,18 @@ export function renderAdminPage(opts: AdminPageOptions): string {
     `<script>${CRON_PICKER_SCRIPT}</script>`,
     "</body></html>",
   ].join("");
+}
+
+/**
+ * Inactivity sliding-window length in ms (`WEBUI_INACTIVITY_TIMEOUT_MINUTES`,
+ * defaults to 30 minutes). Used by the renderer to pass the window length
+ * to the banner script so client-side activity resets know what to reset to.
+ */
+export function getInactivityWindowMs(): number {
+  const raw = process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES;
+  const parsed = raw ? Number(raw) : NaN;
+  const inactivityMinutes = Number.isFinite(parsed) && parsed > 0 ? parsed : 30;
+  return inactivityMinutes * 60 * 1000;
 }
 
 /**
@@ -352,10 +396,7 @@ export function renderAdminPage(opts: AdminPageOptions): string {
  * fall back to inactivity-only (used by tests).
  */
 export function getDisplayedRemainingMs(session?: { expiresAt: Date }): number {
-  const raw = process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES;
-  const parsed = raw ? Number(raw) : NaN;
-  const inactivityMinutes = Number.isFinite(parsed) && parsed > 0 ? parsed : 30;
-  const inactivityMs = inactivityMinutes * 60 * 1000;
+  const inactivityMs = getInactivityWindowMs();
   if (!session) return inactivityMs;
   const hardCapMs = Math.max(0, session.expiresAt.getTime() - Date.now());
   return Math.min(inactivityMs, hardCapMs);

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -6,6 +6,12 @@
  */
 
 import type { ConfigSchema } from "../services/config-schema.js";
+import { getInactivityWindowMs } from "./session.js";
+
+// Re-exported from session.ts so the renderer and the cookie middleware
+// share a single source of truth for the inactivity sliding window.
+// Existing call sites and tests can keep importing it from this module.
+export { getInactivityWindowMs };
 
 /**
  * Enabled-state of feature-gated nav items, keyed by config-schema key.
@@ -237,34 +243,45 @@ const STYLE = [
 //     snappy between polls when the admin is actually interacting.
 //
 // `data-inactivity-ms` is the full sliding window (matches the server's
-// `WEBUI_INACTIVITY_TIMEOUT_MINUTES`); local resets never go beyond
-// that. The ping reconciliation cap (server's hard `expiresAt`) is
-// enforced server-side and surfaces via the ping response.
+// `WEBUI_INACTIVITY_TIMEOUT_MINUTES`); activity-driven local resets
+// never push the deadline past that. The server's hard cap
+// (`expiresAt`, from the ping response) is also tracked and used as a
+// ceiling on the optimistic activity reset so the UI can't briefly
+// promise more time than the session can actually deliver.
 const SCRIPT =
   "(function(){var el=document.getElementById('session-countdown');if(!el)return;" +
-  "var deadline=Date.now()+parseInt(el.getAttribute('data-remaining-ms'),10);" +
-  "var inactivityMs=parseInt(el.getAttribute('data-inactivity-ms'),10)||0;" +
-  "var fired=false;var lastReset=0;" +
+  "function toMs(v){var n=Math.floor(Number(v));return isFinite(n)&&n>0?n:0}" +
+  "var deadline=Date.now()+toMs(el.getAttribute('data-remaining-ms'));" +
+  "var inactivityMs=toMs(el.getAttribute('data-inactivity-ms'));" +
+  // Absolute timestamp (ms since epoch) of the server's hard cap; 0
+  // means "unknown yet" — filled in on the first successful ping.
+  "var hardCapAt=0;var fired=false;var lastReset=0;" +
   "function expire(){if(fired)return;fired=true;window.location.href='/admin/'}" +
   "function tick(){var r=Math.max(0,deadline-Date.now());var s=Math.floor(r/1000);" +
   "var m=Math.floor(s/60);var ss=s%60;el.textContent=m+':'+(ss<10?'0'+ss:ss);" +
   // When the countdown hits 0, navigate to /admin/. The session middleware
   // will reject the now-expired cookie and render the scaffold's 401 page.
   "if(r<=0)expire()}" +
-  "function applyRemaining(ms){deadline=Date.now()+Math.max(0,ms|0);tick()}" +
+  "function applyRemaining(ms){deadline=Date.now()+toMs(ms);tick()}" +
   "function onActivity(){if(inactivityMs<=0||fired)return;" +
   // Debounce so a stream of mousemove events doesn't reset every frame.
-  // Only nudge the deadline forward (never back) — if the server has
-  // already told us a longer remaining via ping, keep it.
+  // Only nudge the deadline forward (never back) — and never past the
+  // server's hard cap if we know it.
   "var now=Date.now();if(now-lastReset<5000)return;lastReset=now;" +
-  "if(deadline-now<inactivityMs)applyRemaining(inactivityMs)}" +
+  "var target=inactivityMs;" +
+  "if(hardCapAt>0){var cap=hardCapAt-now;if(cap<target)target=cap}" +
+  "if(target>0&&deadline-now<target)applyRemaining(target)}" +
   "function poll(){if(fired)return;" +
   "fetch('/admin/session/ping',{credentials:'same-origin',headers:{'Accept':'application/json'},cache:'no-store'})" +
   ".then(function(res){if(res.status===401){expire();return null}" +
   "if(!res.ok)return null;return res.json()})" +
-  ".then(function(data){if(data&&typeof data.remainingMs==='number')applyRemaining(data.remainingMs)})" +
+  ".then(function(data){if(!data)return;" +
+  "if(typeof data.expiresAt==='string'){var t=Date.parse(data.expiresAt);if(!isNaN(t))hardCapAt=t}" +
+  "if(typeof data.remainingMs==='number')applyRemaining(data.remainingMs)})" +
   ".catch(function(){})}" +
-  "tick();setInterval(tick,1000);setInterval(poll,30000);" +
+  // Initial poll fills `hardCapAt` quickly so the activity reset has a
+  // ceiling even before the first 30s interval elapses.
+  "tick();poll();setInterval(tick,1000);setInterval(poll,30000);" +
   "document.addEventListener('mousemove',onActivity,{passive:true});" +
   "document.addEventListener('keydown',onActivity)})();";
 
@@ -369,18 +386,6 @@ export function renderAdminPage(opts: AdminPageOptions): string {
     `<script>${CRON_PICKER_SCRIPT}</script>`,
     "</body></html>",
   ].join("");
-}
-
-/**
- * Inactivity sliding-window length in ms (`WEBUI_INACTIVITY_TIMEOUT_MINUTES`,
- * defaults to 30 minutes). Used by the renderer to pass the window length
- * to the banner script so client-side activity resets know what to reset to.
- */
-export function getInactivityWindowMs(): number {
-  const raw = process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES;
-  const parsed = raw ? Number(raw) : NaN;
-  const inactivityMinutes = Number.isFinite(parsed) && parsed > 0 ? parsed : 30;
-  return inactivityMinutes * 60 * 1000;
 }
 
 /**

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -34,7 +34,10 @@ import {
 } from "../services/voice-channel-manager.js";
 import { WebAuditLog } from "../models/web-audit-log.js";
 import { BOOTSTRAP_VARS } from "./bootstrap-vars.js";
-import type { AuthenticatedRequest } from "./session.js";
+import {
+  createSessionPingHandler,
+  type AuthenticatedRequest,
+} from "./session.js";
 import {
   getDisplayedRemainingMs,
   resolveNavFeatureStatus,
@@ -200,6 +203,14 @@ export function createReadOnlyRouter(
   requireSession: RequestHandler,
 ): Router {
   const router = Router();
+
+  // Session ping (#435). Mounted BEFORE `requireSession` because the
+  // ping is a read-only status query and must NOT itself bump the
+  // session's `act` timestamp — otherwise polling every 30s would keep
+  // an idle session alive forever, defeating the inactivity window.
+  // The handler runs its own (non-mutating) cookie + DB validation.
+  router.get("/session/ping", createSessionPingHandler());
+
   router.use(requireSession);
 
   // ---------- Dashboard ----------

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -1,9 +1,10 @@
 import { Buffer } from "buffer";
 import { Client } from "discord.js";
-import { Request, Response, NextFunction } from "express";
+import { Request, RequestHandler, Response, NextFunction } from "express";
 import logger from "../utils/logger.js";
 import { PermissionsService } from "../services/permissions-service.js";
 import { WebSessionService } from "../services/web-session-service.js";
+import type { IWebSession } from "../models/web-session.js";
 import {
   clearCookie,
   parseCookies,
@@ -77,6 +78,32 @@ export function clearSessionCookie(res: Response): void {
   clearCookie(res, SESSION_COOKIE, { path: SESSION_COOKIE_PATH });
 }
 
+/**
+ * Cookie + DB validation shared by `createSessionMiddleware` and the
+ * read-only `/session/ping` handler. Enforces the sliding inactivity
+ * window against `payload.act` and the server-side hard cap on the DB
+ * row. Does NOT touch the cookie or run any permission revalidation —
+ * callers layer those on as needed.
+ */
+async function loadValidSession(
+  payload: CookiePayload,
+  now: number,
+): Promise<IWebSession | null> {
+  const inactivityMs = getInactivityMinutes() * 60 * 1000;
+  if (now - payload.act > inactivityMs) return null;
+  const dbSession = await WebSessionService.getInstance().findById(payload.sid);
+  if (
+    !dbSession ||
+    dbSession.revokedAt ||
+    dbSession.expiresAt.getTime() <= now ||
+    dbSession.discordUserId !== payload.uid ||
+    dbSession.guildId !== payload.gid
+  ) {
+    return null;
+  }
+  return dbSession;
+}
+
 function readSessionCookie(req: Request): CookiePayload | null {
   const cookies = parseCookies(req);
   const raw = cookies.get(SESSION_COOKIE);
@@ -129,26 +156,13 @@ export function createSessionMiddleware(
     }
 
     const now = Date.now();
-    const inactivityMs = getInactivityMinutes() * 60 * 1000;
-    if (now - payload.act > inactivityMs) {
+    const dbSession = await loadValidSession(payload, now);
+    if (!dbSession) {
       clearSessionCookie(res);
       respondUnauthorized(res);
       return;
     }
-
     const sessionService = WebSessionService.getInstance();
-    const dbSession = await sessionService.findById(payload.sid);
-    if (
-      !dbSession ||
-      dbSession.revokedAt ||
-      dbSession.expiresAt.getTime() <= now ||
-      dbSession.discordUserId !== payload.uid ||
-      dbSession.guildId !== payload.gid
-    ) {
-      clearSessionCookie(res);
-      respondUnauthorized(res);
-      return;
-    }
 
     try {
       const permissions = PermissionsService.getInstance(client);
@@ -186,6 +200,57 @@ export function createSessionMiddleware(
     };
     next();
   };
+}
+
+/**
+ * Read-only status handler for `GET /admin/session/ping` (#435).
+ *
+ * The banner polls this so an admin who has been working on a single
+ * page for a few minutes sees a fresh countdown rather than watching
+ * their (server-side genuinely fresh) session tick to zero.
+ *
+ * Crucial property: this handler must NOT count as activity. It does
+ * not call `writeSessionCookie`, so `payload.act` is never bumped and
+ * the inactivity sliding window keeps advancing for a user who is only
+ * polling and not making real requests. Validation otherwise mirrors
+ * `createSessionMiddleware`: cookie present, inactivity window OK, DB
+ * session live. Permission revalidation is intentionally omitted — the
+ * next real admin request will hit the middleware and revoke if needed.
+ */
+export function createSessionPingHandler(): RequestHandler {
+  return async function sessionPing(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      const payload = readSessionCookie(req);
+      if (!payload) {
+        respondPingUnauthorized(res);
+        return;
+      }
+      const now = Date.now();
+      const dbSession = await loadValidSession(payload, now);
+      if (!dbSession) {
+        respondPingUnauthorized(res);
+        return;
+      }
+      const inactivityMs = getInactivityMinutes() * 60 * 1000;
+      const inactivityRemaining = Math.max(0, payload.act + inactivityMs - now);
+      const hardCapRemaining = Math.max(0, dbSession.expiresAt.getTime() - now);
+      const remainingMs = Math.min(inactivityRemaining, hardCapRemaining);
+      res.status(200).json({
+        remainingMs,
+        expiresAt: dbSession.expiresAt.toISOString(),
+      });
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
+function respondPingUnauthorized(res: Response): void {
+  res.status(401).json({ error: "unauthorized" });
 }
 
 function respondUnauthorized(res: Response): void {

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -59,6 +59,16 @@ function getInactivityMinutes(): number {
     : DEFAULT_INACTIVITY_MINUTES;
 }
 
+/**
+ * Inactivity sliding-window length in ms. Single source of truth for
+ * both the server (cookie expiry / middleware checks) and the renderer
+ * (banner `data-inactivity-ms` attribute) so the two can't drift on
+ * what counts as "the full window".
+ */
+export function getInactivityWindowMs(): number {
+  return getInactivityMinutes() * 60 * 1000;
+}
+
 export function writeSessionCookie(
   res: Response,
   payload: CookiePayload,
@@ -70,7 +80,7 @@ export function writeSessionCookie(
     sameSite: "lax",
     secure: shouldUseSecureCookies(),
     path: SESSION_COOKIE_PATH,
-    maxAge: getInactivityMinutes() * 60 * 1000,
+    maxAge: getInactivityWindowMs(),
   });
 }
 
@@ -89,8 +99,7 @@ async function loadValidSession(
   payload: CookiePayload,
   now: number,
 ): Promise<IWebSession | null> {
-  const inactivityMs = getInactivityMinutes() * 60 * 1000;
-  if (now - payload.act > inactivityMs) return null;
+  if (now - payload.act > getInactivityWindowMs()) return null;
   const dbSession = await WebSessionService.getInstance().findById(payload.sid);
   if (
     !dbSession ||
@@ -224,6 +233,10 @@ export function createSessionPingHandler(): RequestHandler {
     next: NextFunction,
   ): Promise<void> {
     try {
+      // Per-session payload — must never be cached by browsers or
+      // intermediary proxies, else a 200 could be served across users.
+      // Applies to both the 200 and 401 paths below.
+      res.setHeader("Cache-Control", "no-store");
       const payload = readSessionCookie(req);
       if (!payload) {
         respondPingUnauthorized(res);
@@ -235,7 +248,7 @@ export function createSessionPingHandler(): RequestHandler {
         respondPingUnauthorized(res);
         return;
       }
-      const inactivityMs = getInactivityMinutes() * 60 * 1000;
+      const inactivityMs = getInactivityWindowMs();
       const inactivityRemaining = Math.max(0, payload.act + inactivityMs - now);
       const hardCapRemaining = Math.max(0, dbSession.expiresAt.getTime() - now);
       const remainingMs = Math.min(inactivityRemaining, hardCapRemaining);


### PR DESCRIPTION
## Summary

Fixes #435 — the admin session banner no longer ticks to zero on a single page while the underlying session is genuinely fresh.

- New `GET /admin/session/ping` returns `{ remainingMs, expiresAt }` from the server's authoritative view. The handler intentionally does NOT call `writeSessionCookie`, so polling it does not bump `payload.act` — genuinely idle admins still time out at the inactivity threshold.
- Banner script (`src/web/admin-layout.ts`) now polls `/admin/session/ping` every 30s and re-syncs the local deadline from the response. On `mousemove` / `keydown` (debounced to 5s) it nudges the local deadline back up to the full inactivity window so the visible number stays snappy between polls.
- Refactored the cookie + DB validation in `createSessionMiddleware` into a shared `loadValidSession` helper used by both the middleware and the new ping handler so the two paths can't drift on what "valid" means. The middleware behavior is unchanged (it still clears the cookie + runs the permissions revalidation + bumps `act`).
- Ping route is mounted before `requireSession` inside `createReadOnlyRouter` so it bypasses the middleware's `act` refresh; the bespoke handler runs its own non-mutating cookie + DB checks.

## Test plan

- [x] `npm test` — 778 tests pass (added 12 new tests across `session-ping.test.ts` and `admin-layout.test.ts`).
- [x] `npm run build` — clean.
- [x] `npm run lint` — no new errors.
- [x] `npm run format:check` — clean.
- Unit tests cover the acceptance criteria explicitly:
  - valid session → returns `remainingMs`/`expiresAt`, and `Set-Cookie` is NOT emitted (ping does not bump `act`).
  - expired (inactivity elapsed) session → 401.
  - revoked / hard-cap-expired / uid-mismatched DB session → 401.
  - hard cap bounds the returned `remainingMs` when it ends before the inactivity window.
  - unexpected DB errors are forwarded to the Express error pipeline.
- Renderer test asserts `data-inactivity-ms` is emitted and the script references `/admin/session/ping`, `mousemove`, and `keydown`.

https://claude.ai/code/session_01KiJxXrADnK1EPPQKGALuQg

---
_Generated by [Claude Code](https://claude.ai/code/session_01KiJxXrADnK1EPPQKGALuQg)_