### PR TITLE
feat(web): Discord slash-command audit log + admin viewer (closes #459)

### DIFF
--- a/WEBUI.md
+++ b/WEBUI.md
@@ -596,6 +596,7 @@ side effect, since the HMAC key changes.
 | **Notices**        | `/notice add`, `edit`, `delete`, `sync`                                                             |
 | **Voice Channels** | `/vc reload`, `/vc force-reload`                                                                    |
 | **Database**       | `/dbtrunk status`, `/dbtrunk run`                                                                   |
+| **Command Audit**  | (new — read-only Discord slash-command audit log)                                                   |
 | **Bootstrap**      | (new — read-only env diagnostics)                                                                   |
 
 User-facing commands (`/ping`, `/voicestats`, `/seen`, `/quote`,

--- a/__tests__/models/discord-command-audit-log.test.ts
+++ b/__tests__/models/discord-command-audit-log.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "@jest/globals";
+
+describe("DiscordCommandAuditLog model", () => {
+  it("loads without throwing under the global mongoose mock", async () => {
+    const mod = await import(
+      "../../src/models/discord-command-audit-log.js"
+    );
+    expect(mod.DiscordCommandAuditLog).toBeDefined();
+  });
+
+  it("accepts the canonical entry shape", () => {
+    // Type-only check that the interface compiles with the documented
+    // result enum + optional-nullable fields, matching what
+    // `CommandManager.executeCommand` produces and what
+    // `recordCommandAudit` persists.
+    const sample = {
+      guildId: "g1",
+      discordUserId: "u1",
+      commandName: "quote",
+      subcommand: "add" as string | null,
+      channelId: "c1" as string | null,
+      result: "success" as "success" | "error" | "denied",
+      errorMessage: null as string | null,
+      durationMs: 42,
+      createdAt: new Date(),
+    };
+    expect(sample.result).toBe("success");
+    expect(sample.guildId).toBe("g1");
+  });
+});

--- a/__tests__/services/command-audit-cleanup.test.ts
+++ b/__tests__/services/command-audit-cleanup.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+
+const mockGetBoolean = jest.fn<(key: string, def: boolean) => Promise<boolean>>();
+const mockGetNumber = jest.fn<(key: string, def: number) => Promise<number>>();
+
+jest.unstable_mockModule("../../src/services/config-service.js", () => ({
+  ConfigService: {
+    getInstance: jest.fn(() => ({
+      getBoolean: mockGetBoolean,
+      getNumber: mockGetNumber,
+    })),
+  },
+}));
+
+const mockDeleteMany =
+  jest.fn<() => Promise<{ deletedCount: number }>>();
+
+jest.unstable_mockModule(
+  "../../src/models/discord-command-audit-log.js",
+  () => ({
+    DiscordCommandAuditLog: { deleteMany: mockDeleteMany },
+  }),
+);
+
+jest.unstable_mockModule("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.unstable_mockModule("cron", () => ({
+  CronJob: class {
+    start(): void {}
+    stop(): void {}
+  },
+}));
+
+const { CommandAuditCleanupService } = await import(
+  "../../src/services/command-audit-cleanup.js"
+);
+
+describe("CommandAuditCleanupService", () => {
+  beforeEach(() => {
+    CommandAuditCleanupService.reset();
+    mockGetBoolean.mockReset();
+    mockGetNumber.mockReset();
+    mockDeleteMany.mockReset();
+  });
+
+  it("is a no-op when audit logging is disabled", async () => {
+    mockGetBoolean.mockResolvedValue(false);
+    const service = CommandAuditCleanupService.getInstance();
+    const result = await service.runCleanup();
+    expect(result).toBeNull();
+    expect(mockDeleteMany).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when retention is non-positive", async () => {
+    mockGetBoolean.mockResolvedValue(true);
+    mockGetNumber.mockResolvedValue(0);
+    const result = await CommandAuditCleanupService.getInstance().runCleanup();
+    expect(result).toBeNull();
+    expect(mockDeleteMany).not.toHaveBeenCalled();
+  });
+
+  it("deletes rows older than the configured retention window", async () => {
+    mockGetBoolean.mockResolvedValue(true);
+    mockGetNumber.mockResolvedValue(7);
+    mockDeleteMany.mockResolvedValue({ deletedCount: 3 });
+
+    const before = Date.now();
+    const result = await CommandAuditCleanupService.getInstance().runCleanup();
+    const after = Date.now();
+
+    expect(result).toEqual({ deleted: 3 });
+    expect(mockDeleteMany).toHaveBeenCalledTimes(1);
+    const arg = mockDeleteMany.mock.calls[0]?.[0] as {
+      createdAt: { $lt: Date };
+    };
+    const cutoff = arg.createdAt.$lt.getTime();
+    const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+    // Cutoff is "now - 7d" computed inside the service; allow for the
+    // tiny wall-clock drift between the test's bounds and the service call.
+    expect(cutoff).toBeGreaterThanOrEqual(before - sevenDaysMs);
+    expect(cutoff).toBeLessThanOrEqual(after - sevenDaysMs);
+  });
+
+  it("returns null and swallows DB errors", async () => {
+    mockGetBoolean.mockResolvedValue(true);
+    mockGetNumber.mockResolvedValue(30);
+    mockDeleteMany.mockRejectedValueOnce(new Error("mongo down"));
+    const result = await CommandAuditCleanupService.getInstance().runCleanup();
+    expect(result).toBeNull();
+  });
+});

--- a/__tests__/services/config-schema.test.ts
+++ b/__tests__/services/config-schema.test.ts
@@ -181,6 +181,13 @@ describe('Config Schema', () => {
       'achievements.dm_notifications.enabled': true,
       'notices.header_enabled': true,
       'notices.header_pin_enabled': true,
+
+      // ─── Core infrastructure (always on; not feature-gated) ─────────
+      // Audit logging is a cross-cutting operator-visibility feature
+      // rather than a user-facing toggle, so it ships on by default —
+      // analogous to how WebAuditLog records every WebUI write without
+      // requiring opt-in.
+      'core.command_audit.enabled': true,
     };
 
     // Parent feature each rule-2 (default-true) sub-feature is gated by.

--- a/__tests__/utils/record-command-audit.test.ts
+++ b/__tests__/utils/record-command-audit.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+const createMock = jest.fn<() => Promise<unknown>>();
+const errorMock = jest.fn();
+
+jest.unstable_mockModule(
+  '../../src/models/discord-command-audit-log.js',
+  () => ({
+    DiscordCommandAuditLog: { create: createMock },
+  }),
+);
+
+jest.unstable_mockModule('../../src/utils/logger.js', () => ({
+  default: {
+    error: errorMock,
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const { recordCommandAudit } = await import(
+  '../../src/utils/record-command-audit.js'
+);
+
+describe('recordCommandAudit', () => {
+  beforeEach(() => {
+    createMock.mockClear();
+    errorMock.mockClear();
+    createMock.mockResolvedValue({});
+  });
+
+  it('persists every supplied field', async () => {
+    await recordCommandAudit({
+      guildId: 'g1',
+      discordUserId: 'u1',
+      commandName: 'quote',
+      subcommand: 'add',
+      channelId: 'c1',
+      result: 'success',
+      errorMessage: null,
+      durationMs: 42,
+    });
+    expect(createMock).toHaveBeenCalledTimes(1);
+    expect(createMock).toHaveBeenCalledWith({
+      guildId: 'g1',
+      discordUserId: 'u1',
+      commandName: 'quote',
+      subcommand: 'add',
+      channelId: 'c1',
+      result: 'success',
+      errorMessage: null,
+      durationMs: 42,
+    });
+  });
+
+  it('coerces missing optional fields to null', async () => {
+    await recordCommandAudit({
+      guildId: 'g1',
+      discordUserId: 'u1',
+      commandName: 'ping',
+      result: 'error',
+      durationMs: 5,
+    });
+    const arg = createMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(arg.subcommand).toBeNull();
+    expect(arg.channelId).toBeNull();
+    expect(arg.errorMessage).toBeNull();
+  });
+
+  it('swallows DB errors so the user-facing command is unaffected', async () => {
+    createMock.mockRejectedValueOnce(new Error('mongo down'));
+    await expect(
+      recordCommandAudit({
+        guildId: 'g1',
+        discordUserId: 'u1',
+        commandName: 'ping',
+        result: 'success',
+        durationMs: 1,
+      }),
+    ).resolves.toBeUndefined();
+    expect(errorMock).toHaveBeenCalledWith(
+      'Failed to record Discord command audit entry',
+      expect.any(Error),
+    );
+  });
+});

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -3,6 +3,7 @@ import {
   parseCronToPickerState,
   renderAnnouncementsPage,
   renderBootstrapPage,
+  renderCommandAuditPage,
   renderDashboardPage,
   renderDatabasePage,
   renderImportDiffPage,
@@ -1304,5 +1305,128 @@ describe("renderSettingsPage cron picker", () => {
     expect(html).toMatch(
       /<input type="number" class="cron-dom"[^>]*value="15"/,
     );
+  });
+});
+
+describe("renderCommandAuditPage", () => {
+  const BASE_FILTERS = {
+    commandName: "",
+    userId: "",
+    result: "",
+    from: "",
+    to: "",
+  };
+
+  it("renders the empty state when no rows match", () => {
+    const html = renderCommandAuditPage({
+      ...COMMON,
+      enabled: true,
+      retentionDays: 90,
+      commandOptions: ["ping", "quote"],
+      userOptions: [],
+      filters: BASE_FILTERS,
+      rows: [],
+      total: 0,
+      page: 1,
+      pageSize: 50,
+    });
+    expect(html).toContain("Slash-command audit log");
+    expect(html).toContain("No command invocations match");
+    expect(html).toContain('class="tag tag-on">enabled');
+    expect(html).toContain("90 days");
+    // Prev/Next are disabled buttons on a single-page result set.
+    expect(html).toMatch(/<button[^>]*disabled[^>]*>← Prev<\/button>/);
+    expect(html).toMatch(/<button[^>]*disabled[^>]*>Next →<\/button>/);
+  });
+
+  it("renders an invocation row with the user, command, and result tag", () => {
+    const html = renderCommandAuditPage({
+      ...COMMON,
+      enabled: true,
+      retentionDays: 30,
+      commandOptions: ["quote"],
+      userOptions: [{ id: "u1", label: "Alice" }],
+      filters: BASE_FILTERS,
+      rows: [
+        {
+          createdAt: "2026-05-08T12:34:56.000Z",
+          discordUserId: "u1",
+          userLabel: "Alice",
+          commandName: "quote",
+          subcommand: "add",
+          channelId: "c1",
+          channelLabel: "general",
+          result: "success",
+          errorMessage: null,
+          durationMs: 123,
+        },
+      ],
+      total: 1,
+      page: 1,
+      pageSize: 50,
+    });
+    expect(html).toContain("Alice");
+    expect(html).toContain("/quote add");
+    expect(html).toContain("general");
+    expect(html).toContain('class="tag tag-on">success');
+    expect(html).toContain("123ms");
+  });
+
+  it("preserves filters in pagination links and form state", () => {
+    const html = renderCommandAuditPage({
+      ...COMMON,
+      enabled: true,
+      retentionDays: 90,
+      commandOptions: ["quote", "ping"],
+      userOptions: [{ id: "u1", label: "Alice" }],
+      filters: {
+        commandName: "quote",
+        userId: "u1",
+        result: "error",
+        from: "2026-05-01",
+        to: "2026-05-31",
+      },
+      rows: Array.from({ length: 50 }, (_, i) => ({
+        createdAt: `2026-05-${(i + 1).toString().padStart(2, "0")}T00:00:00.000Z`,
+        discordUserId: "u1",
+        userLabel: "Alice",
+        commandName: "quote",
+        subcommand: null,
+        channelId: null,
+        channelLabel: null,
+        result: "error" as const,
+        errorMessage: "boom",
+        durationMs: 1,
+      })),
+      total: 120,
+      page: 1,
+      pageSize: 50,
+    });
+    expect(html).toContain('value="quote" selected');
+    expect(html).toContain('value="u1" selected');
+    expect(html).toContain('value="error" selected');
+    expect(html).toContain('value="2026-05-01"');
+    expect(html).toContain('value="2026-05-31"');
+    // Next link carries every active filter plus the next page number.
+    expect(html).toMatch(
+      /href="\/admin\/audit\/commands\?command=quote&user=u1&result=error&from=2026-05-01&to=2026-05-31&page=2"/,
+    );
+  });
+
+  it("renders the disabled-feature hint when audit logging is off", () => {
+    const html = renderCommandAuditPage({
+      ...COMMON,
+      enabled: false,
+      retentionDays: 90,
+      commandOptions: [],
+      userOptions: [],
+      filters: BASE_FILTERS,
+      rows: [],
+      total: 0,
+      page: 1,
+      pageSize: 50,
+    });
+    expect(html).toContain('class="tag tag-off">disabled');
+    expect(html).toContain("core.command_audit.enabled");
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import {
 import { VoiceChannelTracker } from "./services/voice-channel-tracker.js";
 import { VoiceChannelAnnouncer } from "./services/voice-channel-announcer.js";
 import { VoiceChannelTruncationService } from "./services/voice-channel-truncation.js";
+import { CommandAuditCleanupService } from "./services/command-audit-cleanup.js";
 import { ScheduledAnnouncementService } from "./services/scheduled-announcement-service.js";
 import { ChannelInitializer } from "./services/channel-initializer.js";
 import { StartupMigrator } from "./services/startup-migrator.js";
@@ -417,6 +418,7 @@ async function gracefulShutdown(signal: string): Promise<void> {
         voiceChannelManager.destroy();
         voiceChannelAnnouncer.destroy();
         voiceChannelTruncation.destroy();
+        CommandAuditCleanupService.getInstance().destroy();
         await noticesChannelManager.stop();
         pollService.destroy();
         leaderboardRoleService.destroy();
@@ -584,6 +586,9 @@ async function initializeServices(): Promise<void> {
 
     // Initialize leaderboard role rewards service
     await leaderboardRoleService.start();
+
+    // Start the slash-command audit log cleanup cron (#459)
+    CommandAuditCleanupService.getInstance().start();
 
     // Initialize permissions service and set up default permissions
     const permissionsService = PermissionsService.getInstance(client);

--- a/src/models/discord-command-audit-log.ts
+++ b/src/models/discord-command-audit-log.ts
@@ -1,0 +1,48 @@
+import mongoose, { Document, Schema } from "mongoose";
+
+/**
+ * Audit-log entry for Discord slash-command invocations (issue #459).
+ * One row per `CommandManager.executeCommand` call so an operator can see
+ * who ran which command, when, and what the outcome was. Mirrors the
+ * shape of `WebAuditLog` but keyed by Discord user rather than WebUI
+ * session because slash-command runs don't have a WebUI session.
+ *
+ * Raw command arguments are deliberately excluded — they may contain
+ * user-private text (e.g. /quote add) and rotate too often to be useful
+ * for the operator-visibility use case this log was designed for.
+ */
+export interface IDiscordCommandAuditLog extends Document {
+  guildId: string;
+  discordUserId: string;
+  commandName: string;
+  subcommand: string | null;
+  channelId: string | null;
+  result: "success" | "error" | "denied";
+  errorMessage: string | null;
+  durationMs: number;
+  createdAt: Date;
+}
+
+const DiscordCommandAuditLogSchema = new Schema<IDiscordCommandAuditLog>(
+  {
+    guildId: { type: String, required: true, index: true },
+    discordUserId: { type: String, required: true, index: true },
+    commandName: { type: String, required: true, index: true },
+    subcommand: { type: String, default: null },
+    channelId: { type: String, default: null },
+    result: {
+      type: String,
+      enum: ["success", "error", "denied"],
+      required: true,
+    },
+    errorMessage: { type: String, default: null },
+    durationMs: { type: Number, required: true },
+    createdAt: { type: Date, required: true, default: Date.now, index: true },
+  },
+  { timestamps: false },
+);
+
+export const DiscordCommandAuditLog = mongoose.model<IDiscordCommandAuditLog>(
+  "DiscordCommandAuditLog",
+  DiscordCommandAuditLogSchema,
+);

--- a/src/services/command-audit-cleanup.ts
+++ b/src/services/command-audit-cleanup.ts
@@ -1,0 +1,82 @@
+import { CronJob } from "cron";
+import logger from "../utils/logger.js";
+import { DiscordCommandAuditLog } from "../models/discord-command-audit-log.js";
+import { ConfigService } from "./config-service.js";
+
+/**
+ * Periodically prune Discord slash-command audit rows older than
+ * `core.command_audit.retention_days` (issue #459). Runs once a day at
+ * 03:00 server time — far enough from midnight to avoid contention with
+ * the voice-tracking cleanup that defaults to 00:00.
+ *
+ * No-op when `core.command_audit.enabled` is false, so a disabled audit
+ * feature doesn't keep pruning a static table.
+ */
+export class CommandAuditCleanupService {
+  private static instance: CommandAuditCleanupService;
+  private configService: ConfigService;
+  private job: CronJob | null = null;
+
+  private constructor() {
+    this.configService = ConfigService.getInstance();
+  }
+
+  public static getInstance(): CommandAuditCleanupService {
+    if (!CommandAuditCleanupService.instance) {
+      CommandAuditCleanupService.instance = new CommandAuditCleanupService();
+    }
+    return CommandAuditCleanupService.instance;
+  }
+
+  public static reset(): void {
+    CommandAuditCleanupService.instance =
+      undefined as unknown as CommandAuditCleanupService;
+  }
+
+  public start(): void {
+    if (this.job) return;
+    this.job = new CronJob("0 3 * * *", () => {
+      this.runCleanup().catch((err) => {
+        logger.error("Command audit cleanup failed:", err);
+      });
+    });
+    this.job.start();
+    logger.info("Command audit cleanup scheduled (daily at 03:00)");
+  }
+
+  public destroy(): void {
+    if (this.job) {
+      this.job.stop();
+      this.job = null;
+    }
+  }
+
+  public async runCleanup(): Promise<{ deleted: number } | null> {
+    const enabled = await this.configService
+      .getBoolean("core.command_audit.enabled", true)
+      .catch(() => true);
+    if (!enabled) return null;
+
+    const retentionDays = await this.configService
+      .getNumber("core.command_audit.retention_days", 90)
+      .catch(() => 90);
+    if (!Number.isFinite(retentionDays) || retentionDays <= 0) return null;
+
+    const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+    try {
+      const result = await DiscordCommandAuditLog.deleteMany({
+        createdAt: { $lt: cutoff },
+      });
+      const deleted = result.deletedCount ?? 0;
+      if (deleted > 0) {
+        logger.info(
+          `Command audit cleanup removed ${deleted} rows older than ${retentionDays}d`,
+        );
+      }
+      return { deleted };
+    } catch (err) {
+      logger.error("Command audit deleteMany failed:", err);
+      return null;
+    }
+  }
+}

--- a/src/services/command-manager.ts
+++ b/src/services/command-manager.ts
@@ -11,6 +11,7 @@ import {
 import { config as dotenvConfig } from "dotenv";
 import logger, { isDebugMode } from "../utils/logger.js";
 import { getErrorMessage } from "../utils/error-guards.js";
+import { recordCommandAudit } from "../utils/record-command-audit.js";
 import { ConfigService } from "./config-service.js";
 import { MonitoringService } from "./monitoring-service.js";
 import { CooldownManager } from "./cooldown-manager.js";
@@ -425,6 +426,39 @@ export class CommandManager {
     const monitoringService = MonitoringService.getInstance();
     const startTime = Date.now();
     const trackingId = monitoringService.trackCommandStart(commandName);
+    // `getSubcommand(false)` returns null when the command has no
+    // subcommand group rather than throwing — safe to call on every
+    // chat-input interaction.
+    let subcommand: string | null = null;
+    try {
+      subcommand = interaction.options.getSubcommand(false) ?? null;
+    } catch {
+      subcommand = null;
+    }
+
+    const auditCommon = {
+      commandName,
+      subcommand,
+      channelId: interaction.channelId ?? null,
+      discordUserId: interaction.user.id,
+    };
+    const recordAudit = async (
+      result: "success" | "error" | "denied",
+      errorMessage: string | null,
+    ): Promise<void> => {
+      if (!interaction.guildId) return;
+      const enabled = await this.configService
+        .getBoolean("core.command_audit.enabled", true)
+        .catch(() => true);
+      if (!enabled) return;
+      await recordCommandAudit({
+        ...auditCommon,
+        guildId: interaction.guildId,
+        result,
+        errorMessage,
+        durationMs: Date.now() - startTime,
+      });
+    };
 
     try {
       // Check permissions (admins bypass this check inside the service)
@@ -451,6 +485,7 @@ export class CommandManager {
             startTime,
             false,
           );
+          await recordAudit("denied", "Permission denied");
           return;
         }
       }
@@ -506,6 +541,7 @@ export class CommandManager {
               startTime,
               false,
             );
+            await recordAudit("denied", "Rate limited");
             return;
           }
 
@@ -521,6 +557,7 @@ export class CommandManager {
         startTime,
         true,
       );
+      await recordAudit("success", null);
     } catch (error) {
       monitoringService.trackCommandEnd(
         commandName,
@@ -529,6 +566,7 @@ export class CommandManager {
         false,
       );
       monitoringService.trackError(commandName, error as Error);
+      await recordAudit("error", getErrorMessage(error).slice(0, 500));
       throw error;
     }
   }

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -75,6 +75,10 @@ export interface ConfigSchema {
   "leaderboard_roles.update_cron": string; // Cron schedule for recalculation
   "leaderboard_roles.tiers": string; // Comma-separated "topN:roleId" pairs, e.g. "1:111,3:222,10:333"
   "leaderboard_roles.announcement_channel_id": string; // Optional channel ID for role-change announcements
+
+  // Discord slash-command audit log (issue #459)
+  "core.command_audit.enabled": boolean;
+  "core.command_audit.retention_days": number;
 }
 
 /**
@@ -184,6 +188,12 @@ export const defaultConfig: ConfigSchema = {
   "leaderboard_roles.update_cron": "0 0 * * 1", // Every Monday at 00:00
   "leaderboard_roles.tiers": "",
   "leaderboard_roles.announcement_channel_id": "",
+
+  // Discord slash-command audit log defaults (#459). On by default so
+  // fresh installs get operator visibility out of the box; retention
+  // matches the proposal in the issue (90 days).
+  "core.command_audit.enabled": true,
+  "core.command_audit.retention_days": 90,
 };
 
 /**
@@ -289,6 +299,11 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
     title: "Leaderboard Role Rewards",
     description:
       "Auto-assign Discord roles based on a user's position in the voice-activity leaderboard.",
+  },
+  core: {
+    title: "Core",
+    description:
+      "Core bot infrastructure: audit logging, retention, and other cross-cutting concerns.",
   },
   other: {
     title: "Other",
@@ -660,5 +675,21 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
       "Optional channel ID where role-change announcements are posted. Leave empty to disable announcements.",
     category: "leaderboard_roles",
     type: "channel",
+  },
+
+  // Discord slash-command audit log (#459)
+  "core.command_audit.enabled": {
+    label: "Slash-command audit log enabled",
+    description:
+      "Record one row per Discord slash-command invocation (who, what, when, outcome) so operators can audit command usage from the WebUI. Raw command arguments are never recorded.",
+    category: "core",
+    type: "boolean",
+  },
+  "core.command_audit.retention_days": {
+    label: "Slash-command audit retention (days)",
+    description:
+      "Days to keep slash-command audit rows before the cleanup job prunes them.",
+    category: "core",
+    type: "number",
   },
 };

--- a/src/utils/record-command-audit.ts
+++ b/src/utils/record-command-audit.ts
@@ -1,0 +1,42 @@
+/**
+ * Audit-log helper for Discord slash-command invocations (issue #459).
+ * `CommandManager.executeCommand` calls this exactly once per command
+ * run so each invocation produces one row in `DiscordCommandAuditLog`.
+ * Analogous to `src/web/audit.ts` but keyed by Discord user rather
+ * than a WebUI session.
+ */
+
+import logger from "./logger.js";
+import { DiscordCommandAuditLog } from "../models/discord-command-audit-log.js";
+
+export interface CommandAuditEntry {
+  guildId: string;
+  discordUserId: string;
+  commandName: string;
+  subcommand?: string | null;
+  channelId?: string | null;
+  result: "success" | "error" | "denied";
+  errorMessage?: string | null;
+  durationMs: number;
+}
+
+export async function recordCommandAudit(
+  entry: CommandAuditEntry,
+): Promise<void> {
+  try {
+    await DiscordCommandAuditLog.create({
+      guildId: entry.guildId,
+      discordUserId: entry.discordUserId,
+      commandName: entry.commandName,
+      subcommand: entry.subcommand ?? null,
+      channelId: entry.channelId ?? null,
+      result: entry.result,
+      errorMessage: entry.errorMessage ?? null,
+      durationMs: entry.durationMs,
+    });
+  } catch (err) {
+    // Audit failures must never break the user's command. Surface them in
+    // logs so operators notice persistent breakage.
+    logger.error("Failed to record Discord command audit entry", err);
+  }
+}

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -92,6 +92,7 @@ export const NAV_ITEMS: NavItem[] = [
     featureKey: "voicechannels.enabled",
   },
   { href: "/admin/database", label: "Database" },
+  { href: "/admin/audit/commands", label: "Command Audit" },
   { href: "/admin/bootstrap", label: "Bootstrap" },
 ];
 

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -1724,3 +1724,184 @@ ${renderFlash(props.flash)}
     navFeatureStatus: props.navFeatureStatus,
   });
 }
+
+// ---------- Command Audit Log ----------
+
+export interface CommandAuditRow {
+  createdAt: string;
+  discordUserId: string;
+  userLabel: string;
+  commandName: string;
+  subcommand: string | null;
+  channelId: string | null;
+  channelLabel: string | null;
+  result: "success" | "error" | "denied";
+  errorMessage: string | null;
+  durationMs: number;
+}
+
+export interface CommandAuditProps extends CommonProps {
+  enabled: boolean;
+  retentionDays: number;
+  /** All command names registered on the bot — populates the filter dropdown. */
+  commandOptions: string[];
+  /** All distinct user IDs in the current result page — populates the user filter. */
+  userOptions: Array<{ id: string; label: string }>;
+  /** Currently-applied filter values, echoed back into the form. */
+  filters: {
+    commandName: string;
+    userId: string;
+    result: string;
+    from: string;
+    to: string;
+  };
+  rows: CommandAuditRow[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+function resultTag(result: "success" | "error" | "denied"): string {
+  if (result === "success") return '<span class="tag tag-on">success</span>';
+  if (result === "denied") return '<span class="tag tag-warn">denied</span>';
+  return '<span class="tag tag-off">error</span>';
+}
+
+function buildAuditQueryString(
+  filters: CommandAuditProps["filters"],
+  page: number,
+): string {
+  const parts: string[] = [];
+  if (filters.commandName)
+    parts.push(`command=${encodeURIComponent(filters.commandName)}`);
+  if (filters.userId) parts.push(`user=${encodeURIComponent(filters.userId)}`);
+  if (filters.result)
+    parts.push(`result=${encodeURIComponent(filters.result)}`);
+  if (filters.from) parts.push(`from=${encodeURIComponent(filters.from)}`);
+  if (filters.to) parts.push(`to=${encodeURIComponent(filters.to)}`);
+  if (page > 1) parts.push(`page=${page}`);
+  return parts.length === 0 ? "" : `?${parts.join("&")}`;
+}
+
+export function renderCommandAuditPage(props: CommandAuditProps): string {
+  const totalPages = Math.max(1, Math.ceil(props.total / props.pageSize));
+  const page = Math.min(Math.max(1, props.page), totalPages);
+
+  const commandOptionsHtml = props.commandOptions
+    .map((c) => {
+      const sel = c === props.filters.commandName ? " selected" : "";
+      return `<option value="${escapeHtml(c)}"${sel}>/${escapeHtml(c)}</option>`;
+    })
+    .join("");
+  const userOptionsHtml = props.userOptions
+    .map((u) => {
+      const sel = u.id === props.filters.userId ? " selected" : "";
+      return `<option value="${escapeHtml(u.id)}"${sel}>${escapeHtml(u.label)}</option>`;
+    })
+    .join("");
+  const resultOpt = (val: string, label: string): string => {
+    const sel = val === props.filters.result ? " selected" : "";
+    return `<option value="${escapeHtml(val)}"${sel}>${escapeHtml(label)}</option>`;
+  };
+
+  const rowsHtml =
+    props.rows.length === 0
+      ? `<div class="empty">No command invocations match the current filters.</div>`
+      : `<table>
+<thead><tr>
+<th>When</th><th>User</th><th>Command</th><th>Channel</th>
+<th>Result</th><th>Duration</th><th>Error</th>
+</tr></thead>
+<tbody>${props.rows
+          .map((r) => {
+            const cmd = r.subcommand
+              ? `/${escapeHtml(r.commandName)} ${escapeHtml(r.subcommand)}`
+              : `/${escapeHtml(r.commandName)}`;
+            return `<tr>
+<td class="muted mono">${escapeHtml(r.createdAt)}</td>
+<td title="${escapeHtml(r.discordUserId)}">${escapeHtml(r.userLabel)}</td>
+<td class="mono">${cmd}</td>
+<td class="muted">${escapeHtml(r.channelLabel ?? r.channelId ?? "—")}</td>
+<td>${resultTag(r.result)}</td>
+<td class="muted">${r.durationMs}ms</td>
+<td class="muted">${r.errorMessage ? escapeHtml(r.errorMessage.slice(0, 80)) : "—"}</td>
+</tr>`;
+          })
+          .join("")}</tbody></table>`;
+
+  const prevLink =
+    page > 1
+      ? `<a class="btn btn-sm" href="/admin/audit/commands${buildAuditQueryString(props.filters, page - 1)}">← Prev</a>`
+      : `<button class="btn btn-sm" disabled>← Prev</button>`;
+  const nextLink =
+    page < totalPages
+      ? `<a class="btn btn-sm" href="/admin/audit/commands${buildAuditQueryString(props.filters, page + 1)}">Next →</a>`
+      : `<button class="btn btn-sm" disabled>Next →</button>`;
+
+  const body = `
+<h1>Slash-command audit log</h1>
+<p class="subtitle">One row per Discord slash-command invocation. Raw command arguments are deliberately omitted.</p>
+
+<div class="card">
+  <h2>Status</h2>
+  <dl class="kv">
+    <dt>Audit logging</dt><dd>${props.enabled ? '<span class="tag tag-on">enabled</span>' : '<span class="tag tag-off">disabled</span>'}</dd>
+    <dt>Retention</dt><dd>${props.retentionDays} days</dd>
+    <dt>Rows matched</dt><dd>${props.total}</dd>
+  </dl>
+  ${props.enabled ? "" : '<p class="muted">Enable <code>core.command_audit.enabled</code> in Settings to start recording.</p>'}
+</div>
+
+<div class="card">
+  <h2>Filters</h2>
+  <form method="GET" action="/admin/audit/commands" class="inline-form">
+    <label>Command
+      <select name="command">
+        <option value="">— any —</option>
+        ${commandOptionsHtml}
+      </select>
+    </label>
+    <label>User
+      <select name="user">
+        <option value="">— any —</option>
+        ${userOptionsHtml}
+      </select>
+    </label>
+    <label>Result
+      <select name="result">
+        <option value="">— any —</option>
+        ${resultOpt("success", "success")}
+        ${resultOpt("error", "error")}
+        ${resultOpt("denied", "denied")}
+      </select>
+    </label>
+    <label>From
+      <input type="date" name="from" value="${escapeHtml(props.filters.from)}">
+    </label>
+    <label>To
+      <input type="date" name="to" value="${escapeHtml(props.filters.to)}">
+    </label>
+    <button type="submit" class="btn btn-primary btn-sm">Apply</button>
+    <a class="btn btn-sm" href="/admin/audit/commands">Reset</a>
+  </form>
+</div>
+
+<div class="card">
+  <h2>Invocations (page ${page} of ${totalPages})</h2>
+  ${rowsHtml}
+  <div class="inline-form" style="margin-top:.75rem">
+    ${prevLink}
+    ${nextLink}
+    <span class="muted">${props.pageSize} per page</span>
+  </div>
+</div>
+`;
+  return renderAdminPage({
+    title: "Command audit",
+    active: "/admin/audit/commands",
+    body,
+    csrfToken: props.csrfToken,
+    remainingMs: props.remainingMs,
+    navFeatureStatus: props.navFeatureStatus,
+  });
+}

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -33,6 +33,7 @@ import {
   resolveManagedCategory,
 } from "../services/voice-channel-manager.js";
 import { WebAuditLog } from "../models/web-audit-log.js";
+import { DiscordCommandAuditLog } from "../models/discord-command-audit-log.js";
 import { BOOTSTRAP_VARS } from "./bootstrap-vars.js";
 import type { AuthenticatedRequest } from "./session.js";
 import {
@@ -43,6 +44,7 @@ import {
 import {
   renderAnnouncementsPage,
   renderBootstrapPage,
+  renderCommandAuditPage,
   renderDashboardPage,
   renderDatabasePage,
   renderNoticesPage,
@@ -52,6 +54,7 @@ import {
   renderSettingsPage,
   renderVoiceChannelsPage,
   type ChannelOption,
+  type CommandAuditRow,
   type DbTrunkHistoryRow,
   type FlashMessage,
   type NoticeCategoryOption,
@@ -860,6 +863,138 @@ export function createReadOnlyRouter(
           channels,
           categoryFound,
           flash: readFlash(req),
+        }),
+      );
+    }),
+  );
+
+  // ---------- Command Audit Log (#459) ----------
+  router.get(
+    "/audit/commands",
+    asyncHandler(async (req, res) => {
+      const common = await commonFromReq(req);
+      const config = ConfigService.getInstance();
+
+      const pageSize = 50;
+      const pageRaw = Number.parseInt(String(req.query.page ?? "1"), 10);
+      const page = Number.isFinite(pageRaw) && pageRaw > 0 ? pageRaw : 1;
+
+      const commandFilter = String(req.query.command ?? "").trim();
+      const userFilter = String(req.query.user ?? "").trim();
+      const resultFilterRaw = String(req.query.result ?? "").trim();
+      const resultFilter =
+        resultFilterRaw === "success" ||
+        resultFilterRaw === "error" ||
+        resultFilterRaw === "denied"
+          ? resultFilterRaw
+          : "";
+      const fromFilter = String(req.query.from ?? "").trim();
+      const toFilter = String(req.query.to ?? "").trim();
+
+      const query: Record<string, unknown> = { guildId: common.guildId };
+      if (commandFilter) query.commandName = commandFilter;
+      if (userFilter) query.discordUserId = userFilter;
+      if (resultFilter) query.result = resultFilter;
+
+      const dateRange: Record<string, Date> = {};
+      const parsedFrom = fromFilter ? new Date(fromFilter) : null;
+      const parsedTo = toFilter ? new Date(toFilter) : null;
+      if (parsedFrom && !Number.isNaN(parsedFrom.getTime())) {
+        dateRange.$gte = parsedFrom;
+      }
+      if (parsedTo && !Number.isNaN(parsedTo.getTime())) {
+        // Treat `to` as inclusive end-of-day so date pickers behave intuitively.
+        const inclusive = new Date(parsedTo);
+        inclusive.setHours(23, 59, 59, 999);
+        dateRange.$lte = inclusive;
+      }
+      if (Object.keys(dateRange).length > 0) {
+        query.createdAt = dateRange;
+      }
+
+      const [enabled, retentionDays, total, docs] = await Promise.all([
+        config.getBoolean("core.command_audit.enabled", true),
+        config.getNumber("core.command_audit.retention_days", 90),
+        DiscordCommandAuditLog.countDocuments(query).catch(() => 0),
+        DiscordCommandAuditLog.find(query)
+          .sort({ createdAt: -1 })
+          .skip((page - 1) * pageSize)
+          .limit(pageSize)
+          .lean()
+          .catch(() => [] as Array<Record<string, unknown>>),
+      ]);
+
+      // Resolve user labels from the guild member cache so the table
+      // shows names rather than raw snowflakes. One fetch per request.
+      const userIdsOnPage = new Set<string>();
+      for (const d of docs) {
+        if (typeof d.discordUserId === "string") {
+          userIdsOnPage.add(d.discordUserId);
+        }
+      }
+      const userLabels = new Map<string, string>();
+      try {
+        const guild = await client.guilds.fetch(common.guildId);
+        for (const id of userIdsOnPage) {
+          try {
+            const member = await guild.members.fetch(id);
+            userLabels.set(id, member.displayName ?? member.user.username);
+          } catch {
+            // Member left the guild or fetch failed; fall back to ID.
+          }
+        }
+      } catch (err) {
+        logger.debug("audit page user-label fetch failed", err);
+      }
+
+      const channelData = await fetchChannelData(client, common.guildId);
+
+      const rows: CommandAuditRow[] = docs.map((d) => {
+        const userId = String(d.discordUserId ?? "");
+        const channelId = typeof d.channelId === "string" ? d.channelId : null;
+        return {
+          createdAt:
+            d.createdAt instanceof Date
+              ? d.createdAt.toISOString()
+              : String(d.createdAt ?? ""),
+          discordUserId: userId,
+          userLabel: userLabels.get(userId) ?? userId,
+          commandName: String(d.commandName ?? ""),
+          subcommand: typeof d.subcommand === "string" ? d.subcommand : null,
+          channelId,
+          channelLabel: channelId
+            ? (channelData.names.get(channelId) ?? channelId)
+            : null,
+          result: (d.result as "success" | "error" | "denied") ?? "success",
+          errorMessage:
+            typeof d.errorMessage === "string" ? d.errorMessage : null,
+          durationMs: typeof d.durationMs === "number" ? d.durationMs : 0,
+        };
+      });
+
+      const commandOptions = Array.from(client.commands.keys()).sort();
+      const userOptions = Array.from(userIdsOnPage)
+        .sort()
+        .map((id) => ({ id, label: userLabels.get(id) ?? id }));
+
+      res.type("text/html").send(
+        renderCommandAuditPage({
+          ...common,
+          enabled,
+          retentionDays,
+          commandOptions,
+          userOptions,
+          filters: {
+            commandName: commandFilter,
+            userId: userFilter,
+            result: resultFilter,
+            from: fromFilter,
+            to: toFilter,
+          },
+          rows,
+          total,
+          page,
+          pageSize,
         }),
       );
     }),


### PR DESCRIPTION
Closes #459.

## Summary

Mirror the existing `WebAuditLog` (which captures every WebUI write) with a parallel `DiscordCommandAuditLog` so operators can see who ran which slash command, when, in which channel, and whether it succeeded. Surfaced as a new read-only `/admin/audit/commands` page in the existing admin layout.

## Changes

**Model & helper** (`src/models/discord-command-audit-log.ts`, `src/utils/record-command-audit.ts`)
- One row per `CommandManager.executeCommand` call: `guildId`, `discordUserId`, `commandName`, `subcommand`, `channelId`, `result` (`success`/`error`/`denied`), `errorMessage`, `durationMs`, `createdAt`.
- Audit writes are best-effort — DB failures are logged but never break the user-facing command.

**CommandManager hook** (`src/services/command-manager.ts`)
- `executeCommand` now records exactly one audit row per invocation: `denied` for permission rejection or rate-limit refusal, `error` for thrown exceptions (re-thrown after recording), `success` otherwise.
- Subcommand is extracted via `interaction.options.getSubcommand(false)`. Raw arguments are deliberately excluded.

**Config schema** (`src/services/config-schema.ts`)
- New `core.command_audit.enabled` (default `true`) and `core.command_audit.retention_days` (default `90`). New `core` category metadata.
- The `*enabled` default-audit test (#445) updated to include the new key with a comment explaining why it's not feature-gated.

**WebUI page** (`src/web/admin-views.ts`, `src/web/read-only-routes.ts`, `src/web/admin-layout.ts`)
- New `/admin/audit/commands` page rendered via `renderAdminPage` for layout consistency.
- Table is paginated (50/page, newest first) with filters for command name, user ID, result, and date range. Filters round-trip through the URL so links/refresh stay stable.
- User and channel IDs are resolved to display names via the guild cache (one fetch per request).
- Nav entry added under Database.

**Retention** (`src/services/command-audit-cleanup.ts`)
- Dedicated cron at 03:00 daily (offset from the 00:00 voice-tracking cleanup) prunes rows older than the configured retention. No-op when audit is disabled or retention ≤ 0. Wired into `initializeServices` and graceful shutdown in `src/index.ts`.

**Docs**: WEBUI.md page-list updated.

## Test plan

- [x] `npm run check:all` — type-check, lint, format-check, all 80 test suites (778 passed / 1 skipped) green.
- [x] New tests cover the helper (3), the cleanup service (4), the page renderer (4), and the model load (2).
- [ ] Manual: in a running dev container, redeem a `/config` session and visit `/admin/audit/commands` to confirm filters and pagination behave on a live MongoDB.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LqeqgJChzZFgYQaWz1rS5U)_