### PR TITLE
feat: weekly voice-activity digest with WebUI opt-out (closes #483)

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -34,6 +34,7 @@ Complete configuration reference for all KoolBot settings.
 - [Voice Channel Cleanup](#-voice-channel-cleanup)
 - [Announcements](#-announcements)
 - [Achievements System](#-achievements-system)
+- [Weekly Digest](#-weekly-digest)
 - [Reaction Roles](#-reaction-roles)
 - [Leaderboard Role Rewards](#-leaderboard-role-rewards)
 - [Rate Limiting](#-rate-limiting)
@@ -419,6 +420,36 @@ accolade list and usage.
 
 ---
 
+## 📬 Weekly Digest
+
+Per-user weekly DM that summarises voice activity, leaderboard rank,
+streak, and achievements earned in the last 7 days. Opt-out lives on
+the user's **/me/notifications** page (no slash command).
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `digest.enabled` | `false` | Master switch — enables the cron job and DM delivery |
+| `digest.cron` | `"0 9 * * 1"` | Cron schedule (default: Mondays at 09:00 host timezone) |
+| `digest.min_active_minutes` | `30` | Minimum weekly voice minutes a user needs to receive a digest |
+| `digest.streak_min_minutes` | `30` | Minutes of weekly activity that count toward the consecutive-weeks streak |
+| `digest.include_achievements` | `true` | Include accolades and achievements earned in the past week |
+
+**Notes:**
+
+- Requires `voicetracking.enabled = true` so the underlying weekly stats
+  exist.
+- Per-user opt-out is honoured before each send via the
+  `prefs.digest` field set on `/me/notifications`.
+- Users with DMs closed are silently skipped (same pattern the
+  `AchievementsService` already uses).
+- A summary row (qualifying / sent / opted-out / DMs closed / failed)
+  is posted to the configured `core.cron.channel_id` log channel after
+  every run.
+- Delta + streak math uses a per-user `DigestState` row that is updated
+  after each successful delivery.
+
+---
+
 ### Cron schedule format
 
 ```text
@@ -752,6 +783,14 @@ above).
 - `achievements.enabled` (bool, default: false)
 - `achievements.announcements.enabled` (bool, default: true)
 - `achievements.dm_notifications.enabled` (bool, default: true)
+
+#### Weekly Digest
+
+- `digest.enabled` (bool, default: false)
+- `digest.cron` (string, default: `"0 9 * * 1"`)
+- `digest.min_active_minutes` (number, default: 30)
+- `digest.streak_min_minutes` (number, default: 30)
+- `digest.include_achievements` (bool, default: true)
 
 #### Cleanup
 

--- a/__tests__/services/config-schema.test.ts
+++ b/__tests__/services/config-schema.test.ts
@@ -160,6 +160,7 @@ describe('Config Schema', () => {
       'ratelimit.enabled': false,
       'announcements.enabled': false,
       'achievements.enabled': false,
+      'digest.enabled': false,
       'reactionroles.enabled': false,
       'notices.enabled': false,
       'polls.enabled': false,
@@ -179,6 +180,7 @@ describe('Config Schema', () => {
       'quotes.header_pin_enabled': true,
       'achievements.announcements.enabled': true,
       'achievements.dm_notifications.enabled': true,
+      'digest.include_achievements': true,
       'notices.header_enabled': true,
       'notices.header_pin_enabled': true,
 
@@ -198,6 +200,7 @@ describe('Config Schema', () => {
       'quotes.header_pin_enabled': 'quotes.enabled',
       'achievements.announcements.enabled': 'achievements.enabled',
       'achievements.dm_notifications.enabled': 'achievements.enabled',
+      'digest.include_achievements': 'digest.enabled',
       'notices.header_enabled': 'notices.enabled',
       'notices.header_pin_enabled': 'notices.enabled',
     };

--- a/__tests__/services/digest-service.test.ts
+++ b/__tests__/services/digest-service.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import type { Client } from "discord.js";
+
+const mockRegisterReloadCallback = jest.fn();
+const mockConfigGetBoolean = jest.fn();
+const mockConfigGetString = jest.fn();
+const mockConfigGetNumber = jest.fn();
+
+const mockGetTopUsers = jest.fn();
+const mockTrackerGetInstance = jest.fn(() => ({
+  getTopUsers: mockGetTopUsers,
+}));
+
+const mockGetPrefs = jest.fn();
+const mockPrefsGetInstance = jest.fn(() => ({
+  getPrefs: mockGetPrefs,
+}));
+
+const mockAchievementsGetInstance = jest.fn(() => ({}));
+
+const mockLoggerIsReady = jest.fn(() => false);
+const mockLogCronSuccess = jest.fn();
+const mockDiscordLoggerGetInstance = jest.fn(() => ({
+  isReady: mockLoggerIsReady,
+  logCronSuccess: mockLogCronSuccess,
+}));
+
+const mockUserSend = jest.fn();
+const mockUsersFetch = jest.fn();
+
+const mockDigestStateFindOne = jest.fn();
+const mockDigestStateFindOneAndUpdate = jest.fn();
+
+const mockUserAchievementsFindOne = jest.fn();
+
+jest.unstable_mockModule("../../src/services/config-service.js", () => ({
+  ConfigService: {
+    getInstance: jest.fn(() => ({
+      registerReloadCallback: mockRegisterReloadCallback,
+      getBoolean: mockConfigGetBoolean,
+      getString: mockConfigGetString,
+      getNumber: mockConfigGetNumber,
+    })),
+  },
+}));
+
+jest.unstable_mockModule("../../src/services/voice-channel-tracker.js", () => ({
+  VoiceChannelTracker: { getInstance: mockTrackerGetInstance },
+}));
+
+jest.unstable_mockModule(
+  "../../src/services/user-notification-prefs-service.js",
+  () => ({
+    UserNotificationPrefsService: { getInstance: mockPrefsGetInstance },
+  }),
+);
+
+jest.unstable_mockModule("../../src/services/achievements-service.js", () => ({
+  AchievementsService: { getInstance: mockAchievementsGetInstance },
+}));
+
+jest.unstable_mockModule("../../src/services/discord-logger.js", () => ({
+  DiscordLogger: { getInstance: mockDiscordLoggerGetInstance },
+}));
+
+jest.unstable_mockModule("../../src/models/digest-state.js", () => ({
+  DigestState: {
+    findOne: mockDigestStateFindOne,
+    findOneAndUpdate: mockDigestStateFindOneAndUpdate,
+  },
+}));
+
+jest.unstable_mockModule("../../src/models/user-achievements.js", () => ({
+  UserAchievements: { findOne: mockUserAchievementsFindOne },
+}));
+
+jest.unstable_mockModule("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const { DigestService } = await import(
+  "../../src/services/digest-service.js"
+);
+
+type ServiceInstance = InstanceType<typeof DigestService>;
+
+function resetSingleton(): void {
+  (DigestService as unknown as { instance: unknown }).instance = undefined;
+}
+
+function makeClient(): Client {
+  return {
+    users: { fetch: mockUsersFetch },
+  } as unknown as Client;
+}
+
+describe("DigestService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetSingleton();
+    mockConfigGetBoolean.mockImplementation(async (key: unknown) => {
+      const k = key as string;
+      if (k === "digest.enabled") return true;
+      if (k === "digest.include_achievements") return false;
+      return false;
+    });
+    mockConfigGetString.mockImplementation(async (key: unknown) => {
+      const k = key as string;
+      if (k === "GUILD_ID") return "guild-1";
+      if (k === "digest.cron") return "0 9 * * 1";
+      return "";
+    });
+    mockConfigGetNumber.mockImplementation(async (key: unknown, def: unknown) => {
+      const k = key as string;
+      if (k === "digest.min_active_minutes") return 30;
+      if (k === "digest.streak_min_minutes") return 30;
+      return (def as number) ?? 0;
+    });
+    mockGetPrefs.mockResolvedValue({
+      achievements: true,
+      digest: true,
+      rewind: true,
+    });
+    mockDigestStateFindOne.mockResolvedValue(null);
+    mockDigestStateFindOneAndUpdate.mockResolvedValue({});
+    mockUserAchievementsFindOne.mockResolvedValue(null);
+    mockUsersFetch.mockImplementation(async (userId: unknown) => ({
+      id: userId as string,
+      username: `user-${userId as string}`,
+      send: mockUserSend,
+    }));
+    mockUserSend.mockResolvedValue(undefined);
+  });
+
+  describe("singleton", () => {
+    it("returns the same instance for the same client", () => {
+      const client = makeClient();
+      const a = DigestService.getInstance(client);
+      const b = DigestService.getInstance(client);
+      expect(a).toBe(b);
+    });
+
+    it("throws when called with a different client", () => {
+      DigestService.getInstance(makeClient());
+      expect(() => DigestService.getInstance(makeClient())).toThrow(
+        /already initialised with a different client/,
+      );
+    });
+
+    it("registers a reload callback on construction", () => {
+      DigestService.getInstance(makeClient());
+      expect(mockRegisterReloadCallback).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("runNow guards", () => {
+    it("returns null when the feature is disabled", async () => {
+      mockConfigGetBoolean.mockResolvedValue(false);
+      const svc: ServiceInstance = DigestService.getInstance(makeClient());
+      const result = await svc.runNow();
+      expect(result).toBeNull();
+      expect(mockGetTopUsers).not.toHaveBeenCalled();
+    });
+
+    it("returns null when GUILD_ID is missing", async () => {
+      mockConfigGetString.mockImplementation(async (key: unknown) => {
+        if (key === "GUILD_ID") return "";
+        return "";
+      });
+      const svc: ServiceInstance = DigestService.getInstance(makeClient());
+      const result = await svc.runNow();
+      expect(result).toBeNull();
+      expect(mockGetTopUsers).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("opt-out enforcement (#483)", () => {
+    it("skips users whose prefs.digest is false and does not send a DM", async () => {
+      mockGetTopUsers.mockResolvedValue([
+        // 60 minutes — clears min_active_minutes=30
+        { userId: "u1", username: "u1", totalTime: 60 * 60 },
+      ]);
+      mockGetPrefs.mockResolvedValue({
+        achievements: true,
+        digest: false,
+        rewind: true,
+      });
+
+      const svc: ServiceInstance = DigestService.getInstance(makeClient());
+      const result = await svc.runNow();
+
+      expect(result).not.toBeNull();
+      expect(result!.qualifying).toBe(1);
+      expect(result!.sent).toBe(0);
+      expect(result!.skippedOptOut).toBe(1);
+      // The DM and the state write are both gated behind the prefs check.
+      expect(mockUserSend).not.toHaveBeenCalled();
+      expect(mockDigestStateFindOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it("sends a DM and persists DigestState when prefs.digest is true", async () => {
+      mockGetTopUsers.mockResolvedValue([
+        { userId: "u1", username: "u1", totalTime: 60 * 60 },
+      ]);
+
+      const svc: ServiceInstance = DigestService.getInstance(makeClient());
+      const result = await svc.runNow();
+
+      expect(result).not.toBeNull();
+      expect(result!.sent).toBe(1);
+      expect(result!.skippedOptOut).toBe(0);
+      expect(mockUserSend).toHaveBeenCalledTimes(1);
+      expect(mockDigestStateFindOneAndUpdate).toHaveBeenCalledTimes(1);
+      const [filter, update] = mockDigestStateFindOneAndUpdate.mock.calls[0] as [
+        Record<string, unknown>,
+        { $set: Record<string, unknown> },
+      ];
+      expect(filter).toEqual({ userId: "u1", guildId: "guild-1" });
+      expect(update.$set).toMatchObject({
+        userId: "u1",
+        guildId: "guild-1",
+        lastWeekTotalTime: 60 * 60,
+        lastWeekRank: 1,
+      });
+    });
+
+    it("silently skips users with DMs closed (Discord error 50007)", async () => {
+      mockGetTopUsers.mockResolvedValue([
+        { userId: "u1", username: "u1", totalTime: 60 * 60 },
+      ]);
+      const dmError = Object.assign(new Error("DMs closed"), { code: 50007 });
+      mockUserSend.mockRejectedValueOnce(dmError);
+
+      const svc: ServiceInstance = DigestService.getInstance(makeClient());
+      const result = await svc.runNow();
+
+      expect(result!.sent).toBe(0);
+      expect(result!.skippedDmsClosed).toBe(1);
+      expect(result!.failed).toBe(0);
+      expect(mockDigestStateFindOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it("filters out users below the min_active_minutes threshold", async () => {
+      mockGetTopUsers.mockResolvedValue([
+        { userId: "u1", username: "u1", totalTime: 60 * 60 }, // 60 min - qualifies
+        { userId: "u2", username: "u2", totalTime: 60 * 5 }, // 5 min - does not
+      ]);
+
+      const svc: ServiceInstance = DigestService.getInstance(makeClient());
+      const result = await svc.runNow();
+
+      expect(result!.qualifying).toBe(1);
+      expect(result!.sent).toBe(1);
+      expect(mockGetPrefs).toHaveBeenCalledTimes(1);
+      expect(mockGetPrefs).toHaveBeenCalledWith("u1", "guild-1");
+    });
+  });
+});

--- a/__tests__/services/settings-metadata.test.ts
+++ b/__tests__/services/settings-metadata.test.ts
@@ -43,6 +43,7 @@ describe("settingsMetadata", () => {
       "help",
       "quotes",
       "core",
+      "digest",
       "ratelimit",
       "announcements",
       "achievements",

--- a/__tests__/web/user-routes.test.ts
+++ b/__tests__/web/user-routes.test.ts
@@ -408,9 +408,9 @@ describe("/me/notifications", () => {
     );
   });
 
-  it("renders 'coming soon' hint for digest and rewind rows", async () => {
+  it("renders 'coming soon' hint for the rewind row only (digest shipped in #483)", async () => {
     const out = await dispatch({ method: "GET" });
-    expect(out.body).toContain("#483");
+    expect(out.body).not.toContain("#483");
     expect(out.body).toContain("#484");
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import { PermissionsService } from "./services/permissions-service.js";
 import { ReactionRoleService } from "./services/reaction-role-service.js";
 import { PollService } from "./services/poll-service.js";
 import { LeaderboardRoleService } from "./services/leaderboard-role-service.js";
+import { DigestService } from "./services/digest-service.js";
 import { WizardService } from "./services/wizard-service.js";
 import { MonitoringService } from "./services/monitoring-service.js";
 import {
@@ -424,6 +425,7 @@ async function gracefulShutdown(signal: string): Promise<void> {
         await noticesChannelManager.stop();
         pollService.destroy();
         leaderboardRoleService.destroy();
+        digestService.destroy();
         WizardService.getInstance().shutdown();
         MonitoringService.getInstance().destroy();
         await botStatusService.shutdown();
@@ -484,6 +486,7 @@ let noticesChannelManager: NoticesChannelManager;
 let reactionRoleService: ReactionRoleService;
 let pollService: PollService;
 let leaderboardRoleService: LeaderboardRoleService;
+let digestService: DigestService;
 
 // Wrap service instantiation in try-catch to ensure errors are caught
 try {
@@ -502,6 +505,7 @@ try {
   reactionRoleService = ReactionRoleService.getInstance(client);
   pollService = PollService.getInstance(client);
   leaderboardRoleService = LeaderboardRoleService.getInstance(client);
+  digestService = DigestService.getInstance(client);
 } catch (error) {
   logger.error("❌ Fatal error during service instantiation:", error);
   process.exit(1);
@@ -588,6 +592,9 @@ async function initializeServices(): Promise<void> {
 
     // Initialize leaderboard role rewards service
     await leaderboardRoleService.start();
+
+    // Initialize weekly voice-activity digest service (#483)
+    await digestService.start();
 
     // Start the slash-command audit log cleanup cron (#459)
     CommandAuditCleanupService.getInstance().start();

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -32,6 +32,7 @@ const ConfigSchema = new Schema<IConfig>(
         "amikool", // Kept for backward compatibility; key removed but legacy rows may exist
         "announcements",
         "core",
+        "digest",
         "fun", // Kept for backward compatibility; key removed but legacy rows may exist
         "gamification", // Kept for backward compatibility during migration
         "help",

--- a/src/models/digest-state.ts
+++ b/src/models/digest-state.ts
@@ -8,8 +8,7 @@ import mongoose, { Document, Schema } from "mongoose";
  * (voice-time, rank) and maintain the consecutive-weeks streak without
  * re-aggregating beyond the current 7-day window.
  *
- * Rows are written by `DigestService` after a digest is sent (or after
- * a qualifying-but-undeliverable week, to keep streak math correct);
+ * Rows are written by `DigestService` after a digest is successfully sent;
  * deletions happen only when the user is purged from the guild and are
  * not the digest job's responsibility.
  */

--- a/src/models/digest-state.ts
+++ b/src/models/digest-state.ts
@@ -1,0 +1,42 @@
+import mongoose, { Document, Schema } from "mongoose";
+
+/**
+ * Per-user weekly digest delivery state (#483).
+ *
+ * One row per `(userId, guildId)`. The fields capture the snapshot from
+ * the previous successful delivery so the next run can compute deltas
+ * (voice-time, rank) and maintain the consecutive-weeks streak without
+ * re-aggregating beyond the current 7-day window.
+ *
+ * Rows are written by `DigestService` after a digest is sent (or after
+ * a qualifying-but-undeliverable week, to keep streak math correct);
+ * deletions happen only when the user is purged from the guild and are
+ * not the digest job's responsibility.
+ */
+export interface IDigestState extends Document {
+  userId: string;
+  guildId: string;
+  lastSentAt: Date;
+  lastWeekTotalTime: number; // seconds
+  lastWeekRank: number | null; // null when user was unranked
+  streakWeeks: number; // consecutive qualifying weeks ending lastSentAt
+}
+
+const DigestStateSchema = new Schema<IDigestState>(
+  {
+    userId: { type: String, required: true },
+    guildId: { type: String, required: true },
+    lastSentAt: { type: Date, required: true },
+    lastWeekTotalTime: { type: Number, required: true, default: 0 },
+    lastWeekRank: { type: Number, default: null },
+    streakWeeks: { type: Number, required: true, default: 0 },
+  },
+  { timestamps: false },
+);
+
+DigestStateSchema.index({ userId: 1, guildId: 1 }, { unique: true });
+
+export const DigestState = mongoose.model<IDigestState>(
+  "DigestState",
+  DigestStateSchema,
+);

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -53,6 +53,14 @@ export interface ConfigSchema {
   "achievements.enabled": boolean;
   "achievements.announcements.enabled": boolean;
   "achievements.dm_notifications.enabled": boolean;
+
+  // Weekly Personal Voice-Activity Digest (#483)
+  "digest.enabled": boolean;
+  "digest.cron": string; // Cron schedule, default Monday 09:00
+  "digest.min_active_minutes": number; // Min weekly minutes to qualify
+  "digest.streak_min_minutes": number; // Per-week minutes that count toward a streak
+  "digest.include_achievements": boolean;
+
   // Reaction Roles
   "reactionroles.enabled": boolean;
   "reactionroles.message_channel_id": string; // Channel for reaction role messages
@@ -166,6 +174,16 @@ export const defaultConfig: ConfigSchema = {
   "achievements.enabled": false,
   "achievements.announcements.enabled": true,
   "achievements.dm_notifications.enabled": true,
+
+  // Weekly digest defaults (#483). Master gate off, follows rule 1. The
+  // achievements sub-toggle defaults on so an operator who flips the
+  // master switch gets the richer embed without an extra step (parent
+  // gate keeps it inert until they do).
+  "digest.enabled": false,
+  "digest.cron": "0 9 * * 1", // Mondays at 09:00 in the host timezone
+  "digest.min_active_minutes": 30,
+  "digest.streak_min_minutes": 30,
+  "digest.include_achievements": true,
   // Reaction Roles defaults
   "reactionroles.enabled": false,
   "reactionroles.message_channel_id": "",
@@ -279,6 +297,11 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
     title: "Achievements",
     description:
       "Award badges based on voice activity, optionally with channel and DM notifications.",
+  },
+  digest: {
+    title: "Weekly Digest",
+    description:
+      "Personalised weekly DM summarising each user's voice activity, rank, streak, and new achievements. Opt-out lives on the user's /me/notifications page.",
   },
   reactionroles: {
     title: "Reaction Roles",
@@ -569,6 +592,43 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
     label: "DM notifications for earned achievements",
     description: "DM users when they earn a new achievement.",
     category: "achievements",
+    type: "boolean",
+  },
+
+  // Weekly Personal Voice-Activity Digest (#483)
+  "digest.enabled": {
+    label: "Weekly voice-activity digest enabled",
+    description:
+      "Send a personalised weekly DM summarising each eligible user's voice activity, rank, streak, and new achievements.",
+    category: "digest",
+    type: "boolean",
+  },
+  "digest.cron": {
+    label: "Digest schedule (cron)",
+    description:
+      "Cron expression for when the weekly digest job runs (defaults to Mondays 09:00 in the host timezone).",
+    category: "digest",
+    type: "cron",
+  },
+  "digest.min_active_minutes": {
+    label: "Minimum active minutes to qualify",
+    description:
+      "Users with less than this many minutes of voice activity in the past 7 days are skipped.",
+    category: "digest",
+    type: "number",
+  },
+  "digest.streak_min_minutes": {
+    label: "Streak threshold (minutes per week)",
+    description:
+      "Minutes of voice activity that count a week toward the consecutive-weeks streak.",
+    category: "digest",
+    type: "number",
+  },
+  "digest.include_achievements": {
+    label: "Include weekly achievements in digest",
+    description:
+      "Embed the achievements earned during the past week alongside the activity summary.",
+    category: "digest",
     type: "boolean",
   },
 

--- a/src/services/digest-service.ts
+++ b/src/services/digest-service.ts
@@ -1,0 +1,588 @@
+import {
+  Client,
+  EmbedBuilder,
+  type ColorResolvable,
+  type User,
+} from "discord.js";
+import { CronJob, CronTime } from "cron";
+import { ConfigService } from "./config-service.js";
+import { VoiceChannelTracker } from "./voice-channel-tracker.js";
+import { UserNotificationPrefsService } from "./user-notification-prefs-service.js";
+import { AchievementsService } from "./achievements-service.js";
+import { DiscordLogger } from "./discord-logger.js";
+import { DigestState } from "../models/digest-state.js";
+import { UserAchievements } from "../models/user-achievements.js";
+import {
+  ACCOLADE_METADATA,
+  type AccoladeType,
+} from "../content/accolades.js";
+import { ACHIEVEMENT_METADATA } from "../content/achievements.js";
+import logger from "../utils/logger.js";
+
+interface QualifyingUser {
+  userId: string;
+  username: string;
+  totalTime: number;
+  rank: number;
+}
+
+export interface DigestRunSummary {
+  ranAt: Date;
+  qualifying: number;
+  sent: number;
+  skippedOptOut: number;
+  skippedDmsClosed: number;
+  failed: number;
+}
+
+const DEFAULT_CRON = "0 9 * * 1";
+const SECONDS_PER_MINUTE = 60;
+const SECONDS_PER_WEEK = 7 * 24 * 60 * 60;
+const EMBED_COLOR: ColorResolvable = "#5865f2";
+
+function sanitizeCronExpression(expression: string): string {
+  return expression.trim().replace(/^["']|["']$/g, "");
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < SECONDS_PER_MINUTE) return `${seconds}s`;
+  const totalMinutes = Math.floor(seconds / SECONDS_PER_MINUTE);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours === 0) return `${minutes}m`;
+  if (minutes === 0) return `${hours}h`;
+  return `${hours}h ${minutes}m`;
+}
+
+function formatDelta(currentSeconds: number, previousSeconds: number): string {
+  const diff = currentSeconds - previousSeconds;
+  if (Math.abs(diff) < SECONDS_PER_MINUTE) {
+    return previousSeconds === 0 ? "first tracked week" : "no change";
+  }
+  const arrow = diff > 0 ? "▲" : "▼";
+  return `${arrow} ${formatDuration(Math.abs(diff))} vs last week`;
+}
+
+function formatRank(rank: number | null): string {
+  return rank === null ? "unranked" : `#${rank}`;
+}
+
+function formatRankDelta(
+  current: number | null,
+  previous: number | null,
+): string | null {
+  if (current === null || previous === null) return null;
+  if (current === previous) return "no change";
+  const diff = previous - current; // positive = moved up the leaderboard
+  return diff > 0 ? `▲ ${diff}` : `▼ ${Math.abs(diff)}`;
+}
+
+/**
+ * Pick a motivational footer line. We reuse the accolade descriptions
+ * from `src/content/accolades.ts` as a small but consistent flavour
+ * library — every line ties back to a real badge the user could earn.
+ */
+function pickMotivationalFooter(seed: number): string {
+  const descriptions = Object.values(ACCOLADE_METADATA).map((m) => m.description);
+  if (descriptions.length === 0) return "Keep it up!";
+  const index = ((seed % descriptions.length) + descriptions.length) %
+    descriptions.length;
+  return descriptions[index];
+}
+
+export class DigestService {
+  private static instance: DigestService;
+  private client: Client;
+  private configService: ConfigService;
+  private job: CronJob | null = null;
+  private isInitialized = false;
+  private isRunning = false;
+  private inFlight: Promise<DigestRunSummary | null> | null = null;
+
+  private constructor(client: Client) {
+    this.client = client;
+    this.configService = ConfigService.getInstance();
+
+    this.configService.registerReloadCallback(async () => {
+      try {
+        logger.info("Weekly digest configuration changed, reloading...");
+
+        const enabled = await this.configService.getBoolean(
+          "digest.enabled",
+          false,
+        );
+
+        if (!enabled && this.isInitialized) {
+          logger.info("Weekly digest disabled, stopping cron job...");
+          this.destroy();
+        } else if (enabled) {
+          await this.reload();
+        }
+      } catch (error) {
+        logger.error(
+          "Error reloading weekly digest service after configuration change:",
+          error,
+        );
+      }
+    });
+  }
+
+  public static getInstance(client: Client): DigestService {
+    if (!DigestService.instance) {
+      DigestService.instance = new DigestService(client);
+    } else if (DigestService.instance.client !== client) {
+      throw new Error(
+        "DigestService already initialised with a different client",
+      );
+    }
+    return DigestService.instance;
+  }
+
+  public static reset(): void {
+    if (DigestService.instance) {
+      DigestService.instance.destroy();
+    }
+    DigestService.instance = undefined as unknown as DigestService;
+  }
+
+  private validateCronExpression(expression: string): boolean {
+    try {
+      new CronTime(expression);
+      return true;
+    } catch (error) {
+      logger.error(`Invalid cron expression for digest: ${expression}`, error);
+      return false;
+    }
+  }
+
+  public async start(): Promise<void> {
+    if (this.isInitialized) {
+      logger.warn("Digest service is already initialized, skipping...");
+      return;
+    }
+
+    try {
+      const enabled = await this.configService.getBoolean(
+        "digest.enabled",
+        false,
+      );
+
+      if (!enabled) {
+        logger.info("Weekly digest is disabled");
+        this.isInitialized = true;
+        return;
+      }
+
+      const rawCron = await this.configService.getString(
+        "digest.cron",
+        DEFAULT_CRON,
+      );
+      const cronExpression = sanitizeCronExpression(rawCron);
+
+      if (!this.validateCronExpression(cronExpression)) {
+        logger.error(
+          `Digest service not started: invalid cron "${rawCron}"`,
+        );
+        this.isInitialized = true;
+        return;
+      }
+
+      this.job = new CronJob(cronExpression, async () => {
+        try {
+          await this.runNow();
+        } catch (error) {
+          logger.error("Error running weekly digest job:", error);
+        }
+      });
+      this.job.start();
+
+      const nextRun = this.job.nextDate();
+      logger.info(
+        `Digest service started (cron: "${cronExpression}", next run: ${nextRun.toLocaleString()})`,
+      );
+
+      this.isInitialized = true;
+    } catch (error) {
+      logger.error("Error starting digest service:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Run the digest job immediately. Used by the cron handler and by
+   * future admin "send now" triggers. Concurrent invocations coalesce
+   * onto the first one so a slow run + the next cron tick can't
+   * double-deliver.
+   */
+  public async runNow(): Promise<DigestRunSummary | null> {
+    if (this.inFlight) return this.inFlight;
+    this.inFlight = this.runOnce();
+    try {
+      return await this.inFlight;
+    } finally {
+      this.inFlight = null;
+    }
+  }
+
+  private async runOnce(): Promise<DigestRunSummary | null> {
+    if (this.isRunning) {
+      logger.warn("Digest run already in progress, skipping");
+      return null;
+    }
+    this.isRunning = true;
+    try {
+      const enabled = await this.configService.getBoolean(
+        "digest.enabled",
+        false,
+      );
+      if (!enabled) {
+        logger.info("Digest run aborted: feature disabled");
+        return null;
+      }
+
+      const guildId = await this.configService.getString("GUILD_ID", "");
+      if (!guildId) {
+        logger.error("Digest run aborted: GUILD_ID not configured");
+        return null;
+      }
+
+      const minActiveMinutes = await this.configService.getNumber(
+        "digest.min_active_minutes",
+        30,
+      );
+      const streakMinMinutes = await this.configService.getNumber(
+        "digest.streak_min_minutes",
+        30,
+      );
+      const includeAchievements = await this.configService.getBoolean(
+        "digest.include_achievements",
+        true,
+      );
+
+      const minActiveSeconds = Math.max(0, minActiveMinutes) * SECONDS_PER_MINUTE;
+      const streakMinSeconds = Math.max(0, streakMinMinutes) * SECONDS_PER_MINUTE;
+
+      const tracker = VoiceChannelTracker.getInstance(this.client);
+      const prefsService = UserNotificationPrefsService.getInstance();
+      // Ensure the singleton is alive so a guild that flips this on
+      // without ever having earned an accolade still has the service
+      // ready when we look up weekly rows below.
+      AchievementsService.getInstance(this.client);
+
+      // Top-N is large enough that ranks are meaningful for nearly any
+      // realistic guild; users below this rank still get a digest, just
+      // marked "unranked".
+      const ranked = await tracker.getTopUsers(1000, "week");
+      const qualifying: QualifyingUser[] = ranked
+        .map((user, index) => ({
+          userId: user.userId,
+          username: user.username,
+          totalTime: user.totalTime,
+          rank: index + 1,
+        }))
+        .filter((user) => user.totalTime >= minActiveSeconds);
+
+      const summary: DigestRunSummary = {
+        ranAt: new Date(),
+        qualifying: qualifying.length,
+        sent: 0,
+        skippedOptOut: 0,
+        skippedDmsClosed: 0,
+        failed: 0,
+      };
+
+      for (const user of qualifying) {
+        try {
+          const prefs = await prefsService.getPrefs(user.userId, guildId);
+          if (!prefs.digest) {
+            summary.skippedOptOut += 1;
+            continue;
+          }
+
+          const previousState = await DigestState.findOne({
+            userId: user.userId,
+            guildId,
+          });
+
+          const streakWeeks = this.computeStreak(
+            user.totalTime,
+            streakMinSeconds,
+            previousState?.lastSentAt ?? null,
+            previousState?.streakWeeks ?? 0,
+            summary.ranAt,
+          );
+
+          let weeklyAchievements: Array<{
+            emoji: string;
+            name: string;
+            description: string;
+          }> = [];
+          if (includeAchievements) {
+            weeklyAchievements = await this.collectWeeklyAchievements(
+              user.userId,
+              summary.ranAt,
+            );
+          }
+
+          const embed = this.buildEmbed({
+            user,
+            previousState,
+            streakWeeks,
+            includeAchievements,
+            weeklyAchievements,
+          });
+
+          const delivered = await this.sendDigestDM(user.userId, embed);
+          if (!delivered) {
+            summary.skippedDmsClosed += 1;
+            continue;
+          }
+
+          summary.sent += 1;
+
+          await DigestState.findOneAndUpdate(
+            { userId: user.userId, guildId },
+            {
+              $set: {
+                userId: user.userId,
+                guildId,
+                lastSentAt: summary.ranAt,
+                lastWeekTotalTime: user.totalTime,
+                lastWeekRank: user.rank,
+                streakWeeks,
+              },
+            },
+            { upsert: true, new: true, setDefaultsOnInsert: true },
+          );
+        } catch (error) {
+          summary.failed += 1;
+          logger.error(
+            `Error processing digest for user ${user.userId}:`,
+            error,
+          );
+        }
+      }
+
+      logger.info(
+        `Weekly digest complete: qualifying=${summary.qualifying} sent=${summary.sent} ` +
+          `opted_out=${summary.skippedOptOut} dms_closed=${summary.skippedDmsClosed} failed=${summary.failed}`,
+      );
+
+      await this.logSummary(summary);
+      return summary;
+    } finally {
+      this.isRunning = false;
+    }
+  }
+
+  /**
+   * If the previous digest landed inside the last ~10 days the user is
+   * "still on the streak" — increment if they qualify this week, reset
+   * to 1 if not. A longer gap means the streak was already broken, so
+   * we start fresh at 1 when they qualify again.
+   */
+  private computeStreak(
+    currentSeconds: number,
+    streakMinSeconds: number,
+    lastSentAt: Date | null,
+    previousStreak: number,
+    now: Date,
+  ): number {
+    const qualifiesThisWeek = currentSeconds >= streakMinSeconds;
+    if (!qualifiesThisWeek) return 0;
+    if (!lastSentAt) return 1;
+    const elapsedMs = now.getTime() - lastSentAt.getTime();
+    const tenDaysMs = 10 * 24 * 60 * 60 * 1000;
+    if (elapsedMs > tenDaysMs) return 1;
+    return Math.max(1, previousStreak) + 1;
+  }
+
+  /**
+   * Look up the user's achievement / accolade rows in the last 7 days.
+   * Both records live on `UserAchievements` so a single query covers
+   * everything; the service formats them for the embed.
+   */
+  private async collectWeeklyAchievements(
+    userId: string,
+    now: Date,
+  ): Promise<Array<{ emoji: string; name: string; description: string }>> {
+    const oneWeekAgo = new Date(now.getTime() - SECONDS_PER_WEEK * 1000);
+    const row = await UserAchievements.findOne({ userId });
+    if (!row) return [];
+
+    const lines: Array<{ emoji: string; name: string; description: string }> = [];
+
+    for (const accolade of row.accolades ?? []) {
+      if (!accolade.earnedAt || accolade.earnedAt < oneWeekAgo) continue;
+      const meta = ACCOLADE_METADATA[accolade.type as AccoladeType];
+      if (!meta) continue;
+      lines.push({
+        emoji: meta.emoji,
+        name: meta.name,
+        description: meta.description,
+      });
+    }
+
+    for (const achievement of row.achievements ?? []) {
+      if (!achievement.earnedAt || achievement.earnedAt < oneWeekAgo) continue;
+      const meta = (
+        ACHIEVEMENT_METADATA as Record<
+          string,
+          { emoji: string; name: string; description: string }
+        >
+      )[achievement.type];
+      if (!meta) continue;
+      lines.push({
+        emoji: meta.emoji,
+        name: meta.name,
+        description: meta.description,
+      });
+    }
+
+    return lines;
+  }
+
+  private buildEmbed(args: {
+    user: QualifyingUser;
+    previousState:
+      | {
+          lastWeekTotalTime: number;
+          lastWeekRank: number | null;
+        }
+      | null;
+    streakWeeks: number;
+    includeAchievements: boolean;
+    weeklyAchievements: Array<{
+      emoji: string;
+      name: string;
+      description: string;
+    }>;
+  }): EmbedBuilder {
+    const { user, previousState, streakWeeks, includeAchievements, weeklyAchievements } = args;
+    const previousTime = previousState?.lastWeekTotalTime ?? 0;
+    const previousRank = previousState?.lastWeekRank ?? null;
+
+    const fields: Array<{ name: string; value: string; inline: boolean }> = [
+      {
+        name: "This week",
+        value: `${formatDuration(user.totalTime)}\n${formatDelta(
+          user.totalTime,
+          previousTime,
+        )}`,
+        inline: true,
+      },
+    ];
+
+    const rankDelta = formatRankDelta(user.rank, previousRank);
+    fields.push({
+      name: "Rank",
+      value: rankDelta
+        ? `${formatRank(user.rank)}\n${rankDelta}`
+        : formatRank(user.rank),
+      inline: true,
+    });
+
+    fields.push({
+      name: "Streak",
+      value:
+        streakWeeks === 0
+          ? "—"
+          : `${streakWeeks} week${streakWeeks === 1 ? "" : "s"}`,
+      inline: true,
+    });
+
+    if (includeAchievements) {
+      const achievementsValue =
+        weeklyAchievements.length === 0
+          ? "_None this week — there's always next week!_"
+          : weeklyAchievements
+              .slice(0, 10)
+              .map((a) => `${a.emoji} **${a.name}** — ${a.description}`)
+              .join("\n");
+      fields.push({
+        name: "Achievements earned this week",
+        value: achievementsValue,
+        inline: false,
+      });
+    }
+
+    const footer = pickMotivationalFooter(user.userId.length + user.totalTime);
+
+    return new EmbedBuilder()
+      .setTitle("📊 Your weekly voice digest")
+      .setColor(EMBED_COLOR)
+      .setDescription(
+        `Here's a snapshot of your last 7 days in voice, ${user.username}.`,
+      )
+      .addFields(fields)
+      .setFooter({
+        text: `${footer}\nDon't want these? Run /config to manage your notifications.`,
+      })
+      .setTimestamp(new Date());
+  }
+
+  /**
+   * Send the digest DM. Returns true on delivery, false if the user has
+   * DMs closed (silent skip, matches `AchievementsService` behaviour).
+   * Any other error rethrows so the caller can record `failed`.
+   */
+  private async sendDigestDM(
+    userId: string,
+    embed: EmbedBuilder,
+  ): Promise<boolean> {
+    let user: User;
+    try {
+      user = await this.client.users.fetch(userId);
+    } catch (error) {
+      logger.warn(`Digest: could not fetch user ${userId}: ${error}`);
+      return false;
+    }
+    try {
+      await user.send({ embeds: [embed] });
+      return true;
+    } catch (error) {
+      const code = (error as { code?: number }).code;
+      // 50007 = "Cannot send messages to this user" (DMs closed / blocked)
+      if (code === 50007) {
+        logger.debug(`Digest: DMs closed for ${userId}, skipping`);
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  private async logSummary(summary: DigestRunSummary): Promise<void> {
+    try {
+      const discordLogger = DiscordLogger.getInstance(this.client);
+      if (!discordLogger.isReady()) {
+        return;
+      }
+      const message =
+        `Qualifying: ${summary.qualifying} · sent: ${summary.sent} · ` +
+        `opted out: ${summary.skippedOptOut} · DMs closed: ${summary.skippedDmsClosed} · ` +
+        `failed: ${summary.failed}`;
+      await discordLogger.logCronSuccess("Weekly Digest", message);
+    } catch (error) {
+      logger.error("Digest: failed to post run summary to Discord:", error);
+    }
+  }
+
+  public async reload(): Promise<void> {
+    logger.info("Reloading digest service...");
+    if (this.job) {
+      this.job.stop();
+      this.job = null;
+    }
+    this.isInitialized = false;
+    await this.start();
+  }
+
+  public destroy(): void {
+    if (this.job) {
+      this.job.stop();
+      this.job = null;
+    }
+    this.isInitialized = false;
+    logger.info("Digest service destroyed");
+  }
+}

--- a/src/services/digest-service.ts
+++ b/src/services/digest-service.ts
@@ -12,10 +12,7 @@ import { AchievementsService } from "./achievements-service.js";
 import { DiscordLogger } from "./discord-logger.js";
 import { DigestState } from "../models/digest-state.js";
 import { UserAchievements } from "../models/user-achievements.js";
-import {
-  ACCOLADE_METADATA,
-  type AccoladeType,
-} from "../content/accolades.js";
+import { ACCOLADE_METADATA, type AccoladeType } from "../content/accolades.js";
 import { ACHIEVEMENT_METADATA } from "../content/achievements.js";
 import logger from "../utils/logger.js";
 
@@ -83,10 +80,12 @@ function formatRankDelta(
  * library — every line ties back to a real badge the user could earn.
  */
 function pickMotivationalFooter(seed: number): string {
-  const descriptions = Object.values(ACCOLADE_METADATA).map((m) => m.description);
+  const descriptions = Object.values(ACCOLADE_METADATA).map(
+    (m) => m.description,
+  );
   if (descriptions.length === 0) return "Keep it up!";
-  const index = ((seed % descriptions.length) + descriptions.length) %
-    descriptions.length;
+  const index =
+    ((seed % descriptions.length) + descriptions.length) % descriptions.length;
   return descriptions[index];
 }
 
@@ -180,9 +179,7 @@ export class DigestService {
       const cronExpression = sanitizeCronExpression(rawCron);
 
       if (!this.validateCronExpression(cronExpression)) {
-        logger.error(
-          `Digest service not started: invalid cron "${rawCron}"`,
-        );
+        logger.error(`Digest service not started: invalid cron "${rawCron}"`);
         this.isInitialized = true;
         return;
       }
@@ -259,8 +256,10 @@ export class DigestService {
         true,
       );
 
-      const minActiveSeconds = Math.max(0, minActiveMinutes) * SECONDS_PER_MINUTE;
-      const streakMinSeconds = Math.max(0, streakMinMinutes) * SECONDS_PER_MINUTE;
+      const minActiveSeconds =
+        Math.max(0, minActiveMinutes) * SECONDS_PER_MINUTE;
+      const streakMinSeconds =
+        Math.max(0, streakMinMinutes) * SECONDS_PER_MINUTE;
 
       const tracker = VoiceChannelTracker.getInstance(this.client);
       const prefsService = UserNotificationPrefsService.getInstance();
@@ -410,7 +409,8 @@ export class DigestService {
     const row = await UserAchievements.findOne({ userId });
     if (!row) return [];
 
-    const lines: Array<{ emoji: string; name: string; description: string }> = [];
+    const lines: Array<{ emoji: string; name: string; description: string }> =
+      [];
 
     for (const accolade of row.accolades ?? []) {
       if (!accolade.earnedAt || accolade.earnedAt < oneWeekAgo) continue;
@@ -444,12 +444,10 @@ export class DigestService {
 
   private buildEmbed(args: {
     user: QualifyingUser;
-    previousState:
-      | {
-          lastWeekTotalTime: number;
-          lastWeekRank: number | null;
-        }
-      | null;
+    previousState: {
+      lastWeekTotalTime: number;
+      lastWeekRank: number | null;
+    } | null;
     streakWeeks: number;
     includeAchievements: boolean;
     weeklyAchievements: Array<{
@@ -458,7 +456,13 @@ export class DigestService {
       description: string;
     }>;
   }): EmbedBuilder {
-    const { user, previousState, streakWeeks, includeAchievements, weeklyAchievements } = args;
+    const {
+      user,
+      previousState,
+      streakWeeks,
+      includeAchievements,
+      weeklyAchievements,
+    } = args;
     const previousTime = previousState?.lastWeekTotalTime ?? 0;
     const previousRank = previousState?.lastWeekRank ?? null;
 

--- a/src/services/digest-service.ts
+++ b/src/services/digest-service.ts
@@ -1,9 +1,4 @@
-import {
-  Client,
-  EmbedBuilder,
-  type ColorResolvable,
-  type User,
-} from "discord.js";
+import { Client, EmbedBuilder, type ColorResolvable } from "discord.js";
 import { CronJob, CronTime } from "cron";
 import { ConfigService } from "./config-service.js";
 import { VoiceChannelTracker } from "./voice-channel-tracker.js";
@@ -268,10 +263,7 @@ export class DigestService {
       // ready when we look up weekly rows below.
       AchievementsService.getInstance(this.client);
 
-      // Top-N is large enough that ranks are meaningful for nearly any
-      // realistic guild; users below this rank still get a digest, just
-      // marked "unranked".
-      const ranked = await tracker.getTopUsers(1000, "week");
+      const ranked = await tracker.getTopUsers(0, "week");
       const qualifying: QualifyingUser[] = ranked
         .map((user, index) => ({
           userId: user.userId,
@@ -393,7 +385,7 @@ export class DigestService {
     const elapsedMs = now.getTime() - lastSentAt.getTime();
     const tenDaysMs = 10 * 24 * 60 * 60 * 1000;
     if (elapsedMs > tenDaysMs) return 1;
-    return Math.max(1, previousStreak) + 1;
+    return previousStreak > 0 ? previousStreak + 1 : 1;
   }
 
   /**
@@ -528,19 +520,13 @@ export class DigestService {
   /**
    * Send the digest DM. Returns true on delivery, false if the user has
    * DMs closed (silent skip, matches `AchievementsService` behaviour).
-   * Any other error rethrows so the caller can record `failed`.
+   * Fetch failures and other errors rethrow so the caller records `failed`.
    */
   private async sendDigestDM(
     userId: string,
     embed: EmbedBuilder,
   ): Promise<boolean> {
-    let user: User;
-    try {
-      user = await this.client.users.fetch(userId);
-    } catch (error) {
-      logger.warn(`Digest: could not fetch user ${userId}: ${error}`);
-      return false;
-    }
+    const user = await this.client.users.fetch(userId);
     try {
       await user.send({ embeds: [embed] });
       return true;

--- a/src/services/voice-channel-tracker.ts
+++ b/src/services/voice-channel-tracker.ts
@@ -466,14 +466,8 @@ export class VoiceChannelTracker {
         case "week":
           startDate = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
           users = await VoiceChannelTracking.aggregate([
-            {
-              $unwind: "$sessions",
-            },
-            {
-              $match: {
-                "sessions.startTime": { $gte: startDate },
-              },
-            },
+            { $unwind: "$sessions" },
+            { $match: { "sessions.startTime": { $gte: startDate } } },
             {
               $group: {
                 _id: "$userId",
@@ -481,25 +475,15 @@ export class VoiceChannelTracker {
                 totalTime: { $sum: "$sessions.duration" },
               },
             },
-            {
-              $sort: { totalTime: -1 },
-            },
-            {
-              $limit: limit,
-            },
+            { $sort: { totalTime: -1 } },
+            ...(limit > 0 ? [{ $limit: limit }] : []),
           ]);
           break;
         case "month":
           startDate = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
           users = await VoiceChannelTracking.aggregate([
-            {
-              $unwind: "$sessions",
-            },
-            {
-              $match: {
-                "sessions.startTime": { $gte: startDate },
-              },
-            },
+            { $unwind: "$sessions" },
+            { $match: { "sessions.startTime": { $gte: startDate } } },
             {
               $group: {
                 _id: "$userId",
@@ -507,12 +491,8 @@ export class VoiceChannelTracker {
                 totalTime: { $sum: "$sessions.duration" },
               },
             },
-            {
-              $sort: { totalTime: -1 },
-            },
-            {
-              $limit: limit,
-            },
+            { $sort: { totalTime: -1 } },
+            ...(limit > 0 ? [{ $limit: limit }] : []),
           ]);
           break;
         case "alltime":
@@ -524,12 +504,8 @@ export class VoiceChannelTracker {
                 totalTime: { $sum: "$totalTime" },
               },
             },
-            {
-              $sort: { totalTime: -1 },
-            },
-            {
-              $limit: limit,
-            },
+            { $sort: { totalTime: -1 } },
+            ...(limit > 0 ? [{ $limit: limit }] : []),
           ]);
           break;
       }

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -108,7 +108,6 @@ const NOTIFICATION_ROW_DEFS: readonly NotificationRowDef[] = [
     label: "Weekly digest",
     description:
       "Once-a-week DM summarising your activity and the server's highlights.",
-    comingSoon: "Toggle works today; the matching DM lands in #483.",
   },
   {
     key: "rewind",


### PR DESCRIPTION
## Summary

Ships the weekly personal voice-activity digest from #483 — a personalised DM that summarises each user's last 7 days in voice, with the opt-out routed through `/me/notifications` (the `prefs.digest` field landed in #482) instead of a new slash command.

- `DigestService` (singleton + `CronJob`, follows the `LeaderboardRoleService` pattern) queries `VoiceChannelTracker.getTopUsers("week")`, filters by `digest.min_active_minutes`, and DMs each qualifying user whose `prefs.digest` is true. Users with DMs closed are silently skipped via Discord error 50007.
- `DigestState` model: per-`(userId, guildId)` snapshot of the last delivery (time, rank, streak) used to compute next week's deltas and keep the consecutive-weeks streak correct across runs.
- 5 new DB-backed config keys under a new `digest` category — `digest.enabled` (off by default, parent gate), `digest.cron` (default Mondays 09:00), `digest.min_active_minutes`, `digest.streak_min_minutes`, `digest.include_achievements` (sub-feature on by default, parent-gated).
- After every run, a summary row (`qualifying / sent / opted-out / DMs-closed / failed`) is posted to the configured `core.cron` log channel via `DiscordLogger.logCronSuccess`.
- WebUI: removes the "coming soon (#483)" hint from the digest row on `/me/notifications` — the toggle itself was already wired up in #482.

## Acceptance (from #483)

- [x] `digest.enabled = false` by default; flipping it on starts the cron without a bot restart (existing `registerReloadCallback` path).
- [x] Eligible users (active ≥ `digest.min_active_minutes`) receive the embed on schedule.
- [x] Users with `prefs.digest === false` are skipped (covered by unit test).
- [x] Users with DMs closed are skipped silently (covered by unit test).
- [x] Embed shows: voice time, delta, rank, rank delta, achievements (if enabled), streak.
- [x] Summary log posted to the configured Discord log channel.
- [x] `SETTINGS.md` documents the new keys; the "coming soon" hint on the `digest` row of `/me/notifications` is removed in this PR.
- [x] No new slash command introduced.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors (114 pre-existing warnings unchanged)
- [x] `npm test` — 834 pass, 1 skipped, 0 fail
  - New `__tests__/services/digest-service.test.ts` covers singleton, runNow guards, opt-out skip, DMs-closed silent skip, min-active threshold, DigestState write.
  - Updated `config-schema.test.ts` audit matrix to include `digest.enabled` and `digest.include_achievements`.
  - Updated `settings-metadata.test.ts` known-categories list.
  - Updated `user-routes.test.ts` to assert the `#483` hint is gone and `#484` still present.
- [ ] Manual smoke (deferred — requires live Discord/Mongo): flip `digest.enabled` true with a low `min_active_minutes`, verify DM lands and the cron summary appears in the log channel.

https://claude.ai/code/session_01W5PaNEpq7dGmrmpabH4qrs

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5PaNEpq7dGmrmpabH4qrs)_