### PR TITLE
feat(webui): render fixed-option settings as selectors

### DIFF
--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -535,6 +535,118 @@ describe("renderSettingsPage", () => {
       '<option value="999-deleted" selected>(missing) 999-deleted</option>',
     );
   });
+
+  it("renders an options-typed setting as a single-select with the current value pre-selected", () => {
+    const html = renderSettingsPage({
+      ...COMMON,
+      textChannels: [],
+      categoryChannels: [],
+      roles: [],
+      groups: [
+        {
+          category: "leaderboard_roles",
+          rows: [
+            {
+              key: "leaderboard_roles.period",
+              label: "Period",
+              current: "month",
+              defaultValue: "alltime",
+              type: "string",
+              description: "",
+              category: "leaderboard_roles",
+              options: [
+                { value: "week", label: "This week" },
+                { value: "month", label: "This month" },
+                { value: "alltime", label: "All time" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(html).toContain('<select name="value_leaderboard_roles.period">');
+    expect(html).toContain('<option value="week">This week</option>');
+    expect(html).toContain(
+      '<option value="month" selected>This month</option>',
+    );
+    expect(html).toContain('<option value="alltime">All time</option>');
+    // No free-text input is emitted for an options key.
+    expect(html).not.toContain(
+      '<input type="text" name="value_leaderboard_roles.period"',
+    );
+  });
+
+  it("surfaces an out-of-range options value as a selected `(unknown)` option", () => {
+    const html = renderSettingsPage({
+      ...COMMON,
+      textChannels: [],
+      categoryChannels: [],
+      roles: [],
+      groups: [
+        {
+          category: "leaderboard_roles",
+          rows: [
+            {
+              key: "leaderboard_roles.period",
+              label: "Period",
+              current: "fortnight",
+              defaultValue: "alltime",
+              type: "string",
+              description: "",
+              category: "leaderboard_roles",
+              options: [
+                { value: "week", label: "This week" },
+                { value: "month", label: "This month" },
+                { value: "alltime", label: "All time" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(html).toContain(
+      '<option value="fortnight" selected>(unknown) fortnight</option>',
+    );
+    // None of the known options should be selected when the stored value is
+    // out of range.
+    expect(html).not.toMatch(/value="(week|month|alltime)" selected/);
+  });
+
+  it("surfaces an empty options value as a selected `(choose a value)` placeholder rather than defaulting to the first option", () => {
+    const html = renderSettingsPage({
+      ...COMMON,
+      textChannels: [],
+      categoryChannels: [],
+      roles: [],
+      groups: [
+        {
+          category: "leaderboard_roles",
+          rows: [
+            {
+              key: "leaderboard_roles.period",
+              label: "Period",
+              current: "",
+              defaultValue: "alltime",
+              type: "string",
+              description: "",
+              category: "leaderboard_roles",
+              options: [
+                { value: "week", label: "This week" },
+                { value: "month", label: "This month" },
+                { value: "alltime", label: "All time" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    // An empty stored value is out-of-range for an options key (coerceConfigValue
+    // rejects ""), so it must not silently select+submit the first valid option.
+    expect(html).toContain(
+      '<option value="" selected>(choose a value)</option>',
+    );
+    expect(html).not.toMatch(/value="(week|month|alltime)" selected/);
+  });
 });
 
 describe("renderPermissionsPage", () => {
@@ -1134,6 +1246,67 @@ describe("renderWizardStepPage", () => {
     expect(html).toContain("Enable VC");
   });
 
+  it("renders an options-backed key as a <select> using the raw key name and pre-selects the current value", () => {
+    const html = renderWizardStepPage({
+      ...COMMON,
+      stepIndex: 0,
+      totalSteps: 1,
+      featureKey: "leaderboard_roles",
+      settingKeys: ["leaderboard_roles.period"],
+      currentValues: { "leaderboard_roles.period": "month" },
+      defaultValues: { "leaderboard_roles.period": "alltime" },
+      metadata: {
+        "leaderboard_roles.period": {
+          description: "Activity window",
+          category: "leaderboard_roles",
+          options: [
+            { value: "week", label: "This week" },
+            { value: "month", label: "This month" },
+            { value: "alltime", label: "All time" },
+          ],
+        },
+      },
+    });
+    // The wizard posts raw key names (not the value_-prefixed settings form
+    // field), so the select must carry the bare key.
+    expect(html).toContain('<select name="leaderboard_roles.period">');
+    expect(html).toContain(
+      '<option value="month" selected>This month</option>',
+    );
+    expect(html).toContain('<option value="week">This week</option>');
+    // No free-text input for an options key.
+    expect(html).not.toContain(
+      '<input type="text" id="wiz-leaderboard_roles.period"',
+    );
+  });
+
+  it("surfaces an out-of-range options value in the wizard as a selected `(unknown)` option", () => {
+    const html = renderWizardStepPage({
+      ...COMMON,
+      stepIndex: 0,
+      totalSteps: 1,
+      featureKey: "leaderboard_roles",
+      settingKeys: ["leaderboard_roles.period"],
+      currentValues: { "leaderboard_roles.period": "fortnight" },
+      defaultValues: { "leaderboard_roles.period": "alltime" },
+      metadata: {
+        "leaderboard_roles.period": {
+          description: "Activity window",
+          category: "leaderboard_roles",
+          options: [
+            { value: "week", label: "This week" },
+            { value: "month", label: "This month" },
+            { value: "alltime", label: "All time" },
+          ],
+        },
+      },
+    });
+    expect(html).toContain(
+      '<option value="fortnight" selected>(unknown) fortnight</option>',
+    );
+    expect(html).not.toMatch(/value="(week|month|alltime)" selected/);
+  });
+
   it("renders a flash banner when coercion drops fields", () => {
     const html = renderWizardStepPage({
       ...COMMON,
@@ -1221,9 +1394,7 @@ describe("renderWizardStepPage", () => {
       metadata: {},
     });
     // The step form is the cascade scope.
-    expect(html).toContain(
-      'action="/admin/wizard/step/0" data-cascade-scope',
-    );
+    expect(html).toContain('action="/admin/wizard/step/0" data-cascade-scope');
     // Only the top-level feature toggle is the master; the sub-toggle is a
     // dependent (no data-cascade-master attribute).
     expect(html).toMatch(
@@ -1257,9 +1428,7 @@ describe("findCascadeMasterKey", () => {
   });
 
   it("ignores non-boolean .enabled keys", () => {
-    expect(
-      findCascadeMasterKey([row("quotes.enabled", "string")]),
-    ).toBeNull();
+    expect(findCascadeMasterKey([row("quotes.enabled", "string")])).toBeNull();
   });
 
   it("returns null when no .enabled key exists", () => {

--- a/__tests__/web/write-routes.test.ts
+++ b/__tests__/web/write-routes.test.ts
@@ -189,6 +189,39 @@ describe("coerceConfigValue", () => {
     const r = coerceConfigValue("quotes.max_length", [500]);
     expect(r.ok).toBe(false);
   });
+
+  describe("fixed-options (selector) keys", () => {
+    // leaderboard_roles.period is a string key with an `options` whitelist
+    // (week / month / alltime); values outside it must be refused.
+    it("accepts a value in the options whitelist", () => {
+      expect(
+        coerceConfigValue("leaderboard_roles.period", "week"),
+      ).toEqual({ ok: true, value: "week" });
+      expect(
+        coerceConfigValue("leaderboard_roles.period", "month"),
+      ).toEqual({ ok: true, value: "month" });
+      expect(
+        coerceConfigValue("leaderboard_roles.period", "alltime"),
+      ).toEqual({ ok: true, value: "alltime" });
+    });
+
+    it("rejects a value outside the options whitelist with an enumerated reason", () => {
+      const r = coerceConfigValue("leaderboard_roles.period", "daily");
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.reason).toMatch(/invalid option/i);
+        // The error enumerates the valid choices so the operator can fix it.
+        expect(r.reason).toContain("week");
+        expect(r.reason).toContain("month");
+        expect(r.reason).toContain("alltime");
+      }
+    });
+
+    it("rejects an empty value for an options key (no blank choice)", () => {
+      const r = coerceConfigValue("leaderboard_roles.period", "");
+      expect(r.ok).toBe(false);
+    });
+  });
 });
 
 describe("findSectionMasterKey", () => {

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -260,11 +260,29 @@ export type SettingType =
   | "channel_list"
   | "role_list";
 
+/**
+ * A single choice in a fixed-options setting. `value` is the raw value
+ * stored in the DB (and validated against on POST); `label` is the
+ * human-readable text shown in the `<select>` option.
+ */
+export interface SettingOption {
+  value: string;
+  label: string;
+}
+
 export interface SettingMetadata {
   label: string;
   description: string;
   category: string;
   type: SettingType;
+  /**
+   * When present, the WebUI renders this setting as a `<select>` whose
+   * choices are exactly these options (instead of a free-text input), and
+   * server-side POST validation refuses any value not in this whitelist.
+   * Only meaningful for `string`-typed keys with a fixed enumerated set of
+   * valid values (e.g. `leaderboard_roles.period`).
+   */
+  options?: SettingOption[];
 }
 
 /**
@@ -750,11 +768,16 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
     type: "boolean",
   },
   "leaderboard_roles.period": {
-    label: "Leaderboard period",
+    label: "Period",
     description:
-      'Leaderboard period to evaluate: "week", "month", or "alltime".',
+      "Activity window the leaderboard role tiers are computed from.",
     category: "leaderboard_roles",
     type: "string",
+    options: [
+      { value: "week", label: "This week" },
+      { value: "month", label: "This month" },
+      { value: "alltime", label: "All time" },
+    ],
   },
   "leaderboard_roles.update_cron": {
     label: "Recalculation schedule (cron)",

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -10,7 +10,10 @@ import {
   renderAdminPage,
   type NavFeatureStatus,
 } from "./admin-layout.js";
-import { categoryMetadata } from "../services/config-schema.js";
+import {
+  categoryMetadata,
+  type SettingOption,
+} from "../services/config-schema.js";
 
 interface CommonProps {
   csrfToken: string;
@@ -178,6 +181,12 @@ export interface SettingRow {
   type: string;
   description: string;
   category: string;
+  /**
+   * When present, the value control renders as a `<select>` limited to
+   * these choices instead of a free-text input. Sourced from the key's
+   * `SettingMetadata.options`.
+   */
+  options?: SettingOption[];
 }
 
 export interface SettingsProps extends CommonProps {
@@ -410,6 +419,38 @@ export function findCascadeMasterKey(rows: SettingRow[]): string | null {
   return master?.key ?? null;
 }
 
+/**
+ * Render a single-select `<select>` for a fixed-options setting. Each
+ * option's `value` is the raw stored value; `label` is the display text.
+ * If the current stored value isn't one of the known options it's surfaced
+ * as a selected placeholder so the browser doesn't silently default to the
+ * first valid choice and overwrite the out-of-range value on save:
+ *   - a non-empty unknown value (stale row, hand-edited DB) shows as
+ *     `(unknown) <value>`;
+ *   - an empty value shows a neutral `(choose a value)` placeholder.
+ * Both round-trip the current value, so on save `coerceConfigValue`
+ * rejects it with a clear error and forces the operator to pick.
+ */
+function renderOptionsSelect(
+  valueName: string,
+  options: SettingOption[],
+  current: string,
+): string {
+  const known = options.some((o) => o.value === current);
+  const opts = options
+    .map((o) => {
+      const sel = o.value === current ? " selected" : "";
+      return `<option value="${escapeHtml(o.value)}"${sel}>${escapeHtml(o.label)}</option>`;
+    })
+    .join("");
+  const placeholder = known
+    ? ""
+    : `<option value="${escapeHtml(current)}" selected>${
+        current === "" ? "(choose a value)" : `(unknown) ${escapeHtml(current)}`
+      }</option>`;
+  return `<select name="${valueName}">${opts}${placeholder}</select>`;
+}
+
 function renderSettingControl(
   r: SettingRow,
   pickers: {
@@ -423,6 +464,12 @@ function renderSettingControl(
   const currentStr = typeof primitive === "string" ? primitive : "";
   const valueName = escapeHtml(settingValueFieldName(r.key));
 
+  // Fixed-options keys render as a single-select dropdown regardless of
+  // their underlying `type`, so operators pick from the valid set instead
+  // of typing a value the server will reject.
+  if (r.options && r.options.length > 0) {
+    return renderOptionsSelect(valueName, r.options, currentStr);
+  }
   if (r.type === "boolean") {
     const checked = primitive === true ? " checked" : "";
     const masterAttr = isCascadeMaster ? " data-cascade-master" : "";
@@ -900,7 +947,10 @@ export interface WizardStepPageProps extends CommonProps {
   featureKey: string;
   settingKeys: string[];
   currentValues: Record<string, unknown>;
-  metadata: Record<string, { description: string; category: string }>;
+  metadata: Record<
+    string,
+    { description: string; category: string; options?: SettingOption[] }
+  >;
   defaultValues: Record<string, unknown>;
   flash?: FlashMessage | null;
 }
@@ -939,7 +989,12 @@ export function renderWizardStepPage(props: WizardStepPageProps): string {
           : "";
 
       let control: string;
-      if (type === "boolean") {
+      if (meta?.options && meta.options.length > 0) {
+        // Fixed-options keys render as a dropdown in the wizard too, so the
+        // value posted back is always one the server will accept.
+        const currentStr = typeof current === "string" ? current : "";
+        control = renderOptionsSelect(escapeHtml(k), meta.options, currentStr);
+      } else if (type === "boolean") {
         const checked = current === true ? " checked" : "";
         const masterAttr = k === masterKey ? " data-cascade-master" : "";
         control = `<label class="checkbox" style="display:inline-flex;gap:.4rem;align-items:center;cursor:pointer"><input type="checkbox" id="${escapeHtml(inputId)}" name="${escapeHtml(k)}" value="true"${checked}${masterAttr}> Enable</label>`;

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -374,6 +374,7 @@ export function createReadOnlyRouter(
             description: dbEntry?.description ?? meta?.description ?? "",
             category:
               dbEntry?.category ?? meta?.category ?? deriveCategory(key),
+            options: meta?.options,
           };
         },
       );

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -236,7 +236,21 @@ export function coerceConfigValue(
     if (!Number.isFinite(n)) return { ok: false, reason: "invalid number" };
     return { ok: true, value: n };
   }
-  return { ok: true, value: String(raw ?? "") };
+  const value = String(raw ?? "");
+  // Fixed-options keys carry an `options` whitelist in their metadata. Any
+  // value outside it (mistyped form field, crafted POST, stale YAML import)
+  // is refused with a clear, enumerated error rather than silently stored.
+  const options =
+    settingsMetadata[key as keyof typeof settingsMetadata]?.options;
+  if (options && !options.some((o) => o.value === value)) {
+    return {
+      ok: false,
+      reason: `invalid option (must be one of: ${options
+        .map((o) => o.value)
+        .join(", ")})`,
+    };
+  }
+  return { ok: true, value };
 }
 
 /**


### PR DESCRIPTION
## Summary

Settings with a fixed enumerated set of valid values were rendered as free-text inputs in the admin WebUI, so operators had no way to discover the valid options and could mistype them with no feedback. This adds an optional `options` whitelist to `SettingMetadata` so such keys render as `<select>` dropdowns on both the Settings page and the setup wizard, and refuses out-of-range values server-side.

Closes #488.

## Changes

- **`SettingMetadata.options`** — new `options?: { value: string; label: string }[]` field (plus a `SettingOption` type) in `src/services/config-schema.ts`. When present, the key renders as a selector and POST validation enforces the whitelist.
- **`leaderboard_roles.period` converted** to a selector with `week` / `month` / `alltime` (label/description aligned with the issue text). Default remains `alltime`.
- **Renderer** (`src/web/admin-views.ts`) — a shared `renderOptionsSelect` helper emits a single-select for any row carrying `options`, used by both `renderSettingControl` (Settings page) and the wizard step renderer (parity per the issue). An out-of-range stored value is surfaced as a selected `(unknown) <value>` option so the browser doesn't silently default to the first choice and the operator can see the bad value before saving over it.
- **`SettingRow.options`** plumbed through `src/web/read-only-routes.ts` from the metadata.
- **Validation** (`src/web/write-routes.ts`) — `coerceConfigValue` rejects any value outside the `options` whitelist with an enumerated error (`invalid option (must be one of: …)`). Because every write path (`/settings/set`, `/settings/save-section`, YAML import, and the wizard step) funnels through this one function, the whitelist is enforced everywhere.

## Audit of other selector candidates

Scanned every `string`-typed key in `ConfigSchema` / `defaultConfig`:

- `*.channel_id` / `*.category_id` / `*.message_channel_id`, `*.excluded_channels`, `*.delete_roles` → already use dedicated channel / category / role / list pickers.
- `*.cron` / `*.schedule` → handled by the cron picker (#444); left alone.
- `*.tiers` (`topN:roleId` pairs), `*.header_message_id` (auto-managed), lobby names / prefix / suffix → open-ended free-text, not a fixed set.

`leaderboard_roles.period` is the **only** fixed-enum string key, so it's the only conversion in this PR. No follow-ups needed.

## Tests

- `__tests__/web/write-routes.test.ts` — accepts whitelisted values, rejects out-of-range and empty values with an enumerated reason.
- `__tests__/web/admin-views.test.ts` — renders the selector with the current value pre-selected and no free-text input; surfaces an out-of-range value as `(unknown)`.

All 88 suites pass; `tsc --noEmit` and `npm run lint` clean (0 errors).

## Acceptance checklist

- [x] `SettingMetadata` supports an optional `options` array.
- [x] `/admin/settings` and the wizard render selectors for keys with `options`.
- [x] `POST` handlers reject values outside the `options` whitelist with a clear error.
- [x] `leaderboard_roles.period` converted; the current DB value is shown pre-selected when present.
- [x] Audit documented; only candidate converted.
- [x] Unit test covers the selector validation path.

https://claude.ai/code/session_01AcycJDY8vYv9LP1G5CMuWm

---
_Generated by [Claude Code](https://claude.ai/code/session_01AcycJDY8vYv9LP1G5CMuWm)_