### PR TITLE
feat(web): per-user notification preferences via /me/notifications (closes #482)

### DIFF
--- a/WEBUI.md
+++ b/WEBUI.md
@@ -661,10 +661,10 @@ side effect, since the HMAC key changes.
 
 ### User self-service (`/me/*`, both admin and user roles)
 
-| Page                                | What it's for                                                                                                                                                                       |
-| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Overview** (`/me/`)               | Index for your own settings — links to the available per-user pages.                                                                                                                |
-| **Notifications** (`/me/notifications`) | Opt in or out of DM nudges from Koolbot (achievements today; weekly digest + year-in-review once #483 / #484 ship). Missing record = all enabled. Each toggle records a `WebAuditLog` row with `role: "user"` (or `"admin"` if the toggler is an admin on their own surface). |
+| Page                                    | What it's for                                                                                                                                             |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Overview** (`/me/`)                   | Index for your own settings — links to the available per-user pages.                                                                                      |
+| **Notifications** (`/me/notifications`) | Opt in or out of DM nudges from Koolbot (achievements today; #483 weekly digest and #484 Rewind once they land). Each toggle records a `WebAuditLog` row. |
 
 Notification preferences are scoped per `(userId, guildId)`. The page
 lists every notification type with the current state and a checkbox;

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -661,14 +661,21 @@ side effect, since the HMAC key changes.
 
 ### User self-service (`/me/*`, both admin and user roles)
 
-| Page                    | What it's for                                                                                  |
-| ----------------------- | ---------------------------------------------------------------------------------------------- |
-| **Overview** (`/me/`)   | Index for your own settings — placeholder cards listing the pages future sub-issues will land. |
+| Page                                | What it's for                                                                                                                                                                       |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Overview** (`/me/`)               | Index for your own settings — links to the available per-user pages.                                                                                                                |
+| **Notifications** (`/me/notifications`) | Opt in or out of DM nudges from Koolbot (achievements today; weekly digest + year-in-review once #483 / #484 ship). Missing record = all enabled. Each toggle records a `WebAuditLog` row with `role: "user"` (or `"admin"` if the toggler is an admin on their own surface). |
 
-Per-user features bolt onto `/me` in #482 (notification preferences)
-and #484 (Rewind), among others. Each adds its own card to the index
-plus a dedicated sub-page; the layout, session, and self-scope
-plumbing are already in place.
+Notification preferences are scoped per `(userId, guildId)`. The page
+lists every notification type with the current state and a checkbox;
+toggling one row is a single POST that records the diff in the audit
+log and PRG-redirects back to the page. Rows for features that haven't
+shipped yet (`digest`, `rewind`) are still functional — the stored
+toggle is read by the dependent issues' DM paths when they land.
+
+Future per-user features (Rewind in #484, etc.) bolt onto `/me` as
+their own pages; the layout, session, and self-scope plumbing are
+already in place.
 
 User-facing commands (`/ping`, `/voicestats`, `/seen`, `/quote`,
 `/achievements`, `/help`) are **not** affected and stay in

--- a/__tests__/services/achievements-service.test.ts
+++ b/__tests__/services/achievements-service.test.ts
@@ -35,6 +35,7 @@ jest.mock('../../src/services/quote-service.js', () => ({
 import { AchievementsService, GamificationService } from '../../src/services/achievements-service.js';
 import { UserAchievements } from '../../src/models/user-achievements.js';
 import { VoiceChannelTracking, type IVoiceChannelTracking } from '../../src/models/voice-channel-tracking.js';
+import { UserNotificationPrefsService } from '../../src/services/user-notification-prefs-service.js';
 
 // Helper to create an AchievementsService with injected config
 function createAchievementsService(mockClient: Partial<Client>) {
@@ -67,6 +68,21 @@ describe('AchievementsService', () => {
 
     // Reset singleton between tests
     (AchievementsService as unknown as { instance: unknown }).instance = undefined;
+
+    // Default the per-user prefs gate to "all enabled" so existing tests
+    // that don't care about #482 keep passing. `mockClear` resets the
+    // call history (jest.spyOn returns the same spy across tests, so
+    // without this `toHaveBeenCalled` assertions would see stale calls
+    // from earlier tests in the suite).
+    (UserNotificationPrefsService as unknown as { instance: unknown }).instance = null;
+    const prefsSpy = jest
+      .spyOn(UserNotificationPrefsService.prototype, 'getPrefs')
+      .mockResolvedValue({
+        achievements: true,
+        digest: true,
+        rewind: true,
+      });
+    prefsSpy.mockClear();
   });
 
   describe('singleton pattern', () => {
@@ -305,6 +321,68 @@ describe('AchievementsService', () => {
       await expect(
         service.notifyUserOfAccolades('user123', [{ type: 'first_hour', earnedAt: new Date(), metadata: {} }])
       ).resolves.not.toThrow();
+    });
+
+    it('skips DM when per-user notification prefs say achievements:false (#482)', async () => {
+      const { service, mockConfigService } = createAchievementsService(mockClient);
+      mockConfigService.getBoolean.mockResolvedValue(true);
+      mockConfigService.getString.mockResolvedValue('guild-1');
+
+      const mockUser = { username: 'TestUser', send: jest.fn().mockResolvedValue(undefined) };
+      (mockClient.users as any).fetch = jest.fn().mockResolvedValue(mockUser);
+
+      const getPrefsSpy = jest
+        .spyOn(UserNotificationPrefsService.prototype, 'getPrefs')
+        .mockResolvedValue({
+          achievements: false,
+          digest: true,
+          rewind: true,
+        });
+
+      await service.notifyUserOfAccolades('user123', [
+        { type: 'first_hour', earnedAt: new Date(), metadata: {} },
+      ]);
+
+      expect(getPrefsSpy).toHaveBeenCalledWith('user123', 'guild-1');
+      expect(mockUser.send).not.toHaveBeenCalled();
+    });
+
+    it('sends DM and appends the /config footer when prefs leave achievements on (#482)', async () => {
+      const { service, mockConfigService } = createAchievementsService(mockClient);
+      mockConfigService.getBoolean.mockResolvedValue(true);
+      mockConfigService.getString.mockResolvedValue('guild-1');
+
+      const mockUser = { username: 'TestUser', send: jest.fn().mockResolvedValue(undefined) };
+      (mockClient.users as any).fetch = jest.fn().mockResolvedValue(mockUser);
+
+      await service.notifyUserOfAccolades('user123', [
+        { type: 'first_hour', earnedAt: new Date(), metadata: {} },
+      ]);
+
+      expect(mockUser.send).toHaveBeenCalledTimes(1);
+      const sent = (mockUser.send as jest.Mock).mock.calls[0][0] as string;
+      expect(sent).toContain('Manage notifications: run `/config`');
+    });
+
+    it('falls through and DMs when GUILD_ID is unset (no prefs lookup possible)', async () => {
+      const { service, mockConfigService } = createAchievementsService(mockClient);
+      mockConfigService.getBoolean.mockResolvedValue(true);
+      mockConfigService.getString.mockResolvedValue('');
+
+      const mockUser = { username: 'TestUser', send: jest.fn().mockResolvedValue(undefined) };
+      (mockClient.users as any).fetch = jest.fn().mockResolvedValue(mockUser);
+
+      const getPrefsSpy = jest.spyOn(
+        UserNotificationPrefsService.prototype,
+        'getPrefs',
+      );
+
+      await service.notifyUserOfAccolades('user123', [
+        { type: 'first_hour', earnedAt: new Date(), metadata: {} },
+      ]);
+
+      expect(getPrefsSpy).not.toHaveBeenCalled();
+      expect(mockUser.send).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/__tests__/services/user-notification-prefs-service.test.ts
+++ b/__tests__/services/user-notification-prefs-service.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for UserNotificationPrefsService (#482).
+ *
+ * Covers:
+ *  - missing row → all defaults true
+ *  - DB error → all defaults true (so a transient outage cannot
+ *    silence every DM by misreporting "user opted out")
+ *  - setPrefs writes a row via findOneAndUpdate + upsert and returns
+ *    the merged result
+ *  - setPrefs ignores non-boolean keys in the patch
+ *  - get/set both refuse empty userId / guildId without throwing on the
+ *    read path
+ */
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+jest.mock('../../src/utils/logger.js', () => ({
+  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+// Mock the model so we can control find/upsert outcomes per test.
+jest.mock('../../src/models/user-notification-prefs.js', () => ({
+  UserNotificationPrefs: {
+    findOne: jest.fn(),
+    findOneAndUpdate: jest.fn(),
+  },
+}));
+
+import { UserNotificationPrefs } from '../../src/models/user-notification-prefs.js';
+import {
+  DEFAULT_PREFS,
+  NOTIFICATION_PREF_KEYS,
+  UserNotificationPrefsService,
+} from '../../src/services/user-notification-prefs-service.js';
+
+const findOne = UserNotificationPrefs.findOne as jest.Mock;
+const findOneAndUpdate = UserNotificationPrefs.findOneAndUpdate as jest.Mock;
+
+describe('UserNotificationPrefsService', () => {
+  beforeEach(() => {
+    findOne.mockReset();
+    findOneAndUpdate.mockReset();
+    (UserNotificationPrefsService as unknown as { instance: unknown }).instance = null;
+  });
+
+  describe('getPrefs', () => {
+    it('returns all defaults when no row exists', async () => {
+      findOne.mockResolvedValueOnce(null);
+      const prefs = await UserNotificationPrefsService.getInstance().getPrefs('u1', 'g1');
+      expect(prefs).toEqual(DEFAULT_PREFS);
+      expect(findOne).toHaveBeenCalledWith({ userId: 'u1', guildId: 'g1' });
+    });
+
+    it('returns the stored row when present', async () => {
+      findOne.mockResolvedValueOnce({
+        userId: 'u1',
+        guildId: 'g1',
+        achievements: false,
+        digest: true,
+        rewind: false,
+        updatedAt: new Date(),
+      });
+      const prefs = await UserNotificationPrefsService.getInstance().getPrefs('u1', 'g1');
+      expect(prefs).toEqual({ achievements: false, digest: true, rewind: false });
+    });
+
+    it('collapses to defaults on DB error so a transient outage cannot silence DMs', async () => {
+      findOne.mockRejectedValueOnce(new Error('mongo down'));
+      const prefs = await UserNotificationPrefsService.getInstance().getPrefs('u1', 'g1');
+      expect(prefs).toEqual(DEFAULT_PREFS);
+    });
+
+    it('returns defaults for empty userId/guildId without touching the DB', async () => {
+      const svc = UserNotificationPrefsService.getInstance();
+      expect(await svc.getPrefs('', 'g1')).toEqual(DEFAULT_PREFS);
+      expect(await svc.getPrefs('u1', '')).toEqual(DEFAULT_PREFS);
+      expect(findOne).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setPrefs', () => {
+    it('writes only the keys present in the patch and returns the merged row', async () => {
+      findOneAndUpdate.mockResolvedValueOnce({
+        userId: 'u1',
+        guildId: 'g1',
+        achievements: false,
+        digest: true,
+        rewind: true,
+        updatedAt: new Date(),
+      });
+      const result = await UserNotificationPrefsService.getInstance().setPrefs(
+        'u1',
+        'g1',
+        { achievements: false },
+      );
+      expect(result).toEqual({ achievements: false, digest: true, rewind: true });
+      const [filter, update, opts] = findOneAndUpdate.mock.calls[0] as [
+        Record<string, unknown>,
+        { $set: Record<string, unknown> },
+        Record<string, unknown>,
+      ];
+      expect(filter).toEqual({ userId: 'u1', guildId: 'g1' });
+      expect(update.$set).toHaveProperty('achievements', false);
+      expect(update.$set).not.toHaveProperty('digest');
+      expect(update.$set).not.toHaveProperty('rewind');
+      expect(opts).toMatchObject({ upsert: true, new: true });
+    });
+
+    it('drops non-boolean values silently rather than coercing', async () => {
+      findOneAndUpdate.mockResolvedValueOnce({
+        userId: 'u1',
+        guildId: 'g1',
+        achievements: true,
+        digest: true,
+        rewind: true,
+        updatedAt: new Date(),
+      });
+      await UserNotificationPrefsService.getInstance().setPrefs('u1', 'g1', {
+        // @ts-expect-error - test bad input on purpose
+        achievements: 'true',
+        // @ts-expect-error - test bad input on purpose
+        digest: 1,
+        rewind: true,
+      });
+      const update = findOneAndUpdate.mock.calls[0][1] as { $set: Record<string, unknown> };
+      expect(update.$set).not.toHaveProperty('achievements');
+      expect(update.$set).not.toHaveProperty('digest');
+      expect(update.$set).toHaveProperty('rewind', true);
+    });
+
+    it('throws on empty userId/guildId — write path must not silently no-op', async () => {
+      const svc = UserNotificationPrefsService.getInstance();
+      await expect(svc.setPrefs('', 'g1', { achievements: false })).rejects.toThrow();
+      await expect(svc.setPrefs('u1', '', { achievements: false })).rejects.toThrow();
+      expect(findOneAndUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  it('exposes a stable list of known pref keys', () => {
+    expect(NOTIFICATION_PREF_KEYS).toEqual(['achievements', 'digest', 'rewind']);
+  });
+});

--- a/__tests__/web/user-routes.test.ts
+++ b/__tests__/web/user-routes.test.ts
@@ -233,6 +233,291 @@ describe("createUserRouter / index page", () => {
   });
 });
 
+describe("/me/notifications", () => {
+  beforeEach(() => {
+    process.env.WEBUI_SESSION_SECRET = SECRET;
+    process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES = "30";
+    (WebSessionService as unknown as { instance: unknown }).instance = null;
+  });
+
+  async function dispatch(opts: {
+    method: "GET" | "POST";
+    body?: Record<string, unknown>;
+    csrfHeader?: string;
+    csrfCookie?: string;
+    prefs?: { achievements: boolean; digest: boolean; rewind: boolean };
+    setPrefsImpl?: jest.Mock;
+    role?: "admin" | "user";
+  }): Promise<{
+    statusCode: number;
+    body: string;
+    headers: Record<string, unknown>;
+    redirectedTo?: string;
+  }> {
+    const now = Date.now();
+    const payload: CookiePayload = {
+      sid: "session-id",
+      uid: "user-1",
+      gid: "guild-1",
+      rol: opts.role ?? "user",
+      iat: now - 60_000,
+      act: now - 60_000,
+    };
+    const csrfCookie = opts.csrfCookie ?? "csrf-1";
+    const cookie = `koolbot_session=${buildCookie(payload)}; koolbot_csrf=${csrfCookie}`;
+
+    const svc = WebSessionService.getInstance();
+    jest.spyOn(svc, "findById").mockResolvedValue({
+      discordUserId: "user-1",
+      guildId: "guild-1",
+      role: opts.role ?? "user",
+      scopes: [],
+      revokedAt: null,
+      expiresAt: new Date(now + 60 * 60 * 1000),
+    } as never);
+    jest.spyOn(svc, "revokeSession").mockResolvedValue(true);
+
+    const { PermissionsService } =
+      await import("../../src/services/permissions-service.js");
+    jest.spyOn(PermissionsService, "getInstance").mockReturnValue({
+      checkCommandPermission: async () => true,
+    } as never);
+
+    const { UserNotificationPrefsService } =
+      await import("../../src/services/user-notification-prefs-service.js");
+    const getPrefs = jest
+      .fn<() => Promise<{ achievements: boolean; digest: boolean; rewind: boolean }>>()
+      .mockResolvedValue(
+        opts.prefs ?? { achievements: true, digest: true, rewind: true },
+      );
+    const setPrefs =
+      opts.setPrefsImpl ??
+      jest
+        .fn<
+          (
+            userId: string,
+            guildId: string,
+            patch: Record<string, boolean>,
+          ) => Promise<{ achievements: boolean; digest: boolean; rewind: boolean }>
+        >()
+        .mockImplementation(async (_u, _g, patch) => ({
+          achievements: true,
+          digest: true,
+          rewind: true,
+          ...patch,
+        }));
+    jest.spyOn(UserNotificationPrefsService, "getInstance").mockReturnValue({
+      getPrefs,
+      setPrefs,
+    } as never);
+
+    const { WebAuditLog } = await import("../../src/models/web-audit-log.js");
+    jest.spyOn(WebAuditLog, "create").mockResolvedValue({} as never);
+
+    const mockClient = {} as never;
+    const { createSessionMiddleware } =
+      await import("../../src/web/session.js");
+    const requireSession = createSessionMiddleware(mockClient);
+    const router = createUserRouter(mockClient, requireSession);
+
+    const headers: Record<string, unknown> = { cookie };
+    if (opts.method === "POST" && opts.csrfHeader) {
+      headers["x-csrf-token"] = opts.csrfHeader;
+    }
+
+    const captured: {
+      statusCode: number;
+      body: string;
+      headers: Record<string, unknown>;
+      redirectedTo?: string;
+    } = {
+      statusCode: 200,
+      body: "",
+      headers: {},
+    };
+    const res = {
+      ...makeRes(),
+    } as ReturnType<typeof makeRes> & {
+      redirect: jest.Mock;
+      header: jest.Mock;
+    };
+    res.status.mockImplementation((code: number) => {
+      captured.statusCode = code;
+      res.statusCode = code;
+      return res;
+    });
+    res.send.mockImplementation((body: unknown) => {
+      captured.body = typeof body === "string" ? body : String(body);
+      res.body = captured.body;
+      return res;
+    });
+    res.setHeader.mockImplementation((name: string, value: unknown) => {
+      captured.headers[name.toLowerCase()] = value;
+      return res;
+    });
+    res.redirect = jest.fn((code: unknown, url?: unknown) => {
+      if (typeof code === "number") {
+        captured.statusCode = code;
+        captured.redirectedTo = String(url);
+      } else {
+        captured.statusCode = 302;
+        captured.redirectedTo = String(code);
+      }
+      return res;
+    });
+    res.header = jest.fn(() => res);
+
+    const req = {
+      method: opts.method,
+      url: opts.method === "POST" ? "/notifications" : "/notifications",
+      originalUrl:
+        opts.method === "POST" ? "/me/notifications" : "/me/notifications",
+      path: "/notifications",
+      baseUrl: "/me",
+      headers,
+      body: opts.body ?? {},
+      query: {},
+      csrfToken: "csrf-1",
+      header: (name: string) => headers[name.toLowerCase()],
+    } as never as Parameters<typeof router>[0];
+
+    await new Promise<void>((resolve) => {
+      router(
+        req as never,
+        res as never,
+        (() => {
+          resolve();
+        }) as never,
+      );
+      setTimeout(resolve, 0);
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    return captured;
+  }
+
+  it("renders the notifications form for a user-role session", async () => {
+    const out = await dispatch({ method: "GET" });
+    expect(out.body).toContain("Notifications");
+    expect(out.body).toContain('action="/me/notifications"');
+    expect(out.body).toContain('name="achievements"');
+    expect(out.body).toContain('name="digest"');
+    expect(out.body).toContain('name="rewind"');
+    // All checkboxes should be `checked` when prefs default to enabled.
+    expect(out.body).toContain(
+      'name="achievements" value="true" checked',
+    );
+  });
+
+  it("renders 'coming soon' hint for digest and rewind rows", async () => {
+    const out = await dispatch({ method: "GET" });
+    expect(out.body).toContain("#483");
+    expect(out.body).toContain("#484");
+  });
+
+  it("renders unchecked when stored prefs are off", async () => {
+    const out = await dispatch({
+      method: "GET",
+      prefs: { achievements: false, digest: true, rewind: false },
+    });
+    // achievements unchecked, digest checked
+    expect(out.body).toContain('name="achievements" value="true">');
+    expect(out.body).toContain('name="digest" value="true" checked');
+    expect(out.body).toContain('name="rewind" value="true">');
+  });
+
+  it("rejects POST without a CSRF token", async () => {
+    const out = await dispatch({
+      method: "POST",
+      body: { submitted_achievements: "1" },
+      // no csrfHeader, no _csrf in body
+    });
+    expect(out.statusCode).toBe(403);
+  });
+
+  it("treats checkbox absence as 'off' when the hidden submitted flag is present", async () => {
+    let captured: { patch: Record<string, boolean>; user: string; guild: string } | null = null;
+    const setPrefs = jest
+      .fn<
+        (
+          userId: string,
+          guildId: string,
+          patch: Record<string, boolean>,
+        ) => Promise<{ achievements: boolean; digest: boolean; rewind: boolean }>
+      >()
+      .mockImplementation(async (user, guild, patch) => {
+        captured = { user, guild, patch };
+        return {
+          achievements: patch.achievements ?? true,
+          digest: patch.digest ?? true,
+          rewind: patch.rewind ?? true,
+        };
+      });
+
+    const out = await dispatch({
+      method: "POST",
+      body: {
+        _csrf: "csrf-1",
+        // Only the achievements row was submitted, and the checkbox is
+        // absent (= unchecked).
+        submitted_achievements: "1",
+      },
+      csrfHeader: "csrf-1",
+      setPrefsImpl: setPrefs,
+    });
+    expect(out.statusCode).toBe(303);
+    expect(out.redirectedTo).toMatch(/^\/me\/notifications\?/);
+    expect(setPrefs).toHaveBeenCalledTimes(1);
+    expect(captured).not.toBeNull();
+    expect(captured!.user).toBe("user-1");
+    expect(captured!.guild).toBe("guild-1");
+    expect(captured!.patch).toEqual({ achievements: false });
+  });
+
+  it("records a WebAuditLog row with role:'user' on successful save", async () => {
+    const { WebAuditLog } = await import("../../src/models/web-audit-log.js");
+    const out = await dispatch({
+      method: "POST",
+      body: {
+        _csrf: "csrf-1",
+        submitted_achievements: "1",
+        achievements: "true",
+      },
+      csrfHeader: "csrf-1",
+    });
+    expect(out.statusCode).toBe(303);
+    expect(WebAuditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "user.notifications.set",
+        role: "user",
+        discordUserId: "user-1",
+        guildId: "guild-1",
+        result: "success",
+      }),
+    );
+  });
+
+  it("records role:'admin' when an admin toggles their own prefs", async () => {
+    const { WebAuditLog } = await import("../../src/models/web-audit-log.js");
+    const out = await dispatch({
+      method: "POST",
+      role: "admin",
+      body: {
+        _csrf: "csrf-1",
+        submitted_achievements: "1",
+        achievements: "true",
+      },
+      csrfHeader: "csrf-1",
+    });
+    expect(out.statusCode).toBe(303);
+    expect(WebAuditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "user.notifications.set",
+        role: "admin",
+      }),
+    );
+  });
+});
+
 describe("userWebErrorHandler", () => {
   it("rewrites SelfScopeError to a 403 HTML page (not a generic 500)", async () => {
     const { userWebErrorHandler } = await import("../../src/web/index.js");

--- a/src/models/user-notification-prefs.ts
+++ b/src/models/user-notification-prefs.ts
@@ -1,0 +1,39 @@
+import mongoose, { Document, Schema } from "mongoose";
+
+/**
+ * Per-user notification preferences (#482).
+ *
+ * A missing row means "all defaults true" — see
+ * `UserNotificationPrefsService.getPrefs`. Storage is per `(userId, guildId)`.
+ *
+ * The `digest` (#483) and `rewind` (#484) fields ship from day one with
+ * defaulting writes so the schema is stable across all three sub-issues:
+ * downstream PRs only have to read them in their own DM paths.
+ */
+export interface IUserNotificationPrefs extends Document {
+  userId: string;
+  guildId: string;
+  achievements: boolean;
+  digest: boolean;
+  rewind: boolean;
+  updatedAt: Date;
+}
+
+const UserNotificationPrefsSchema = new Schema<IUserNotificationPrefs>(
+  {
+    userId: { type: String, required: true },
+    guildId: { type: String, required: true },
+    achievements: { type: Boolean, required: true, default: true },
+    digest: { type: Boolean, required: true, default: true },
+    rewind: { type: Boolean, required: true, default: true },
+    updatedAt: { type: Date, required: true, default: Date.now },
+  },
+  { timestamps: false },
+);
+
+UserNotificationPrefsSchema.index({ userId: 1, guildId: 1 }, { unique: true });
+
+export const UserNotificationPrefs = mongoose.model<IUserNotificationPrefs>(
+  "UserNotificationPrefs",
+  UserNotificationPrefsSchema,
+);

--- a/src/services/achievements-service.ts
+++ b/src/services/achievements-service.ts
@@ -9,6 +9,7 @@ import {
   type IVoiceChannelTracking,
 } from "../models/voice-channel-tracking.js";
 import { ConfigService } from "./config-service.js";
+import { UserNotificationPrefsService } from "./user-notification-prefs-service.js";
 import logger from "../utils/logger.js";
 import mongoose from "mongoose";
 import { quoteService } from "./quote-service.js";
@@ -1183,6 +1184,25 @@ export class AchievementsService {
         return;
       }
 
+      // Per-user opt-out (#482). Single-guild bot: resolve guildId from
+      // bootstrap config so this guard works whether or not the caller
+      // threaded it through. An empty/unset GUILD_ID falls through to the
+      // legacy "always send when global toggle is on" behaviour so a
+      // misconfiguration doesn't silence every DM.
+      const guildId = await this.configService.getString("GUILD_ID", "");
+      if (guildId) {
+        const prefs = await UserNotificationPrefsService.getInstance().getPrefs(
+          userId,
+          guildId,
+        );
+        if (!prefs.achievements) {
+          logger.info(
+            `Skipping accolade DM for ${userId}: per-user achievements pref is off`,
+          );
+          return;
+        }
+      }
+
       const messages = accolades
         .map((accolade) => {
           const definition = this.getAccoladeDefinition(accolade.type);
@@ -1202,6 +1222,8 @@ export class AchievementsService {
           ...messages,
           "",
           "Use `/achievements` to see all your earned badges!",
+          "",
+          "Manage notifications: run `/config`.",
         ].join("\n");
 
         await user.send(message);

--- a/src/services/user-notification-prefs-service.ts
+++ b/src/services/user-notification-prefs-service.ts
@@ -1,0 +1,106 @@
+import logger from "../utils/logger.js";
+import {
+  UserNotificationPrefs,
+  type IUserNotificationPrefs,
+} from "../models/user-notification-prefs.js";
+
+/**
+ * Plain shape (no Mongoose doc methods) returned by the service. Callers
+ * outside of this module work with `NotificationPrefs`, never the raw
+ * `IUserNotificationPrefs` document.
+ */
+export interface NotificationPrefs {
+  achievements: boolean;
+  digest: boolean;
+  rewind: boolean;
+}
+
+export type NotificationPrefKey = keyof NotificationPrefs;
+
+export const NOTIFICATION_PREF_KEYS: readonly NotificationPrefKey[] = [
+  "achievements",
+  "digest",
+  "rewind",
+];
+
+export const DEFAULT_PREFS: NotificationPrefs = {
+  achievements: true,
+  digest: true,
+  rewind: true,
+};
+
+/**
+ * Per-user notification preferences service (#482).
+ *
+ * Backed by `UserNotificationPrefs` (one row per `(userId, guildId)`).
+ * A missing row is treated as "all defaults true", so guards in DM-send
+ * paths can call `getPrefs` unconditionally without first checking
+ * whether the user has ever opened `/me/notifications`.
+ */
+export class UserNotificationPrefsService {
+  private static instance: UserNotificationPrefsService | null = null;
+
+  private constructor() {}
+
+  public static getInstance(): UserNotificationPrefsService {
+    if (!UserNotificationPrefsService.instance) {
+      UserNotificationPrefsService.instance =
+        new UserNotificationPrefsService();
+    }
+    return UserNotificationPrefsService.instance;
+  }
+
+  /**
+   * Read the prefs for a user in a guild. Missing row → defaults
+   * (everything enabled). DB errors are logged and also collapse to
+   * defaults so a transient failure can't accidentally silence every DM.
+   */
+  public async getPrefs(
+    userId: string,
+    guildId: string,
+  ): Promise<NotificationPrefs> {
+    if (!userId || !guildId) return { ...DEFAULT_PREFS };
+    try {
+      const row = await UserNotificationPrefs.findOne({ userId, guildId });
+      if (!row) return { ...DEFAULT_PREFS };
+      return rowToPrefs(row);
+    } catch (err) {
+      logger.error("Failed to load notification prefs", err);
+      return { ...DEFAULT_PREFS };
+    }
+  }
+
+  /**
+   * Apply a partial update. Only keys present in `patch` are written;
+   * absent keys keep their prior stored value (or default if no row
+   * existed). The merged result is returned so callers can render the
+   * post-update state without an extra read.
+   */
+  public async setPrefs(
+    userId: string,
+    guildId: string,
+    patch: Partial<NotificationPrefs>,
+  ): Promise<NotificationPrefs> {
+    if (!userId) throw new Error("userId required");
+    if (!guildId) throw new Error("guildId required");
+    const cleaned: Partial<NotificationPrefs> = {};
+    for (const key of NOTIFICATION_PREF_KEYS) {
+      const value = patch[key];
+      if (typeof value === "boolean") cleaned[key] = value;
+    }
+    const row = await UserNotificationPrefs.findOneAndUpdate(
+      { userId, guildId },
+      { $set: { ...cleaned, updatedAt: new Date() } },
+      { new: true, upsert: true, setDefaultsOnInsert: true },
+    );
+    return row ? rowToPrefs(row) : { ...DEFAULT_PREFS, ...cleaned };
+  }
+}
+
+function rowToPrefs(row: IUserNotificationPrefs): NotificationPrefs {
+  return {
+    achievements: row.achievements !== false,
+    digest: row.digest !== false,
+    rewind: row.rewind !== false,
+  };
+}

--- a/src/web/user-layout.ts
+++ b/src/web/user-layout.ts
@@ -19,13 +19,20 @@ interface UserNavItem {
 }
 
 /**
- * Nav items in the user self-service surface. The v1 scaffold ships
- * only the index page; the placeholders below sit ready for #482/#484
- * to fill in, but they don't render until those pages exist.
+ * Inline page nav for the user self-service surface. Rendered above the
+ * main column on every `/me/*` page (see `renderPageNav` below). New
+ * pages from later sub-issues (#484 Rewind, etc.) bolt on by appending
+ * to this list.
  */
 export const USER_NAV_ITEMS: UserNavItem[] = [
   { href: "/me/", label: "Overview" },
+  { href: "/me/notifications", label: "Notifications" },
 ];
+
+export interface UserFlashMessage {
+  type: "ok" | "warn" | "err";
+  text: string;
+}
 
 export interface UserPageOptions {
   title: string;
@@ -40,6 +47,12 @@ export interface UserPageOptions {
    * the admin layout (added in the same issue) does the inverse.
    */
   isAdmin: boolean;
+  /**
+   * Optional flash notice rendered above `body`. Used by POST handlers
+   * that PRG-redirect back to a GET (e.g. /me/notifications) and need to
+   * surface the outcome.
+   */
+  flash?: UserFlashMessage | null;
 }
 
 const STYLE = [
@@ -71,10 +84,27 @@ const STYLE = [
   ".tag-info{background:#1e3a8a;color:#bfdbfe}",
   ".notice{padding:.6rem .8rem;border-radius:6px;margin:0 0 1rem}",
   ".notice.info{background:#1d2a44;color:#bfdbfe}",
+  ".notice.ok{background:#14532d;color:#bbf7d0}",
+  ".notice.warn{background:#78350f;color:#fed7aa}",
+  ".notice.err{background:#7f1d1d;color:#fecaca}",
+  ".prefs-table{width:100%;border-collapse:collapse}",
+  ".prefs-table th,.prefs-table td{text-align:left;padding:.6rem .5rem;vertical-align:top;border-bottom:1px solid #1f2937}",
+  ".prefs-table th{font-weight:600;color:#cbd5e1;font-size:.85rem;text-transform:uppercase;letter-spacing:.04em}",
+  ".prefs-table tr:last-child td{border-bottom:0}",
+  ".prefs-table .toggle{display:flex;align-items:center;gap:.4rem;font-size:.85rem;color:#94a3b8}",
+  ".prefs-table .pref-desc{color:#94a3b8;font-size:.85rem;margin-top:.15rem}",
+  ".prefs-table .pref-soon{display:block;color:#f59e0b;font-size:.75rem;font-style:italic;margin-top:.15rem}",
+  ".btn{background:#2563eb;color:#fff;border:0;padding:.45rem .9rem;border-radius:4px;cursor:pointer;font-weight:600;font-size:.9rem}",
+  ".btn:hover{background:#1d4ed8}",
+  ".form-actions{margin-top:1rem;display:flex;gap:.5rem;align-items:center}",
   ".feature-list{list-style:none;padding:0;margin:0;display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:.75rem}",
   ".feature-list li{background:#0f1115;border:1px solid #2d3748;border-radius:6px;padding:.75rem 1rem}",
   ".feature-list .feature-name{font-weight:600;display:block;margin-bottom:.2rem;color:#e4e6eb}",
   ".feature-list .feature-desc{font-size:.8rem;color:#94a3b8}",
+  ".page-nav{display:flex;gap:.5rem;flex-wrap:wrap;margin:0 0 1.5rem}",
+  ".page-nav a{padding:.35rem .75rem;border-radius:4px;background:#161a22;border:1px solid #2d3748;color:#cbd5e1;font-size:.85rem;font-weight:600}",
+  ".page-nav a:hover{background:#1f2937;text-decoration:none;color:#fff}",
+  ".page-nav a.active{background:#1e3a8a;border-color:#1e3a8a;color:#fff}",
 ].join("");
 
 // Same DOM hooks (`#session-countdown`, `data-remaining-ms`,
@@ -138,17 +168,34 @@ export function renderUserPage(opts: UserPageOptions): string {
     '<button type="submit">Finish</button>',
     "</form></div></div>",
     '<div class="shell">',
-    `<main>${opts.body}</main></div>`,
+    `<main>${renderPageNav(opts.active)}${renderFlash(opts.flash)}${opts.body}</main></div>`,
     `<script>${SCRIPT}</script>`,
     "</body></html>",
   ].join("");
 }
 
+function renderPageNav(active: string): string {
+  const items = USER_NAV_ITEMS.map((item) => {
+    const isActive =
+      item.href === active ||
+      (item.href === "/me/" && (active === "/me" || active === "/me/"));
+    const cls = isActive ? ' class="active"' : "";
+    return `<a href="${escapeHtml(item.href)}"${cls}>${escapeHtml(item.label)}</a>`;
+  }).join("");
+  return `<nav class="page-nav">${items}</nav>`;
+}
+
+function renderFlash(flash?: UserFlashMessage | null): string {
+  if (!flash) return "";
+  const cls =
+    flash.type === "ok" ? "ok" : flash.type === "warn" ? "warn" : "err";
+  return `<div class="notice ${cls}">${escapeHtml(flash.text)}</div>`;
+}
+
 /**
  * Page body for `/me/`. Self-contained — the layout supplies the chrome,
- * this function supplies just the inner HTML. Intentionally a stub: #482
- * (notification prefs) and #484 (Rewind) bolt their own cards onto this
- * page as they land.
+ * this function supplies just the inner HTML. The Notifications card
+ * landed in #482; later cards (#484 Rewind, etc.) bolt on as they ship.
  */
 export function renderUserIndexBody(opts: {
   discordUserId: string;
@@ -162,13 +209,13 @@ export function renderUserIndexBody(opts: {
     "<h1>My preferences</h1>",
     greeting,
     '<div class="card">',
-    "<h2>Nothing here yet</h2>",
-    `<p>Koolbot is laying the groundwork for per-user self-service. The pages below will fill in as <a href="https://github.com/lonix/koolbot/issues/480">#480</a>'s sub-issues land.</p>`,
+    "<h2>What you can manage</h2>",
+    `<p>Self-service settings scoped to you on this server.</p>`,
     '<ul class="feature-list">',
-    '<li><span class="feature-name">Notification preferences</span>' +
-      '<span class="feature-desc">Opt in or out of achievement DMs, leaderboard pings, etc. (issue #482)</span></li>',
+    '<li><span class="feature-name"><a href="/me/notifications">Notifications</a></span>' +
+      '<span class="feature-desc">Opt in or out of DM nudges from Koolbot.</span></li>',
     '<li><span class="feature-name">Rewind</span>' +
-      '<span class="feature-desc">A personal recap of your activity on this server (issue #484)</span></li>',
+      '<span class="feature-desc">A personal recap of your activity on this server (coming in #484).</span></li>',
     "</ul>",
     "</div>",
     '<div class="card">',
@@ -176,5 +223,77 @@ export function renderUserIndexBody(opts: {
     `<p class="mono">User: ${escapeHtml(opts.discordUserId)} · Guild: ${escapeHtml(opts.guildId)}</p>`,
     "<p>To sign in as a different user, run <code>/config</code> in Discord with that account.</p>",
     "</div>",
+  ].join("");
+}
+
+interface NotificationRow {
+  key: string;
+  label: string;
+  description: string;
+  enabled: boolean;
+  /**
+   * When set, the row is rendered with a "coming soon" hint and the
+   * dependent-issue reference. The toggle itself stays functional so
+   * users can pre-set their preference before the matching DM path
+   * lands. See #482 acceptance criteria.
+   */
+  comingSoon?: string;
+}
+
+export interface NotificationsPageBodyOptions {
+  csrfToken: string;
+  rows: NotificationRow[];
+}
+
+/**
+ * Inner HTML for `GET /me/notifications` (#482). One form, one POST.
+ * Each toggle is a real checkbox (no JS), submitted along with the
+ * other rows so the page is friendly to keyboard / no-JS sessions.
+ */
+export function renderUserNotificationsBody(
+  opts: NotificationsPageBodyOptions,
+): string {
+  const rows = opts.rows
+    .map((row) => {
+      const soon = row.comingSoon
+        ? `<span class="pref-soon">${escapeHtml(row.comingSoon)}</span>`
+        : "";
+      return [
+        "<tr>",
+        "<td>",
+        `<strong>${escapeHtml(row.label)}</strong>`,
+        `<div class="pref-desc">${escapeHtml(row.description)}</div>`,
+        soon,
+        "</td>",
+        '<td class="toggle">',
+        // Mirrors the admin "checkbox + hidden flag" pattern: when the
+        // checkbox is unchecked the browser submits nothing for that
+        // name, so the hidden `submitted` flag lets the server tell
+        // "explicitly off" from "key not in form".
+        `<input type="hidden" name="submitted_${escapeHtml(row.key)}" value="1">`,
+        `<label><input type="checkbox" name="${escapeHtml(row.key)}" value="true"${row.enabled ? " checked" : ""}> Enabled</label>`,
+        "</td>",
+        "</tr>",
+      ].join("");
+    })
+    .join("");
+  return [
+    "<h1>Notifications</h1>",
+    `<p class="subtitle">Choose which DMs Koolbot may send you on this server. Untoggling a row stops the matching DM immediately.</p>`,
+    '<form method="POST" action="/me/notifications">',
+    `<input type="hidden" name="_csrf" value="${escapeHtml(opts.csrfToken)}">`,
+    '<div class="card">',
+    '<table class="prefs-table"><thead><tr>',
+    "<th>Notification</th>",
+    "<th>Current state</th>",
+    "</tr></thead><tbody>",
+    rows,
+    "</tbody></table>",
+    '<div class="form-actions">',
+    '<button class="btn" type="submit">Save preferences</button>',
+    '<span class="muted">Missing record on first save → defaults to all-enabled.</span>',
+    "</div>",
+    "</div>",
+    "</form>",
   ].join("");
 }

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -16,7 +16,14 @@ import {
   type RequestHandler,
 } from "express";
 import { Client } from "discord.js";
+import logger from "../utils/logger.js";
 import { WebSessionService } from "../services/web-session-service.js";
+import {
+  NOTIFICATION_PREF_KEYS,
+  UserNotificationPrefsService,
+  type NotificationPrefKey,
+  type NotificationPrefs,
+} from "../services/user-notification-prefs-service.js";
 import { requireCsrf } from "./csrf.js";
 import {
   AuthenticatedRequest,
@@ -25,7 +32,13 @@ import {
   type WebSessionContext,
 } from "./session.js";
 import { getDisplayedRemainingMs } from "./admin-layout.js";
-import { renderUserIndexBody, renderUserPage } from "./user-layout.js";
+import {
+  renderUserIndexBody,
+  renderUserNotificationsBody,
+  renderUserPage,
+  type UserFlashMessage,
+} from "./user-layout.js";
+import { recordAudit } from "./audit.js";
 import { renderSignedOut } from "./views.js";
 
 function asyncHandler(
@@ -38,6 +51,87 @@ function asyncHandler(
 
 function getCsrfToken(req: AuthenticatedRequest): string {
   return (req as AuthenticatedRequest & { csrfToken?: string }).csrfToken ?? "";
+}
+
+function readCheckbox(value: unknown): boolean {
+  // The page posts "true" when checked; absent → unchecked.
+  if (typeof value === "string") return value === "true" || value === "on";
+  return value === true;
+}
+
+const NOTIFICATION_FLASH_MAX = 300;
+
+function flashUrl(path: string, flash: UserFlashMessage): string {
+  const text =
+    flash.text.length > NOTIFICATION_FLASH_MAX
+      ? `${flash.text.slice(0, NOTIFICATION_FLASH_MAX - 1)}…`
+      : flash.text;
+  const qs = new globalThis.URLSearchParams({
+    flash: flash.type,
+    msg: text,
+  }).toString();
+  return `${path}?${qs}`;
+}
+
+function readFlashFromQuery(
+  req: AuthenticatedRequest,
+): UserFlashMessage | null {
+  const type = String(req.query.flash ?? "");
+  const text = String(req.query.msg ?? "");
+  if (!text) return null;
+  if (type !== "ok" && type !== "warn" && type !== "err") return null;
+  return {
+    type,
+    text:
+      text.length > NOTIFICATION_FLASH_MAX
+        ? `${text.slice(0, NOTIFICATION_FLASH_MAX - 1)}…`
+        : text,
+  };
+}
+
+interface NotificationRowDef {
+  key: NotificationPrefKey;
+  label: string;
+  description: string;
+  comingSoon?: string;
+}
+
+const NOTIFICATION_ROW_DEFS: readonly NotificationRowDef[] = [
+  {
+    key: "achievements",
+    label: "Achievement DMs",
+    description:
+      "Direct messages from Koolbot when you earn a new accolade or badge.",
+  },
+  {
+    key: "digest",
+    label: "Weekly digest",
+    description:
+      "Once-a-week DM summarising your activity and the server's highlights.",
+    comingSoon: "Toggle works today; the matching DM lands in #483.",
+  },
+  {
+    key: "rewind",
+    label: "Year-in-review (Rewind)",
+    description: "End-of-year personal recap of your activity on this server.",
+    comingSoon: "Toggle works today; the matching DM lands in #484.",
+  },
+];
+
+function buildNotificationRows(prefs: NotificationPrefs): Array<{
+  key: string;
+  label: string;
+  description: string;
+  enabled: boolean;
+  comingSoon?: string;
+}> {
+  return NOTIFICATION_ROW_DEFS.map((def) => ({
+    key: def.key,
+    label: def.label,
+    description: def.description,
+    enabled: prefs[def.key],
+    comingSoon: def.comingSoon,
+  }));
 }
 
 /**
@@ -120,6 +214,123 @@ export function createUserRouter(
           isAdmin: session.role === "admin",
         }),
       );
+    }),
+  );
+
+  // ---------- Notifications (#482) ----------
+  router.get(
+    "/notifications",
+    asyncHandler(async (req, res) => {
+      const session = req.webSession;
+      if (!session) {
+        res.status(500).type("text/plain").send("session missing");
+        return;
+      }
+      const { userId, guildId } = assertSelfScope(session, {
+        userId: session.discordUserId,
+        guildId: session.guildId,
+      });
+      const prefs = await UserNotificationPrefsService.getInstance().getPrefs(
+        userId,
+        guildId,
+      );
+      const flash = readFlashFromQuery(req);
+      res.type("text/html").send(
+        renderUserPage({
+          title: "Notifications",
+          active: "/me/notifications",
+          body: renderUserNotificationsBody({
+            csrfToken: getCsrfToken(req),
+            rows: buildNotificationRows(prefs),
+          }),
+          csrfToken: getCsrfToken(req),
+          remainingMs: getDisplayedRemainingMs(session),
+          isAdmin: session.role === "admin",
+          flash,
+        }),
+      );
+    }),
+  );
+
+  router.post(
+    "/notifications",
+    requireCsrf,
+    asyncHandler(async (req, res) => {
+      const session = req.webSession;
+      if (!session) {
+        res.status(500).type("text/plain").send("session missing");
+        return;
+      }
+      const { userId, guildId } = assertSelfScope(session, {
+        userId: session.discordUserId,
+        guildId: session.guildId,
+      });
+
+      const body = (req.body as Record<string, unknown> | undefined) ?? {};
+      const service = UserNotificationPrefsService.getInstance();
+      const before = await service.getPrefs(userId, guildId);
+
+      // Per-row toggle: the page submits a hidden `submitted_<key>` flag
+      // alongside each checkbox, so we can distinguish "explicitly off"
+      // (flag present, checkbox absent) from "row not on this page"
+      // (flag absent — leave the stored value alone). Without the
+      // hidden flag a single missing checkbox would silently default to
+      // "false" on every save and quietly reset opt-ins on unrelated
+      // rows that future sub-issues append.
+      const patch: Partial<NotificationPrefs> = {};
+      for (const key of NOTIFICATION_PREF_KEYS) {
+        const submitted = body[`submitted_${key}`];
+        if (typeof submitted !== "string" || submitted.length === 0) continue;
+        patch[key] = readCheckbox(body[key]);
+      }
+
+      let result: "success" | "failure" = "success";
+      let errorMessage: string | null = null;
+      let after: NotificationPrefs = before;
+      try {
+        after = await service.setPrefs(userId, guildId, patch);
+      } catch (err) {
+        result = "failure";
+        errorMessage = err instanceof Error ? err.message : String(err);
+        logger.error("Failed to save notification prefs", err);
+      }
+
+      // Diff only the keys that actually changed so the audit row stays
+      // small and the row count grows linearly with deliberate toggles.
+      const changed = NOTIFICATION_PREF_KEYS.reduce<Record<string, unknown>>(
+        (acc, key) => {
+          if (before[key] !== after[key]) {
+            acc[key] = { before: before[key], after: after[key] };
+          }
+          return acc;
+        },
+        {},
+      );
+
+      await recordAudit(session, {
+        action: "user.notifications.set",
+        targetId: userId,
+        details:
+          result === "success"
+            ? { changed, submitted: Object.keys(patch) }
+            : { submitted: Object.keys(patch) },
+        result,
+        errorMessage,
+      });
+
+      const flash: UserFlashMessage =
+        result === "failure"
+          ? {
+              type: "err",
+              text: `Could not save your notification preferences: ${errorMessage ?? "unknown error"}.`,
+            }
+          : Object.keys(changed).length === 0
+            ? { type: "ok", text: "No changes — preferences already match." }
+            : {
+                type: "ok",
+                text: `Saved ${Object.keys(changed).length} preference change${Object.keys(changed).length === 1 ? "" : "s"}.`,
+              };
+      res.redirect(303, flashUrl("/me/notifications", flash));
     }),
   );
 


### PR DESCRIPTION
Closes #482. Builds on the `/me` foundation merged in #491 (#481).

## Summary

Adds a self-service notification-preferences page under `/me/notifications` so guild members can opt out of DM nudges from Koolbot without a slash command. Achievement DMs honour the new toggle today; `digest` (#483) and `rewind` (#484) toggles ship now with functional storage so the dependent issues only need to read them in their own DM paths.

## Changes

- **Model** — new `UserNotificationPrefs` keyed by `(userId, guildId)` with a compound unique index. Missing row = all defaults true; no migration needed.
- **Service** — `UserNotificationPrefsService` (`getPrefs`/`setPrefs`) with defaults-on-missing and defaults-on-failure on the read path so a transient DB outage cannot silently silence every DM.
- **Routes** — `GET/POST /me/notifications`, CSRF-checked, scoped via `assertSelfScope` (admin sessions on `/me/*` still see only their own prefs). Each save writes one `WebAuditLog` row with the session's role (admin or user) and a diff of the changed keys.
- **Per-row submission** — the page emits a hidden `submitted_<key>` flag alongside each checkbox so a missing field is treated as "explicitly off" without clobbering rows that future sub-issues append.
- **Achievements integration** — `AchievementsService.notifyUserOfAccolades` resolves `GUILD_ID` via `ConfigService` and short-circuits when the user has opted out. The DM body gains a single-line `Manage notifications: run /config` footer so users discover the opt-out.
- **Layout** — `user-layout.ts` gains a slim inline page-nav, flash mechanism, and a renderer for the notifications form. The Overview body now links to `/me/notifications`.
- **Docs** — WEBUI.md documents the new page.

## Acceptance criteria (from issue)

- [x] `/me/notifications` lists every notification type with current state and a working toggle; `digest`/`rewind` rows show a "coming soon" hint until #483/#484 ship.
- [x] Toggling achievements off prevents the next achievement DM (verified by `achievements-service.test.ts` "skips DM when per-user notification prefs say achievements:false").
- [x] Missing prefs record is treated as all-enabled (verified by `user-notification-prefs-service.test.ts`).
- [x] `WebAuditLog` records each toggle with the actor's user ID and the session's role (verified by route tests covering both `role:"user"` and `role:"admin"` cases).
- [x] Unit tests cover `UserNotificationPrefsService` get/set/default.
- [x] WEBUI.md documents the new page; no entry in COMMANDS.md (deliberately no command).
- [x] No new slash command introduced.

## Test plan

- [x] `npm test` — 825 passed, 1 skipped across 84 suites
- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors (114 pre-existing warnings unchanged)
- [x] `npm run format:check` — clean
- [ ] Manual: load `/me/notifications` as a user-role session, toggle achievements off, verify next accolade does not DM; verify audit row appears in `/admin/audit`.
- [ ] Manual: load `/me/notifications` as an admin-role session, toggle digest off, verify audit row records `role:"admin"`.

https://claude.ai/code/session_01CGwsVr3QyJDaSTcXoDAzTw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGwsVr3QyJDaSTcXoDAzTw)_