### PR TITLE
feat(web): wizard Previous button + cascading disable on master toggle (closes #485)

### DIFF
--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "@jest/globals";
 import {
+  findCascadeMasterKey,
   parseCronToPickerState,
   renderAnnouncementsPage,
   renderBootstrapPage,
@@ -1136,6 +1137,186 @@ describe("renderWizardStepPage", () => {
     });
     expect(html).toContain("Review →");
     expect(html).not.toContain("Next →");
+  });
+
+  it("omits the Previous button on the first step (#485)", () => {
+    const html = renderWizardStepPage({
+      ...COMMON,
+      stepIndex: 0,
+      totalSteps: 3,
+      featureKey: "quotes",
+      settingKeys: [],
+      currentValues: {},
+      defaultValues: {},
+      metadata: {},
+    });
+    expect(html).not.toContain("← Previous");
+  });
+
+  it("shows a Previous button linking to the prior step on later steps (#485)", () => {
+    const html = renderWizardStepPage({
+      ...COMMON,
+      stepIndex: 2,
+      totalSteps: 3,
+      featureKey: "quotes",
+      settingKeys: [],
+      currentValues: {},
+      defaultValues: {},
+      metadata: {},
+    });
+    expect(html).toContain("← Previous");
+    expect(html).toContain('href="/admin/wizard?step=1"');
+  });
+
+  it("marks the feature master toggle and form scope for cascading disable (#485)", () => {
+    const html = renderWizardStepPage({
+      ...COMMON,
+      stepIndex: 0,
+      totalSteps: 1,
+      featureKey: "voicetracking",
+      settingKeys: [
+        "voicetracking.enabled",
+        "voicetracking.announcements.enabled",
+        "voicetracking.announcements.channel_id",
+      ],
+      currentValues: {
+        "voicetracking.enabled": true,
+        "voicetracking.announcements.enabled": false,
+        "voicetracking.announcements.channel_id": "",
+      },
+      defaultValues: {
+        "voicetracking.enabled": false,
+        "voicetracking.announcements.enabled": false,
+        "voicetracking.announcements.channel_id": "",
+      },
+      metadata: {},
+    });
+    // The step form is the cascade scope.
+    expect(html).toContain(
+      'action="/admin/wizard/step/0" data-cascade-scope',
+    );
+    // Only the top-level feature toggle is the master; the sub-toggle is a
+    // dependent (no data-cascade-master attribute).
+    expect(html).toMatch(
+      /name="voicetracking.enabled"[^>]*value="true"[^>]*data-cascade-master/,
+    );
+    expect(html).not.toMatch(
+      /name="voicetracking.announcements.enabled"[^>]*data-cascade-master/,
+    );
+  });
+});
+
+describe("findCascadeMasterKey", () => {
+  const row = (key: string, type: string) => ({
+    key,
+    label: key,
+    current: undefined,
+    defaultValue: undefined,
+    type,
+    description: "",
+    category: key.split(".")[0],
+  });
+
+  it("returns the shortest boolean .enabled key as the master", () => {
+    expect(
+      findCascadeMasterKey([
+        row("voicetracking.enabled", "boolean"),
+        row("voicetracking.announcements.enabled", "boolean"),
+        row("voicetracking.announcements.channel_id", "channel"),
+      ]),
+    ).toBe("voicetracking.enabled");
+  });
+
+  it("ignores non-boolean .enabled keys", () => {
+    expect(
+      findCascadeMasterKey([row("quotes.enabled", "string")]),
+    ).toBeNull();
+  });
+
+  it("returns null when no .enabled key exists", () => {
+    expect(
+      findCascadeMasterKey([
+        row("quotes.max_length", "number"),
+        row("quotes.channel_id", "channel"),
+      ]),
+    ).toBeNull();
+  });
+});
+
+describe("renderSettingsPage cascading disable (#485)", () => {
+  it("marks the section master toggle and scopes the form when a .enabled row exists", () => {
+    const html = renderSettingsPage({
+      ...COMMON,
+      groups: [
+        {
+          category: "voicechannels",
+          rows: [
+            {
+              key: "voicechannels.enabled",
+              current: true,
+              defaultValue: false,
+              type: "boolean",
+              description: "",
+              category: "voicechannels",
+            },
+            {
+              key: "voicechannels.controlpanel.enabled",
+              current: true,
+              defaultValue: false,
+              type: "boolean",
+              description: "",
+              category: "voicechannels",
+            },
+            {
+              key: "voicechannels.lobby.name",
+              current: "Lobby",
+              defaultValue: "Lobby",
+              type: "string",
+              description: "",
+              category: "voicechannels",
+            },
+          ],
+        },
+      ],
+    });
+    expect(html).toContain(
+      'action="/admin/settings/save-section" data-cascade-scope',
+    );
+    expect(html).toMatch(
+      /name="value_voicechannels.enabled"[^>]*data-cascade-master/,
+    );
+    // The sub-toggle is a dependent, not a master.
+    expect(html).not.toMatch(
+      /name="value_voicechannels.controlpanel.enabled"[^>]*data-cascade-master/,
+    );
+  });
+
+  it("does not scope sections without a boolean .enabled row", () => {
+    const html = renderSettingsPage({
+      ...COMMON,
+      groups: [
+        {
+          category: "quotes",
+          rows: [
+            {
+              key: "quotes.max_length",
+              current: 500,
+              defaultValue: 1000,
+              type: "number",
+              description: "",
+              category: "quotes",
+            },
+          ],
+        },
+      ],
+    });
+    // The save-section form carries no cascade-scope attribute, and no
+    // control is tagged as a master. (The shared client script — which
+    // references these attribute names as query selectors — is always
+    // embedded, so assert against the form/control markup specifically.)
+    expect(html).toContain('action="/admin/settings/save-section">');
+    expect(html).not.toMatch(/<form[^>]*data-cascade-scope/);
+    expect(html).not.toMatch(/name="value_[^"]*"[^>]*data-cascade-master/);
   });
 });
 

--- a/__tests__/web/write-routes.test.ts
+++ b/__tests__/web/write-routes.test.ts
@@ -5,7 +5,10 @@
  */
 
 import { describe, it, expect } from "@jest/globals";
-import { coerceConfigValue } from "../../src/web/write-routes.js";
+import {
+  coerceConfigValue,
+  findSectionMasterKey,
+} from "../../src/web/write-routes.js";
 import {
   BOOTSTRAP_VARS,
   PROTECTED_KEYS,
@@ -152,5 +155,29 @@ describe("coerceConfigValue", () => {
   it("rejects an array payload for a number key", () => {
     const r = coerceConfigValue("quotes.max_length", [500]);
     expect(r.ok).toBe(false);
+  });
+});
+
+describe("findSectionMasterKey", () => {
+  it("returns the shortest boolean .enabled key in the section (#485)", () => {
+    expect(
+      findSectionMasterKey([
+        "voicechannels.enabled",
+        "voicechannels.controlpanel.enabled",
+        "voicechannels.lobby.name",
+      ]),
+    ).toBe("voicechannels.enabled");
+  });
+
+  it("ignores .enabled keys that aren't boolean in the schema", () => {
+    // `quotes.channel_id` ends with neither; a hypothetical non-boolean
+    // `.enabled` (not present in defaultConfig) is also skipped.
+    expect(
+      findSectionMasterKey(["quotes.channel_id", "quotes.max_length"]),
+    ).toBeNull();
+  });
+
+  it("returns null for an unknown key that merely ends with .enabled", () => {
+    expect(findSectionMasterKey(["bogus.feature.enabled"])).toBeNull();
   });
 });

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -212,6 +212,8 @@ const STYLE = [
   ".field-row{display:flex;flex-direction:column;gap:.25rem;margin-bottom:.75rem}",
   ".field-row > label{font-size:.85rem;color:#94a3b8}",
   ".field-row .help{font-size:.75rem;color:#6b7280;margin-top:.15rem}",
+  // Cascade greying: rows whose master `.enabled` toggle is off (#485).
+  ".cascade-off{opacity:.5}",
   ".wizard-features{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:.75rem;margin-bottom:1rem}",
   ".feature-card{background:#0f1115;border:1px solid #2d3748;border-radius:6px;padding:.75rem 1rem;display:flex;gap:.75rem;align-items:flex-start}",
   ".feature-card input{margin-top:.2rem;flex-shrink:0}",
@@ -343,6 +345,27 @@ const CRON_PICKER_SCRIPT =
   "refresh()}" +
   "document.querySelectorAll('.cron-picker').forEach(wire)})();";
 
+// Cascading disable (#485). When a master `.enabled` checkbox
+// (`[data-cascade-master]`) inside a `[data-cascade-scope]` container is
+// unchecked, every other input/select/textarea in that scope is disabled
+// and its row greyed via `.cascade-off`. Re-checking re-enables them with
+// their values intact (we only toggle `disabled`, never the value). Hidden
+// inputs (csrf/keys/category) and buttons are left alone so the form still
+// submits correctly. Used by both the wizard step form and the per-section
+// Settings forms.
+const CASCADE_DISABLE_SCRIPT =
+  "(function(){" +
+  "function wire(master){" +
+  "var scope=master.closest('[data-cascade-scope]');if(!scope)return;" +
+  "function apply(){var off=!master.checked;" +
+  "scope.querySelectorAll('input,select,textarea').forEach(function(el){" +
+  "if(el===master||el.type==='hidden')return;" +
+  "el.disabled=off;" +
+  "var row=el.closest('.field-row,tr');" +
+  "if(row)row.classList.toggle('cascade-off',off)})}" +
+  "master.addEventListener('change',apply);apply()}" +
+  "document.querySelectorAll('[data-cascade-master]').forEach(wire)})();";
+
 function renderNav(
   active: string,
   navFeatureStatus?: NavFeatureStatus,
@@ -394,6 +417,7 @@ export function renderAdminPage(opts: AdminPageOptions): string {
     `<main>${opts.body}</main></div>`,
     `<script>${SCRIPT}</script>`,
     `<script>${CRON_PICKER_SCRIPT}</script>`,
+    `<script>${CASCADE_DISABLE_SCRIPT}</script>`,
     "</body></html>",
   ].join("");
 }

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -384,6 +384,28 @@ export function settingValueFieldName(key: string): string {
   return `value_${key}`;
 }
 
+/**
+ * Pick the cascade "master" toggle for a settings section: the boolean
+ * `.enabled` key with the fewest dotted segments (the top-level feature
+ * switch). Sub-feature toggles like `voicetracking.announcements.enabled`
+ * are dependents, not masters. Returns null when the section has no
+ * `.enabled` boolean to gate on. Shared by the wizard and Settings page so
+ * both surfaces grey out the same way (issue #485).
+ */
+export function findCascadeMasterKey(rows: SettingRow[]): string | null {
+  let master: SettingRow | null = null;
+  for (const r of rows) {
+    if (r.type !== "boolean" || !r.key.endsWith(".enabled")) continue;
+    if (
+      master === null ||
+      r.key.split(".").length < master.key.split(".").length
+    ) {
+      master = r;
+    }
+  }
+  return master?.key ?? null;
+}
+
 function renderSettingControl(
   r: SettingRow,
   pickers: {
@@ -391,6 +413,7 @@ function renderSettingControl(
     categoryChannels: ChannelOption[];
     roles: RoleOption[];
   },
+  isCascadeMaster = false,
 ): string {
   const primitive = coerceToDisplayValue(r.current);
   const currentStr = typeof primitive === "string" ? primitive : "";
@@ -398,9 +421,10 @@ function renderSettingControl(
 
   if (r.type === "boolean") {
     const checked = primitive === true ? " checked" : "";
+    const masterAttr = isCascadeMaster ? " data-cascade-master" : "";
     return (
       `<label class="checkbox" style="display:inline-flex;gap:.4rem;align-items:center;cursor:pointer">` +
-      `<input type="checkbox" name="${valueName}" value="true"${checked}> ` +
+      `<input type="checkbox" name="${valueName}" value="true"${checked}${masterAttr}> ` +
       `<span class="mono">${primitive === true ? "true" : "false"}</span>` +
       `</label>`
     );
@@ -487,6 +511,13 @@ export function renderSettingsPage(props: SettingsProps): string {
         title: g.category,
         description: "",
       };
+      // The section's top-level feature toggle is the cascade master: the
+      // shortest `.enabled` boolean key in the section (e.g.
+      // `voicechannels.enabled`, not `voicechannels.controlpanel.enabled`).
+      // When it's off, every other control in the section greys out and is
+      // ignored on save — the save-section handler skips the dependents so
+      // they aren't clobbered (issue #485).
+      const cascadeMasterKey = findCascadeMasterKey(g.rows);
       const rows = g.rows
         .map(
           (r) => `<tr>
@@ -495,7 +526,7 @@ export function renderSettingsPage(props: SettingsProps): string {
   <code class="mono muted" style="font-size:.85em">${escapeHtml(r.key)}</code>
   <input type="hidden" name="keys" value="${escapeHtml(r.key)}">
 </td>
-<td>${renderSettingControl(r, pickers)}${renderResetButton(r.key)}</td>
+<td>${renderSettingControl(r, pickers, r.key === cascadeMasterKey)}${renderResetButton(r.key)}</td>
 <td><span class="tag tag-info">${escapeHtml(r.type)}</span></td>
 <td style="white-space:nowrap">${formatValue(r.defaultValue)}</td>
 <td class="muted">${escapeHtml(r.description)}</td>
@@ -508,11 +539,12 @@ export function renderSettingsPage(props: SettingsProps): string {
       // One <form> per category. Save submits every row's value in one
       // atomic request; Reset buttons inside the same form use formaction
       // to retarget /admin/settings/reset for a single key (issue #433).
+      const scopeAttr = cascadeMasterKey ? " data-cascade-scope" : "";
       return `
 <div class="card">
   <h2>${escapeHtml(meta.title)}</h2>
   ${descHtml}
-  <form method="POST" action="/admin/settings/save-section">
+  <form method="POST" action="/admin/settings/save-section"${scopeAttr}>
     <input type="hidden" name="_csrf" value="${csrf}">
     <input type="hidden" name="category" value="${escapeHtml(g.category)}">
     <table>
@@ -854,6 +886,12 @@ export function renderWizardStepPage(props: WizardStepPageProps): string {
     desc: "",
   };
 
+  // The feature's top-level `.enabled` toggle is the "master" for this step:
+  // when it's off, every other control greys out and is ignored on submit
+  // (issue #485). Sub-toggles like `voicetracking.announcements.enabled` are
+  // dependents, not masters.
+  const masterKey = `${props.featureKey}.enabled`;
+
   const fields = props.settingKeys
     .map((k) => {
       const current = props.currentValues[k];
@@ -877,7 +915,8 @@ export function renderWizardStepPage(props: WizardStepPageProps): string {
       let control: string;
       if (type === "boolean") {
         const checked = current === true ? " checked" : "";
-        control = `<label class="checkbox" style="display:inline-flex;gap:.4rem;align-items:center;cursor:pointer"><input type="checkbox" id="${escapeHtml(inputId)}" name="${escapeHtml(k)}" value="true"${checked}> Enable</label>`;
+        const masterAttr = k === masterKey ? " data-cascade-master" : "";
+        control = `<label class="checkbox" style="display:inline-flex;gap:.4rem;align-items:center;cursor:pointer"><input type="checkbox" id="${escapeHtml(inputId)}" name="${escapeHtml(k)}" value="true"${checked}${masterAttr}> Enable</label>`;
       } else if (type === "number") {
         control = `<input type="number" id="${escapeHtml(inputId)}" name="${escapeHtml(k)}" value="${escapeHtml(display)}">`;
       } else {
@@ -896,15 +935,26 @@ export function renderWizardStepPage(props: WizardStepPageProps): string {
   const nextLabel =
     props.stepIndex + 1 < props.totalSteps ? "Next →" : "Review →";
 
+  // A "← Previous" link appears on every step after the first. It's a plain
+  // GET back to the prior step — the wizard session already holds the saved
+  // values, and the step renderer pre-fills from `wizard.getConfiguration`,
+  // so navigating back preserves in-progress state without re-submitting
+  // this step's form (issue #485).
+  const previousButton =
+    props.stepIndex >= 1
+      ? `<a href="/admin/wizard?step=${props.stepIndex - 1}" class="btn">← Previous</a>`
+      : "";
+
   const body = `
 <h1>${escapeHtml(info.name)} <span class="muted" style="font-size:1rem">${escapeHtml(stepLabel)}</span></h1>
 <p class="subtitle">${escapeHtml(info.desc)}</p>
 ${renderFlash(props.flash)}
-<form method="POST" action="/admin/wizard/step/${props.stepIndex}">
+<form method="POST" action="/admin/wizard/step/${props.stepIndex}" data-cascade-scope>
   <input type="hidden" name="_csrf" value="${csrf}">
   <div class="card">${fields}</div>
   <div class="actions">
     <button type="submit" class="btn btn-primary">${nextLabel}</button>
+    ${previousButton}
     <a href="/admin/wizard" class="btn">← Back to features</a>
   </div>
 </form>

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -239,6 +239,27 @@ export function coerceConfigValue(
   return { ok: true, value: String(raw ?? "") };
 }
 
+/**
+ * Pick the cascade "master" toggle for a Settings section: the boolean
+ * `.enabled` key with the fewest dotted segments among the submitted keys
+ * (the top-level feature switch). Mirrors `findCascadeMasterKey` in
+ * admin-views so the server skips the same dependents the client greyed out
+ * (issue #485). Returns null when the section has no boolean `.enabled` key.
+ */
+export function findSectionMasterKey(keys: string[]): string | null {
+  let master: string | null = null;
+  for (const key of keys) {
+    if (!key.endsWith(".enabled")) continue;
+    if (typeof defaultConfig[key as keyof typeof defaultConfig] !== "boolean") {
+      continue;
+    }
+    if (master === null || key.split(".").length < master.split(".").length) {
+      master = key;
+    }
+  }
+  return master;
+}
+
 function getCsrfFromReq(req: AuthenticatedRequest): string {
   return (req as Request & { csrfToken?: string }).csrfToken ?? "";
 }
@@ -429,6 +450,19 @@ export function createWriteRouter(
         return;
       }
 
+      // Cascading disable (#485): when the section's master `.enabled` toggle
+      // (the shortest boolean `.enabled` key in the section) is unchecked, the
+      // dependent controls were greyed out client-side and aren't submitted.
+      // Honour that here — write only the master flag and leave the rest
+      // untouched, so disabling a feature can't silently clobber its
+      // sub-settings (an absent number field would otherwise be rejected, an
+      // absent string blanked).
+      const masterKey = findSectionMasterKey(keys);
+      const masterOff =
+        masterKey !== null &&
+        body[settingValueFieldName(masterKey)] !== "true" &&
+        body[settingValueFieldName(masterKey)] !== true;
+
       // Phase 1: coerce every value before touching the DB. An array of
       // unique keys is required so a duplicate hidden input can't trick
       // the handler into double-writing or mis-counting rejections.
@@ -441,6 +475,7 @@ export function createWriteRouter(
       for (const key of keys) {
         if (seen.has(key)) continue;
         seen.add(key);
+        if (masterOff && key !== masterKey) continue;
         const raw = body[settingValueFieldName(key)];
         const r = coerceConfigValue(key, raw);
         if (r.ok) {
@@ -1081,9 +1116,23 @@ export function createWriteRouter(
 
       const featureKey = state.selectedFeatures[stepIndex];
       const settingKeys = WIZARD_FEATURE_SETTINGS[featureKey] ?? [];
+
+      // Cascading disable (#485): when the feature's master `.enabled` toggle
+      // is off, the dependent controls were greyed out client-side and aren't
+      // submitted. Mirror that on the server — record only `<feature>.enabled
+      // = false` and skip the rest, so absent dependents don't surface as
+      // bogus "invalid input" drops (a missing number field would otherwise
+      // fail coercion).
+      const masterKey = `${featureKey}.enabled`;
+      const masterOff =
+        settingKeys.includes(masterKey) &&
+        (req.body as Record<string, unknown> | undefined)?.[masterKey] !==
+          "true";
+
       const saved: Record<string, unknown> = {};
       const dropped: Array<{ key: string; reason: string }> = [];
       for (const k of settingKeys) {
+        if (masterOff && k !== masterKey) continue;
         const raw = (req.body as Record<string, unknown> | undefined)?.[k];
         const coerced = coerceConfigValue(k, raw);
         if (coerced.ok) {


### PR DESCRIPTION
## Summary

Two UX improvements to the admin setup wizard and Settings page, per #485.

### a) Previous button
Every wizard step after the first (`stepIndex ≥ 1`) now shows a **"← Previous"** link back to the prior step. It's a plain `GET /admin/wizard?step=N-1` — the `WizardSession` already holds saved values and the step renderer pre-fills from `wizard.getConfiguration`, so navigating back preserves in-progress state without re-submitting the current form. The existing "← Back to features" link is retained alongside it.

### b) Cascading disable when a feature is toggled off
When a feature's top-level `.enabled` toggle is unchecked, every other control in that step's form greys out and is ignored on submit:

- A shared client script wires `[data-cascade-master]` checkboxes to their `[data-cascade-scope]` container, toggling `disabled` on dependent `input`/`select`/`textarea` (values left intact so re-checking restores them) and a `.cascade-off` greying class on the row. Hidden inputs (csrf/keys/category) and buttons are untouched so the form still submits.
- The **master** is the shortest boolean `.enabled` key in the scope (e.g. `voicechannels.enabled`, not `voicechannels.controlpanel.enabled`); sub-toggles are dependents.
- The same markup is applied to the per-section forms on `/admin/settings`.

Server-side mirrors this so absent dependents aren't clobbered (a missing number field would otherwise fail coercion; a missing string would blank out): both the `POST /wizard/step/:n` handler and the `POST /settings/save-section` handler skip dependent keys when the section's master `.enabled` resolves false, writing only the feature-off flag.

## Acceptance
- [x] Every wizard step at index ≥ 1 shows a "← Previous" button that preserves wizard state and pre-fills the prior step.
- [x] Toggling a master `.enabled` checkbox off greys out and disables every other control in that step's form.
- [x] Toggling it back on re-enables them with their prior values intact (only `disabled` is toggled, never the value).
- [x] The Settings page (non-wizard) gets the same cascading-disable behaviour.

## Tests
- `findCascadeMasterKey` / `findSectionMasterKey` unit tests (shortest `.enabled`, boolean-only, null cases).
- Wizard step: Previous button presence/absence + target, master/scope markup.
- Settings page: master/scope markup, and no scope when a section has no boolean `.enabled`.
- Full suite green (888 passed, 1 skipped); lint clean; `tsc --noEmit` clean.

## Notes
On the Settings page, turning a feature off and saving now intentionally ignores that section's other fields (cascading semantics) rather than clobbering them — matching the wizard.

https://claude.ai/code/session_015VpWZULM1Psnk369A9L3J5

---
_Generated by [Claude Code](https://claude.ai/code/session_015VpWZULM1Psnk369A9L3J5)_