### PR TITLE
web(settings): per-section Save replaces per-row Set (closes #433)

### DIFF
--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -165,7 +165,7 @@ describe("renderSettingsPage", () => {
     expect(html).toContain('class="tag tag-info">boolean');
   });
 
-  it("renders inline set/reset forms with the current value pre-filled", () => {
+  it("wraps each section in one save form, exposes per-row reset, and pre-fills values (issue #433)", () => {
     const html = renderSettingsPage({
       ...COMMON,
       groups: [
@@ -192,11 +192,25 @@ describe("renderSettingsPage", () => {
         },
       ],
     });
-    expect(html).toContain('action="/admin/settings/set"');
-    expect(html).toContain('action="/admin/settings/reset"');
+    // Single per-section save form (replaces the per-row "Set" button).
+    expect(html).toContain('action="/admin/settings/save-section"');
+    expect(html).toContain('name="category" value="quotes"');
+    expect(html).toContain('<button type="submit" class="btn btn-primary">Save</button>');
+    // Each row contributes its key via a hidden `keys` input so the
+    // handler can enumerate the section without trusting `value_*` names.
+    expect(html).toContain('name="keys" value="quotes.max_length"');
+    expect(html).toContain('name="keys" value="quotes.channel_id"');
+    // Per-row Reset is retained via HTML5 formaction so a single click
+    // posts just that key to the existing /settings/reset handler.
+    expect(html).toContain('formaction="/admin/settings/reset"');
     expect(html).toContain('name="key" value="quotes.max_length"');
+    // Value controls use the per-row name and round-trip the current value.
+    expect(html).toContain('name="value_quotes.max_length"');
+    expect(html).toContain('name="value_quotes.channel_id"');
     expect(html).toContain('value="500"');
     expect(html).toContain('value="12345"');
+    // No per-row "Set" submit survives.
+    expect(html).not.toContain('action="/admin/settings/set"');
   });
 
   it("renders the action bar and import textarea", () => {
@@ -237,7 +251,9 @@ describe("renderSettingsPage", () => {
         },
       ],
     });
-    expect(onHtml).toMatch(/type="checkbox" name="value" value="true" checked/);
+    expect(onHtml).toMatch(
+      /type="checkbox" name="value_x\.enabled" value="true" checked/,
+    );
 
     const offHtml = renderSettingsPage({
       ...COMMON,
@@ -258,7 +274,7 @@ describe("renderSettingsPage", () => {
       ],
     });
     expect(offHtml).not.toMatch(
-      /type="checkbox" name="value" value="true" checked/,
+      /type="checkbox" name="value_x\.enabled" value="true" checked/,
     );
   });
 
@@ -288,7 +304,9 @@ describe("renderSettingsPage", () => {
         },
       ],
     });
-    expect(html).toContain('<select name="value">');
+    expect(html).toContain(
+      '<select name="value_voicetracking.announcements.channel_id">',
+    );
     expect(html).toContain('<option value="111">#general</option>');
     expect(html).toContain('<option value="222" selected>#voice-stats</option>');
   });
@@ -378,7 +396,9 @@ describe("renderSettingsPage", () => {
         },
       ],
     });
-    expect(html).toMatch(/<select name="value" multiple/);
+    expect(html).toMatch(
+      /<select name="value_voicetracking\.excluded_channels" multiple/,
+    );
     expect(html).toContain('<option value="111" selected>#general</option>');
     expect(html).toContain('<option value="222">#afk</option>');
     expect(html).toContain('<option value="333" selected>#other</option>');
@@ -410,7 +430,9 @@ describe("renderSettingsPage", () => {
         },
       ],
     });
-    expect(html).toMatch(/<select name="value" multiple/);
+    expect(html).toMatch(
+      /<select name="value_quotes\.delete_roles" multiple/,
+    );
     expect(html).toContain('<option value="r1">@Admin</option>');
     expect(html).toContain('<option value="r2" selected>@Mod</option>');
   });
@@ -1268,7 +1290,11 @@ describe("renderSettingsPage cron picker", () => {
   it("renders the cron picker with mode selector and a hidden value field", () => {
     const html = withCron("0 16 * * 5");
     expect(html).toContain('<div class="cron-picker" data-mode="weekly">');
-    expect(html).toContain('<input type="hidden" name="value" value="0 16 * * 5">');
+    // The hidden input is found by the bootstrap script via `.cron-hidden`
+    // so its `name` can vary per row under the per-section save form.
+    expect(html).toContain(
+      '<input type="hidden" class="cron-hidden" name="value_voicetracking.announcements.schedule" value="0 16 * * 5">',
+    );
     expect(html).toContain('<select class="cron-mode"');
     expect(html).toContain('<option value="weekly" selected>Weekly</option>');
     // Weekly mode reveals the day-of-week control with the right day picked.

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -248,7 +248,7 @@ const SCRIPT =
 const CRON_PICKER_SCRIPT =
   "(function(){" +
   "function clamp(n,lo,hi){return Math.max(lo,Math.min(hi,n))}" +
-  "function wire(p){var hidden=p.querySelector('input[name=value]');" +
+  "function wire(p){var hidden=p.querySelector('.cron-hidden');" +
   "var mode=p.querySelector('.cron-mode');" +
   "var time=p.querySelector('.cron-time');" +
   "var dow=p.querySelector('.cron-dow');" +

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -238,13 +238,15 @@ const SCRIPT =
   "tick();setInterval(tick,1000)})();";
 
 // Cron schedule picker (#444). Each .cron-picker on the page wraps a
-// hidden `name="value"` input that the form actually submits, plus a
-// mode <select> ("daily" / "weekly" / "monthly" / "custom"), a time
-// picker, and day-of-week / day-of-month controls. This script keeps
-// the hidden input in sync as the operator changes the controls so the
-// form posts a canonical cron string. Custom mode just mirrors the raw
-// text input verbatim, which is what server-side coercion expects for
-// a `cron`-typed key today.
+// hidden input (located via the `.cron-hidden` class — its form-field
+// name varies per row under the per-section save form, e.g.
+// `value_<key>`) that the form actually submits, plus a mode <select>
+// ("daily" / "weekly" / "monthly" / "custom"), a time picker, and
+// day-of-week / day-of-month controls. This script keeps the hidden
+// input in sync as the operator changes the controls so the form posts
+// a canonical cron string. Custom mode just mirrors the raw text input
+// verbatim, which is what server-side coercion expects for a `cron`-
+// typed key today.
 const CRON_PICKER_SCRIPT =
   "(function(){" +
   "function clamp(n,lo,hi){return Math.max(lo,Math.min(hi,n))}" +

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -331,7 +331,7 @@ const WEEKDAY_NAMES = [
   "Saturday",
 ];
 
-function renderCronPicker(currentValue: string): string {
+function renderCronPicker(currentValue: string, valueName: string): string {
   const state = parseCronToPickerState(currentValue);
   const pad = (n: number) => String(n).padStart(2, "0");
   const timeAttr = `${pad(state.hour)}:${pad(state.minute)}`;
@@ -343,11 +343,13 @@ function renderCronPicker(currentValue: string): string {
       `<option value="${i}"${sel(state.dayOfWeek === i)}>${name}</option>`,
   ).join("");
 
-  // Hidden input is the canonical `name="value"` the form submits. The
-  // bootstrap script in admin-layout keeps it in sync with the controls.
+  // The hidden input is what the form actually submits. The bootstrap
+  // script in admin-layout keeps it in sync with the controls; it locates
+  // the input via the `.cron-hidden` class so the form-field name can vary
+  // per row (e.g. `value_<key>` under the per-section save form).
   return (
     `<div class="cron-picker" data-mode="${state.mode}">` +
-    `<input type="hidden" name="value" value="${escapeHtml(currentValue)}">` +
+    `<input type="hidden" class="cron-hidden" name="${escapeHtml(valueName)}" value="${escapeHtml(currentValue)}">` +
     `<select class="cron-mode" aria-label="Schedule type">` +
     `<option value="daily"${sel(state.mode === "daily")}>Daily</option>` +
     `<option value="weekly"${sel(state.mode === "weekly")}>Weekly</option>` +
@@ -370,35 +372,43 @@ function renderCronPicker(currentValue: string): string {
   );
 }
 
-function renderSettingInput(
+/**
+ * Form-field name for a setting's value inside the per-section save form.
+ * Prefixed so the section handler can read each row's value via
+ * `req.body[settingValueFieldName(key)]` and so the field can't collide
+ * with the form-level `_csrf` / `category` / `keys` / clicked-reset `key`
+ * fields. The dotted suffix is kept verbatim — `extended: false` on
+ * `express.urlencoded` treats names as opaque strings, so no nesting.
+ */
+export function settingValueFieldName(key: string): string {
+  return `value_${key}`;
+}
+
+function renderSettingControl(
   r: SettingRow,
-  csrfToken: string,
   pickers: {
     textChannels: ChannelOption[];
     categoryChannels: ChannelOption[];
     roles: RoleOption[];
   },
 ): string {
-  const csrf = `<input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">`;
-  const keyField = `<input type="hidden" name="key" value="${escapeHtml(r.key)}">`;
   const primitive = coerceToDisplayValue(r.current);
   const currentStr = typeof primitive === "string" ? primitive : "";
+  const valueName = escapeHtml(settingValueFieldName(r.key));
 
-  let control: string;
   if (r.type === "boolean") {
     const checked = primitive === true ? " checked" : "";
-    control =
+    return (
       `<label class="checkbox" style="display:inline-flex;gap:.4rem;align-items:center;cursor:pointer">` +
-      `<input type="checkbox" name="value" value="true"${checked}> ` +
+      `<input type="checkbox" name="${valueName}" value="true"${checked}> ` +
       `<span class="mono">${primitive === true ? "true" : "false"}</span>` +
-      `</label>`;
-  } else if (r.type === "number") {
-    control = `<input type="number" name="value" value="${escapeHtml(primitive)}" style="width:8rem">`;
-  } else if (
-    r.type === "channel" ||
-    r.type === "category" ||
-    r.type === "role"
-  ) {
+      `</label>`
+    );
+  }
+  if (r.type === "number") {
+    return `<input type="number" name="${valueName}" value="${escapeHtml(primitive)}" style="width:8rem">`;
+  }
+  if (r.type === "channel" || r.type === "category" || r.type === "role") {
     const options =
       r.type === "channel"
         ? pickers.textChannels
@@ -407,11 +417,13 @@ function renderSettingInput(
           : pickers.roles;
     const prefix = r.type === "role" ? "@" : "#";
     const selected = currentStr ? new Set([currentStr]) : new Set<string>();
-    control =
-      `<select name="value">` +
+    return (
+      `<select name="${valueName}">` +
       buildOptionsHtml(options, selected, prefix, true) +
-      `</select>`;
-  } else if (r.type === "channel_list" || r.type === "role_list") {
+      `</select>`
+    );
+  }
+  if (r.type === "channel_list" || r.type === "role_list") {
     const options =
       r.type === "channel_list" ? pickers.textChannels : pickers.roles;
     const prefix = r.type === "role_list" ? "@" : "#";
@@ -421,29 +433,32 @@ function renderSettingInput(
         .map((v) => v.trim())
         .filter((v) => v !== ""),
     );
-    control =
-      `<select name="value" multiple size="${Math.min(8, Math.max(3, options.length))}">` +
+    return (
+      `<select name="${valueName}" multiple size="${Math.min(8, Math.max(3, options.length))}">` +
       buildOptionsHtml(options, selected, prefix, false) +
-      `</select>`;
-  } else if (r.type === "cron") {
-    control = renderCronPicker(currentStr);
-  } else {
-    // string or unknown type → plain text input.
-    control = `<input type="text" name="value" value="${escapeHtml(primitive)}">`;
+      `</select>`
+    );
   }
+  if (r.type === "cron") {
+    return renderCronPicker(currentStr, settingValueFieldName(r.key));
+  }
+  // string or unknown type → plain text input.
+  return `<input type="text" name="${valueName}" value="${escapeHtml(primitive)}">`;
+}
 
+/**
+ * Per-row Reset submit button. Lives inside the per-section save form and
+ * uses HTML5 `formaction` to redirect submission to the single-key reset
+ * route. Only the clicked button's `name`/`value` is sent on submission,
+ * so the `key=<row-key>` it contributes does not collide with the `keys`
+ * hidden inputs the section form uses to enumerate its rows.
+ */
+function renderResetButton(key: string): string {
+  const escaped = escapeHtml(key);
   return (
-    `<form method="POST" action="/admin/settings/set" class="inline-form">` +
-    csrf +
-    keyField +
-    control +
-    `<button type="submit" class="btn btn-primary btn-sm">Set</button>` +
-    `</form>` +
-    `<form method="POST" action="/admin/settings/reset" class="inline-form" style="margin-top:.25rem">` +
-    csrf +
-    keyField +
-    `<button type="submit" class="btn btn-sm">Reset</button>` +
-    `</form>`
+    `<button type="submit" formaction="/admin/settings/reset" ` +
+    `name="key" value="${escaped}" class="btn btn-sm" ` +
+    `style="margin-left:.4rem">Reset</button>`
   );
 }
 
@@ -478,8 +493,9 @@ export function renderSettingsPage(props: SettingsProps): string {
 <td>
   <div><strong>${escapeHtml(r.label || r.key)}</strong></div>
   <code class="mono muted" style="font-size:.85em">${escapeHtml(r.key)}</code>
+  <input type="hidden" name="keys" value="${escapeHtml(r.key)}">
 </td>
-<td>${renderSettingInput(r, props.csrfToken, pickers)}</td>
+<td>${renderSettingControl(r, pickers)}${renderResetButton(r.key)}</td>
 <td><span class="tag tag-info">${escapeHtml(r.type)}</span></td>
 <td style="white-space:nowrap">${formatValue(r.defaultValue)}</td>
 <td class="muted">${escapeHtml(r.description)}</td>
@@ -489,14 +505,24 @@ export function renderSettingsPage(props: SettingsProps): string {
       const descHtml = meta.description
         ? `<p class="muted" style="margin:.25rem 0 .75rem">${escapeHtml(meta.description)}</p>`
         : "";
+      // One <form> per category. Save submits every row's value in one
+      // atomic request; Reset buttons inside the same form use formaction
+      // to retarget /admin/settings/reset for a single key (issue #433).
       return `
 <div class="card">
   <h2>${escapeHtml(meta.title)}</h2>
   ${descHtml}
-  <table>
-    <thead><tr><th>Setting</th><th>Edit</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
-    <tbody>${rows}</tbody>
-  </table>
+  <form method="POST" action="/admin/settings/save-section">
+    <input type="hidden" name="_csrf" value="${csrf}">
+    <input type="hidden" name="category" value="${escapeHtml(g.category)}">
+    <table>
+      <thead><tr><th>Setting</th><th>Edit</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table>
+    <div class="actions" style="margin-top:.75rem">
+      <button type="submit" class="btn btn-primary">Save</button>
+    </div>
+  </form>
 </div>`;
     })
     .join("");

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -490,7 +490,11 @@ export function createWriteRouter(
           applied.push({ key, before, after: value });
         } catch (err) {
           const text = err instanceof Error ? err.message : "set failed";
-          logger.error(`save-section: failed to set ${key}`, err);
+          // The audit row records which key failed (see `failed` below) so
+          // the log message keeps the user-supplied key out of the format
+          // string — CodeQL flags template interpolation of body fields as
+          // log injection even when validation guarantees the value.
+          logger.error("save-section: failed to write setting", err);
           failed.push({ key, reason: text });
         }
       }

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -48,6 +48,7 @@ import {
   renderWizardPage,
   renderWizardStepPage,
   renderWizardConfirmPage,
+  settingValueFieldName,
   type ImportDiffRow,
 } from "./admin-views.js";
 
@@ -387,6 +388,142 @@ export function createWriteRouter(
           text: `Failed to reset ${key}: ${text}`,
         });
       }
+    }),
+  );
+
+  // Bulk save for a single Settings section (issue #433). Replaces the
+  // per-row "Set" button with one "Save" per category, posting every key
+  // in the section in a single request. Atomic: if any value fails to
+  // coerce, no DB writes happen and the operator gets a flash listing the
+  // offending keys. Once coercion passes, the writes are applied
+  // sequentially; a write that throws is reported in the flash but
+  // earlier writes are not rolled back (ConfigService has no transaction
+  // primitive, and partial application matches the YAML-import semantics).
+  router.post(
+    "/settings/save-section",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const body = (req.body as Record<string, unknown> | undefined) ?? {};
+      const category = getString(req, "category");
+
+      const rawKeys = body.keys;
+      const keys: string[] = Array.isArray(rawKeys)
+        ? rawKeys.map(String).filter((k) => k.length > 0)
+        : typeof rawKeys === "string" && rawKeys.length > 0
+          ? [rawKeys]
+          : [];
+
+      if (keys.length === 0) {
+        await recordAudit(session, {
+          action: "settings.save-section",
+          targetId: category || null,
+          result: "failure",
+          errorMessage: "no keys submitted",
+        });
+        flashRedirect(res, "/admin/settings", {
+          type: "err",
+          text: `No settings submitted for section ${category || "(unknown)"}.`,
+        });
+        return;
+      }
+
+      // Phase 1: coerce every value before touching the DB. An array of
+      // unique keys is required so a duplicate hidden input can't trick
+      // the handler into double-writing or mis-counting rejections.
+      const seen = new Set<string>();
+      const coerced: Array<{
+        key: string;
+        value: string | number | boolean;
+      }> = [];
+      const rejected: Array<{ key: string; reason: string }> = [];
+      for (const key of keys) {
+        if (seen.has(key)) continue;
+        seen.add(key);
+        const raw = body[settingValueFieldName(key)];
+        const r = coerceConfigValue(key, raw);
+        if (r.ok) {
+          coerced.push({ key, value: r.value });
+        } else {
+          rejected.push({ key, reason: r.reason });
+        }
+      }
+
+      if (rejected.length > 0) {
+        await recordAudit(session, {
+          action: "settings.save-section",
+          targetId: category || null,
+          details: {
+            rejected,
+            attemptedCount: coerced.length + rejected.length,
+          },
+          result: "failure",
+          errorMessage: rejected.map((r) => `${r.key}: ${r.reason}`).join("; "),
+        });
+        const detail = rejected.map((r) => `${r.key} (${r.reason})`).join(", ");
+        flashRedirect(res, "/admin/settings", {
+          type: "err",
+          text: `No changes saved — ${rejected.length} invalid value${rejected.length === 1 ? "" : "s"} in ${category || "section"}: ${detail}.`,
+        });
+        return;
+      }
+
+      // Phase 2: apply. Snapshot `before` per key for the audit row.
+      const config = ConfigService.getInstance();
+      const applied: Array<{ key: string; before: unknown; after: unknown }> =
+        [];
+      const failed: Array<{ key: string; reason: string }> = [];
+      for (const { key, value } of coerced) {
+        let before: unknown;
+        try {
+          before = await config.get(key);
+        } catch {
+          before = defaultConfig[key as keyof typeof defaultConfig];
+        }
+        const meta = settingsMetadata[key as keyof typeof settingsMetadata];
+        try {
+          await config.set(
+            key,
+            value,
+            meta?.description ?? "",
+            meta?.category ?? key.split(".")[0],
+          );
+          applied.push({ key, before, after: value });
+        } catch (err) {
+          const text = err instanceof Error ? err.message : "set failed";
+          logger.error(`save-section: failed to set ${key}`, err);
+          failed.push({ key, reason: text });
+        }
+      }
+
+      await recordAudit(session, {
+        action: "settings.save-section",
+        targetId: category || null,
+        details: {
+          applied,
+          failed,
+          appliedCount: applied.length,
+          failedCount: failed.length,
+        },
+        result: failed.length === 0 ? "success" : "failure",
+        errorMessage:
+          failed.length > 0
+            ? failed.map((f) => `${f.key}: ${f.reason}`).join("; ")
+            : null,
+      });
+
+      const label = category || "section";
+      if (failed.length === 0) {
+        flashRedirect(res, "/admin/settings", {
+          type: "ok",
+          text: `Saved ${applied.length} setting${applied.length === 1 ? "" : "s"} in ${label}.`,
+        });
+        return;
+      }
+      const firstError = failed[0];
+      flashRedirect(res, "/admin/settings", {
+        type: applied.length > 0 ? "warn" : "err",
+        text: `Saved ${applied.length}/${applied.length + failed.length} in ${label}. Failed: ${firstError.key} (${firstError.reason})${failed.length > 1 ? ` and ${failed.length - 1} more` : ""}.`,
+      });
     }),
   );
 

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -468,17 +468,17 @@ export function createWriteRouter(
       }
 
       // Phase 2: apply. Snapshot `before` per key for the audit row.
+      // `config.get()` returns null (not throw) on errors and for keys
+      // that aren't stored, so fall back via `??` so unset keys record
+      // their schema default in the audit instead of a misleading null.
       const config = ConfigService.getInstance();
       const applied: Array<{ key: string; before: unknown; after: unknown }> =
         [];
       const failed: Array<{ key: string; reason: string }> = [];
       for (const { key, value } of coerced) {
-        let before: unknown;
-        try {
-          before = await config.get(key);
-        } catch {
-          before = defaultConfig[key as keyof typeof defaultConfig];
-        }
+        const stored = await config.get(key);
+        const before =
+          stored ?? defaultConfig[key as keyof typeof defaultConfig];
         const meta = settingsMetadata[key as keyof typeof settingsMetadata];
         try {
           await config.set(
@@ -499,6 +499,13 @@ export function createWriteRouter(
         }
       }
 
+      // Tri-state outcome that mirrors the YAML-import audit (see
+      // `/settings/import/apply`): `result: "failure"` only when nothing
+      // landed, otherwise `success` with a `partial` flag in details so
+      // an audit query for `result: "success"` doesn't exclude partial
+      // saves. The user-facing flash already uses `warn` for partial.
+      const outcome: "ok" | "partial" | "failed" =
+        failed.length === 0 ? "ok" : applied.length > 0 ? "partial" : "failed";
       await recordAudit(session, {
         action: "settings.save-section",
         targetId: category || null,
@@ -507,8 +514,9 @@ export function createWriteRouter(
           failed,
           appliedCount: applied.length,
           failedCount: failed.length,
+          outcome,
         },
-        result: failed.length === 0 ? "success" : "failure",
+        result: outcome === "failed" ? "failure" : "success",
         errorMessage:
           failed.length > 0
             ? failed.map((f) => `${f.key}: ${f.reason}`).join("; ")


### PR DESCRIPTION
## Summary
- `/admin/settings` now wraps each category card in a single `<form>` that posts every row's value to a new `/admin/settings/save-section` handler. One "Save" per section instead of N per-row "Set" clicks.
- Reset stays per-row: each Reset button uses HTML5 `formaction="/admin/settings/reset"` + `name="key" value="<row-key>"` so it submits inside the section form without nesting forms.
- The new handler is atomic on coercion: if any value fails to coerce, no DB writes happen and the operator gets a flash listing offending keys. Writes themselves are sequential — a mid-batch write failure mirrors the YAML-import semantics (earlier writes stay, the flash reports the partial outcome).
- Cron picker's hidden input is now found by `.cron-hidden` class instead of `name="value"`, so its form-field name can vary per row (each row uses `value_<key>`).
- Per-key inline error markers were deferred (the issue suggested inline; I went with the flash banner first since it's simpler and matches the rest of the WebUI's flash pattern).

## Touches
- `src/web/admin-views.ts` — refactor `renderSettingInput` → `renderSettingControl` + `renderResetButton`; wrap each section in one form; export `settingValueFieldName`.
- `src/web/admin-layout.ts` — cron-picker bootstrap script targets `.cron-hidden` instead of `input[name=value]`.
- `src/web/write-routes.ts` — new `/settings/save-section` handler (atomic coercion, sequential apply, single audit row).
- `__tests__/web/admin-views.test.ts` — update the affected render assertions; add a section-form/Save coverage test.

## Test plan
- [x] `npm test` — 765 passing (was 765 baseline).
- [x] `npm run build` clean.
- [x] `npm run format:check` clean.
- [x] `npm run lint` — no new warnings (111 pre-existing across the repo).
- [ ] Manual: load `/admin/settings`, tick/untick a few rows in one section, click Save → flash confirms count; intentionally break a value (e.g. non-numeric in a number field) → flash lists the offending key, nothing in the section is written.
- [ ] Manual: click a per-row Reset → only that key is reset, other unsaved edits in the section are discarded (expected — reset short-circuits the section save).

## Notes
- The legacy `POST /admin/settings/set` handler is left in place. It's no longer reachable from the UI but removing it is tangential to this issue.
- `setting.set` audit rows are no longer emitted from the UI path; the new `settings.save-section` action is. There's no audit-log consumer in this repo that hardcodes action names.

https://claude.ai/code/session_01EsUCuAHwQWkLJezjBcFTM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsUCuAHwQWkLJezjBcFTM9)_