### PR TITLE
feat(web): user-scoped sessions + /me self-service surface (closes #481)

### DIFF
--- a/WEBUI.md
+++ b/WEBUI.md
@@ -55,10 +55,10 @@ port to learn. It is dark unless `WEBUI_ENABLED=true`.
 The Web UI ships two parallel surfaces on the same Express server, both
 gated by the same magic-link flow:
 
-| Surface  | Mount     | Who can reach it          | What it's for                                              |
-| -------- | --------- | ------------------------- | ---------------------------------------------------------- |
-| Admin    | `/admin/` | sessions with `role:admin` | Server-wide config — Settings, Permissions, Wizard, etc.   |
-| Self     | `/me/`    | both `admin` and `user`   | The signed-in **user's own** preferences and Rewind        |
+| Surface | Mount     | Who can reach it           | What it's for                                            |
+| ------- | --------- | -------------------------- | -------------------------------------------------------- |
+| Admin   | `/admin/` | sessions with `role:admin` | Server-wide config — Settings, Permissions, Wizard, etc. |
+| Self    | `/me/`    | both `admin` and `user`    | The signed-in **user's own** preferences and Rewind      |
 
 What changes per session:
 
@@ -665,10 +665,10 @@ side effect, since the HMAC key changes.
 | ----------------------- | ---------------------------------------------------------------------------------------------- |
 | **Overview** (`/me/`)   | Index for your own settings — placeholder cards listing the pages future sub-issues will land. |
 
-Per-user features bolt onto `/me` in #482 (notification preferences),
-#484 (Rewind), and friends. Each adds its own card to the index plus a
-dedicated sub-page; the layout, session, and self-scope plumbing are
-already in place.
+Per-user features bolt onto `/me` in #482 (notification preferences)
+and #484 (Rewind), among others. Each adds its own card to the index
+plus a dedicated sub-page; the layout, session, and self-scope
+plumbing are already in place.
 
 User-facing commands (`/ping`, `/voicestats`, `/seen`, `/quote`,
 `/achievements`, `/help`) are **not** affected and stay in

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -6,6 +6,12 @@ Everything that used to live behind `/config set`, `/permissions`, `/setup`,
 `/botstats` is now reached by running a single Discord slash command,
 `/config`, which DMs you a one-time sign-in link.
 
+Since #481 the same `/config` flow also opens a **user self-service
+surface** at `/me/*` — non-admin guild members can manage their own
+preferences (notifications, Rewind, etc.) without ever touching the
+admin panel, while admins can hop between the two surfaces using a
+single redeemed session.
+
 This document explains how to enable it, expose it, and operate it.
 
 ---
@@ -13,6 +19,7 @@ This document explains how to enable it, expose it, and operate it.
 ## 📋 Table of Contents
 
 - [TL;DR](#tldr)
+- [Two surfaces: `/admin` and `/me`](#two-surfaces-admin-and-me)
 - [How the magic-link flow works](#how-the-magic-link-flow-works)
 - [Configuration boundary: env vs. database](#configuration-boundary-env-vs-database)
 - [Bootstrap environment variables](#bootstrap-environment-variables)
@@ -43,6 +50,53 @@ port to learn. It is dark unless `WEBUI_ENABLED=true`.
 
 ---
 
+## Two surfaces: `/admin` and `/me`
+
+The Web UI ships two parallel surfaces on the same Express server, both
+gated by the same magic-link flow:
+
+| Surface  | Mount     | Who can reach it          | What it's for                                              |
+| -------- | --------- | ------------------------- | ---------------------------------------------------------- |
+| Admin    | `/admin/` | sessions with `role:admin` | Server-wide config — Settings, Permissions, Wizard, etc.   |
+| Self     | `/me/`    | both `admin` and `user`   | The signed-in **user's own** preferences and Rewind        |
+
+What changes per session:
+
+- **Non-admin guild member runs `/config`.** They get a session with
+  `role:user`, the DM points at `/me/`, and `/admin/*` returns 403
+  (the page tells them to head to `/me`).
+- **Administrator runs `/config`.** They get a session with `role:admin`.
+  The DM mentions both entry points. They land on `/admin/` by default,
+  but every admin page header carries a "My preferences" link that takes
+  them to `/me/` without re-running `/config`. The `/me/*` layout in turn
+  carries a "Back to admin panel" link.
+- **A `/me/*` handler can only read/write the signed-in user's own rows.**
+  This is enforced by the `assertSelfScope` helper (see
+  `src/web/user-routes.ts`) and applies to admin-role sessions too — an
+  admin on `/me/notifications` sees *their* prefs, not the guild's. Admins
+  who need to act on another user's data do so via the admin panel's
+  audit/user tooling, not by impersonating them on `/me/*`.
+
+> **v1 is foundations only.** Today `/me/` is a stub index page that
+> announces the surface; the per-user features (notifications, Rewind,
+> achievements, etc.) land in the dependent sub-issues of #480. The
+> session model, layout, and self-scope helper are all in place so those
+> issues can bolt on without touching auth, routing, or layout.
+
+The role is decided **server-side** at `/config` time from the invoker's
+live guild permissions (`Administrator` bit → `admin`, anything else →
+`user`) and baked into the redeemed session row + signed cookie. The
+slash-command itself is not gated by `default_member_permissions` —
+that would hide the command from non-admins entirely, defeating the
+user surface.
+
+Audit-log rows produced through the Web UI now record the role the
+session was acting under, so the admin audit page can filter by `admin`
+vs. `user` writes. An admin acting on their own `/me/*` is logged with
+`role: "admin"` (the role is the session's, not the URL surface's).
+
+---
+
 ## How the magic-link flow works
 
 ```text
@@ -66,12 +120,16 @@ port to learn. It is dark unless `WEBUI_ENABLED=true`.
                             │ - mark used      │
                             │ - issue cookie   │
                             │ - 302 → /admin/  │
+                            │   (role=admin)   │
+                            │   or /me/        │
+                            │   (role=user)    │
                             └──────────────────┘
                                  │
                                  │ authenticated by signed cookie
                                  ▼
                             ┌──────────────────┐
-                            │ /admin/* pages   │
+                            │ /admin/* (admin) │
+                            │ /me/*   (either) │
                             │ permissions re-  │
                             │ checked each req │
                             └──────────────────┘
@@ -584,6 +642,8 @@ side effect, since the HMAC key changes.
 
 ## What the Web UI lets you do
 
+### Admin panel (`/admin/*`, admin-role sessions only)
+
 | Page               | Replaces                                                                                            |
 | ------------------ | --------------------------------------------------------------------------------------------------- |
 | **Dashboard**      | `/botstats`                                                                                         |
@@ -598,6 +658,17 @@ side effect, since the HMAC key changes.
 | **Database**       | `/dbtrunk status`, `/dbtrunk run`                                                                   |
 | **Command Audit**  | (new — read-only Discord slash-command audit log)                                                   |
 | **Bootstrap**      | (new — read-only env diagnostics)                                                                   |
+
+### User self-service (`/me/*`, both admin and user roles)
+
+| Page                    | What it's for                                                                                  |
+| ----------------------- | ---------------------------------------------------------------------------------------------- |
+| **Overview** (`/me/`)   | Index for your own settings — placeholder cards listing the pages future sub-issues will land. |
+
+Per-user features bolt onto `/me` in #482 (notification preferences),
+#484 (Rewind), and friends. Each adds its own card to the index plus a
+dedicated sub-page; the layout, session, and self-scope plumbing are
+already in place.
 
 User-facing commands (`/ping`, `/voicestats`, `/seen`, `/quote`,
 `/achievements`, `/help`) are **not** affected and stay in

--- a/__tests__/commands/config.test.ts
+++ b/__tests__/commands/config.test.ts
@@ -53,9 +53,13 @@ describe("Config Command — metadata", () => {
     expect(json).toHaveProperty("description");
   });
 
-  it("requires administrator permissions", () => {
+  it("does NOT gate via default_member_permissions (#481: every guild member can run /config)", () => {
+    // Role is decided server-side from the invoker's live permissions
+    // and baked into the redeemed session; the slash-command itself is
+    // open. Discord's `default_member_permissions` would otherwise hide
+    // the command from non-admins, defeating the user surface.
     const json = data.toJSON();
-    expect(json.default_member_permissions).toBeDefined();
+    expect(json.default_member_permissions ?? null).toBeNull();
   });
 
   it("exposes no subcommands (bare /config launches the WebUI)", () => {
@@ -90,7 +94,16 @@ describe("Config Command — execute", () => {
   let userSend: jest.Mock;
 
   function buildInteraction(
-    overrides: { guildId?: string | null; userId?: string } = {},
+    overrides: {
+      guildId?: string | null;
+      userId?: string;
+      /**
+       * Permission bitfield string as Discord's interaction payload
+       * delivers it for non-cached members. "8" sets the Administrator
+       * bit. Omit to simulate a non-admin guild member.
+       */
+      permissionsBitfield?: string;
+    } = {},
   ): ChatInputCommandInteraction {
     deferReply = jest.fn().mockResolvedValue(undefined as never);
     editReply = jest.fn().mockResolvedValue(undefined as never);
@@ -100,6 +113,12 @@ describe("Config Command — execute", () => {
       deferReply,
       editReply,
       guildId: overrides.guildId === undefined ? "g1" : overrides.guildId,
+      member:
+        overrides.guildId === null
+          ? null
+          : {
+              permissions: overrides.permissionsBitfield ?? "0",
+            },
       user: {
         id: overrides.userId ?? "u1",
         send: userSend,
@@ -123,6 +142,7 @@ describe("Config Command — execute", () => {
     mockCreateSession.mockResolvedValue({
       url: "https://example.test/admin/s/tok",
       expiresAt: new Date(Date.now() + 10 * 60_000),
+      role: "user",
     });
     const interaction = buildInteraction();
 
@@ -173,12 +193,13 @@ describe("Config Command — execute", () => {
     mockCreateSession.mockResolvedValue({
       url: "https://example.test/admin/s/tok",
       expiresAt: new Date(Date.now() + 10 * 60_000),
+      role: "user",
     });
     const interaction = buildInteraction();
 
     await execute(interaction);
 
-    expect(mockCreateSession).toHaveBeenCalledWith("u1", "g1");
+    expect(mockCreateSession).toHaveBeenCalledWith("u1", "g1", "user");
     expect(userSend).toHaveBeenCalledWith(
       expect.stringContaining("https://example.test/admin/s/tok"),
     );
@@ -187,10 +208,47 @@ describe("Config Command — execute", () => {
     });
   });
 
+  it("issues an admin-role session when the invoker has Administrator", async () => {
+    mockCreateSession.mockResolvedValue({
+      url: "https://example.test/admin/s/tok",
+      expiresAt: new Date(Date.now() + 10 * 60_000),
+      role: "admin",
+    });
+    // Administrator bit is `0x8`; the bitfield-as-string form is what
+    // non-cached interactions deliver.
+    const interaction = buildInteraction({ permissionsBitfield: "8" });
+
+    await execute(interaction);
+
+    expect(mockCreateSession).toHaveBeenCalledWith("u1", "g1", "admin");
+    // Admin DM body advertises both surfaces.
+    const dm = userSend.mock.calls[0][0] as string;
+    expect(dm).toContain("/admin/");
+    expect(dm).toContain("/me/");
+  });
+
+  it("issues a user-role session for non-administrators", async () => {
+    mockCreateSession.mockResolvedValue({
+      url: "https://example.test/admin/s/tok",
+      expiresAt: new Date(Date.now() + 10 * 60_000),
+      role: "user",
+    });
+    const interaction = buildInteraction({ permissionsBitfield: "0" });
+
+    await execute(interaction);
+
+    expect(mockCreateSession).toHaveBeenCalledWith("u1", "g1", "user");
+    // Non-admin DM body must NOT advertise the admin panel.
+    const dm = userSend.mock.calls[0][0] as string;
+    expect(dm).toContain("/me/");
+    expect(dm).not.toMatch(/admin panel/i);
+  });
+
   it("falls back to ephemeral reply when DM fails", async () => {
     mockCreateSession.mockResolvedValue({
       url: "https://example.test/admin/s/tok",
       expiresAt: new Date(Date.now() + 10 * 60_000),
+      role: "user",
     });
     const interaction = buildInteraction();
     userSend.mockRejectedValueOnce(new Error("DMs blocked") as never);

--- a/__tests__/services/web-session-service.test.ts
+++ b/__tests__/services/web-session-service.test.ts
@@ -51,17 +51,34 @@ describe("WebSessionService", () => {
     (WebSession as unknown as { create: unknown }).create = create;
 
     const svc = WebSessionService.getInstance();
-    const result = await svc.create("user-1", "guild-1", ["scope:a"]);
+    const result = await svc.create("user-1", "guild-1", "admin", ["scope:a"]);
 
     expect(updateMany).toHaveBeenCalledWith(
       { discordUserId: "user-1", revokedAt: null },
       { $set: expect.objectContaining({ revokedAt: expect.any(Date) }) },
     );
     expect(create).toHaveBeenCalledTimes(1);
+    expect(create.mock.calls[0][0]).toMatchObject({ role: "admin" });
     expect(result.url).toMatch(
       /^https:\/\/example\.test\/admin\/s\/[A-Za-z0-9_-]+$/,
     );
+    expect(result.role).toBe("admin");
     expect(result.expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("create defaults to user role when none is supplied", async () => {
+    (WebSession as unknown as { updateMany: unknown }).updateMany = jest
+      .fn()
+      .mockResolvedValue({ modifiedCount: 0 });
+    const create = jest.fn().mockResolvedValue({ _id: "abc" });
+    (WebSession as unknown as { create: unknown }).create = create;
+
+    const svc = WebSessionService.getInstance();
+    const result = await svc.create("user-1", "guild-1");
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(create.mock.calls[0][0]).toMatchObject({ role: "user" });
+    expect(result.role).toBe("user");
   });
 
   it("redeem returns null when no matching unused session exists", async () => {
@@ -81,11 +98,11 @@ describe("WebSessionService", () => {
       _id: { toString: () => "session-id" },
       discordUserId: "user-1",
       guildId: "guild-1",
+      role: "user",
       scopes: ["scope:a"],
     });
-    (
-      WebSession as unknown as { findOneAndUpdate: unknown }
-    ).findOneAndUpdate = findOneAndUpdate;
+    (WebSession as unknown as { findOneAndUpdate: unknown }).findOneAndUpdate =
+      findOneAndUpdate;
 
     const svc = WebSessionService.getInstance();
     const result = await svc.redeem("any-token");
@@ -94,6 +111,7 @@ describe("WebSessionService", () => {
       sessionId: "session-id",
       discordUserId: "user-1",
       guildId: "guild-1",
+      role: "user",
       scopes: ["scope:a"],
     });
     const call = findOneAndUpdate.mock.calls[0];
@@ -102,6 +120,20 @@ describe("WebSessionService", () => {
       revokedAt: null,
     });
     expect(call[1]).toMatchObject({ $set: { usedAt: expect.any(Date) } });
+  });
+
+  it("redeem promotes a missing role to legacy admin (pre-#481 rows)", async () => {
+    (WebSession as unknown as { findOneAndUpdate: unknown }).findOneAndUpdate =
+      jest.fn().mockResolvedValue({
+        _id: { toString: () => "session-id" },
+        discordUserId: "user-1",
+        guildId: "guild-1",
+        // role intentionally absent — pre-#481 row.
+        scopes: [],
+      });
+    const svc = WebSessionService.getInstance();
+    const result = await svc.redeem("any-token");
+    expect(result?.role).toBe("admin");
   });
 
   it("revokeSession returns true when modifiedCount > 0", async () => {
@@ -240,10 +272,11 @@ describe("WebSessionService", () => {
       const fn = jest.fn().mockResolvedValue(existing);
       (WebSession as unknown as { findOne: unknown }).findOne = fn;
       // No findOneAndUpdate stub — peek must not call it.
-      (WebSession as unknown as { findOneAndUpdate: unknown }).findOneAndUpdate =
-        jest.fn(() => {
-          throw new Error("peek() must not consume the token");
-        });
+      (
+        WebSession as unknown as { findOneAndUpdate: unknown }
+      ).findOneAndUpdate = jest.fn(() => {
+        throw new Error("peek() must not consume the token");
+      });
       return fn;
     }
 
@@ -252,6 +285,7 @@ describe("WebSessionService", () => {
         _id: { toString: () => "session-id" },
         discordUserId: "user-1",
         guildId: "guild-1",
+        role: "user",
         scopes: ["scope:a"],
         usedAt: null,
         revokedAt: null,
@@ -263,6 +297,7 @@ describe("WebSessionService", () => {
         sessionId: "session-id",
         discordUserId: "user-1",
         guildId: "guild-1",
+        role: "user",
         scopes: ["scope:a"],
       });
       expect(findOne).toHaveBeenCalledTimes(1);
@@ -297,9 +332,7 @@ describe("WebSessionService", () => {
       });
       const svc = WebSessionService.getInstance();
       expect(await svc.peek("anything")).toBeNull();
-      expect(infoMock).toHaveBeenCalledWith(
-        expect.stringContaining("revoked"),
-      );
+      expect(infoMock).toHaveBeenCalledWith(expect.stringContaining("revoked"));
     });
 
     it("returns null and logs 'already_used' when usedAt is set", async () => {
@@ -331,9 +364,7 @@ describe("WebSessionService", () => {
       });
       const svc = WebSessionService.getInstance();
       expect(await svc.peek("anything")).toBeNull();
-      expect(infoMock).toHaveBeenCalledWith(
-        expect.stringContaining("expired"),
-      );
+      expect(infoMock).toHaveBeenCalledWith(expect.stringContaining("expired"));
     });
   });
 });

--- a/__tests__/web/session-admin-role.test.ts
+++ b/__tests__/web/session-admin-role.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for the role-checking session middleware introduced in
+ * #481 (`requireAdminRoleMiddleware`). Verifies:
+ *
+ *   - Admin-role sessions pass through.
+ *   - User-role sessions get a 403 HTML page that points at `/me`.
+ *   - A missing session collapses to 401 (defensive — the caller is
+ *     expected to mount this AFTER `createSessionMiddleware`).
+ */
+
+import { describe, it, expect, jest } from "@jest/globals";
+import {
+  requireAdminRoleMiddleware,
+  type WebSessionContext,
+} from "../../src/web/session.js";
+
+function makeRes(): {
+  statusCode: number;
+  body: string;
+  status: jest.Mock;
+  type: jest.Mock;
+  send: jest.Mock;
+} {
+  const res = {
+    statusCode: 200,
+    body: "",
+    status: jest.fn(),
+    type: jest.fn(),
+    send: jest.fn(),
+  } as never as {
+    statusCode: number;
+    body: string;
+    status: jest.Mock;
+    type: jest.Mock;
+    send: jest.Mock;
+  };
+  res.status.mockImplementation((code: number) => {
+    res.statusCode = code;
+    return res;
+  });
+  res.type.mockImplementation(() => res);
+  res.send.mockImplementation((body: unknown) => {
+    res.body = typeof body === "string" ? body : String(body);
+    return res;
+  });
+  return res;
+}
+
+const baseSession: WebSessionContext = {
+  sessionId: "s1",
+  discordUserId: "u1",
+  guildId: "g1",
+  role: "admin",
+  scopes: [],
+  lastActivityAt: 0,
+  expiresAt: new Date(),
+};
+
+describe("requireAdminRoleMiddleware", () => {
+  it("calls next() for an admin-role session", () => {
+    const next = jest.fn();
+    const req = { webSession: { ...baseSession, role: "admin" } } as never;
+    requireAdminRoleMiddleware()(req, makeRes() as never, next as never);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a user-role session with a 403 HTML page pointing at /me", () => {
+    const next = jest.fn();
+    const res = makeRes();
+    const req = {
+      webSession: { ...baseSession, role: "user" },
+    } as never;
+    requireAdminRoleMiddleware()(req, res as never, next as never);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toContain("Forbidden");
+    expect(res.body).toContain('href="/me/"');
+  });
+
+  it("returns 401 (not 403) when no webSession is attached", () => {
+    // Defensive: surfaces a mounting bug rather than silently dropping
+    // a request through to a handler with no session context.
+    const next = jest.fn();
+    const res = makeRes();
+    const req = {} as never;
+    requireAdminRoleMiddleware()(req, res as never, next as never);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/__tests__/web/user-routes.test.ts
+++ b/__tests__/web/user-routes.test.ts
@@ -232,3 +232,35 @@ describe("createUserRouter / index page", () => {
     expect(html).toContain('href="/admin/"');
   });
 });
+
+describe("userWebErrorHandler", () => {
+  it("rewrites SelfScopeError to a 403 HTML page (not a generic 500)", async () => {
+    const { userWebErrorHandler } = await import("../../src/web/index.js");
+    const res = makeRes();
+    const next = jest.fn();
+    userWebErrorHandler(
+      new SelfScopeError("test: user-a tried to read user-b's row"),
+      {} as never,
+      res as never,
+      next as never,
+    );
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toContain("Forbidden");
+    expect(res.body).toContain('href="/me/"');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("falls through to a generic 500 for any other error", async () => {
+    const { userWebErrorHandler } = await import("../../src/web/index.js");
+    const res = makeRes();
+    const next = jest.fn();
+    userWebErrorHandler(
+      new Error("totally unrelated"),
+      {} as never,
+      res as never,
+      next as never,
+    );
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toBe("Internal Server Error");
+  });
+});

--- a/__tests__/web/user-routes.test.ts
+++ b/__tests__/web/user-routes.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Unit tests for the user self-service surface (#481).
+ *
+ * Covers:
+ *  - `assertSelfScope`: a session may only act on its own (userId, guildId);
+ *    admins on `/me/*` see their own data, not someone else's.
+ *  - The `/me` index handler renders for both admin and user-role sessions.
+ *  - The "Back to admin panel" link only appears for admin-role sessions.
+ *  - The CSRF-protected `/me/finish` revokes the session and clears the cookie.
+ */
+
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { Buffer } from "buffer";
+import {
+  assertSelfScope,
+  createUserRouter,
+  SelfScopeError,
+} from "../../src/web/user-routes.js";
+import { signValue } from "../../src/web/cookies.js";
+import { WebSessionService } from "../../src/services/web-session-service.js";
+import type { WebSessionContext } from "../../src/web/session.js";
+
+interface CookiePayload {
+  sid: string;
+  uid: string;
+  gid: string;
+  rol?: "admin" | "user";
+  iat: number;
+  act: number;
+}
+
+const SECRET = "test-secret-for-user-routes";
+
+function buildCookie(payload: CookiePayload): string {
+  const encoded = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return signValue(encoded, SECRET);
+}
+
+function makeRes(): {
+  statusCode: number;
+  body: string;
+  headers: Record<string, unknown>;
+  status: jest.Mock;
+  type: jest.Mock;
+  send: jest.Mock;
+  setHeader: jest.Mock;
+  getHeader: jest.Mock;
+} {
+  const headers: Record<string, unknown> = {};
+  const res = {
+    statusCode: 200,
+    body: "",
+    headers,
+    status: jest.fn(),
+    type: jest.fn(),
+    send: jest.fn(),
+    setHeader: jest.fn((name: string, value: unknown) => {
+      headers[name.toLowerCase()] = value;
+      return res;
+    }),
+    getHeader: jest.fn((name: string) => headers[name.toLowerCase()]),
+  } as never as {
+    statusCode: number;
+    body: string;
+    headers: Record<string, unknown>;
+    status: jest.Mock;
+    type: jest.Mock;
+    send: jest.Mock;
+    setHeader: jest.Mock;
+    getHeader: jest.Mock;
+  };
+  res.status.mockImplementation((code: number) => {
+    res.statusCode = code;
+    return res;
+  });
+  res.type.mockImplementation(() => res);
+  res.send.mockImplementation((body: unknown) => {
+    res.body = typeof body === "string" ? body : String(body);
+    return res;
+  });
+  return res;
+}
+
+describe("assertSelfScope", () => {
+  const sessionAdmin: WebSessionContext = {
+    sessionId: "s1",
+    discordUserId: "owner-1",
+    guildId: "guild-1",
+    role: "admin",
+    scopes: [],
+    lastActivityAt: 0,
+    expiresAt: new Date(),
+  };
+  const sessionUser: WebSessionContext = {
+    ...sessionAdmin,
+    role: "user",
+    discordUserId: "user-2",
+  };
+
+  it("returns the validated pair when target matches the session", () => {
+    expect(
+      assertSelfScope(sessionUser, {
+        userId: "user-2",
+        guildId: "guild-1",
+      }),
+    ).toEqual({ userId: "user-2", guildId: "guild-1" });
+  });
+
+  it("throws SelfScopeError when the userId differs", () => {
+    expect(() =>
+      assertSelfScope(sessionUser, {
+        userId: "someone-else",
+        guildId: "guild-1",
+      }),
+    ).toThrow(SelfScopeError);
+  });
+
+  it("throws SelfScopeError when the guildId differs", () => {
+    expect(() =>
+      assertSelfScope(sessionUser, {
+        userId: "user-2",
+        guildId: "another-guild",
+      }),
+    ).toThrow(SelfScopeError);
+  });
+
+  it("applies equally to admin-role sessions on /me/* (no impersonation bypass)", () => {
+    // The crucial property from #481: admins acting on `/me/*` see THEIR
+    // own data, not another user's. The helper does not relax checks for
+    // admin role.
+    expect(() =>
+      assertSelfScope(sessionAdmin, {
+        userId: "victim",
+        guildId: "guild-1",
+      }),
+    ).toThrow(SelfScopeError);
+
+    // Admin acting on their own row is fine.
+    expect(
+      assertSelfScope(sessionAdmin, {
+        userId: "owner-1",
+        guildId: "guild-1",
+      }),
+    ).toEqual({ userId: "owner-1", guildId: "guild-1" });
+  });
+});
+
+describe("createUserRouter / index page", () => {
+  beforeEach(() => {
+    process.env.WEBUI_SESSION_SECRET = SECRET;
+    process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES = "30";
+    (WebSessionService as unknown as { instance: unknown }).instance = null;
+  });
+
+  async function dispatchIndex(role: "admin" | "user"): Promise<string> {
+    const now = Date.now();
+    const payload: CookiePayload = {
+      sid: "session-id",
+      uid: "user-1",
+      gid: "guild-1",
+      rol: role,
+      iat: now - 60_000,
+      act: now - 60_000,
+    };
+    const cookie = `koolbot_session=${buildCookie(payload)}; koolbot_csrf=csrf-1`;
+
+    const svc = WebSessionService.getInstance();
+    jest.spyOn(svc, "findById").mockResolvedValue({
+      discordUserId: "user-1",
+      guildId: "guild-1",
+      role,
+      scopes: [],
+      revokedAt: null,
+      expiresAt: new Date(now + 60 * 60 * 1000),
+    } as never);
+
+    // Permission revalidation runs from the cookie-session middleware
+    // inside `createUserRouter`; mock it to a pass-through so the user
+    // surface doesn't drag the whole PermissionsService into this test.
+    const mockClient = {} as never;
+    const { PermissionsService } =
+      await import("../../src/services/permissions-service.js");
+    jest.spyOn(PermissionsService, "getInstance").mockReturnValue({
+      checkCommandPermission: async () => true,
+    } as never);
+
+    const { createSessionMiddleware } =
+      await import("../../src/web/session.js");
+    const requireSession = createSessionMiddleware(mockClient);
+    const router = createUserRouter(mockClient, requireSession);
+
+    const req = {
+      method: "GET",
+      url: "/",
+      originalUrl: "/me/",
+      path: "/",
+      baseUrl: "/me",
+      headers: { cookie },
+      csrfToken: "csrf-1",
+    } as never as Parameters<typeof router>[0];
+    const res = makeRes();
+    const next = jest.fn();
+    await new Promise<void>((resolve) => {
+      router(
+        req as never,
+        res as never,
+        ((err: unknown) => {
+          next(err);
+          resolve();
+        }) as never,
+      );
+      // The handler is async — wait one macrotask so the response
+      // settles. `setTimeout(..., 0)` plays the same role as
+      // `setImmediate` here without needing Node typings in the test.
+      setTimeout(resolve, 0);
+    });
+    // Give the async handler a chance to complete.
+    await new Promise((r) => setTimeout(r, 10));
+    return res.body;
+  }
+
+  it("renders the index for a user-role session without the admin link", async () => {
+    const html = await dispatchIndex("user");
+    expect(html).toContain("My preferences");
+    expect(html).not.toContain("Back to admin panel");
+  });
+
+  it("renders the index for an admin-role session WITH the admin link", async () => {
+    const html = await dispatchIndex("admin");
+    expect(html).toContain("My preferences");
+    expect(html).toContain("Back to admin panel");
+    expect(html).toContain('href="/admin/"');
+  });
+});

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,16 +1,19 @@
 import {
   SlashCommandBuilder,
   ChatInputCommandInteraction,
+  GuildMember,
   PermissionFlagsBits,
 } from "discord.js";
 import logger from "../utils/logger.js";
 import { WebSessionService } from "../services/web-session-service.js";
+import type { WebSessionRole } from "../models/web-session.js";
 import { getMissingWebUIEnvVars, isWebUIEnabled } from "../web/index.js";
 
 export const data = new SlashCommandBuilder()
   .setName("config")
-  .setDescription("Open the admin web UI (sends you a single-use sign-in link)")
-  .setDefaultMemberPermissions(PermissionFlagsBits.Administrator);
+  .setDescription(
+    "Open the Koolbot web UI (sends you a single-use sign-in link)",
+  );
 
 export async function execute(
   interaction: ChatInputCommandInteraction,
@@ -53,20 +56,26 @@ export async function execute(
     return;
   }
 
+  // Pick the session role from the invoker's live guild permissions.
+  // Administrator gets `admin` (admin panel + own `/me`); everyone else
+  // gets `user` (only `/me`). Falling through to "user" on a non-member
+  // is conservative — the user surface itself enforces self-scope, so a
+  // bad role wouldn't grant access to anyone else's data.
+  const role: WebSessionRole = invokerIsAdmin(interaction.member)
+    ? "admin"
+    : "user";
+
   try {
     const session = await WebSessionService.getInstance().create(
       userId,
       guildId,
+      role,
     );
     const ttlMinutes = Math.max(
       1,
       Math.round((session.expiresAt.getTime() - Date.now()) / 60_000),
     );
-    const dmBody =
-      `🔗 **Koolbot admin sign-in link**\n` +
-      `${session.url}\n` +
-      `This link is single-use and expires in about ${ttlMinutes} minute(s). ` +
-      `If you did not run \`/config\`, ignore this message.`;
+    const dmBody = buildDmBody(session.url, ttlMinutes, role);
 
     try {
       await interaction.user.send(dmBody);
@@ -92,4 +101,70 @@ export async function execute(
       content: "An error occurred while issuing your sign-in link.",
     });
   }
+}
+
+/**
+ * Determine whether the invoking guild member has the Administrator
+ * permission. Returns false defensively when the member object is null
+ * (DM contexts, partials missing the permissions bitfield, etc.) — that
+ * case is already filtered out earlier in the handler, but the
+ * conservative default makes role escalation impossible from this path
+ * even if the upstream check were removed.
+ */
+function invokerIsAdmin(
+  member: ChatInputCommandInteraction["member"],
+): boolean {
+  if (!member) return false;
+  // Cached members are `GuildMember`; non-cached interactions surface an
+  // `APIInteractionGuildMember` whose `permissions` field is a string
+  // bitfield. We only trust the cached path for the strongly-typed
+  // `.has()` check; the bitfield branch is handled below.
+  if (member instanceof GuildMember) {
+    return member.permissions.has(PermissionFlagsBits.Administrator);
+  }
+  const raw = (member as { permissions?: unknown }).permissions;
+  if (typeof raw !== "string") return false;
+  try {
+    return (
+      (BigInt(raw) & PermissionFlagsBits.Administrator) ===
+      PermissionFlagsBits.Administrator
+    );
+  } catch {
+    return false;
+  }
+}
+
+function buildDmBody(
+  url: string,
+  ttlMinutes: number,
+  role: WebSessionRole,
+): string {
+  const lifecycle =
+    `This link is single-use and expires in about ${ttlMinutes} minute(s). ` +
+    `If you did not run \`/config\`, ignore this message.`;
+  if (role === "admin") {
+    // Admins get one sign-in link plus a note that explains both
+    // post-redemption surfaces. The token covers `/admin/*` and
+    // `/me/*`; we land them on the admin panel by default but the link
+    // to their own preferences is right there in the DM.
+    return (
+      `🔗 **Koolbot sign-in link**\n` +
+      `${url}\n` +
+      `\n` +
+      `Once you've signed in:\n` +
+      `• **Admin panel:** the link above drops you on \`/admin/\`.\n` +
+      `• **My preferences:** switch to \`/me/\` for your own settings ` +
+      `(also reachable via the header link on every admin page).\n` +
+      `\n` +
+      `${lifecycle}`
+    );
+  }
+  return (
+    `🔗 **Koolbot sign-in link**\n` +
+    `${url}\n` +
+    `Opens **My preferences** (\`/me/\`) — your personal Koolbot settings ` +
+    `for this server.\n` +
+    `\n` +
+    `${lifecycle}`
+  );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ import { LeaderboardRoleService } from "./services/leaderboard-role-service.js";
 import { WizardService } from "./services/wizard-service.js";
 import { MonitoringService } from "./services/monitoring-service.js";
 import {
+  createUserWebRouter,
   createWebRouter,
   getMissingWebUIEnvVars,
   isWebUIEnabled,
@@ -167,7 +168,8 @@ function startHealthServer(): void {
         logger.info(`WebUI trust proxy set to: ${trustProxyRaw}`);
       }
       healthApp.use("/admin", createWebRouter(client));
-      logger.info("WebUI mounted at /admin");
+      healthApp.use("/me", createUserWebRouter(client));
+      logger.info("WebUI mounted at /admin and user surface at /me");
     }
   } else {
     logger.debug("WEBUI_ENABLED is not true; /admin routes not mounted");

--- a/src/models/web-audit-log.ts
+++ b/src/models/web-audit-log.ts
@@ -10,6 +10,12 @@ export interface IWebAuditLog extends Document {
   guildId: string;
   sessionId: string;
   discordUserId: string;
+  /**
+   * Role of the session that produced this entry. Defaults to `"admin"` so
+   * audit rows written before #481 (when only admins could redeem a
+   * session) read back consistently.
+   */
+  role: "admin" | "user";
   action: string;
   targetId: string | null;
   details: Record<string, unknown>;
@@ -23,6 +29,13 @@ const WebAuditLogSchema = new Schema<IWebAuditLog>(
     guildId: { type: String, required: true, index: true },
     sessionId: { type: String, required: true, index: true },
     discordUserId: { type: String, required: true, index: true },
+    role: {
+      type: String,
+      enum: ["admin", "user"],
+      required: true,
+      default: "admin",
+      index: true,
+    },
     action: { type: String, required: true },
     targetId: { type: String, default: null },
     details: { type: Schema.Types.Mixed, default: {} },

--- a/src/models/web-session.ts
+++ b/src/models/web-session.ts
@@ -1,9 +1,19 @@
 import mongoose, { Document, Schema } from "mongoose";
 
+export type WebSessionRole = "admin" | "user";
+
 export interface IWebSession extends Document {
   tokenHash: string;
   discordUserId: string;
   guildId: string;
+  /**
+   * Determines which web surface this session is authorised for. `admin`
+   * sessions may use `/admin/*` and `/me/*`; `user` sessions are limited to
+   * `/me/*`. Pre-role rows in the DB are missing this field — callers must
+   * treat that case as legacy `admin` (the only role that could exist before
+   * #481) at read time.
+   */
+  role: WebSessionRole;
   scopes: string[];
   createdAt: Date;
   expiresAt: Date;
@@ -27,6 +37,12 @@ const WebSessionSchema = new Schema<IWebSession>(
     guildId: {
       type: String,
       required: true,
+    },
+    role: {
+      type: String,
+      enum: ["admin", "user"],
+      required: true,
+      default: "user",
     },
     scopes: {
       type: [String],

--- a/src/services/web-session-service.ts
+++ b/src/services/web-session-service.ts
@@ -1,19 +1,36 @@
 import crypto from "crypto";
 import logger from "../utils/logger.js";
-import { WebSession, IWebSession } from "../models/web-session.js";
+import {
+  WebSession,
+  IWebSession,
+  WebSessionRole,
+} from "../models/web-session.js";
 
 const DEFAULT_TTL_MINUTES = 10;
+
+/**
+ * Translate a DB-stored `role` to a strict `WebSessionRole`. Rows written
+ * before #481 lack the field entirely; we treat that case as legacy
+ * `"admin"` (the only role that could exist back then). An unrecognised
+ * value also collapses to `"admin"` defensively so a corrupt row can't
+ * upgrade itself by claiming an unknown role.
+ */
+function normalizeRole(raw: unknown): WebSessionRole {
+  return raw === "user" ? "user" : "admin";
+}
 
 export interface CreatedSession {
   token: string;
   url: string;
   expiresAt: Date;
+  role: WebSessionRole;
 }
 
 export interface RedeemedSession {
   sessionId: string;
   discordUserId: string;
   guildId: string;
+  role: WebSessionRole;
   scopes: string[];
 }
 
@@ -58,10 +75,16 @@ export class WebSessionService {
   /**
    * Create a new magic-link session. Revokes any prior unused/active
    * sessions for this user so re-issuing a link invalidates the old one.
+   *
+   * `role` decides whether the redeemed session can use the admin surface
+   * (`/admin/*`) or only the user self-service surface (`/me/*`). The
+   * default of `"user"` is the safest choice — callers in possession of
+   * Administrator should pass `"admin"` explicitly. See #481.
    */
   public async create(
     discordUserId: string,
     guildId: string,
+    role: WebSessionRole = "user",
     scopes: string[] = [],
   ): Promise<CreatedSession> {
     if (!discordUserId) throw new Error("discordUserId required");
@@ -79,6 +102,7 @@ export class WebSessionService {
       tokenHash,
       discordUserId,
       guildId,
+      role,
       scopes,
       createdAt: now,
       expiresAt,
@@ -87,11 +111,11 @@ export class WebSessionService {
     });
 
     logger.info(
-      `Web session created for user=${discordUserId} guild=${guildId} expires=${expiresAt.toISOString()}`,
+      `Web session created for user=${discordUserId} guild=${guildId} role=${role} expires=${expiresAt.toISOString()}`,
     );
 
     const url = `${this.getBaseUrl()}/admin/s/${token}`;
-    return { token, url, expiresAt };
+    return { token, url, expiresAt, role };
   }
 
   /**
@@ -137,6 +161,7 @@ export class WebSessionService {
       sessionId: String(session._id),
       discordUserId: session.discordUserId,
       guildId: session.guildId,
+      role: normalizeRole(session.role),
       scopes: session.scopes,
     };
   }
@@ -191,6 +216,7 @@ export class WebSessionService {
       sessionId: String(existing._id),
       discordUserId: existing.discordUserId,
       guildId: existing.guildId,
+      role: normalizeRole(existing.role),
       scopes: existing.scopes,
     };
   }

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -152,6 +152,8 @@ const STYLE = [
   ".banner form{display:inline;margin:0}",
   ".banner button{background:#ef4444;color:#fff;border:0;padding:.3rem .7rem;border-radius:4px;cursor:pointer;font-weight:600}",
   ".banner button:hover{background:#dc2626}",
+  ".banner a.surface{color:#cbd5e1;background:#374151;padding:.25rem .55rem;border-radius:4px;font-weight:600;text-decoration:none;margin-right:.5rem}",
+  ".banner a.surface:hover{background:#4b5563;color:#fff}",
   ".shell{display:flex;min-height:calc(100vh - 41px)}",
   "nav.side{background:#161a22;border-right:1px solid #2d3748;width:220px;padding:1rem .5rem;flex-shrink:0}",
   "nav.side ul{list-style:none;padding:0;margin:0}",
@@ -376,7 +378,12 @@ export function renderAdminPage(opts: AdminPageOptions): string {
     "</head><body>",
     '<div class="banner">',
     '<div class="left"><strong>Koolbot Admin</strong></div>',
-    '<div class="right">Session expires in ',
+    '<div class="right">',
+    // "My preferences" link to the parallel `/me` surface added in #481.
+    // The same session covers both surfaces; clicking this never forces
+    // a re-sign-in and never burns a new magic-link token.
+    '<a class="surface" href="/me/">My preferences</a>',
+    "Session expires in ",
     `<span id="session-countdown" data-remaining-ms="${remainingMs}" data-inactivity-ms="${inactivityMs}" class="mono">--:--</span> · `,
     '<form method="POST" action="/admin/finish">',
     `<input type="hidden" name="_csrf" value="${escapeHtml(opts.csrfToken)}">`,

--- a/src/web/audit.ts
+++ b/src/web/audit.ts
@@ -26,6 +26,10 @@ export async function recordAudit(
       guildId: session.guildId,
       sessionId: session.sessionId,
       discordUserId: session.discordUserId,
+      // Whichever role the session is — an admin acting on their own
+      // `/me/*` is logged with role:"admin" (see #481): the role is the
+      // session's, not the URL surface's.
+      role: session.role,
       action: entry.action,
       targetId: entry.targetId ?? null,
       details: entry.details ?? {},

--- a/src/web/csrf.ts
+++ b/src/web/csrf.ts
@@ -5,7 +5,15 @@ import { parseCookies, setCookie } from "./cookies.js";
 
 export const CSRF_COOKIE = "koolbot_csrf";
 export const CSRF_HEADER = "x-csrf-token";
-export const CSRF_COOKIE_PATH = "/admin";
+/**
+ * Cookie path for the CSRF double-submit cookie. Broadened from `/admin`
+ * to `/` in #481 so the same token is mirrored back on POSTs to the new
+ * `/me/*` surface as well as `/admin/*`. The cookie is not HttpOnly by
+ * design — it's the page's mirror of the token — and broadening the
+ * path doesn't change any of that. Both surfaces share `requireCsrf`,
+ * so a single token is enough.
+ */
+export const CSRF_COOKIE_PATH = "/";
 
 /**
  * Double-submit-cookie CSRF protection. The cookie is non-HttpOnly so the

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -13,6 +13,7 @@ import {
 import { renderConsent, renderInvalidLink, renderSignedOut } from "./views.js";
 import { createReadOnlyRouter } from "./read-only-routes.js";
 import { createWriteRouter } from "./write-routes.js";
+import { createUserRouter } from "./user-routes.js";
 
 /**
  * Build the WebUI router. Caller mounts this at /admin on the existing
@@ -90,10 +91,16 @@ export function createWebRouter(client: Client): Router {
           sid: redeemed.sessionId,
           uid: redeemed.discordUserId,
           gid: redeemed.guildId,
+          rol: redeemed.role,
           iat: Date.now(),
           act: Date.now(),
         });
-        res.redirect(302, "/admin/");
+        // Role-based landing: admins drop on the admin panel they're
+        // used to; user-role sessions don't have admin access at all,
+        // so we route them to their own `/me` surface (#481). An admin
+        // can hop to `/me` afterwards via the in-page header link.
+        const dest = redeemed.role === "admin" ? "/admin/" : "/me/";
+        res.redirect(302, dest);
       } catch (err) {
         logger.error("Error redeeming web session token", err);
         res.status(500).type("text/plain").send("Internal Server Error");
@@ -134,6 +141,39 @@ export function createWebRouter(client: Client): Router {
   router.use(
     (err: unknown, _req: Request, res: Response, next: NextFunction): void => {
       logger.error("WebUI router error", err);
+      if (res.headersSent) {
+        next(err);
+        return;
+      }
+      res.status(500).type("text/plain").send("Internal Server Error");
+    },
+  );
+
+  return router;
+}
+
+/**
+ * Build the user self-service router for `/me/*` (#481).
+ *
+ * Lives on the same Express server as `createWebRouter` and shares the
+ * same session cookie (path `/`, set by the magic-link redemption in
+ * `/admin/s/:token`). Mounted at `/me` in `src/index.ts` so user-role
+ * AND admin-role sessions can both reach it — admins use it to manage
+ * their own preferences without giving up the admin panel.
+ */
+export function createUserWebRouter(client: Client): Router {
+  const router = Router();
+
+  router.use(express.urlencoded({ extended: false, limit: "256kb" }));
+  router.use(ensureCsrfCookie);
+
+  const requireSession = createSessionMiddleware(client);
+
+  router.use(createUserRouter(client, requireSession));
+
+  router.use(
+    (err: unknown, _req: Request, res: Response, next: NextFunction): void => {
+      logger.error("UserUI router error", err);
       if (res.headersSent) {
         next(err);
         return;

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -13,7 +13,7 @@ import {
 import { renderConsent, renderInvalidLink, renderSignedOut } from "./views.js";
 import { createReadOnlyRouter } from "./read-only-routes.js";
 import { createWriteRouter } from "./write-routes.js";
-import { createUserRouter } from "./user-routes.js";
+import { createUserRouter, SelfScopeError } from "./user-routes.js";
 
 /**
  * Build the WebUI router. Caller mounts this at /admin on the existing
@@ -171,18 +171,57 @@ export function createUserWebRouter(client: Client): Router {
 
   router.use(createUserRouter(client, requireSession));
 
-  router.use(
-    (err: unknown, _req: Request, res: Response, next: NextFunction): void => {
-      logger.error("UserUI router error", err);
-      if (res.headersSent) {
-        next(err);
-        return;
-      }
-      res.status(500).type("text/plain").send("Internal Server Error");
-    },
-  );
+  router.use(userWebErrorHandler);
 
   return router;
+}
+
+/**
+ * Express error handler for the `/me/*` surface. Translates
+ * `SelfScopeError` into the documented 403 HTML page and lets every
+ * other error fall through to a generic 500 with logging. Exported
+ * so the branch can be unit-tested without spinning up an HTTP server
+ * (Express only dispatches errors to a router's error middleware when
+ * the error originates from within that router's stack, which makes
+ * a black-box HTTP test of just the error handler awkward).
+ */
+export function userWebErrorHandler(
+  err: unknown,
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  // Self-scope violations are a forbidden-access condition, not a
+  // bug — render the documented 403 instead of collapsing them into
+  // a generic 500. No real `/me/*` handler depends on this today
+  // (the v1 index page reads only the session's own ids), but #482
+  // /#484 will, so the branch lands with the helper.
+  if (err instanceof SelfScopeError) {
+    logger.warn("Self-scope violation on /me/*", err.message);
+    if (res.headersSent) {
+      next(err);
+      return;
+    }
+    res
+      .status(403)
+      .type("text/html")
+      .send(
+        `<!doctype html><html><head><meta charset="utf-8"><title>Forbidden</title></head>` +
+          `<body style="font-family:system-ui,sans-serif;padding:2rem;max-width:32rem;margin:0 auto;">` +
+          `<h1>Forbidden</h1>` +
+          `<p>That request targeted another user's data. The user self-service ` +
+          `surface only lets you view and change your own. Head back to ` +
+          `<a href="/me/">/me</a>.</p>` +
+          `</body></html>`,
+      );
+    return;
+  }
+  logger.error("UserUI router error", err);
+  if (res.headersSent) {
+    next(err);
+    return;
+  }
+  res.status(500).type("text/plain").send("Internal Server Error");
 }
 
 export function isWebUIEnabled(): boolean {

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -37,6 +37,7 @@ import { DiscordCommandAuditLog } from "../models/discord-command-audit-log.js";
 import { BOOTSTRAP_VARS } from "./bootstrap-vars.js";
 import {
   createSessionPingHandler,
+  requireAdminRoleMiddleware,
   type AuthenticatedRequest,
 } from "./session.js";
 import {
@@ -215,6 +216,9 @@ export function createReadOnlyRouter(
   router.get("/session/ping", createSessionPingHandler());
 
   router.use(requireSession);
+  // Every `/admin/*` page below this point is admin-only. User-role
+  // sessions get a 403 page that points them at `/me/` (#481).
+  router.use(requireAdminRoleMiddleware());
 
   // ---------- Dashboard ----------
   router.get(

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -4,7 +4,7 @@ import { Request, RequestHandler, Response, NextFunction } from "express";
 import logger from "../utils/logger.js";
 import { PermissionsService } from "../services/permissions-service.js";
 import { WebSessionService } from "../services/web-session-service.js";
-import type { IWebSession } from "../models/web-session.js";
+import type { IWebSession, WebSessionRole } from "../models/web-session.js";
 import {
   clearCookie,
   parseCookies,
@@ -15,7 +15,15 @@ import {
 import { shouldUseSecureCookies } from "./csrf.js";
 
 export const SESSION_COOKIE = "koolbot_session";
-export const SESSION_COOKIE_PATH = "/admin";
+/**
+ * Path on which the session cookie is set. Broadened from the original
+ * `/admin` to `/` in #481 so the same redeemed session covers both
+ * `/admin/*` (admin panel) and `/me/*` (user self-service). The cookie
+ * is still HttpOnly + HMAC-signed; broadening the path only makes the
+ * browser send it on more URLs of the same origin, which is exactly
+ * what we want now that one redemption authorises both surfaces.
+ */
+export const SESSION_COOKIE_PATH = "/";
 
 const DEFAULT_INACTIVITY_MINUTES = 30;
 
@@ -23,6 +31,12 @@ export interface WebSessionContext {
   sessionId: string;
   discordUserId: string;
   guildId: string;
+  /**
+   * Role of the redeemed session, sourced from the DB row on every
+   * request. Authoritative — handlers that need a role check should
+   * read this rather than re-decoding the cookie.
+   */
+  role: WebSessionRole;
   scopes: string[];
   lastActivityAt: number;
   /**
@@ -39,6 +53,13 @@ interface CookiePayload {
   sid: string;
   uid: string;
   gid: string;
+  /**
+   * Role claim. Optional in the parsed payload so legacy cookies issued
+   * before #481 (which had no role field) continue to deserialise — we
+   * cross-check against the DB row in `loadValidSession`, which is the
+   * authoritative source. New cookies always carry a `rol`.
+   */
+  rol?: WebSessionRole;
   iat: number;
   act: number;
 }
@@ -137,6 +158,16 @@ function readSessionCookie(req: Request): CookiePayload | null {
     ) {
       return null;
     }
+    // `rol` is optional for legacy cookies issued before #481; if present
+    // it must be one of the two known roles, else we refuse to parse so a
+    // mangled value can't sneak through.
+    if (
+      parsed.rol !== undefined &&
+      parsed.rol !== "admin" &&
+      parsed.rol !== "user"
+    ) {
+      return null;
+    }
     return parsed;
   } catch {
     return null;
@@ -196,19 +227,68 @@ export function createSessionMiddleware(
       return;
     }
 
-    const refreshed: CookiePayload = { ...payload, act: now };
+    // DB role is authoritative. Refresh the cookie's role claim so a
+    // legacy (pre-#481) cookie picks up its real role on the next hop,
+    // and so a stale `rol` (if someone ever rolled a session's role
+    // forward by DB hand-edit) heals itself.
+    const role = normalizeSessionRole(dbSession.role);
+    const refreshed: CookiePayload = { ...payload, rol: role, act: now };
     writeSessionCookie(res, refreshed);
 
     req.webSession = {
       sessionId: payload.sid,
       discordUserId: payload.uid,
       guildId: payload.gid,
+      role,
       scopes: dbSession.scopes,
       lastActivityAt: now,
       expiresAt: dbSession.expiresAt,
     };
     next();
   };
+}
+
+/**
+ * Express middleware that rejects any request whose redeemed session is
+ * not `role === "admin"`. Mount AFTER `createSessionMiddleware` so the
+ * session is already loaded onto `req.webSession`. A user-role session
+ * hitting this middleware gets a 403 page that explains the surface is
+ * admin-only and points them at their own `/me` surface; this matches
+ * the acceptance criterion in #481.
+ */
+export function requireAdminRoleMiddleware(): (
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+) => void {
+  return function requireAdminRole(req, res, next): void {
+    if (!req.webSession) {
+      // Defensive: caller forgot to mount `createSessionMiddleware` first.
+      // Treat as unauthenticated, not forbidden.
+      respondUnauthorized(res);
+      return;
+    }
+    if (req.webSession.role !== "admin") {
+      res
+        .status(403)
+        .type("text/html")
+        .send(
+          `<!doctype html><html><head><meta charset="utf-8"><title>Forbidden</title></head>` +
+            `<body style="font-family:system-ui,sans-serif;padding:2rem;max-width:32rem;margin:0 auto;">` +
+            `<h1>Forbidden</h1>` +
+            `<p>This page is part of the admin panel and your sign-in link does not authorise it. ` +
+            `Visit <a href="/me/">/me</a> for your own preferences, or ask an Administrator to ` +
+            `re-issue your link via <code>/config</code>.</p>` +
+            `</body></html>`,
+        );
+      return;
+    }
+    next();
+  };
+}
+
+function normalizeSessionRole(raw: unknown): WebSessionRole {
+  return raw === "user" ? "user" : "admin";
 }
 
 /**

--- a/src/web/user-layout.ts
+++ b/src/web/user-layout.ts
@@ -77,11 +77,13 @@ const STYLE = [
   ".feature-list .feature-desc{font-size:.8rem;color:#94a3b8}",
 ].join("");
 
-// Reuse the admin layout's session-banner script: same DOM hooks
-// (`#session-countdown`, `data-remaining-ms`, `data-inactivity-ms`),
-// same `/admin/session/ping` polling endpoint, so the countdown and
-// auto-logout behave identically across surfaces. Inlined verbatim to
-// keep `user-layout.ts` independently bundlable.
+// Same DOM hooks (`#session-countdown`, `data-remaining-ms`,
+// `data-inactivity-ms`) and behaviour as the admin layout's banner
+// script, but polls the surface-local `/me/session/ping` mount so
+// `/me/*` pages never reach into the `/admin` namespace. The two
+// pings hit identical handlers — the path split exists so a future
+// operational change to one surface can't silently break countdown
+// on the other.
 const SCRIPT =
   "(function(){var el=document.getElementById('session-countdown');if(!el)return;" +
   "function toMs(v){var n=Math.floor(Number(v));return isFinite(n)&&n>0?n:0}" +
@@ -99,7 +101,7 @@ const SCRIPT =
   "if(hardCapAt>0){var cap=hardCapAt-now;if(cap<target)target=cap}" +
   "if(target>0&&deadline-now<target)applyRemaining(target)}" +
   "function poll(){if(fired)return;" +
-  "fetch('/admin/session/ping',{credentials:'same-origin',headers:{'Accept':'application/json'},cache:'no-store'})" +
+  "fetch('/me/session/ping',{credentials:'same-origin',headers:{'Accept':'application/json'},cache:'no-store'})" +
   ".then(function(res){if(res.status===401){expire();return null}" +
   "if(!res.ok)return null;return res.json()})" +
   ".then(function(data){if(!data)return;" +

--- a/src/web/user-layout.ts
+++ b/src/web/user-layout.ts
@@ -1,0 +1,178 @@
+/**
+ * Shared layout for the user self-service surface added in #481.
+ *
+ * Deliberately slim: no admin nav, no settings/wizard surfaces — just a
+ * top bar with the session-expiry banner, the "Finish" button, an
+ * optional "Back to admin panel" link for admin-role sessions, and a
+ * narrow main column. As `/me` grows (#482 notification prefs, #484
+ * Rewind), new pages bolt onto `USER_NAV_ITEMS` below without touching
+ * the admin layout.
+ */
+
+import { escapeHtml, getInactivityWindowMs } from "./admin-layout.js";
+
+export { escapeHtml };
+
+interface UserNavItem {
+  href: string;
+  label: string;
+}
+
+/**
+ * Nav items in the user self-service surface. The v1 scaffold ships
+ * only the index page; the placeholders below sit ready for #482/#484
+ * to fill in, but they don't render until those pages exist.
+ */
+export const USER_NAV_ITEMS: UserNavItem[] = [
+  { href: "/me/", label: "Overview" },
+];
+
+export interface UserPageOptions {
+  title: string;
+  active: string;
+  body: string;
+  csrfToken: string;
+  remainingMs: number;
+  /**
+   * When the redeemed session is admin-role, the layout renders a small
+   * "Back to admin panel" link in the top bar so the admin can hop
+   * between surfaces without re-running `/config`. The header link on
+   * the admin layout (added in the same issue) does the inverse.
+   */
+  isAdmin: boolean;
+}
+
+const STYLE = [
+  "*,*::before,*::after{box-sizing:border-box}",
+  "body{margin:0;font-family:system-ui,-apple-system,Segoe UI,sans-serif;background:#0f1115;color:#e4e6eb}",
+  "a{color:#6ea8fe;text-decoration:none}",
+  "a:hover{text-decoration:underline}",
+  ".banner{background:#1f2937;border-bottom:1px solid #2d3748;padding:.5rem 1rem;display:flex;justify-content:space-between;align-items:center;font-size:.85rem;gap:1rem;flex-wrap:wrap}",
+  ".banner .left{display:flex;gap:.75rem;align-items:center}",
+  ".banner .right{display:flex;gap:.75rem;align-items:center}",
+  ".banner .pill{background:#374151;color:#d1d5db;padding:.15rem .5rem;border-radius:999px;font-size:.75rem}",
+  ".banner form{display:inline;margin:0}",
+  ".banner button{background:#ef4444;color:#fff;border:0;padding:.3rem .7rem;border-radius:4px;cursor:pointer;font-weight:600}",
+  ".banner button:hover{background:#dc2626}",
+  ".banner a.surface{color:#cbd5e1;background:#374151;padding:.25rem .55rem;border-radius:4px;font-weight:600}",
+  ".banner a.surface:hover{background:#4b5563;text-decoration:none;color:#fff}",
+  ".shell{display:flex;min-height:calc(100vh - 41px);justify-content:center}",
+  "main{flex:1;padding:2rem 2rem;max-width:64rem}",
+  "h1{margin:0 0 .25rem;font-size:1.5rem}",
+  "h2{margin:1.5rem 0 .5rem;font-size:1.15rem;color:#cbd5e1}",
+  ".subtitle{color:#94a3b8;margin:0 0 1rem}",
+  ".card{background:#161a22;border:1px solid #2d3748;border-radius:8px;padding:1rem 1.25rem;margin:0 0 1rem}",
+  ".card h2{margin-top:0}",
+  ".empty{padding:1rem;color:#94a3b8;font-style:italic}",
+  ".muted{color:#94a3b8}",
+  ".mono{font-family:ui-monospace,SFMono-Regular,SF Mono,Menlo,monospace;font-size:.85rem}",
+  ".pill{background:#374151;color:#d1d5db;padding:.15rem .5rem;border-radius:999px;font-size:.75rem}",
+  ".tag{display:inline-block;padding:.1rem .45rem;border-radius:4px;font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.04em}",
+  ".tag-info{background:#1e3a8a;color:#bfdbfe}",
+  ".notice{padding:.6rem .8rem;border-radius:6px;margin:0 0 1rem}",
+  ".notice.info{background:#1d2a44;color:#bfdbfe}",
+  ".feature-list{list-style:none;padding:0;margin:0;display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:.75rem}",
+  ".feature-list li{background:#0f1115;border:1px solid #2d3748;border-radius:6px;padding:.75rem 1rem}",
+  ".feature-list .feature-name{font-weight:600;display:block;margin-bottom:.2rem;color:#e4e6eb}",
+  ".feature-list .feature-desc{font-size:.8rem;color:#94a3b8}",
+].join("");
+
+// Reuse the admin layout's session-banner script: same DOM hooks
+// (`#session-countdown`, `data-remaining-ms`, `data-inactivity-ms`),
+// same `/admin/session/ping` polling endpoint, so the countdown and
+// auto-logout behave identically across surfaces. Inlined verbatim to
+// keep `user-layout.ts` independently bundlable.
+const SCRIPT =
+  "(function(){var el=document.getElementById('session-countdown');if(!el)return;" +
+  "function toMs(v){var n=Math.floor(Number(v));return isFinite(n)&&n>0?n:0}" +
+  "var deadline=Date.now()+toMs(el.getAttribute('data-remaining-ms'));" +
+  "var inactivityMs=toMs(el.getAttribute('data-inactivity-ms'));" +
+  "var hardCapAt=0;var fired=false;var lastReset=0;" +
+  "function expire(){if(fired)return;fired=true;window.location.href='/me/'}" +
+  "function tick(){var r=Math.max(0,deadline-Date.now());var s=Math.floor(r/1000);" +
+  "var m=Math.floor(s/60);var ss=s%60;el.textContent=m+':'+(ss<10?'0'+ss:ss);" +
+  "if(r<=0)expire()}" +
+  "function applyRemaining(ms){deadline=Date.now()+toMs(ms);tick()}" +
+  "function onActivity(){if(inactivityMs<=0||fired)return;" +
+  "var now=Date.now();if(now-lastReset<5000)return;lastReset=now;" +
+  "var target=inactivityMs;" +
+  "if(hardCapAt>0){var cap=hardCapAt-now;if(cap<target)target=cap}" +
+  "if(target>0&&deadline-now<target)applyRemaining(target)}" +
+  "function poll(){if(fired)return;" +
+  "fetch('/admin/session/ping',{credentials:'same-origin',headers:{'Accept':'application/json'},cache:'no-store'})" +
+  ".then(function(res){if(res.status===401){expire();return null}" +
+  "if(!res.ok)return null;return res.json()})" +
+  ".then(function(data){if(!data)return;" +
+  "if(typeof data.expiresAt==='string'){var t=Date.parse(data.expiresAt);if(!isNaN(t))hardCapAt=t}" +
+  "if(typeof data.remainingMs==='number')applyRemaining(data.remainingMs)})" +
+  ".catch(function(){})}" +
+  "tick();poll();setInterval(tick,1000);setInterval(poll,30000);" +
+  "document.addEventListener('mousemove',onActivity,{passive:true});" +
+  "document.addEventListener('keydown',onActivity)})();";
+
+export function renderUserPage(opts: UserPageOptions): string {
+  const remainingMs = Math.max(0, Math.floor(opts.remainingMs));
+  const inactivityMs = getInactivityWindowMs();
+  const adminLink = opts.isAdmin
+    ? '<a class="surface" href="/admin/">Back to admin panel</a>'
+    : "";
+  return [
+    "<!doctype html>",
+    '<html lang="en"><head>',
+    '<meta charset="utf-8">',
+    '<meta name="viewport" content="width=device-width,initial-scale=1">',
+    '<meta name="referrer" content="strict-origin-when-cross-origin">',
+    `<title>${escapeHtml(opts.title)} — Koolbot</title>`,
+    `<style>${STYLE}</style>`,
+    "</head><body>",
+    '<div class="banner">',
+    '<div class="left"><strong>Koolbot · My preferences</strong></div>',
+    '<div class="right">',
+    adminLink,
+    "Session expires in ",
+    `<span id="session-countdown" data-remaining-ms="${remainingMs}" data-inactivity-ms="${inactivityMs}" class="mono">--:--</span> · `,
+    '<form method="POST" action="/me/finish">',
+    `<input type="hidden" name="_csrf" value="${escapeHtml(opts.csrfToken)}">`,
+    '<button type="submit">Finish</button>',
+    "</form></div></div>",
+    '<div class="shell">',
+    `<main>${opts.body}</main></div>`,
+    `<script>${SCRIPT}</script>`,
+    "</body></html>",
+  ].join("");
+}
+
+/**
+ * Page body for `/me/`. Self-contained — the layout supplies the chrome,
+ * this function supplies just the inner HTML. Intentionally a stub: #482
+ * (notification prefs) and #484 (Rewind) bolt their own cards onto this
+ * page as they land.
+ */
+export function renderUserIndexBody(opts: {
+  discordUserId: string;
+  guildId: string;
+  isAdmin: boolean;
+}): string {
+  const greeting = opts.isAdmin
+    ? `<p class="subtitle">Signed in as an administrator viewing your own preferences. Use the <em>Back to admin panel</em> link above to manage the server.</p>`
+    : `<p class="subtitle">These pages are scoped to <strong>you</strong> — what you see and change here only affects your own data on this server.</p>`;
+  return [
+    "<h1>My preferences</h1>",
+    greeting,
+    '<div class="card">',
+    "<h2>Nothing here yet</h2>",
+    `<p>Koolbot is laying the groundwork for per-user self-service. The pages below will fill in as <a href="https://github.com/lonix/koolbot/issues/480">#480</a>'s sub-issues land.</p>`,
+    '<ul class="feature-list">',
+    '<li><span class="feature-name">Notification preferences</span>' +
+      '<span class="feature-desc">Opt in or out of achievement DMs, leaderboard pings, etc. (issue #482)</span></li>',
+    '<li><span class="feature-name">Rewind</span>' +
+      '<span class="feature-desc">A personal recap of your activity on this server (issue #484)</span></li>',
+    "</ul>",
+    "</div>",
+    '<div class="card">',
+    "<h2>Account context</h2>",
+    `<p class="mono">User: ${escapeHtml(opts.discordUserId)} · Guild: ${escapeHtml(opts.guildId)}</p>`,
+    "<p>To sign in as a different user, run <code>/config</code> in Discord with that account.</p>",
+    "</div>",
+  ].join("");
+}

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -21,6 +21,7 @@ import { requireCsrf } from "./csrf.js";
 import {
   AuthenticatedRequest,
   clearSessionCookie,
+  createSessionPingHandler,
   type WebSessionContext,
 } from "./session.js";
 import { getDisplayedRemainingMs } from "./admin-layout.js";
@@ -82,6 +83,16 @@ export function createUserRouter(
   requireSession: RequestHandler,
 ): Router {
   const router = Router();
+
+  // Surface-local session ping so the `/me` banner script never has to
+  // reach across to `/admin/session/ping`. Identical handler (the ping
+  // is surface-neutral — same cookie, same DB row), just mounted on
+  // both routers so a future split of the admin mount can't silently
+  // break the countdown on `/me/*`. Mounted BEFORE `requireSession` for
+  // the same reason the admin copy is: the ping itself does its own
+  // (non-mutating) cookie + DB validation and must NOT bump `act`.
+  router.get("/session/ping", createSessionPingHandler());
+
   router.use(requireSession);
 
   // ---------- Index ----------

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -1,0 +1,132 @@
+/**
+ * Route handlers for the user self-service surface (#481).
+ *
+ * Mounted at `/me`. Every handler runs behind `requireSession`, accepts
+ * either an `admin`-role or `user`-role session (admins are guild
+ * members too — they have their own preferences/Rewind), and enforces
+ * self-scope via `assertSelfScope`: a session may only read/write rows
+ * keyed by `(session.userId, session.guildId)`. v1 ships a single stub
+ * index page; sub-issues #482/#484 add real content.
+ */
+
+import {
+  Router,
+  type NextFunction,
+  type Response,
+  type RequestHandler,
+} from "express";
+import { Client } from "discord.js";
+import { WebSessionService } from "../services/web-session-service.js";
+import { requireCsrf } from "./csrf.js";
+import {
+  AuthenticatedRequest,
+  clearSessionCookie,
+  type WebSessionContext,
+} from "./session.js";
+import { getDisplayedRemainingMs } from "./admin-layout.js";
+import { renderUserIndexBody, renderUserPage } from "./user-layout.js";
+import { renderSignedOut } from "./views.js";
+
+function asyncHandler(
+  fn: (req: AuthenticatedRequest, res: Response) => Promise<void>,
+): RequestHandler {
+  return (req, res, next: NextFunction): void => {
+    fn(req as AuthenticatedRequest, res).catch(next);
+  };
+}
+
+function getCsrfToken(req: AuthenticatedRequest): string {
+  return (req as AuthenticatedRequest & { csrfToken?: string }).csrfToken ?? "";
+}
+
+/**
+ * Enforce that the session may only act on rows belonging to itself —
+ * both the Discord user id and the guild id must match the session's.
+ *
+ * Crucially this applies to admin-role sessions too. An admin who
+ * lands on `/me/notifications` to manage their own prefs sees their
+ * own row; if they ever try to pass `?userId=someone-else` on a write,
+ * this helper rejects it. Admins who need to act on another user's
+ * data use the admin panel's audit/user tooling, not impersonation on
+ * `/me/*`. See #481 acceptance.
+ *
+ * Returns the validated `(userId, guildId)` pair. Throws `SelfScopeError`
+ * on mismatch — handlers wrap their bodies in `asyncHandler` so the
+ * thrown error reaches the WebUI error pipeline and renders a 403.
+ */
+export function assertSelfScope(
+  session: WebSessionContext,
+  target: { userId: string; guildId: string },
+): { userId: string; guildId: string } {
+  if (
+    target.userId !== session.discordUserId ||
+    target.guildId !== session.guildId
+  ) {
+    throw new SelfScopeError(
+      `Session ${session.sessionId} (user=${session.discordUserId} guild=${session.guildId} role=${session.role}) ` +
+        `attempted to access user=${target.userId} guild=${target.guildId}`,
+    );
+  }
+  return { userId: session.discordUserId, guildId: session.guildId };
+}
+
+export class SelfScopeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SelfScopeError";
+  }
+}
+
+export function createUserRouter(
+  _client: Client,
+  requireSession: RequestHandler,
+): Router {
+  const router = Router();
+  router.use(requireSession);
+
+  // ---------- Index ----------
+  router.get(
+    "/",
+    asyncHandler(async (req, res) => {
+      const session = req.webSession;
+      if (!session) {
+        // `requireSession` guarantees this, but the type narrower
+        // doesn't know that without an explicit check.
+        res.status(500).type("text/plain").send("session missing");
+        return;
+      }
+      res.type("text/html").send(
+        renderUserPage({
+          title: "Overview",
+          active: "/me/",
+          body: renderUserIndexBody({
+            discordUserId: session.discordUserId,
+            guildId: session.guildId,
+            isAdmin: session.role === "admin",
+          }),
+          csrfToken: getCsrfToken(req),
+          remainingMs: getDisplayedRemainingMs(session),
+          isAdmin: session.role === "admin",
+        }),
+      );
+    }),
+  );
+
+  // ---------- Finish (sign out) ----------
+  // CSRF-checked, same pattern as `/admin/finish`. The session row is
+  // revoked server-side so the cookie cannot be re-used elsewhere.
+  router.post(
+    "/finish",
+    requireCsrf,
+    asyncHandler(async (req, res) => {
+      const ctx = req.webSession;
+      if (ctx) {
+        await WebSessionService.getInstance().revokeSession(ctx.sessionId);
+      }
+      clearSessionCookie(res);
+      res.status(200).type("text/html").send(renderSignedOut());
+    }),
+  );
+
+  return router;
+}

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -37,7 +37,10 @@ import Notice from "../models/notice.js";
 import { NOTICE_CATEGORIES } from "../content/notice-categories.js";
 import { requireCsrf } from "./csrf.js";
 import { PROTECTED_KEYS } from "./bootstrap-vars.js";
-import type { AuthenticatedRequest } from "./session.js";
+import {
+  requireAdminRoleMiddleware,
+  type AuthenticatedRequest,
+} from "./session.js";
 import { recordAudit } from "./audit.js";
 import {
   getDisplayedRemainingMs,
@@ -112,14 +115,9 @@ function parseHexColor(input: string): number | null {
   return parseInt(match[1], 16);
 }
 
-function requireSessionContext(req: AuthenticatedRequest): {
-  guildId: string;
-  discordUserId: string;
-  sessionId: string;
-  scopes: string[];
-  lastActivityAt: number;
-  expiresAt: Date;
-} {
+function requireSessionContext(
+  req: AuthenticatedRequest,
+): AuthenticatedRequest["webSession"] & object {
   if (!req.webSession) {
     throw new Error("requireSession middleware must run first");
   }
@@ -261,6 +259,10 @@ export function createWriteRouter(
 ): Router {
   const router = Router();
   router.use(requireSession);
+  // Every write handler below targets the admin panel. User-role
+  // sessions hitting these routes get a 403 from the role middleware;
+  // their own writes (when #482/#484 add them) live on `/me/*`.
+  router.use(requireAdminRoleMiddleware());
   router.use(requireCsrf);
 
   // ============================================================


### PR DESCRIPTION
## Summary

Lays the platform groundwork for **per-user self-service** in the WebUI. Closes #481 — the foundation issue under #480 that unblocks #482/#483/#484.

- Extends `WebSession` with a `role: "admin" | "user"` field (and matching `rol` claim in the signed cookie). `WebSessionService.create()` takes the role explicitly; legacy DB rows with no `role` field are normalised to `admin` on read.
- Opens `/config` to every guild member. Role is decided server-side from the invoker's live `Administrator` bit; the slash-command itself is no longer gated by `default_member_permissions` (that would hide it from non-admins). DM body for admins advertises both `/admin/` and `/me/`; for non-admins only `/me/`.
- Adds a parallel `/me/*` surface on the same Express server, sharing one redeemed session (cookie path broadened from `/admin` to `/`). v1 ships a stub `/me/` index — the layout, session middleware, and self-scope helper are in place so #482/#484 bolt on without further auth changes.
- `assertSelfScope(session, target)` in `src/web/user-routes.ts` enforces that a session can only act on `(session.userId, session.guildId)` rows — including for admin-role sessions on `/me/*`. No impersonation bypass for admins; admins acting on someone else's data do so via the admin panel's audit tooling.
- `requireAdminRoleMiddleware` mounted inside the read-only and write routers makes `/admin/*` reject user-role sessions with a 403 HTML page pointing at `/me/`. `/admin/finish` and `/admin/session/ping` intentionally stay reachable to any valid session (sign-out, banner countdown).
- Admin layout grows a "My preferences" header link; user layout grows a symmetric "Back to admin panel" link visible only on admin-role sessions.
- `WebAuditLog` rows now record the session's role so the audit page can filter `admin` vs `user` writes. An admin acting on their own `/me/*` is logged with `role: "admin"`.
- `WEBUI.md` documents the new surface, the role model, and how admins reach `/me`.

### Acceptance (from #481)

- [x] A non-admin running `/config` receives a sign-in link and lands on `/me`.
- [x] An admin running `/config` receives a sign-in link whose DM body offers both entry points.
- [x] An admin can reach `/me/*` from the admin layout via a header link without re-running `/config`.
- [x] `/admin/*` rejects user-role sessions with a clear 403 page.
- [x] `/me/*` accepts both admin and user sessions, but a session can only view/edit its own data — covered by a unit test on `assertSelfScope`.
- [x] `WEBUI.md` documents the new `/me` surface, the role model, and how admins reach it.
- [x] No new slash commands added.

## Test plan

- [x] `npm test` — 83 suites, 805 passing (was 788). Net 17 new tests across role middleware, self-scope helper, user-routes index rendering, and updated config/session-service expectations.
- [x] `npm run build` — clean.
- [x] `npm run lint` — clean (no new errors; warnings are pre-existing).
- [x] `npm run format:check` — clean.
- [ ] Manual: run `/config` as a non-admin, confirm DM lands on `/me/`; as an admin, confirm DM advertises both surfaces and clicking the admin layout's "My preferences" link reaches `/me/` without re-auth.
- [ ] Manual: as a user-role session, visit `/admin/settings` directly — verify 403 page with the link to `/me`.
- [ ] Manual: confirm existing admin sessions issued before this change continue to work (legacy `admin` fallback path).

### Migration / rollout notes

- The session and CSRF cookies' `Path` attribute changes from `/admin` to `/`. Browsers may still hold old `/admin`-scoped cookies for a short window; the worst case is one forced re-sign-in.
- The `WebSession` Mongoose schema adds `role` with `default: "user"` for new rows. Existing rows without the field are read as `admin` (the only role that could exist before this PR), preserving in-flight admin sessions.

https://claude.ai/code/session_01C2HFDuVZ7tcSyntrJptvzg

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2HFDuVZ7tcSyntrJptvzg)_