### PR TITLE
feat: annual rewind year-in-review WebUI + end-of-year DM nudge (closes #484)

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -35,6 +35,7 @@ Complete configuration reference for all KoolBot settings.
 - [Announcements](#-announcements)
 - [Achievements System](#-achievements-system)
 - [Weekly Digest](#-weekly-digest)
+- [Rewind (Year-in-Review)](#-rewind-year-in-review)
 - [Reaction Roles](#-reaction-roles)
 - [Leaderboard Role Rewards](#-leaderboard-role-rewards)
 - [Rate Limiting](#-rate-limiting)
@@ -450,6 +451,38 @@ the user's **/me/notifications** page (no slash command).
 
 ---
 
+## ✨ Rewind (Year-in-Review)
+
+Per-user year-in-review page at **`/me/rewind`** (also `/me/rewind/:year`
+for past years). Renders total voice time, top channels, peak day,
+longest streak, badges earned, annual rank, and a first/best/last
+weekly-rank journey. Year picker bottom-anchored to years with data.
+The page is always available; the cron job below only sends a one-shot
+end-of-year DM nudge.
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `rewind.enabled` | `false` | Master switch for the end-of-year DM nudge (the WebUI page is unaffected) |
+| `rewind.cron` | `"0 10 30 12 *"` | Cron schedule for the nudge (default: Dec 30 at 10:00 host timezone) |
+| `rewind.min_minutes` | `60` | Minimum annual voice minutes a user needs to receive the nudge |
+
+**Notes:**
+
+- Requires `voicetracking.enabled = true` so the underlying session
+  data exists; the page renders an empty state otherwise.
+- Per-user opt-out is honoured before sending each nudge via the
+  `prefs.rewind` field set on `/me/notifications`.
+- Users with DMs closed are silently skipped (same pattern the digest
+  and `AchievementsService` already use).
+- Aggregation is on-demand and not cached in v1. If real data shows
+  the queries are too slow, a `RewindCache` collection keyed by
+  `(userId, guildId, year)` is the planned follow-up.
+- A summary row (qualifying / sent / opted-out / DMs closed / failed)
+  is posted to the configured `core.cron.channel_id` log channel after
+  every run.
+
+---
+
 ### Cron schedule format
 
 ```text
@@ -791,6 +824,12 @@ above).
 - `digest.min_active_minutes` (number, default: 30)
 - `digest.streak_min_minutes` (number, default: 30)
 - `digest.include_achievements` (bool, default: true)
+
+#### Rewind (Year-in-Review)
+
+- `rewind.enabled` (bool, default: false)
+- `rewind.cron` (string, default: `"0 10 30 12 *"`)
+- `rewind.min_minutes` (number, default: 60)
 
 #### Cleanup
 

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -661,21 +661,23 @@ side effect, since the HMAC key changes.
 
 ### User self-service (`/me/*`, both admin and user roles)
 
-| Page                                    | What it's for                                                                                                                                             |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Overview** (`/me/`)                   | Index for your own settings — links to the available per-user pages.                                                                                      |
-| **Notifications** (`/me/notifications`) | Opt in or out of DM nudges from Koolbot (achievements today; #483 weekly digest and #484 Rewind once they land). Each toggle records a `WebAuditLog` row. |
+| Page                                    | What it's for                                                                                                                          |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| **Overview** (`/me/`)                   | Index for your own settings — links to the available per-user pages.                                                                   |
+| **Notifications** (`/me/notifications`) | Opt in or out of DM nudges from Koolbot (achievements, weekly digest, Rewind nudge). Each toggle records a `WebAuditLog` row.          |
+| **Rewind** (`/me/rewind`)               | Personal year-in-review: voice time, top channels, peak day, longest streak, badges earned, annual rank, and a weekly-rank journey.    |
 
 Notification preferences are scoped per `(userId, guildId)`. The page
 lists every notification type with the current state and a checkbox;
 toggling one row is a single POST that records the diff in the audit
-log and PRG-redirects back to the page. Rows for features that haven't
-shipped yet (`digest`, `rewind`) are still functional — the stored
-toggle is read by the dependent issues' DM paths when they land.
+log and PRG-redirects back to the page.
 
-Future per-user features (Rewind in #484, etc.) bolt onto `/me` as
-their own pages; the layout, session, and self-scope plumbing are
-already in place.
+The **Rewind** page defaults to the current calendar year (UTC);
+`/me/rewind/:year` lets you browse past years. A small year picker at
+the top of the page only offers years for which you have data (voice
+sessions or badges). Years with no data render a friendly empty state.
+Aggregation is on-demand and not cached in v1 — see [`SETTINGS.md`](SETTINGS.md#-rewind-year-in-review)
+for the `rewind.*` keys that control the end-of-year DM nudge.
 
 User-facing commands (`/ping`, `/voicestats`, `/seen`, `/quote`,
 `/achievements`, `/help`) are **not** affected and stay in

--- a/__tests__/services/config-schema.test.ts
+++ b/__tests__/services/config-schema.test.ts
@@ -161,6 +161,7 @@ describe('Config Schema', () => {
       'announcements.enabled': false,
       'achievements.enabled': false,
       'digest.enabled': false,
+      'rewind.enabled': false,
       'reactionroles.enabled': false,
       'notices.enabled': false,
       'polls.enabled': false,

--- a/__tests__/services/rewind-nudge-service.test.ts
+++ b/__tests__/services/rewind-nudge-service.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import type { Client } from "discord.js";
+
+const mockRegisterReloadCallback = jest.fn();
+const mockConfigGetBoolean = jest.fn();
+const mockConfigGetString = jest.fn();
+const mockConfigGetNumber = jest.fn();
+
+const mockGetPrefs = jest.fn();
+const mockPrefsGetInstance = jest.fn(() => ({
+  getPrefs: mockGetPrefs,
+}));
+
+const mockLoggerIsReady = jest.fn(() => false);
+const mockLogCronSuccess = jest.fn();
+const mockDiscordLoggerGetInstance = jest.fn(() => ({
+  isReady: mockLoggerIsReady,
+  logCronSuccess: mockLogCronSuccess,
+}));
+
+const mockUserSend = jest.fn();
+const mockUsersFetch = jest.fn();
+
+const mockTrackingAggregate = jest.fn();
+
+jest.unstable_mockModule("../../src/services/config-service.js", () => ({
+  ConfigService: {
+    getInstance: jest.fn(() => ({
+      registerReloadCallback: mockRegisterReloadCallback,
+      getBoolean: mockConfigGetBoolean,
+      getString: mockConfigGetString,
+      getNumber: mockConfigGetNumber,
+    })),
+  },
+}));
+
+jest.unstable_mockModule(
+  "../../src/services/user-notification-prefs-service.js",
+  () => ({
+    UserNotificationPrefsService: { getInstance: mockPrefsGetInstance },
+  }),
+);
+
+jest.unstable_mockModule("../../src/services/discord-logger.js", () => ({
+  DiscordLogger: { getInstance: mockDiscordLoggerGetInstance },
+}));
+
+jest.unstable_mockModule("../../src/models/voice-channel-tracking.js", () => ({
+  VoiceChannelTracking: {
+    aggregate: (...args: unknown[]) => mockTrackingAggregate(...args),
+  },
+}));
+
+jest.unstable_mockModule("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const { RewindNudgeService } = await import(
+  "../../src/services/rewind-nudge-service.js"
+);
+
+type ServiceInstance = InstanceType<typeof RewindNudgeService>;
+
+function resetSingleton(): void {
+  (RewindNudgeService as unknown as { instance: unknown }).instance = undefined;
+}
+
+function makeClient(): Client {
+  return {
+    users: { fetch: mockUsersFetch },
+  } as unknown as Client;
+}
+
+describe("RewindNudgeService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetSingleton();
+    mockConfigGetBoolean.mockImplementation(async (key: unknown) => {
+      const k = key as string;
+      if (k === "rewind.enabled") return true;
+      return false;
+    });
+    mockConfigGetString.mockImplementation(async (key: unknown) => {
+      const k = key as string;
+      if (k === "GUILD_ID") return "guild-1";
+      if (k === "rewind.cron") return "0 10 30 12 *";
+      return "";
+    });
+    mockConfigGetNumber.mockImplementation(
+      async (key: unknown, def: unknown) => {
+        const k = key as string;
+        if (k === "rewind.min_minutes") return 60;
+        return (def as number) ?? 0;
+      },
+    );
+    mockGetPrefs.mockResolvedValue({
+      achievements: true,
+      digest: true,
+      rewind: true,
+    });
+    mockUsersFetch.mockImplementation(async (userId: unknown) => ({
+      id: userId as string,
+      username: `user-${userId as string}`,
+      send: mockUserSend,
+    }));
+    mockUserSend.mockResolvedValue(undefined);
+    mockTrackingAggregate.mockResolvedValue([]);
+  });
+
+  describe("singleton", () => {
+    it("returns the same instance for the same client", () => {
+      const c = makeClient();
+      expect(RewindNudgeService.getInstance(c)).toBe(
+        RewindNudgeService.getInstance(c),
+      );
+    });
+
+    it("throws when called with a different client", () => {
+      RewindNudgeService.getInstance(makeClient());
+      expect(() => RewindNudgeService.getInstance(makeClient())).toThrow(
+        /different client/,
+      );
+    });
+
+    it("registers a reload callback on construction", () => {
+      RewindNudgeService.getInstance(makeClient());
+      expect(mockRegisterReloadCallback).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("runNow guards", () => {
+    it("returns null when the feature is disabled", async () => {
+      mockConfigGetBoolean.mockResolvedValue(false);
+      const svc: ServiceInstance = RewindNudgeService.getInstance(makeClient());
+      const result = await svc.runNow();
+      expect(result).toBeNull();
+      expect(mockTrackingAggregate).not.toHaveBeenCalled();
+    });
+
+    it("returns null when GUILD_ID is missing", async () => {
+      mockConfigGetString.mockImplementation(async (key: unknown) => {
+        if (key === "GUILD_ID") return "";
+        return "";
+      });
+      const svc: ServiceInstance = RewindNudgeService.getInstance(makeClient());
+      const result = await svc.runNow();
+      expect(result).toBeNull();
+      expect(mockTrackingAggregate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("opt-out enforcement (#484)", () => {
+    it("skips users whose prefs.rewind is false and does not send a DM", async () => {
+      mockTrackingAggregate.mockResolvedValueOnce([
+        { _id: "u1", username: "u1", totalTime: 60 * 60 * 5 },
+      ]);
+      mockGetPrefs.mockResolvedValue({
+        achievements: true,
+        digest: true,
+        rewind: false,
+      });
+
+      const svc: ServiceInstance = RewindNudgeService.getInstance(makeClient());
+      const result = await svc.runNow();
+
+      expect(result).not.toBeNull();
+      expect(result!.qualifying).toBe(1);
+      expect(result!.sent).toBe(0);
+      expect(result!.skippedOptOut).toBe(1);
+      expect(mockUserSend).not.toHaveBeenCalled();
+    });
+
+    it("sends a DM when prefs.rewind is true", async () => {
+      mockTrackingAggregate.mockResolvedValueOnce([
+        { _id: "u1", username: "u1", totalTime: 60 * 60 * 5 },
+      ]);
+
+      const svc: ServiceInstance = RewindNudgeService.getInstance(makeClient());
+      const result = await svc.runNow();
+
+      expect(result!.sent).toBe(1);
+      expect(mockUserSend).toHaveBeenCalledTimes(1);
+    });
+
+    it("silently skips users with DMs closed (Discord error 50007)", async () => {
+      mockTrackingAggregate.mockResolvedValueOnce([
+        { _id: "u1", username: "u1", totalTime: 60 * 60 * 5 },
+      ]);
+      const dmError = Object.assign(new Error("DMs closed"), { code: 50007 });
+      mockUserSend.mockRejectedValueOnce(dmError);
+
+      const svc: ServiceInstance = RewindNudgeService.getInstance(makeClient());
+      const result = await svc.runNow();
+
+      expect(result!.sent).toBe(0);
+      expect(result!.skippedDmsClosed).toBe(1);
+      expect(result!.failed).toBe(0);
+    });
+
+    it("counts non-DM-closed errors as failed", async () => {
+      mockTrackingAggregate.mockResolvedValueOnce([
+        { _id: "u1", username: "u1", totalTime: 60 * 60 * 5 },
+      ]);
+      mockUserSend.mockRejectedValueOnce(new Error("transient API error"));
+
+      const svc: ServiceInstance = RewindNudgeService.getInstance(makeClient());
+      const result = await svc.runNow();
+
+      expect(result!.sent).toBe(0);
+      expect(result!.failed).toBe(1);
+    });
+  });
+});

--- a/__tests__/services/rewind-nudge-service.test.ts
+++ b/__tests__/services/rewind-nudge-service.test.ts
@@ -23,6 +23,9 @@ const mockUsersFetch = jest.fn();
 
 const mockTrackingAggregate = jest.fn();
 
+const mockNudgeStateFindOne = jest.fn();
+const mockNudgeStateFindOneAndUpdate = jest.fn();
+
 jest.unstable_mockModule("../../src/services/config-service.js", () => ({
   ConfigService: {
     getInstance: jest.fn(() => ({
@@ -48,6 +51,13 @@ jest.unstable_mockModule("../../src/services/discord-logger.js", () => ({
 jest.unstable_mockModule("../../src/models/voice-channel-tracking.js", () => ({
   VoiceChannelTracking: {
     aggregate: (...args: unknown[]) => mockTrackingAggregate(...args),
+  },
+}));
+
+jest.unstable_mockModule("../../src/models/rewind-nudge-state.js", () => ({
+  RewindNudgeState: {
+    findOne: mockNudgeStateFindOne,
+    findOneAndUpdate: mockNudgeStateFindOneAndUpdate,
   },
 }));
 
@@ -110,6 +120,9 @@ describe("RewindNudgeService", () => {
     }));
     mockUserSend.mockResolvedValue(undefined);
     mockTrackingAggregate.mockResolvedValue([]);
+    // Default: no prior delivery marker → not a duplicate run.
+    mockNudgeStateFindOne.mockResolvedValue(null);
+    mockNudgeStateFindOneAndUpdate.mockResolvedValue({});
   });
 
   describe("singleton", () => {
@@ -175,7 +188,7 @@ describe("RewindNudgeService", () => {
       expect(mockUserSend).not.toHaveBeenCalled();
     });
 
-    it("sends a DM when prefs.rewind is true", async () => {
+    it("sends a DM when prefs.rewind is true and writes the delivery marker", async () => {
       mockTrackingAggregate.mockResolvedValueOnce([
         { _id: "u1", username: "u1", totalTime: 60 * 60 * 5 },
       ]);
@@ -185,6 +198,39 @@ describe("RewindNudgeService", () => {
 
       expect(result!.sent).toBe(1);
       expect(mockUserSend).toHaveBeenCalledTimes(1);
+      expect(mockNudgeStateFindOneAndUpdate).toHaveBeenCalledTimes(1);
+      const [filter, update] =
+        mockNudgeStateFindOneAndUpdate.mock.calls[0] as [
+          Record<string, unknown>,
+          { $set: Record<string, unknown> },
+        ];
+      const year = new Date().getUTCFullYear();
+      expect(filter).toEqual({ userId: "u1", guildId: "guild-1", year });
+      expect(update.$set).toMatchObject({
+        userId: "u1",
+        guildId: "guild-1",
+        year,
+      });
+    });
+
+    it("skips users who have already been nudged this year (one-shot guard)", async () => {
+      mockTrackingAggregate.mockResolvedValueOnce([
+        { _id: "u1", username: "u1", totalTime: 60 * 60 * 5 },
+      ]);
+      mockNudgeStateFindOne.mockResolvedValueOnce({
+        userId: "u1",
+        guildId: "guild-1",
+        year: new Date().getUTCFullYear(),
+        sentAt: new Date(),
+      });
+
+      const svc: ServiceInstance = RewindNudgeService.getInstance(makeClient());
+      const result = await svc.runNow();
+
+      expect(result!.sent).toBe(0);
+      expect(result!.skippedAlreadySent).toBe(1);
+      expect(mockUserSend).not.toHaveBeenCalled();
+      expect(mockNudgeStateFindOneAndUpdate).not.toHaveBeenCalled();
     });
 
     it("silently skips users with DMs closed (Discord error 50007)", async () => {
@@ -200,6 +246,9 @@ describe("RewindNudgeService", () => {
       expect(result!.sent).toBe(0);
       expect(result!.skippedDmsClosed).toBe(1);
       expect(result!.failed).toBe(0);
+      // Marker is only persisted on successful delivery, so a retry on
+      // the next run can pick the user up again.
+      expect(mockNudgeStateFindOneAndUpdate).not.toHaveBeenCalled();
     });
 
     it("counts non-DM-closed errors as failed", async () => {

--- a/__tests__/services/rewind-service.test.ts
+++ b/__tests__/services/rewind-service.test.ts
@@ -1,0 +1,456 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+// IMPORTANT: This file must NOT statically import from
+// `rewind-service.js` — the static import would cache the real
+// Mongoose models before the `jest.unstable_mockModule` calls below
+// register the test doubles. All bindings come via the `await import`
+// once mocks are in place.
+
+const mockFindOneVc = jest.fn();
+const mockAggregateVc = jest.fn();
+const mockFindOneAch = jest.fn();
+
+jest.unstable_mockModule("../../src/models/voice-channel-tracking.js", () => ({
+  VoiceChannelTracking: {
+    findOne: mockFindOneVc,
+    aggregate: mockAggregateVc,
+  },
+}));
+
+jest.unstable_mockModule("../../src/models/user-achievements.js", () => ({
+  UserAchievements: {
+    findOne: mockFindOneAch,
+  },
+}));
+
+jest.unstable_mockModule("../../src/content/accolades.js", () => ({
+  ACCOLADE_METADATA: {
+    night_owl: {
+      emoji: "🦉",
+      name: "Night Owl",
+      description: "Earned for late-night voice activity.",
+    },
+  },
+}));
+
+jest.unstable_mockModule("../../src/content/achievements.js", () => ({
+  ACHIEVEMENT_METADATA: {
+    weekly_active: {
+      emoji: "📅",
+      name: "Weekly Active",
+      description: "Active this week.",
+    },
+  },
+}));
+
+jest.unstable_mockModule("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const {
+  RewindService,
+  computeLongestStreak,
+  computePeakDay,
+  computeTopChannels,
+  formatFunComparison,
+  formatHoursMinutes,
+  sessionSeconds,
+  toIsoDate,
+  yearBounds,
+} = await import("../../src/services/rewind-service.js");
+
+function resetSingleton(): void {
+  (RewindService as unknown as { instance: unknown }).instance = undefined;
+}
+
+function makeClient(): unknown {
+  return {} as unknown;
+}
+
+describe("RewindService pure helpers", () => {
+  describe("yearBounds", () => {
+    it("returns half-open UTC year bounds", () => {
+      const { start, end } = yearBounds(2026);
+      expect(start.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+      expect(end.toISOString()).toBe("2027-01-01T00:00:00.000Z");
+    });
+  });
+
+  describe("toIsoDate", () => {
+    it("formats a UTC date as YYYY-MM-DD", () => {
+      expect(toIsoDate(new Date("2026-03-15T23:45:00Z"))).toBe("2026-03-15");
+    });
+  });
+
+  describe("sessionSeconds", () => {
+    it("prefers explicit duration when present", () => {
+      expect(
+        sessionSeconds({
+          startTime: new Date("2026-01-01T10:00:00Z"),
+          endTime: new Date("2026-01-01T10:30:00Z"),
+          duration: 60,
+          channelId: "c",
+        }),
+      ).toBe(60);
+    });
+
+    it("falls back to endTime - startTime when duration missing", () => {
+      expect(
+        sessionSeconds({
+          startTime: new Date("2026-01-01T10:00:00Z"),
+          endTime: new Date("2026-01-01T11:00:00Z"),
+          channelId: "c",
+        }),
+      ).toBe(3600);
+    });
+
+    it("returns 0 when neither duration nor endTime is present", () => {
+      expect(
+        sessionSeconds({
+          startTime: new Date("2026-01-01T10:00:00Z"),
+          channelId: "c",
+        }),
+      ).toBe(0);
+    });
+  });
+
+  describe("computeTopChannels", () => {
+    it("sums duration per channel and ranks by total", () => {
+      const sessions = [
+        {
+          startTime: new Date("2026-01-01T10:00:00Z"),
+          duration: 600,
+          channelId: "a",
+          channelName: "alpha",
+        },
+        {
+          startTime: new Date("2026-01-02T10:00:00Z"),
+          duration: 1200,
+          channelId: "b",
+          channelName: "beta",
+        },
+        {
+          startTime: new Date("2026-01-03T10:00:00Z"),
+          duration: 300,
+          channelId: "a",
+          channelName: "alpha",
+        },
+      ];
+      const top = computeTopChannels(sessions, 3);
+      expect(top).toHaveLength(2);
+      expect(top[0]).toMatchObject({ channelId: "b", totalSeconds: 1200 });
+      expect(top[1]).toMatchObject({ channelId: "a", totalSeconds: 900 });
+    });
+
+    it("uses the most recent non-empty channel name for renames", () => {
+      const sessions = [
+        {
+          startTime: new Date("2026-01-01T10:00:00Z"),
+          duration: 600,
+          channelId: "a",
+          channelName: "old-name",
+        },
+        {
+          startTime: new Date("2026-01-02T10:00:00Z"),
+          duration: 600,
+          channelId: "a",
+          channelName: "new-name",
+        },
+      ];
+      const [first] = computeTopChannels(sessions, 3);
+      expect(first.channelName).toBe("new-name");
+    });
+
+    it("honours the limit", () => {
+      const sessions = [
+        { startTime: new Date(), duration: 1, channelId: "a" },
+        { startTime: new Date(), duration: 2, channelId: "b" },
+        { startTime: new Date(), duration: 3, channelId: "c" },
+        { startTime: new Date(), duration: 4, channelId: "d" },
+      ];
+      expect(computeTopChannels(sessions, 2)).toHaveLength(2);
+    });
+  });
+
+  describe("computePeakDay", () => {
+    it("returns the day with the highest summed seconds", () => {
+      const peak = computePeakDay([
+        {
+          startTime: new Date("2026-03-15T10:00:00Z"),
+          duration: 3600,
+          channelId: "a",
+        },
+        {
+          startTime: new Date("2026-03-15T14:00:00Z"),
+          duration: 1800,
+          channelId: "a",
+        },
+        {
+          startTime: new Date("2026-03-16T10:00:00Z"),
+          duration: 3600,
+          channelId: "a",
+        },
+      ]);
+      expect(peak).toEqual({ date: "2026-03-15", totalSeconds: 5400 });
+    });
+
+    it("returns null on empty input", () => {
+      expect(computePeakDay([])).toBeNull();
+    });
+  });
+
+  describe("computeLongestStreak", () => {
+    it("returns 1 for a single day of activity", () => {
+      const r = computeLongestStreak([
+        {
+          startTime: new Date("2026-03-15T10:00:00Z"),
+          duration: 600,
+          channelId: "a",
+        },
+      ]);
+      expect(r).toEqual({
+        days: 1,
+        startDate: "2026-03-15",
+        endDate: "2026-03-15",
+      });
+    });
+
+    it("returns the longest run of consecutive UTC days", () => {
+      const r = computeLongestStreak([
+        // Run of 3: 03-10 → 03-12
+        { startTime: new Date("2026-03-10T10:00:00Z"), duration: 60, channelId: "a" },
+        { startTime: new Date("2026-03-11T10:00:00Z"), duration: 60, channelId: "a" },
+        { startTime: new Date("2026-03-12T10:00:00Z"), duration: 60, channelId: "a" },
+        // Gap
+        // Run of 2: 03-20 → 03-21
+        { startTime: new Date("2026-03-20T10:00:00Z"), duration: 60, channelId: "a" },
+        { startTime: new Date("2026-03-21T10:00:00Z"), duration: 60, channelId: "a" },
+      ]);
+      expect(r.days).toBe(3);
+      expect(r.startDate).toBe("2026-03-10");
+      expect(r.endDate).toBe("2026-03-12");
+    });
+
+    it("returns 0 on empty input", () => {
+      expect(computeLongestStreak([])).toEqual({
+        days: 0,
+        startDate: null,
+        endDate: null,
+      });
+    });
+  });
+
+  describe("formatHoursMinutes", () => {
+    it("renders short for sub-hour values", () => {
+      expect(formatHoursMinutes(45 * 60)).toBe("45 min");
+    });
+    it("renders hours-only for whole hours", () => {
+      expect(formatHoursMinutes(2 * 3600)).toBe("2 hr");
+    });
+    it("renders combined hours/minutes", () => {
+      expect(formatHoursMinutes(2 * 3600 + 15 * 60)).toBe("2 hr 15 min");
+    });
+  });
+
+  describe("formatFunComparison", () => {
+    it("returns null on zero seconds", () => {
+      expect(formatFunComparison(0)).toBeNull();
+    });
+    it("returns a movie comparison for ~2 hours", () => {
+      expect(formatFunComparison(2 * 3600)).toMatch(/movie/);
+    });
+    it("returns a trans-atlantic flight comparison for many hours", () => {
+      expect(formatFunComparison(16 * 3600)).toMatch(/flight/);
+    });
+  });
+});
+
+// ---------------------------------------------------------------
+// Service-level integration: mocks set up above.
+// ---------------------------------------------------------------
+
+describe("RewindService.getSummary", () => {
+  function lean<T>(value: T): { lean: () => Promise<T> } {
+    return { lean: jest.fn(async () => value) };
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetSingleton();
+    // Default chainable returns so tests that don't override the
+    // `findOne` calls still chain through `.lean()` without crashing.
+    mockFindOneVc.mockReturnValue(lean({ sessions: [] }));
+    mockFindOneAch.mockReturnValue(lean(null));
+    mockAggregateVc.mockResolvedValue([]);
+  });
+
+  it("returns hasData=false when the user has no sessions or achievements", async () => {
+    mockFindOneVc.mockReturnValueOnce(lean({ sessions: [] }));
+    mockFindOneAch.mockReturnValueOnce(lean(null));
+    mockAggregateVc
+      // collectAvailableYears
+      .mockResolvedValueOnce([])
+      // computeAnnualRank — skipped because userSeconds <= 0
+      // computeWeeklyJourney — also skipped via short-circuit but we don't gate it
+      .mockResolvedValueOnce([]); // weekly journey aggregate
+
+    const svc = RewindService.getInstance(
+      makeClient() as Parameters<typeof RewindService.getInstance>[0],
+    );
+    const summary = await svc.getSummary("u1", "g1", 2026);
+    expect(summary).not.toBeNull();
+    expect(summary!.hasData).toBe(false);
+    expect(summary!.totalSeconds).toBe(0);
+    expect(summary!.annualRank).toBeNull();
+    expect(summary!.topChannels).toEqual([]);
+  });
+
+  it("aggregates a full summary when the user has voice data", async () => {
+    const year = 2026;
+    const sessions = [
+      {
+        startTime: new Date(`${year}-01-15T10:00:00Z`),
+        duration: 3600,
+        channelId: "general",
+        channelName: "general-vc",
+      },
+      {
+        startTime: new Date(`${year}-01-15T14:00:00Z`),
+        duration: 1800,
+        channelId: "gaming",
+        channelName: "gaming",
+      },
+      {
+        startTime: new Date(`${year}-01-16T10:00:00Z`),
+        duration: 1800,
+        channelId: "general",
+        channelName: "general-vc",
+      },
+      // Out-of-year session — should be filtered out
+      {
+        startTime: new Date(`2025-12-31T22:00:00Z`),
+        duration: 9999,
+        channelId: "general",
+        channelName: "general-vc",
+      },
+    ];
+    mockFindOneVc.mockReturnValueOnce(lean({ sessions }));
+    mockFindOneAch.mockReturnValueOnce(lean(null));
+
+    mockAggregateVc
+      // collectAvailableYears
+      .mockResolvedValueOnce([{ _id: 2026 }, { _id: 2025 }])
+      // computeAnnualRank — sorted descending
+      .mockResolvedValueOnce([
+        { _id: "top-user", totalTime: 36000 },
+        { _id: "u1", totalTime: 7200 },
+        { _id: "another", totalTime: 3600 },
+      ])
+      // computeWeeklyJourney — first/last/best weekly rank for u1
+      .mockResolvedValueOnce([
+        { _id: { userId: "u1", isoYear: 2026, isoWeek: 3 }, totalTime: 5400, rank: 5 },
+        { _id: { userId: "u1", isoYear: 2026, isoWeek: 4 }, totalTime: 7000, rank: 2 },
+        { _id: { userId: "u1", isoYear: 2026, isoWeek: 5 }, totalTime: 4000, rank: 8 },
+      ]);
+
+    const svc = RewindService.getInstance(
+      makeClient() as Parameters<typeof RewindService.getInstance>[0],
+    );
+    const summary = await svc.getSummary("u1", "g1", year);
+    expect(summary).not.toBeNull();
+    expect(summary!.hasData).toBe(true);
+    expect(summary!.totalSeconds).toBe(7200); // 3600 + 1800 + 1800
+    expect(summary!.sessionCount).toBe(3);
+    expect(summary!.daysActive).toBe(2);
+    expect(summary!.topChannels.map((c) => c.channelId)).toEqual([
+      "general",
+      "gaming",
+    ]);
+    expect(summary!.peakDay).toEqual({
+      date: "2026-01-15",
+      totalSeconds: 5400,
+    });
+    expect(summary!.longestStreakDays).toBe(2);
+    expect(summary!.annualRank).toBe(2);
+    expect(summary!.annualGuildMembers).toBe(3);
+    expect(summary!.percentAboveMedian).not.toBeNull();
+    expect(summary!.weeklyJourney.first?.isoWeek).toBe(3);
+    expect(summary!.weeklyJourney.last?.isoWeek).toBe(5);
+    expect(summary!.weeklyJourney.best?.isoWeek).toBe(4);
+    expect(summary!.availableYears).toEqual([2026, 2025]);
+  });
+
+  it("filters achievements and accolades by year and ignores unknown types", async () => {
+    const year = 2026;
+    mockFindOneVc.mockReturnValueOnce(lean({ sessions: [] }));
+    mockFindOneAch.mockReturnValueOnce(
+      lean({
+        accolades: [
+          { type: "night_owl", earnedAt: new Date(`${year}-04-01T00:00:00Z`) },
+          // Wrong year — drop
+          { type: "night_owl", earnedAt: new Date(`2025-12-31T00:00:00Z`) },
+          // Unknown type — drop (no metadata)
+          { type: "mystery_badge", earnedAt: new Date(`${year}-04-01T00:00:00Z`) },
+        ],
+        achievements: [
+          { type: "weekly_active", earnedAt: new Date(`${year}-04-01T00:00:00Z`) },
+        ],
+      }),
+    );
+    mockAggregateVc
+      .mockResolvedValueOnce([{ _id: 2026 }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    const svc = RewindService.getInstance(
+      makeClient() as Parameters<typeof RewindService.getInstance>[0],
+    );
+    const summary = await svc.getSummary("u1", "g1", year);
+    expect(summary!.accolades).toHaveLength(1);
+    expect(summary!.accolades[0].name).toBe("Night Owl");
+    expect(summary!.achievements).toHaveLength(1);
+    expect(summary!.achievements[0].name).toBe("Weekly Active");
+    expect(summary!.hasData).toBe(true);
+  });
+
+  it("returns null when the DB layer throws unexpectedly", async () => {
+    mockFindOneVc.mockReturnValueOnce({
+      lean: jest.fn(async () => {
+        throw new Error("mongo exploded");
+      }),
+    });
+    mockFindOneAch.mockReturnValueOnce(lean(null));
+    mockAggregateVc.mockResolvedValue([]);
+
+    const svc = RewindService.getInstance(
+      makeClient() as Parameters<typeof RewindService.getInstance>[0],
+    );
+    const summary = await svc.getSummary("u1", "g1", 2026);
+    expect(summary).toBeNull();
+  });
+});
+
+describe("RewindService singleton", () => {
+  beforeEach(() => resetSingleton());
+
+  it("returns the same instance for the same client", () => {
+    const c = makeClient() as Parameters<typeof RewindService.getInstance>[0];
+    expect(RewindService.getInstance(c)).toBe(RewindService.getInstance(c));
+  });
+
+  it("throws when called with a different client", () => {
+    RewindService.getInstance(
+      makeClient() as Parameters<typeof RewindService.getInstance>[0],
+    );
+    expect(() =>
+      RewindService.getInstance(
+        makeClient() as Parameters<typeof RewindService.getInstance>[0],
+      ),
+    ).toThrow(/different client/);
+  });
+});

--- a/__tests__/services/settings-metadata.test.ts
+++ b/__tests__/services/settings-metadata.test.ts
@@ -44,6 +44,7 @@ describe("settingsMetadata", () => {
       "quotes",
       "core",
       "digest",
+      "rewind",
       "ratelimit",
       "announcements",
       "achievements",

--- a/__tests__/web/user-routes.test.ts
+++ b/__tests__/web/user-routes.test.ts
@@ -408,10 +408,13 @@ describe("/me/notifications", () => {
     );
   });
 
-  it("renders 'coming soon' hint for the rewind row only (digest shipped in #483)", async () => {
+  it("no longer renders 'coming soon' hints for digest or rewind (both shipped)", async () => {
     const out = await dispatch({ method: "GET" });
     expect(out.body).not.toContain("#483");
-    expect(out.body).toContain("#484");
+    expect(out.body).not.toContain("#484");
+    // The `pref-soon` style is still defined in the layout CSS for
+    // future rows; assert no row actually uses it.
+    expect(out.body).not.toContain('<span class="pref-soon">');
   });
 
   it("renders unchecked when stored prefs are off", async () => {
@@ -547,5 +550,174 @@ describe("userWebErrorHandler", () => {
     );
     expect(res.statusCode).toBe(500);
     expect(res.body).toBe("Internal Server Error");
+  });
+});
+
+describe("/me/rewind", () => {
+  beforeEach(() => {
+    process.env.WEBUI_SESSION_SECRET = SECRET;
+    process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES = "30";
+    (WebSessionService as unknown as { instance: unknown }).instance = null;
+  });
+
+  async function dispatchRewind(opts: {
+    pathSuffix: string; // "" for "/rewind", "/2024" for "/rewind/2024"
+    summary: unknown; // What RewindService.getInstance(...).getSummary should resolve to
+  }): Promise<{ statusCode: number; body: string }> {
+    const now = Date.now();
+    const payload: CookiePayload = {
+      sid: "session-id",
+      uid: "user-1",
+      gid: "guild-1",
+      rol: "user",
+      iat: now - 60_000,
+      act: now - 60_000,
+    };
+    const cookie = `koolbot_session=${buildCookie(payload)}; koolbot_csrf=csrf-1`;
+
+    const svc = WebSessionService.getInstance();
+    jest.spyOn(svc, "findById").mockResolvedValue({
+      discordUserId: "user-1",
+      guildId: "guild-1",
+      role: "user",
+      scopes: [],
+      revokedAt: null,
+      expiresAt: new Date(now + 60 * 60 * 1000),
+    } as never);
+
+    const { PermissionsService } =
+      await import("../../src/services/permissions-service.js");
+    jest.spyOn(PermissionsService, "getInstance").mockReturnValue({
+      checkCommandPermission: async () => true,
+    } as never);
+
+    const { RewindService } =
+      await import("../../src/services/rewind-service.js");
+    const getSummary = jest.fn().mockResolvedValue(opts.summary as never);
+    jest.spyOn(RewindService, "getInstance").mockReturnValue({
+      getSummary,
+    } as never);
+
+    const mockClient = {} as never;
+    const { createSessionMiddleware } =
+      await import("../../src/web/session.js");
+    const requireSession = createSessionMiddleware(mockClient);
+    const router = createUserRouter(mockClient, requireSession);
+
+    const path = `/rewind${opts.pathSuffix}`;
+    const req = {
+      method: "GET",
+      url: path,
+      originalUrl: `/me${path}`,
+      path,
+      baseUrl: "/me",
+      headers: { cookie },
+      query: {},
+      csrfToken: "csrf-1",
+      header: (name: string) => (name === "cookie" ? cookie : undefined),
+    } as never as Parameters<typeof router>[0];
+    const res = makeRes();
+    await new Promise<void>((resolve) => {
+      router(
+        req as never,
+        res as never,
+        (() => resolve()) as never,
+      );
+      setTimeout(resolve, 0);
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    return { statusCode: res.statusCode, body: res.body };
+  }
+
+  function makeSummary(
+    overrides: Record<string, unknown> = {},
+  ): Record<string, unknown> {
+    return {
+      userId: "user-1",
+      guildId: "guild-1",
+      year: 2026,
+      hasData: true,
+      totalSeconds: 3600 * 12,
+      sessionCount: 8,
+      daysActive: 5,
+      topChannels: [
+        { channelId: "c1", channelName: "general-vc", totalSeconds: 3600 * 6 },
+        { channelId: "c2", channelName: "gaming", totalSeconds: 3600 * 4 },
+        { channelId: "c3", channelName: "afk", totalSeconds: 3600 * 2 },
+      ],
+      peakDay: { date: "2026-03-15", totalSeconds: 3600 * 3 },
+      longestStreakDays: 4,
+      longestStreakRange: { startDate: "2026-03-12", endDate: "2026-03-15" },
+      accolades: [],
+      achievements: [],
+      annualRank: 7,
+      annualGuildMembers: 42,
+      percentAboveMedian: 30,
+      weeklyJourney: { first: null, last: null, best: null },
+      availableYears: [2026, 2025],
+      ...overrides,
+    };
+  }
+
+  it("renders the current-year rewind page", async () => {
+    const out = await dispatchRewind({
+      pathSuffix: "",
+      summary: makeSummary({ year: new Date().getUTCFullYear() }),
+    });
+    expect(out.statusCode).toBe(200);
+    expect(out.body).toContain("Rewind");
+    expect(out.body).toContain("general-vc");
+    expect(out.body).toContain("12 hr"); // formatHoursMinutes(3600 * 12)
+    expect(out.body).toContain("#7"); // annual rank
+    expect(out.body).toContain("+30%"); // median delta
+  });
+
+  it("renders a specific past year when the route param is present", async () => {
+    const out = await dispatchRewind({
+      pathSuffix: "/2024",
+      summary: makeSummary({ year: 2024 }),
+    });
+    expect(out.statusCode).toBe(200);
+    expect(out.body).toContain("Rewind 2024");
+  });
+
+  it("renders the empty-state body when the user has no data", async () => {
+    const out = await dispatchRewind({
+      pathSuffix: "/2023",
+      summary: makeSummary({
+        year: 2023,
+        hasData: false,
+        totalSeconds: 0,
+        sessionCount: 0,
+        daysActive: 0,
+        topChannels: [],
+        peakDay: null,
+        longestStreakDays: 0,
+        longestStreakRange: null,
+        annualRank: null,
+        percentAboveMedian: null,
+        availableYears: [2026, 2025],
+      }),
+    });
+    expect(out.statusCode).toBe(200);
+    expect(out.body).toContain("Nothing to recap yet");
+  });
+
+  it("falls back to the current year for a junk year param", async () => {
+    const out = await dispatchRewind({
+      pathSuffix: "/not-a-year",
+      summary: makeSummary({ year: new Date().getUTCFullYear() }),
+    });
+    expect(out.statusCode).toBe(200);
+    expect(out.body).toContain(`Rewind ${new Date().getUTCFullYear()}`);
+  });
+
+  it("returns 500 with a friendly notice when the service yields null", async () => {
+    const out = await dispatchRewind({
+      pathSuffix: "",
+      summary: null,
+    });
+    expect(out.statusCode).toBe(500);
+    expect(out.body).toContain("Could not load your year-in-review");
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ import { ReactionRoleService } from "./services/reaction-role-service.js";
 import { PollService } from "./services/poll-service.js";
 import { LeaderboardRoleService } from "./services/leaderboard-role-service.js";
 import { DigestService } from "./services/digest-service.js";
+import { RewindNudgeService } from "./services/rewind-nudge-service.js";
 import { WizardService } from "./services/wizard-service.js";
 import { MonitoringService } from "./services/monitoring-service.js";
 import {
@@ -426,6 +427,7 @@ async function gracefulShutdown(signal: string): Promise<void> {
         pollService.destroy();
         leaderboardRoleService.destroy();
         digestService.destroy();
+        rewindNudgeService.destroy();
         WizardService.getInstance().shutdown();
         MonitoringService.getInstance().destroy();
         await botStatusService.shutdown();
@@ -487,6 +489,7 @@ let reactionRoleService: ReactionRoleService;
 let pollService: PollService;
 let leaderboardRoleService: LeaderboardRoleService;
 let digestService: DigestService;
+let rewindNudgeService: RewindNudgeService;
 
 // Wrap service instantiation in try-catch to ensure errors are caught
 try {
@@ -506,6 +509,7 @@ try {
   pollService = PollService.getInstance(client);
   leaderboardRoleService = LeaderboardRoleService.getInstance(client);
   digestService = DigestService.getInstance(client);
+  rewindNudgeService = RewindNudgeService.getInstance(client);
 } catch (error) {
   logger.error("❌ Fatal error during service instantiation:", error);
   process.exit(1);
@@ -595,6 +599,11 @@ async function initializeServices(): Promise<void> {
 
     // Initialize weekly voice-activity digest service (#483)
     await digestService.start();
+
+    // Initialize annual rewind nudge service (#484). The /me/rewind
+    // page itself is served by the user WebUI router regardless of
+    // this service — this only schedules the end-of-year DM nudge.
+    await rewindNudgeService.start();
 
     // Start the slash-command audit log cleanup cron (#459)
     CommandAuditCleanupService.getInstance().start();

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -43,6 +43,7 @@ const ConfigSchema = new Schema<IConfig>(
         "quotes",
         "ratelimit",
         "reactionroles",
+        "rewind",
         "voicechannels",
         "voicetracking",
         "wizard", // Kept for backward compatibility; key removed but legacy rows may exist

--- a/src/models/rewind-nudge-state.ts
+++ b/src/models/rewind-nudge-state.ts
@@ -1,0 +1,39 @@
+import mongoose, { Document, Schema } from "mongoose";
+
+/**
+ * Per-user per-year delivery marker for the Rewind nudge (#484).
+ *
+ * One row per `(userId, guildId, year)`. The presence of a row means
+ * the end-of-year nudge has already been sent for that user/year — the
+ * `RewindNudgeService` checks for it before sending so a re-run of the
+ * cron (or a manual `runNow()` during validation) cannot double-DM.
+ *
+ * Rows are only written after a SUCCESSFUL send; DM-closed / failed
+ * deliveries do not record a marker so a retry can pick them up.
+ */
+export interface IRewindNudgeState extends Document {
+  userId: string;
+  guildId: string;
+  year: number;
+  sentAt: Date;
+}
+
+const RewindNudgeStateSchema = new Schema<IRewindNudgeState>(
+  {
+    userId: { type: String, required: true },
+    guildId: { type: String, required: true },
+    year: { type: Number, required: true },
+    sentAt: { type: Date, required: true },
+  },
+  { timestamps: false },
+);
+
+RewindNudgeStateSchema.index(
+  { userId: 1, guildId: 1, year: 1 },
+  { unique: true },
+);
+
+export const RewindNudgeState = mongoose.model<IRewindNudgeState>(
+  "RewindNudgeState",
+  RewindNudgeStateSchema,
+);

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -61,6 +61,11 @@ export interface ConfigSchema {
   "digest.streak_min_minutes": number; // Per-week minutes that count toward a streak
   "digest.include_achievements": boolean;
 
+  // Annual Personal Year-in-Review (Rewind) (#484)
+  "rewind.enabled": boolean;
+  "rewind.cron": string; // Cron schedule for the end-of-year DM nudge
+  "rewind.min_minutes": number; // Min annual minutes to qualify for the nudge
+
   // Reaction Roles
   "reactionroles.enabled": boolean;
   "reactionroles.message_channel_id": string; // Channel for reaction role messages
@@ -184,6 +189,14 @@ export const defaultConfig: ConfigSchema = {
   "digest.min_active_minutes": 30,
   "digest.streak_min_minutes": 30,
   "digest.include_achievements": true,
+
+  // Rewind year-in-review defaults (#484). Master gate off, follows
+  // rule 1. The page works whenever the data exists; this gate only
+  // controls the end-of-year DM nudge.
+  "rewind.enabled": false,
+  "rewind.cron": "0 10 30 12 *", // Dec 30 at 10:00 in the host timezone
+  "rewind.min_minutes": 60,
+
   // Reaction Roles defaults
   "reactionroles.enabled": false,
   "reactionroles.message_channel_id": "",
@@ -302,6 +315,11 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
     title: "Weekly Digest",
     description:
       "Personalised weekly DM summarising each user's voice activity, rank, streak, and new achievements. Opt-out lives on the user's /me/notifications page.",
+  },
+  rewind: {
+    title: "Rewind (Year-in-Review)",
+    description:
+      "Personalised end-of-year recap at /me/rewind plus a one-shot DM nudge in late December. Opt-out lives on the user's /me/notifications page.",
   },
   reactionroles: {
     title: "Reaction Roles",
@@ -630,6 +648,29 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
       "Embed the achievements earned during the past week alongside the activity summary.",
     category: "digest",
     type: "boolean",
+  },
+
+  // Rewind year-in-review (#484)
+  "rewind.enabled": {
+    label: "Rewind end-of-year nudge enabled",
+    description:
+      "Send a one-shot end-of-year DM linking eligible users to their personal year-in-review at /me/rewind. The page itself is always available.",
+    category: "rewind",
+    type: "boolean",
+  },
+  "rewind.cron": {
+    label: "Rewind nudge schedule (cron)",
+    description:
+      "Cron expression for when the end-of-year DM nudge runs (defaults to December 30 at 10:00 in the host timezone).",
+    category: "rewind",
+    type: "cron",
+  },
+  "rewind.min_minutes": {
+    label: "Minimum annual minutes to qualify",
+    description:
+      "Users with less than this many minutes of voice activity in the year are skipped by the end-of-year DM nudge. The /me/rewind page itself is unaffected.",
+    category: "rewind",
+    type: "number",
   },
 
   // Reaction Roles

--- a/src/services/rewind-nudge-service.ts
+++ b/src/services/rewind-nudge-service.ts
@@ -1,0 +1,350 @@
+import { Client, EmbedBuilder, type ColorResolvable } from "discord.js";
+import { CronJob, CronTime } from "cron";
+import { ConfigService } from "./config-service.js";
+import { UserNotificationPrefsService } from "./user-notification-prefs-service.js";
+import { DiscordLogger } from "./discord-logger.js";
+import { VoiceChannelTracking } from "../models/voice-channel-tracking.js";
+import logger from "../utils/logger.js";
+
+/**
+ * End-of-year DM nudge for the Rewind WebUI page (#484).
+ *
+ * Scheduled job. For each user above `rewind.min_minutes` in the
+ * current year, send a single DM with a link to `/me/rewind`. Gated by
+ * the per-user `prefs.rewind` opt-out. DM-closed users (Discord error
+ * 50007) are silently skipped, matching the digest/achievement pattern.
+ *
+ * The page itself works year-round; this service exists only to nudge
+ * users to open it once the year is wrapped up.
+ */
+
+const DEFAULT_CRON = "0 10 30 12 *";
+const SECONDS_PER_MINUTE = 60;
+const EMBED_COLOR: ColorResolvable = "#a855f7";
+
+export interface RewindNudgeRunSummary {
+  ranAt: Date;
+  year: number;
+  qualifying: number;
+  sent: number;
+  skippedOptOut: number;
+  skippedDmsClosed: number;
+  failed: number;
+}
+
+function sanitizeCronExpression(expression: string): string {
+  return expression.trim().replace(/^["']|["']$/g, "");
+}
+
+export class RewindNudgeService {
+  private static instance: RewindNudgeService;
+  private client: Client;
+  private configService: ConfigService;
+  private job: CronJob | null = null;
+  private isInitialized = false;
+  private isRunning = false;
+  private inFlight: Promise<RewindNudgeRunSummary | null> | null = null;
+
+  private constructor(client: Client) {
+    this.client = client;
+    this.configService = ConfigService.getInstance();
+
+    this.configService.registerReloadCallback(async () => {
+      try {
+        const enabled = await this.configService.getBoolean(
+          "rewind.enabled",
+          false,
+        );
+        if (!enabled && this.isInitialized) {
+          logger.info("Rewind nudge disabled, stopping cron job...");
+          this.destroy();
+        } else if (enabled) {
+          await this.reload();
+        }
+      } catch (error) {
+        logger.error(
+          "Error reloading rewind nudge service after configuration change:",
+          error,
+        );
+      }
+    });
+  }
+
+  public static getInstance(client: Client): RewindNudgeService {
+    if (!RewindNudgeService.instance) {
+      RewindNudgeService.instance = new RewindNudgeService(client);
+    } else if (RewindNudgeService.instance.client !== client) {
+      throw new Error(
+        "RewindNudgeService already initialised with a different client",
+      );
+    }
+    return RewindNudgeService.instance;
+  }
+
+  public static reset(): void {
+    if (RewindNudgeService.instance) {
+      RewindNudgeService.instance.destroy();
+    }
+    RewindNudgeService.instance = undefined as unknown as RewindNudgeService;
+  }
+
+  private validateCronExpression(expression: string): boolean {
+    try {
+      new CronTime(expression);
+      return true;
+    } catch (error) {
+      logger.error(
+        `Invalid cron expression for rewind nudge: ${expression}`,
+        error,
+      );
+      return false;
+    }
+  }
+
+  public async start(): Promise<void> {
+    if (this.isInitialized) {
+      logger.warn("Rewind nudge service is already initialized, skipping...");
+      return;
+    }
+
+    try {
+      const enabled = await this.configService.getBoolean(
+        "rewind.enabled",
+        false,
+      );
+      if (!enabled) {
+        logger.info("Rewind nudge is disabled");
+        this.isInitialized = true;
+        return;
+      }
+
+      const rawCron = await this.configService.getString(
+        "rewind.cron",
+        DEFAULT_CRON,
+      );
+      const cronExpression = sanitizeCronExpression(rawCron);
+
+      if (!this.validateCronExpression(cronExpression)) {
+        logger.error(
+          `Rewind nudge service not started: invalid cron "${rawCron}"`,
+        );
+        this.isInitialized = true;
+        return;
+      }
+
+      this.job = new CronJob(cronExpression, async () => {
+        try {
+          await this.runNow();
+        } catch (error) {
+          logger.error("Error running rewind nudge job:", error);
+        }
+      });
+      this.job.start();
+
+      const nextRun = this.job.nextDate();
+      logger.info(
+        `Rewind nudge service started (cron: "${cronExpression}", next run: ${nextRun.toLocaleString()})`,
+      );
+
+      this.isInitialized = true;
+    } catch (error) {
+      logger.error("Error starting rewind nudge service:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Run the nudge immediately. Coalesces concurrent invocations so a
+   * slow run + the next cron tick can't double-deliver.
+   */
+  public async runNow(): Promise<RewindNudgeRunSummary | null> {
+    if (this.inFlight) return this.inFlight;
+    this.inFlight = this.runOnce();
+    try {
+      return await this.inFlight;
+    } finally {
+      this.inFlight = null;
+    }
+  }
+
+  private async runOnce(): Promise<RewindNudgeRunSummary | null> {
+    if (this.isRunning) {
+      logger.warn("Rewind nudge run already in progress, skipping");
+      return null;
+    }
+    this.isRunning = true;
+    try {
+      const enabled = await this.configService.getBoolean(
+        "rewind.enabled",
+        false,
+      );
+      if (!enabled) {
+        logger.info("Rewind nudge aborted: feature disabled");
+        return null;
+      }
+
+      const guildId = await this.configService.getString("GUILD_ID", "");
+      if (!guildId) {
+        logger.error("Rewind nudge aborted: GUILD_ID not configured");
+        return null;
+      }
+
+      const minMinutes = await this.configService.getNumber(
+        "rewind.min_minutes",
+        60,
+      );
+      const minSeconds = Math.max(0, minMinutes) * SECONDS_PER_MINUTE;
+
+      const year = new Date().getUTCFullYear();
+      const summary: RewindNudgeRunSummary = {
+        ranAt: new Date(),
+        year,
+        qualifying: 0,
+        sent: 0,
+        skippedOptOut: 0,
+        skippedDmsClosed: 0,
+        failed: 0,
+      };
+
+      const prefsService = UserNotificationPrefsService.getInstance();
+
+      const yearStart = new Date(Date.UTC(year, 0, 1, 0, 0, 0, 0));
+      const yearEnd = new Date(Date.UTC(year + 1, 0, 1, 0, 0, 0, 0));
+      // Aggregate seconds per user for the current year and filter by
+      // the configured minimum. No `$limit` — every qualifying user
+      // should be considered, not just the top N.
+      const annualUsers = await VoiceChannelTracking.aggregate<{
+        _id: string;
+        username: string;
+        totalTime: number;
+      }>([
+        { $unwind: "$sessions" },
+        {
+          $match: {
+            "sessions.startTime": { $gte: yearStart, $lt: yearEnd },
+          },
+        },
+        {
+          $group: {
+            _id: "$userId",
+            username: { $first: "$username" },
+            totalTime: { $sum: "$sessions.duration" },
+          },
+        },
+        { $match: { totalTime: { $gte: minSeconds } } },
+        { $sort: { totalTime: -1 } },
+      ]);
+      const qualifying = annualUsers.map((u) => ({
+        userId: u._id,
+        username: u.username ?? u._id,
+        totalTime: u.totalTime,
+      }));
+      summary.qualifying = qualifying.length;
+
+      for (const user of qualifying) {
+        try {
+          const prefs = await prefsService.getPrefs(user.userId, guildId);
+          if (!prefs.rewind) {
+            summary.skippedOptOut += 1;
+            continue;
+          }
+          const embed = this.buildEmbed(user.username, year);
+          const delivered = await this.sendNudgeDM(user.userId, embed);
+          if (!delivered) {
+            summary.skippedDmsClosed += 1;
+            continue;
+          }
+          summary.sent += 1;
+        } catch (error) {
+          summary.failed += 1;
+          logger.error(
+            `Error sending rewind nudge for user ${user.userId}:`,
+            error,
+          );
+        }
+      }
+
+      logger.info(
+        `Rewind nudge complete: year=${summary.year} qualifying=${summary.qualifying} ` +
+          `sent=${summary.sent} opted_out=${summary.skippedOptOut} ` +
+          `dms_closed=${summary.skippedDmsClosed} failed=${summary.failed}`,
+      );
+
+      await this.logSummary(summary);
+      return summary;
+    } finally {
+      this.isRunning = false;
+    }
+  }
+
+  private buildEmbed(username: string, year: number): EmbedBuilder {
+    return new EmbedBuilder()
+      .setTitle(`✨ Your Koolbot Rewind for ${year} is ready`)
+      .setColor(EMBED_COLOR)
+      .setDescription(
+        `Hey ${username}, your year-in-review is waiting for you.\n\n` +
+          `Open the user portal with **\`/config\`** and follow the magic link to **/me/rewind** to see your top channels, peak day, longest streak, and the badges you earned this year.\n\n` +
+          `_Don't want these? Run \`/config\` → Notifications to manage your preferences._`,
+      )
+      .setTimestamp(new Date());
+  }
+
+  /**
+   * Send the nudge DM. Returns true on delivery, false if the user has
+   * DMs closed (silent skip). Other errors propagate so they count as
+   * `failed`.
+   */
+  private async sendNudgeDM(
+    userId: string,
+    embed: EmbedBuilder,
+  ): Promise<boolean> {
+    const user = await this.client.users.fetch(userId);
+    try {
+      await user.send({ embeds: [embed] });
+      return true;
+    } catch (error) {
+      const code = (error as { code?: number }).code;
+      if (code === 50007) {
+        logger.debug(`Rewind nudge: DMs closed for ${userId}, skipping`);
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  private async logSummary(summary: RewindNudgeRunSummary): Promise<void> {
+    try {
+      const discordLogger = DiscordLogger.getInstance(this.client);
+      if (!discordLogger.isReady()) return;
+      const message =
+        `Year ${summary.year} · qualifying: ${summary.qualifying} · ` +
+        `sent: ${summary.sent} · opted out: ${summary.skippedOptOut} · ` +
+        `DMs closed: ${summary.skippedDmsClosed} · failed: ${summary.failed}`;
+      await discordLogger.logCronSuccess("Rewind Nudge", message);
+    } catch (error) {
+      logger.error(
+        "Rewind nudge: failed to post run summary to Discord:",
+        error,
+      );
+    }
+  }
+
+  public async reload(): Promise<void> {
+    logger.info("Reloading rewind nudge service...");
+    if (this.job) {
+      this.job.stop();
+      this.job = null;
+    }
+    this.isInitialized = false;
+    await this.start();
+  }
+
+  public destroy(): void {
+    if (this.job) {
+      this.job.stop();
+      this.job = null;
+    }
+    this.isInitialized = false;
+    logger.info("Rewind nudge service destroyed");
+  }
+}

--- a/src/services/rewind-nudge-service.ts
+++ b/src/services/rewind-nudge-service.ts
@@ -4,6 +4,7 @@ import { ConfigService } from "./config-service.js";
 import { UserNotificationPrefsService } from "./user-notification-prefs-service.js";
 import { DiscordLogger } from "./discord-logger.js";
 import { VoiceChannelTracking } from "../models/voice-channel-tracking.js";
+import { RewindNudgeState } from "../models/rewind-nudge-state.js";
 import logger from "../utils/logger.js";
 
 /**
@@ -29,6 +30,8 @@ export interface RewindNudgeRunSummary {
   sent: number;
   skippedOptOut: number;
   skippedDmsClosed: number;
+  /** Already nudged for this year — duplicate-delivery guard. */
+  skippedAlreadySent: number;
   failed: number;
 }
 
@@ -203,6 +206,7 @@ export class RewindNudgeService {
         sent: 0,
         skippedOptOut: 0,
         skippedDmsClosed: 0,
+        skippedAlreadySent: 0,
         failed: 0,
       };
 
@@ -243,6 +247,20 @@ export class RewindNudgeService {
 
       for (const user of qualifying) {
         try {
+          // One-shot per (userId, guildId, year). A re-run of the cron
+          // — or a manual `runNow()` for validation — must not produce
+          // a duplicate DM. We check before any other work so an
+          // already-nudged user costs only this lookup.
+          const existing = await RewindNudgeState.findOne({
+            userId: user.userId,
+            guildId,
+            year,
+          });
+          if (existing) {
+            summary.skippedAlreadySent += 1;
+            continue;
+          }
+
           const prefs = await prefsService.getPrefs(user.userId, guildId);
           if (!prefs.rewind) {
             summary.skippedOptOut += 1;
@@ -255,6 +273,21 @@ export class RewindNudgeService {
             continue;
           }
           summary.sent += 1;
+
+          // Record the delivery marker only after a successful send so
+          // DM-closed / failed deliveries can be retried on the next run.
+          await RewindNudgeState.findOneAndUpdate(
+            { userId: user.userId, guildId, year },
+            {
+              $set: {
+                userId: user.userId,
+                guildId,
+                year,
+                sentAt: summary.ranAt,
+              },
+            },
+            { upsert: true, new: true, setDefaultsOnInsert: true },
+          );
         } catch (error) {
           summary.failed += 1;
           logger.error(
@@ -267,6 +300,7 @@ export class RewindNudgeService {
       logger.info(
         `Rewind nudge complete: year=${summary.year} qualifying=${summary.qualifying} ` +
           `sent=${summary.sent} opted_out=${summary.skippedOptOut} ` +
+          `already_sent=${summary.skippedAlreadySent} ` +
           `dms_closed=${summary.skippedDmsClosed} failed=${summary.failed}`,
       );
 
@@ -319,6 +353,7 @@ export class RewindNudgeService {
       const message =
         `Year ${summary.year} · qualifying: ${summary.qualifying} · ` +
         `sent: ${summary.sent} · opted out: ${summary.skippedOptOut} · ` +
+        `already sent: ${summary.skippedAlreadySent} · ` +
         `DMs closed: ${summary.skippedDmsClosed} · failed: ${summary.failed}`;
       await discordLogger.logCronSuccess("Rewind Nudge", message);
     } catch (error) {

--- a/src/services/rewind-service.ts
+++ b/src/services/rewind-service.ts
@@ -1,0 +1,597 @@
+import { Client } from "discord.js";
+import { VoiceChannelTracking } from "../models/voice-channel-tracking.js";
+import { UserAchievements } from "../models/user-achievements.js";
+import { ACCOLADE_METADATA } from "../content/accolades.js";
+import { ACHIEVEMENT_METADATA } from "../content/achievements.js";
+import logger from "../utils/logger.js";
+
+/**
+ * Year-in-review aggregation service (#484).
+ *
+ * Pure read service — no cron, no DM. Given `(userId, guildId, year)`
+ * it returns a `RewindSummary` the WebUI renders at `/me/rewind`. All
+ * aggregates come from existing collections (`VoiceChannelTracking`,
+ * `UserAchievements`); nothing new is persisted.
+ *
+ * v1 is on-demand and uncached, per the issue spec. If real data shows
+ * the queries are too slow, a `RewindCache` collection keyed by
+ * `(userId, guildId, year)` is the planned follow-up.
+ */
+
+const SECONDS_PER_MINUTE = 60;
+const SECONDS_PER_HOUR = 60 * 60;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export interface RewindChannel {
+  channelId: string;
+  channelName: string;
+  totalSeconds: number;
+}
+
+export interface RewindAchievement {
+  type: string;
+  emoji: string;
+  name: string;
+  description: string;
+  earnedAt: Date;
+}
+
+export interface RewindWeeklyRank {
+  isoYear: number;
+  isoWeek: number;
+  rank: number;
+}
+
+export interface RewindSummary {
+  userId: string;
+  guildId: string;
+  year: number;
+  hasData: boolean;
+  totalSeconds: number;
+  sessionCount: number;
+  daysActive: number;
+  topChannels: RewindChannel[];
+  peakDay: { date: string; totalSeconds: number } | null; // ISO date (YYYY-MM-DD)
+  longestStreakDays: number;
+  longestStreakRange: { startDate: string; endDate: string } | null;
+  accolades: RewindAchievement[];
+  achievements: RewindAchievement[];
+  annualRank: number | null;
+  annualGuildMembers: number;
+  percentAboveMedian: number | null;
+  weeklyJourney: {
+    first: RewindWeeklyRank | null;
+    last: RewindWeeklyRank | null;
+    best: RewindWeeklyRank | null;
+  };
+  // Years for which the user has any data (sessions or achievements).
+  // Used by the page to render a small year picker.
+  availableYears: number[];
+}
+
+interface RawSession {
+  startTime: Date;
+  endTime?: Date;
+  duration?: number;
+  channelId: string;
+  channelName?: string;
+}
+
+// --------------------------------------------------------------------
+// Pure helpers (exported for unit tests).
+// --------------------------------------------------------------------
+
+export function yearBounds(year: number): { start: Date; end: Date } {
+  return {
+    start: new Date(Date.UTC(year, 0, 1, 0, 0, 0, 0)),
+    end: new Date(Date.UTC(year + 1, 0, 1, 0, 0, 0, 0)),
+  };
+}
+
+export function toIsoDate(date: Date): string {
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(date.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+export function sessionSeconds(session: RawSession): number {
+  if (typeof session.duration === "number" && session.duration > 0) {
+    return Math.floor(session.duration);
+  }
+  if (session.endTime && session.startTime) {
+    return Math.max(
+      0,
+      Math.floor(
+        (session.endTime.getTime() - session.startTime.getTime()) / 1000,
+      ),
+    );
+  }
+  return 0;
+}
+
+export function computeTopChannels(
+  sessions: RawSession[],
+  limit = 3,
+): RewindChannel[] {
+  const totals = new Map<
+    string,
+    { channelId: string; channelName: string; totalSeconds: number }
+  >();
+  for (const s of sessions) {
+    const key = s.channelId;
+    const seconds = sessionSeconds(s);
+    if (seconds <= 0) continue;
+    const existing = totals.get(key);
+    if (existing) {
+      existing.totalSeconds += seconds;
+      // Prefer the most recent non-empty name (handles renames).
+      if (s.channelName) existing.channelName = s.channelName;
+    } else {
+      totals.set(key, {
+        channelId: key,
+        channelName: s.channelName ?? "Unknown channel",
+        totalSeconds: seconds,
+      });
+    }
+  }
+  return [...totals.values()]
+    .sort((a, b) => b.totalSeconds - a.totalSeconds)
+    .slice(0, limit);
+}
+
+export function computePeakDay(
+  sessions: RawSession[],
+): { date: string; totalSeconds: number } | null {
+  const byDay = new Map<string, number>();
+  for (const s of sessions) {
+    const seconds = sessionSeconds(s);
+    if (seconds <= 0) continue;
+    const key = toIsoDate(s.startTime);
+    byDay.set(key, (byDay.get(key) ?? 0) + seconds);
+  }
+  if (byDay.size === 0) return null;
+  let bestDate: string | null = null;
+  let bestSeconds = 0;
+  for (const [date, totalSeconds] of byDay) {
+    if (totalSeconds > bestSeconds) {
+      bestDate = date;
+      bestSeconds = totalSeconds;
+    }
+  }
+  return bestDate ? { date: bestDate, totalSeconds: bestSeconds } : null;
+}
+
+/**
+ * Longest run of consecutive UTC days that contain ≥1 session. Returns
+ * the day count and the start/end ISO dates of the winning run. A single
+ * day of activity counts as a streak of 1.
+ */
+export function computeLongestStreak(sessions: RawSession[]): {
+  days: number;
+  startDate: string | null;
+  endDate: string | null;
+} {
+  const days = new Set<string>();
+  for (const s of sessions) {
+    if (sessionSeconds(s) <= 0) continue;
+    days.add(toIsoDate(s.startTime));
+  }
+  if (days.size === 0) return { days: 0, startDate: null, endDate: null };
+  const sorted = [...days].sort();
+  let bestLen = 1;
+  let bestStart = sorted[0];
+  let bestEnd = sorted[0];
+  let runLen = 1;
+  let runStart = sorted[0];
+  for (let i = 1; i < sorted.length; i += 1) {
+    const prev = new Date(`${sorted[i - 1]}T00:00:00Z`).getTime();
+    const cur = new Date(`${sorted[i]}T00:00:00Z`).getTime();
+    if (cur - prev === MS_PER_DAY) {
+      runLen += 1;
+    } else {
+      runLen = 1;
+      runStart = sorted[i];
+    }
+    if (runLen > bestLen) {
+      bestLen = runLen;
+      bestStart = runStart;
+      bestEnd = sorted[i];
+    }
+  }
+  return { days: bestLen, startDate: bestStart, endDate: bestEnd };
+}
+
+function lookupAccolade(type: string): {
+  emoji: string;
+  name: string;
+  description: string;
+} | null {
+  const meta = (
+    ACCOLADE_METADATA as Record<
+      string,
+      { emoji: string; name: string; description: string }
+    >
+  )[type];
+  return meta
+    ? { emoji: meta.emoji, name: meta.name, description: meta.description }
+    : null;
+}
+
+function lookupAchievement(type: string): {
+  emoji: string;
+  name: string;
+  description: string;
+} | null {
+  const meta = (
+    ACHIEVEMENT_METADATA as Record<
+      string,
+      { emoji: string; name: string; description: string }
+    >
+  )[type];
+  return meta
+    ? { emoji: meta.emoji, name: meta.name, description: meta.description }
+    : null;
+}
+
+// --------------------------------------------------------------------
+// Service
+// --------------------------------------------------------------------
+
+export class RewindService {
+  private static instance: RewindService;
+  private client: Client;
+
+  private constructor(client: Client) {
+    this.client = client;
+  }
+
+  public static getInstance(client: Client): RewindService {
+    if (!RewindService.instance) {
+      RewindService.instance = new RewindService(client);
+    } else if (RewindService.instance.client !== client) {
+      throw new Error(
+        "RewindService already initialised with a different client",
+      );
+    }
+    return RewindService.instance;
+  }
+
+  public static reset(): void {
+    RewindService.instance = undefined as unknown as RewindService;
+  }
+
+  /**
+   * Compute the full Rewind summary for `(userId, guildId, year)`.
+   *
+   * Returns a summary even when the user has no data — the `hasData`
+   * flag drives the empty-state branch in the view layer. Returning
+   * `null` is reserved for unexpected DB failure.
+   */
+  public async getSummary(
+    userId: string,
+    guildId: string,
+    year: number,
+  ): Promise<RewindSummary | null> {
+    try {
+      const { start, end } = yearBounds(year);
+
+      const [userDoc, achievementsDoc] = await Promise.all([
+        VoiceChannelTracking.findOne({ userId }).lean<{
+          sessions?: RawSession[];
+        }>(),
+        UserAchievements.findOne({ userId }).lean<{
+          accolades?: Array<{ type: string; earnedAt: Date }>;
+          achievements?: Array<{ type: string; earnedAt: Date }>;
+        }>(),
+      ]);
+
+      const availableYears = await this.collectAvailableYears(
+        userId,
+        achievementsDoc,
+      );
+
+      const sessions = (userDoc?.sessions ?? []).filter(
+        (s) => s.startTime >= start && s.startTime < end,
+      );
+
+      const totalSeconds = sessions.reduce(
+        (sum, s) => sum + sessionSeconds(s),
+        0,
+      );
+      const daysActive = new Set(
+        sessions
+          .filter((s) => sessionSeconds(s) > 0)
+          .map((s) => toIsoDate(s.startTime)),
+      ).size;
+
+      const topChannels = computeTopChannels(sessions, 3);
+      const peakDay = computePeakDay(sessions);
+      const streak = computeLongestStreak(sessions);
+
+      const accolades = (achievementsDoc?.accolades ?? [])
+        .filter((a) => a.earnedAt >= start && a.earnedAt < end)
+        .map((a) => {
+          const meta = lookupAccolade(a.type);
+          return meta ? { type: a.type, ...meta, earnedAt: a.earnedAt } : null;
+        })
+        .filter((a): a is RewindAchievement => a !== null);
+
+      const achievements = (achievementsDoc?.achievements ?? [])
+        .filter((a) => a.earnedAt >= start && a.earnedAt < end)
+        .map((a) => {
+          const meta = lookupAchievement(a.type);
+          return meta ? { type: a.type, ...meta, earnedAt: a.earnedAt } : null;
+        })
+        .filter((a): a is RewindAchievement => a !== null);
+
+      const { annualRank, annualGuildMembers, percentAboveMedian } =
+        await this.computeAnnualRank(userId, start, end, totalSeconds);
+
+      const weeklyJourney = await this.computeWeeklyJourney(userId, start, end);
+
+      const hasData =
+        totalSeconds > 0 || accolades.length > 0 || achievements.length > 0;
+
+      return {
+        userId,
+        guildId,
+        year,
+        hasData,
+        totalSeconds,
+        sessionCount: sessions.filter((s) => sessionSeconds(s) > 0).length,
+        daysActive,
+        topChannels,
+        peakDay,
+        longestStreakDays: streak.days,
+        longestStreakRange:
+          streak.startDate && streak.endDate
+            ? { startDate: streak.startDate, endDate: streak.endDate }
+            : null,
+        accolades,
+        achievements,
+        annualRank,
+        annualGuildMembers,
+        percentAboveMedian,
+        weeklyJourney,
+        availableYears,
+      };
+    } catch (error) {
+      logger.error(
+        `RewindService.getSummary failed for user=${userId} year=${year}:`,
+        error,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Years for which we have any data (sessions or achievements). Used by
+   * the year picker so the page only offers years that won't render an
+   * empty state. Reuses the already-fetched achievements doc to avoid a
+   * second `findOne`.
+   */
+  private async collectAvailableYears(
+    userId: string,
+    achievementsDoc: {
+      accolades?: Array<{ earnedAt: Date }>;
+      achievements?: Array<{ earnedAt: Date }>;
+    } | null,
+  ): Promise<number[]> {
+    const years = new Set<number>();
+    try {
+      const sessionYears = await VoiceChannelTracking.aggregate<{
+        _id: number;
+      }>([
+        { $match: { userId } },
+        { $unwind: "$sessions" },
+        { $group: { _id: { $year: "$sessions.startTime" } } },
+      ]);
+      for (const row of sessionYears) {
+        if (typeof row._id === "number") years.add(row._id);
+      }
+      for (const a of achievementsDoc?.accolades ?? []) {
+        if (a.earnedAt) years.add(a.earnedAt.getUTCFullYear());
+      }
+      for (const a of achievementsDoc?.achievements ?? []) {
+        if (a.earnedAt) years.add(a.earnedAt.getUTCFullYear());
+      }
+    } catch (error) {
+      logger.warn(
+        `RewindService.collectAvailableYears partial failure for ${userId}:`,
+        error,
+      );
+    }
+    return [...years].sort((a, b) => b - a);
+  }
+
+  /**
+   * Compute the user's rank for the full year against everyone else who
+   * had any voice activity in `[start, end)`. Also returns the guild
+   * total active members and the percent the user is above the median.
+   * If the user has zero time, rank is `null`.
+   */
+  private async computeAnnualRank(
+    userId: string,
+    start: Date,
+    end: Date,
+    userSeconds: number,
+  ): Promise<{
+    annualRank: number | null;
+    annualGuildMembers: number;
+    percentAboveMedian: number | null;
+  }> {
+    if (userSeconds <= 0) {
+      return {
+        annualRank: null,
+        annualGuildMembers: 0,
+        percentAboveMedian: null,
+      };
+    }
+    const totals = await VoiceChannelTracking.aggregate<{
+      _id: string;
+      totalTime: number;
+    }>([
+      { $unwind: "$sessions" },
+      {
+        $match: {
+          "sessions.startTime": { $gte: start, $lt: end },
+        },
+      },
+      {
+        $group: {
+          _id: "$userId",
+          totalTime: { $sum: "$sessions.duration" },
+        },
+      },
+      { $match: { totalTime: { $gt: 0 } } },
+      { $sort: { totalTime: -1 } },
+    ]);
+
+    if (totals.length === 0) {
+      return {
+        annualRank: null,
+        annualGuildMembers: 0,
+        percentAboveMedian: null,
+      };
+    }
+
+    const rankIndex = totals.findIndex((row) => row._id === userId);
+    const annualRank = rankIndex >= 0 ? rankIndex + 1 : null;
+
+    // Median across active members.
+    const sortedTotals = totals.map((t) => t.totalTime).sort((a, b) => a - b);
+    const mid = Math.floor(sortedTotals.length / 2);
+    const median =
+      sortedTotals.length % 2 === 1
+        ? sortedTotals[mid]
+        : (sortedTotals[mid - 1] + sortedTotals[mid]) / 2;
+    const percentAboveMedian =
+      median > 0 ? Math.round(((userSeconds - median) / median) * 100) : null;
+
+    return {
+      annualRank,
+      annualGuildMembers: totals.length,
+      percentAboveMedian,
+    };
+  }
+
+  /**
+   * Compute the user's weekly rank for every ISO week of the year and
+   * return the first, last and best (lowest rank number) entries.
+   *
+   * Uses `$setWindowFields` to rank across all users per week in a
+   * single aggregation. If the user had zero qualifying weeks, all
+   * three are `null`.
+   */
+  private async computeWeeklyJourney(
+    userId: string,
+    start: Date,
+    end: Date,
+  ): Promise<RewindSummary["weeklyJourney"]> {
+    try {
+      const rows = await VoiceChannelTracking.aggregate<{
+        _id: { userId: string; isoYear: number; isoWeek: number };
+        totalTime: number;
+        rank: number;
+      }>([
+        { $unwind: "$sessions" },
+        {
+          $match: {
+            "sessions.startTime": { $gte: start, $lt: end },
+          },
+        },
+        {
+          $group: {
+            _id: {
+              userId: "$userId",
+              isoYear: { $isoWeekYear: "$sessions.startTime" },
+              isoWeek: { $isoWeek: "$sessions.startTime" },
+            },
+            totalTime: { $sum: "$sessions.duration" },
+          },
+        },
+        { $match: { totalTime: { $gt: 0 } } },
+        {
+          $setWindowFields: {
+            partitionBy: { isoYear: "$_id.isoYear", isoWeek: "$_id.isoWeek" },
+            sortBy: { totalTime: -1 },
+            output: { rank: { $rank: {} } },
+          },
+        },
+        { $match: { "_id.userId": userId } },
+        { $sort: { "_id.isoYear": 1, "_id.isoWeek": 1 } },
+      ]);
+
+      if (rows.length === 0) {
+        return { first: null, last: null, best: null };
+      }
+      const journey: RewindWeeklyRank[] = rows.map((r) => ({
+        isoYear: r._id.isoYear,
+        isoWeek: r._id.isoWeek,
+        rank: r.rank,
+      }));
+      const best = journey.reduce(
+        (acc, cur) => (acc === null || cur.rank < acc.rank ? cur : acc),
+        null as RewindWeeklyRank | null,
+      );
+      return {
+        first: journey[0],
+        last: journey[journey.length - 1],
+        best,
+      };
+    } catch (error) {
+      logger.warn(
+        `RewindService.computeWeeklyJourney failed for ${userId}:`,
+        error,
+      );
+      return { first: null, last: null, best: null };
+    }
+  }
+}
+
+// --------------------------------------------------------------------
+// View-layer formatting helpers (kept in the service module so tests
+// and the view share the same source of truth).
+// --------------------------------------------------------------------
+
+export function formatHoursMinutes(totalSeconds: number): string {
+  const totalMinutes = Math.floor(totalSeconds / SECONDS_PER_MINUTE);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours === 0) return `${minutes} min`;
+  if (minutes === 0) return `${hours} hr`;
+  return `${hours} hr ${minutes} min`;
+}
+
+/**
+ * Build a short, lightly humorous "≈ X movies / flights" comparison.
+ * Picks the largest unit whose value is ≥1 so the line stays readable
+ * for both heavy and light users.
+ */
+export function formatFunComparison(totalSeconds: number): string | null {
+  if (totalSeconds <= 0) return null;
+  const totalHours = totalSeconds / SECONDS_PER_HOUR;
+  // Tuned for chat-friendly comparisons; rough rather than precise.
+  const candidates: Array<{ unit: string; hours: number; singular: string }> = [
+    {
+      unit: "trans-atlantic flights",
+      hours: 8,
+      singular: "trans-atlantic flight",
+    },
+    {
+      unit: "feature-length movies",
+      hours: 2,
+      singular: "feature-length movie",
+    },
+    { unit: "long lunch breaks", hours: 1, singular: "long lunch break" },
+    { unit: "songs", hours: 3 / 60, singular: "song" },
+  ];
+  for (const c of candidates) {
+    const count = Math.round(totalHours / c.hours);
+    if (count >= 1) {
+      return `≈ ${count} ${count === 1 ? c.singular : c.unit}`;
+    }
+  }
+  return null;
+}

--- a/src/web/user-layout.ts
+++ b/src/web/user-layout.ts
@@ -27,6 +27,7 @@ interface UserNavItem {
 export const USER_NAV_ITEMS: UserNavItem[] = [
   { href: "/me/", label: "Overview" },
   { href: "/me/notifications", label: "Notifications" },
+  { href: "/me/rewind", label: "Rewind" },
 ];
 
 export interface UserFlashMessage {
@@ -105,6 +106,36 @@ const STYLE = [
   ".page-nav a{padding:.35rem .75rem;border-radius:4px;background:#161a22;border:1px solid #2d3748;color:#cbd5e1;font-size:.85rem;font-weight:600}",
   ".page-nav a:hover{background:#1f2937;text-decoration:none;color:#fff}",
   ".page-nav a.active{background:#1e3a8a;border-color:#1e3a8a;color:#fff}",
+  ".rw-hero{background:linear-gradient(135deg,#1e1b4b 0%,#312e81 100%);border:1px solid #4338ca;border-radius:8px;padding:1.5rem;margin:0 0 1rem;text-align:center}",
+  ".rw-hero .total{font-size:2.5rem;font-weight:700;color:#fff;line-height:1.1}",
+  ".rw-hero .compare{margin-top:.4rem;color:#c7d2fe;font-size:1rem}",
+  ".rw-hero .sub{margin-top:.6rem;color:#a5b4fc;font-size:.85rem}",
+  ".rw-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:.75rem;margin:0 0 1rem}",
+  ".rw-stat{background:#161a22;border:1px solid #2d3748;border-radius:8px;padding:.85rem 1rem}",
+  ".rw-stat .label{font-size:.7rem;color:#94a3b8;text-transform:uppercase;letter-spacing:.05em}",
+  ".rw-stat .value{font-size:1.2rem;color:#e4e6eb;font-weight:600;margin-top:.2rem}",
+  ".rw-stat .detail{font-size:.8rem;color:#94a3b8;margin-top:.1rem}",
+  ".rw-channels{list-style:none;padding:0;margin:0}",
+  ".rw-channels li{display:flex;justify-content:space-between;align-items:baseline;padding:.4rem 0;border-bottom:1px solid #1f2937;gap:.5rem}",
+  ".rw-channels li:last-child{border-bottom:0}",
+  ".rw-channels .name{color:#e4e6eb;font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}",
+  ".rw-channels .dur{color:#94a3b8;font-size:.85rem;flex-shrink:0}",
+  ".rw-badges{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:.6rem}",
+  ".rw-badge{background:#0f1115;border:1px solid #2d3748;border-radius:6px;padding:.6rem .8rem;display:flex;gap:.6rem;align-items:flex-start}",
+  ".rw-badge .emoji{font-size:1.4rem;line-height:1}",
+  ".rw-badge .body{flex:1;min-width:0}",
+  ".rw-badge .body .name{font-weight:600;color:#e4e6eb;font-size:.9rem}",
+  ".rw-badge .body .desc{color:#94a3b8;font-size:.75rem;margin-top:.15rem}",
+  ".rw-badge .body .date{color:#64748b;font-size:.7rem;margin-top:.2rem}",
+  ".rw-year-picker{display:flex;gap:.4rem;flex-wrap:wrap;margin:0 0 1rem}",
+  ".rw-year-picker a{padding:.3rem .7rem;border-radius:999px;background:#161a22;border:1px solid #2d3748;color:#cbd5e1;font-size:.8rem;font-weight:600}",
+  ".rw-year-picker a:hover{background:#1f2937;text-decoration:none;color:#fff}",
+  ".rw-year-picker a.current{background:#312e81;border-color:#4338ca;color:#fff}",
+  ".rw-journey{display:flex;justify-content:space-around;gap:.5rem;flex-wrap:wrap}",
+  ".rw-journey .step{text-align:center;flex:1;min-width:100px}",
+  ".rw-journey .step .num{font-size:1.4rem;font-weight:700;color:#e4e6eb}",
+  ".rw-journey .step .when{font-size:.75rem;color:#94a3b8;margin-top:.15rem}",
+  ".rw-journey .step .label{font-size:.7rem;color:#64748b;text-transform:uppercase;letter-spacing:.05em;margin-bottom:.2rem}",
 ].join("");
 
 // Same DOM hooks (`#session-countdown`, `data-remaining-ms`,
@@ -214,8 +245,8 @@ export function renderUserIndexBody(opts: {
     '<ul class="feature-list">',
     '<li><span class="feature-name"><a href="/me/notifications">Notifications</a></span>' +
       '<span class="feature-desc">Opt in or out of DM nudges from Koolbot.</span></li>',
-    '<li><span class="feature-name">Rewind</span>' +
-      '<span class="feature-desc">A personal recap of your activity on this server (coming in #484).</span></li>',
+    '<li><span class="feature-name"><a href="/me/rewind">Rewind</a></span>' +
+      '<span class="feature-desc">Your personal year-in-review of voice activity, top channels, peak day, and badges earned.</span></li>',
     "</ul>",
     "</div>",
     '<div class="card">',
@@ -223,6 +254,206 @@ export function renderUserIndexBody(opts: {
     `<p class="mono">User: ${escapeHtml(opts.discordUserId)} · Guild: ${escapeHtml(opts.guildId)}</p>`,
     "<p>To sign in as a different user, run <code>/config</code> in Discord with that account.</p>",
     "</div>",
+  ].join("");
+}
+
+// --------------------------------------------------------------------
+// Rewind page (#484)
+// --------------------------------------------------------------------
+
+export interface RewindBadgeView {
+  emoji: string;
+  name: string;
+  description: string;
+  earnedAt: string; // ISO date already formatted by the route
+}
+
+export interface RewindChannelView {
+  channelId: string;
+  channelName: string;
+  duration: string; // pre-formatted
+}
+
+export interface RewindBodyOptions {
+  year: number;
+  availableYears: number[]; // includes `year` for the current selection
+  hasData: boolean;
+  totalDuration: string; // pre-formatted "X hr Y min"
+  funComparison: string | null;
+  sessionCount: number;
+  daysActive: number;
+  topChannels: RewindChannelView[];
+  peakDay: { date: string; duration: string } | null;
+  longestStreakDays: number;
+  longestStreakRange: { startDate: string; endDate: string } | null;
+  accolades: RewindBadgeView[];
+  achievements: RewindBadgeView[];
+  annualRank: number | null;
+  annualGuildMembers: number;
+  percentAboveMedian: number | null;
+  weeklyJourney: {
+    first: { isoYear: number; isoWeek: number; rank: number } | null;
+    last: { isoYear: number; isoWeek: number; rank: number } | null;
+    best: { isoYear: number; isoWeek: number; rank: number } | null;
+  };
+}
+
+function renderYearPicker(current: number, years: number[]): string {
+  if (years.length <= 1) return "";
+  const items = years
+    .map((y) => {
+      const cls = y === current ? ' class="current"' : "";
+      return `<a href="/me/rewind/${y}"${cls}>${y}</a>`;
+    })
+    .join("");
+  return `<nav class="rw-year-picker">${items}</nav>`;
+}
+
+function renderBadges(badges: RewindBadgeView[]): string {
+  if (badges.length === 0) {
+    return '<div class="empty">_None this year — there\'s always next year!_</div>';
+  }
+  return (
+    '<div class="rw-badges">' +
+    badges
+      .map(
+        (b) =>
+          '<div class="rw-badge">' +
+          `<div class="emoji">${escapeHtml(b.emoji)}</div>` +
+          '<div class="body">' +
+          `<div class="name">${escapeHtml(b.name)}</div>` +
+          `<div class="desc">${escapeHtml(b.description)}</div>` +
+          `<div class="date">Earned ${escapeHtml(b.earnedAt)}</div>` +
+          "</div></div>",
+      )
+      .join("") +
+    "</div>"
+  );
+}
+
+function renderJourney(j: RewindBodyOptions["weeklyJourney"]): string {
+  if (!j.first && !j.last && !j.best) {
+    return '<div class="empty">No qualifying weekly leaderboards this year.</div>';
+  }
+  const cell = (
+    label: string,
+    entry: { isoYear: number; isoWeek: number; rank: number } | null,
+  ): string => {
+    if (!entry) {
+      return (
+        '<div class="step">' +
+        `<div class="label">${escapeHtml(label)}</div>` +
+        '<div class="num">—</div>' +
+        "</div>"
+      );
+    }
+    return (
+      '<div class="step">' +
+      `<div class="label">${escapeHtml(label)}</div>` +
+      `<div class="num">#${entry.rank}</div>` +
+      `<div class="when">${entry.isoYear} · W${entry.isoWeek}</div>` +
+      "</div>"
+    );
+  };
+  return (
+    '<div class="rw-journey">' +
+    cell("First", j.first) +
+    cell("Best", j.best) +
+    cell("Last", j.last) +
+    "</div>"
+  );
+}
+
+export function renderUserRewindBody(opts: RewindBodyOptions): string {
+  const years = opts.availableYears.includes(opts.year)
+    ? opts.availableYears
+    : [opts.year, ...opts.availableYears];
+  const picker = renderYearPicker(opts.year, years);
+
+  if (!opts.hasData) {
+    return [
+      `<h1>Rewind ${opts.year}</h1>`,
+      '<p class="subtitle">Your personal year-in-review.</p>',
+      picker,
+      '<div class="card">',
+      "<h2>Nothing to recap yet</h2>",
+      `<p class="muted">We didn't find any voice activity or badges for you in ${opts.year}. Hop into a tracked voice channel and your stats will start filling in.</p>`,
+      "</div>",
+    ].join("");
+  }
+
+  const hero = [
+    '<div class="rw-hero">',
+    `<div class="total">${escapeHtml(opts.totalDuration)}</div>`,
+    opts.funComparison
+      ? `<div class="compare">${escapeHtml(opts.funComparison)}</div>`
+      : "",
+    `<div class="sub">${opts.sessionCount} session${opts.sessionCount === 1 ? "" : "s"} across ${opts.daysActive} day${opts.daysActive === 1 ? "" : "s"}</div>`,
+    "</div>",
+  ].join("");
+
+  const peak = opts.peakDay
+    ? `<div class="value">${escapeHtml(opts.peakDay.date)}</div><div class="detail">${escapeHtml(opts.peakDay.duration)} that day</div>`
+    : '<div class="value">—</div>';
+
+  const streak = opts.longestStreakDays
+    ? `<div class="value">${opts.longestStreakDays} day${opts.longestStreakDays === 1 ? "" : "s"}</div>` +
+      (opts.longestStreakRange
+        ? `<div class="detail">${escapeHtml(opts.longestStreakRange.startDate)} → ${escapeHtml(opts.longestStreakRange.endDate)}</div>`
+        : "")
+    : '<div class="value">—</div>';
+
+  const rankStat =
+    opts.annualRank !== null
+      ? `<div class="value">#${opts.annualRank}</div><div class="detail">of ${opts.annualGuildMembers} active members</div>`
+      : '<div class="value">—</div>';
+
+  const medianStat =
+    opts.percentAboveMedian !== null
+      ? opts.percentAboveMedian >= 0
+        ? `<div class="value">+${opts.percentAboveMedian}%</div><div class="detail">vs. the guild median</div>`
+        : `<div class="value">${opts.percentAboveMedian}%</div><div class="detail">vs. the guild median</div>`
+      : '<div class="value">—</div>';
+
+  const channels =
+    opts.topChannels.length === 0
+      ? '<div class="empty">No tracked channels this year.</div>'
+      : '<ul class="rw-channels">' +
+        opts.topChannels
+          .map(
+            (c) =>
+              "<li>" +
+              `<span class="name">${escapeHtml(c.channelName)}</span>` +
+              `<span class="dur">${escapeHtml(c.duration)}</span>` +
+              "</li>",
+          )
+          .join("") +
+        "</ul>";
+
+  return [
+    `<h1>Rewind ${opts.year}</h1>`,
+    '<p class="subtitle">Your personal year-in-review.</p>',
+    picker,
+    hero,
+    '<div class="rw-grid">',
+    '<div class="rw-stat"><div class="label">Peak day</div>' + peak + "</div>",
+    '<div class="rw-stat"><div class="label">Longest streak</div>' +
+      streak +
+      "</div>",
+    '<div class="rw-stat"><div class="label">Annual rank</div>' +
+      rankStat +
+      "</div>",
+    '<div class="rw-stat"><div class="label">Above median</div>' +
+      medianStat +
+      "</div>",
+    "</div>",
+    '<div class="card"><h2>Top channels</h2>' + channels + "</div>",
+    '<div class="card"><h2>Rank journey</h2>' +
+      renderJourney(opts.weeklyJourney) +
+      "</div>",
+    '<div class="card"><h2>Badges earned this year</h2>' +
+      renderBadges([...opts.accolades, ...opts.achievements]) +
+      "</div>",
   ].join("");
 }
 

--- a/src/web/user-layout.ts
+++ b/src/web/user-layout.ts
@@ -311,7 +311,7 @@ function renderYearPicker(current: number, years: number[]): string {
 
 function renderBadges(badges: RewindBadgeView[]): string {
   if (badges.length === 0) {
-    return '<div class="empty">_None this year — there\'s always next year!_</div>';
+    return '<div class="empty">None this year — there\'s always next year!</div>';
   }
   return (
     '<div class="rw-badges">' +

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -36,8 +36,14 @@ import {
   renderUserIndexBody,
   renderUserNotificationsBody,
   renderUserPage,
+  renderUserRewindBody,
   type UserFlashMessage,
 } from "./user-layout.js";
+import {
+  RewindService,
+  formatFunComparison,
+  formatHoursMinutes,
+} from "../services/rewind-service.js";
 import { recordAudit } from "./audit.js";
 import { renderSignedOut } from "./views.js";
 
@@ -112,8 +118,8 @@ const NOTIFICATION_ROW_DEFS: readonly NotificationRowDef[] = [
   {
     key: "rewind",
     label: "Year-in-review (Rewind)",
-    description: "End-of-year personal recap of your activity on this server.",
-    comingSoon: "Toggle works today; the matching DM lands in #484.",
+    description:
+      "End-of-year DM nudge with a link to your personal recap at /me/rewind.",
   },
 ];
 
@@ -171,8 +177,18 @@ export class SelfScopeError extends Error {
   }
 }
 
+function parseYearParam(raw: unknown, fallback: number): number {
+  if (typeof raw !== "string" || raw.length === 0) return fallback;
+  const n = Number.parseInt(raw, 10);
+  // Clamp to a plausible range so a junk URL can't produce a billion-year
+  // query against Mongo. Years before the project existed have no data
+  // anyway; far-future years are nonsense.
+  if (!Number.isFinite(n) || n < 2000 || n > 9999) return fallback;
+  return n;
+}
+
 export function createUserRouter(
-  _client: Client,
+  client: Client,
   requireSession: RequestHandler,
 ): Router {
   const router = Router();
@@ -332,6 +348,99 @@ export function createUserRouter(
       res.redirect(303, flashUrl("/me/notifications", flash));
     }),
   );
+
+  // ---------- Rewind (#484) ----------
+  // `/me/rewind` defaults to the current calendar year (UTC); the
+  // `/:year` variant lets users browse past years. Both gate on
+  // `assertSelfScope` — admin sessions land on their own Rewind.
+  const rewindHandler = asyncHandler(async (req, res) => {
+    const session = req.webSession;
+    if (!session) {
+      res.status(500).type("text/plain").send("session missing");
+      return;
+    }
+    const { userId, guildId } = assertSelfScope(session, {
+      userId: session.discordUserId,
+      guildId: session.guildId,
+    });
+    const currentYear = new Date().getUTCFullYear();
+    const year = parseYearParam(req.params.year, currentYear);
+
+    const summary = await RewindService.getInstance(client).getSummary(
+      userId,
+      guildId,
+      year,
+    );
+
+    if (!summary) {
+      res
+        .status(500)
+        .type("text/html")
+        .send(
+          renderUserPage({
+            title: "Rewind",
+            active: "/me/rewind",
+            body:
+              `<h1>Rewind ${year}</h1>` +
+              '<div class="notice err">Could not load your year-in-review. Please try again later.</div>',
+            csrfToken: getCsrfToken(req),
+            remainingMs: getDisplayedRemainingMs(session),
+            isAdmin: session.role === "admin",
+          }),
+        );
+      return;
+    }
+
+    res.type("text/html").send(
+      renderUserPage({
+        title: `Rewind ${year}`,
+        active: "/me/rewind",
+        body: renderUserRewindBody({
+          year: summary.year,
+          availableYears: summary.availableYears,
+          hasData: summary.hasData,
+          totalDuration: formatHoursMinutes(summary.totalSeconds),
+          funComparison: formatFunComparison(summary.totalSeconds),
+          sessionCount: summary.sessionCount,
+          daysActive: summary.daysActive,
+          topChannels: summary.topChannels.map((c) => ({
+            channelId: c.channelId,
+            channelName: c.channelName,
+            duration: formatHoursMinutes(c.totalSeconds),
+          })),
+          peakDay: summary.peakDay
+            ? {
+                date: summary.peakDay.date,
+                duration: formatHoursMinutes(summary.peakDay.totalSeconds),
+              }
+            : null,
+          longestStreakDays: summary.longestStreakDays,
+          longestStreakRange: summary.longestStreakRange,
+          accolades: summary.accolades.map((a) => ({
+            emoji: a.emoji,
+            name: a.name,
+            description: a.description,
+            earnedAt: a.earnedAt.toISOString().slice(0, 10),
+          })),
+          achievements: summary.achievements.map((a) => ({
+            emoji: a.emoji,
+            name: a.name,
+            description: a.description,
+            earnedAt: a.earnedAt.toISOString().slice(0, 10),
+          })),
+          annualRank: summary.annualRank,
+          annualGuildMembers: summary.annualGuildMembers,
+          percentAboveMedian: summary.percentAboveMedian,
+          weeklyJourney: summary.weeklyJourney,
+        }),
+        csrfToken: getCsrfToken(req),
+        remainingMs: getDisplayedRemainingMs(session),
+        isAdmin: session.role === "admin",
+      }),
+    );
+  });
+  router.get("/rewind", rewindHandler);
+  router.get("/rewind/:year", rewindHandler);
 
   // ---------- Finish (sign out) ----------
   // CSRF-checked, same pattern as `/admin/finish`. The session row is


### PR DESCRIPTION
## Summary

Implements #484 — a Spotify-Wrapped-style **personal year-in-review** at `/me/rewind` (with `/me/rewind/:year` for past years) and a one-shot **end-of-year DM nudge** gated by the per-user `prefs.rewind` opt-out from #482.

The page itself is always available; the cron job only schedules the DM nudge.

## What's in the page

- **Hero**: total voice time + fun comparison (≈ N movies / flights / songs)
- **Stats grid**: peak day, longest streak, annual rank, % above guild median
- **Top channels**: top-3 by time spent
- **Rank journey**: first / best / last weekly leaderboard rank (single `$setWindowFields` aggregation)
- **Badges**: accolades + achievements earned this year, with unlock dates
- **Year picker**: only offers years for which the user has data
- **Empty state**: years with zero data show a friendly empty card

## Service layer

- `RewindService` — pure-read singleton, takes `(userId, guildId, year)` and returns a `RewindSummary`. Reads from `VoiceChannelTracking` + `UserAchievements`; no new persistence in v1. Pure helpers (`computeTopChannels`, `computePeakDay`, `computeLongestStreak`, `formatHoursMinutes`, `formatFunComparison`, etc.) are exported and unit-tested in isolation.
- `RewindNudgeService` — cron-driven singleton modeled on `DigestService`. Default schedule `0 10 30 12 *` (Dec 30 at 10:00). Honours `prefs.rewind`, silently skips DM-closed users (Discord code 50007), counts other errors as `failed`.

## Config

New `rewind` category with three keys:

| Key | Default | Description |
|---|---|---|
| `rewind.enabled` | `false` | Master switch for the nudge (page unaffected) |
| `rewind.cron` | `"0 10 30 12 *"` | When to send the nudge |
| `rewind.min_minutes` | `60` | Minimum annual minutes to receive the nudge |

Added to `ConfigSchema`, `defaultConfig`, `settingsMetadata`, `categoryMetadata`, and the Mongo `Config` model's category enum.

## WebUI changes

- New route handlers in `src/web/user-routes.ts` for `/me/rewind` and `/me/rewind/:year`, both behind `assertSelfScope`.
- New nav item; the overview Rewind tile is now a working link.
- The `comingSoon` hint on the rewind row of `/me/notifications` is removed (toggle stays).
- New `renderUserRewindBody()` and rewind-specific CSS in `src/web/user-layout.ts`.

## Wiring

`RewindNudgeService` is instantiated alongside `DigestService` in `src/index.ts`, started after `digestService.start()`, and destroyed in the graceful-shutdown timer-cleanup step.

## Tests

- 34 new tests for `RewindService` (pure helpers + aggregation flow, mocks the Mongoose models via `jest.unstable_mockModule` with a dynamic import — see the comment at the top of the test file for why static imports would break the mock).
- New `rewind-nudge-service` suite covering opt-out, DM-closed silent skip, fetch-failure → `failed`, disabled / missing-guild guards.
- New `/me/rewind` route tests: current year, year param, empty state, junk param fallback, service-failure path.
- Updated user-routes test: rewind row no longer renders a "coming soon" hint.
- Added `rewind` to known categories in `settings-metadata.test.ts`.
- Added `rewind.enabled: false` to `EXPECTED_ENABLED_DEFAULTS` in `config-schema.test.ts`.

**873 tests pass · 0 TS errors · lint clean · Prettier clean · markdownlint clean.**

## Docs

- `SETTINGS.md`: new "Rewind (Year-in-Review)" section + quick-reference entry.
- `WEBUI.md`: Rewind row in the user-surface table + behaviour paragraph.

## Out of scope (called out in the issue as follow-ups)

- Shareable image / Open Graph card generation
- Server-wide Rewind ("the guild in <year>")
- Caching layer — only if real data shows it's needed
- Text-message counts (would need a new tracking collection / message event listener — better as its own issue)

## Test plan

- [ ] `npm run check && npm test` is green
- [ ] Open `/me/rewind` for a user with data — verify hero, stats grid, top channels, rank journey, badges
- [ ] Open `/me/rewind/:year` for a year with no data — verify empty state and year picker
- [ ] Toggle `prefs.rewind` off on `/me/notifications`, run `RewindNudgeService.runNow()` — confirm the user is skipped
- [ ] Flip `rewind.enabled` from `false` → `true` while the bot is running — cron job picks up via reload callback

https://claude.ai/code/session_01W5PaNEpq7dGmrmpabH4qrs

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5PaNEpq7dGmrmpabH4qrs)_