### PR TITLE
feat(webui): add "Reset all settings to defaults" action (#487)

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -713,6 +713,28 @@ re-syncs the registration.
 
 For any setting, click **Reset to default** on the Settings page.
 
+### Reset all settings to defaults
+
+The **Danger zone** at the bottom of the Settings page wipes the live
+config back to the built-in defaults from `src/services/config-schema.ts`
+in one action — the equivalent of clicking **Reset to default** on every
+row at once, without touching MongoDB by hand.
+
+- **Scope** — every key in the schema is rewritten to its default value,
+  and any **orphan** keys left in the DB by removed features (keys no
+  longer present in the schema) are deleted.
+- **Two-step confirm** — a browser prompt guards the click, and you must
+  additionally type the **guild name** (or guild id, if the name can't be
+  fetched) into the confirmation field before the reset commits.
+- **Not touched** — bootstrap / environment variables (`DISCORD_TOKEN`,
+  `MONGODB_URI`, every `WEBUI_*`, and the rest of the `.env` values) are
+  never affected; they don't live in the `configs` collection.
+- **After resetting** — the flash banner reports how many keys were
+  updated (and how many orphans removed). Because command enablement may
+  have changed, click **Reload commands to Discord** afterwards.
+- **Audit** — the reset records a single `WebAuditLog` entry with
+  `action: "settings.reset-defaults"` and the count of keys touched.
+
 ### Value types
 
 The Web UI form controls map to the underlying schema types:

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -652,7 +652,7 @@ side effect, since the HMAC key changes.
 | Page               | Replaces                                                                                            |
 | ------------------ | --------------------------------------------------------------------------------------------------- |
 | **Dashboard**      | `/botstats`                                                                                         |
-| **Settings**       | `/config list`, `get`, `set`, `reset`, `import`, `export`, `reload`                                 |
+| **Settings**       | `/config list`, `get`, `set`, `reset`, `reset-all` (Danger zone), `import`, `export`, `reload`      |
 | **Permissions**    | `/permissions set`, `add`, `remove`, `clear`, `list`, `view`                                        |
 | **Setup Wizard**   | `/setup wizard`                                                                                     |
 | **Announcements**  | `/announce create`, `list`, `delete`                                                                |

--- a/__tests__/web/write-routes.test.ts
+++ b/__tests__/web/write-routes.test.ts
@@ -8,11 +8,44 @@ import { describe, it, expect } from "@jest/globals";
 import {
   coerceConfigValue,
   findSectionMasterKey,
+  resetConfigToDefaults,
+  type ResetConfigStore,
 } from "../../src/web/write-routes.js";
 import {
   BOOTSTRAP_VARS,
   PROTECTED_KEYS,
 } from "../../src/web/bootstrap-vars.js";
+import { defaultConfig } from "../../src/services/config-schema.js";
+
+/**
+ * In-memory `ResetConfigStore` seeded from `initial` rows. Records every
+ * set/delete so the reset behaviour can be asserted without Mongo.
+ */
+function makeFakeStore(initial: Record<string, unknown>): ResetConfigStore & {
+  rows: Map<string, unknown>;
+  setCalls: Array<{ key: string; value: unknown }>;
+  deleted: string[];
+} {
+  const rows = new Map<string, unknown>(Object.entries(initial));
+  const setCalls: Array<{ key: string; value: unknown }> = [];
+  const deleted: string[] = [];
+  return {
+    rows,
+    setCalls,
+    deleted,
+    async getAll() {
+      return Array.from(rows.keys()).map((key) => ({ key }));
+    },
+    async set(key, value) {
+      setCalls.push({ key, value });
+      rows.set(key, value);
+    },
+    async delete(key) {
+      deleted.push(key);
+      rows.delete(key);
+    },
+  };
+}
 
 describe("PROTECTED_KEYS", () => {
   it("covers every bootstrap env variable (derived from BOOTSTRAP_VARS)", () => {
@@ -179,5 +212,80 @@ describe("findSectionMasterKey", () => {
 
   it("returns null for an unknown key that merely ends with .enabled", () => {
     expect(findSectionMasterKey(["bogus.feature.enabled"])).toBeNull();
+  });
+});
+
+describe("resetConfigToDefaults (#487)", () => {
+  const schemaKeys = Object.keys(defaultConfig);
+
+  it("rewrites every schema key back to its default value", async () => {
+    // Fixture DB with a couple of non-default overrides.
+    const store = makeFakeStore({
+      "voicechannels.enabled": true,
+      "quotes.max_length": 999,
+    });
+
+    const { updated } = await resetConfigToDefaults(store);
+
+    expect(updated).toBe(schemaKeys.length);
+    // Every schema key was written exactly once, with its default value.
+    expect(store.setCalls.map((c) => c.key).sort()).toEqual(
+      [...schemaKeys].sort(),
+    );
+    for (const key of schemaKeys) {
+      expect(store.rows.get(key)).toEqual(
+        defaultConfig[key as keyof typeof defaultConfig],
+      );
+    }
+  });
+
+  it("deletes orphan DB keys that are no longer in the schema", async () => {
+    const store = makeFakeStore({
+      "voicechannels.enabled": true,
+      "legacy.removed_feature": "stale",
+      "another.orphan": 42,
+    });
+
+    const { updated, deleted } = await resetConfigToDefaults(store);
+
+    expect(updated).toBe(schemaKeys.length);
+    expect(deleted).toBe(2);
+    expect(store.deleted.sort()).toEqual(
+      ["another.orphan", "legacy.removed_feature"].sort(),
+    );
+    expect(store.rows.has("legacy.removed_feature")).toBe(false);
+    expect(store.rows.has("another.orphan")).toBe(false);
+  });
+
+  it("never deletes a protected bootstrap key, even if a stray row exists", async () => {
+    // PROTECTED_KEYS shouldn't live in the configs collection, but a stray
+    // row must not be dropped by the reset.
+    const store = makeFakeStore({
+      DISCORD_TOKEN: "should-not-be-touched",
+      "orphan.key": "x",
+    });
+
+    const { deleted } = await resetConfigToDefaults(store);
+
+    expect(deleted).toBe(1);
+    expect(store.deleted).toEqual(["orphan.key"]);
+    expect(store.deleted).not.toContain("DISCORD_TOKEN");
+    expect(store.rows.get("DISCORD_TOKEN")).toBe("should-not-be-touched");
+  });
+
+  it("collects per-key failures and keeps going (partial application)", async () => {
+    const store = makeFakeStore({ "orphan.key": "x" });
+    const firstSchemaKey = schemaKeys[0];
+    const realSet = store.set.bind(store);
+    store.set = async (key, value, description, category) => {
+      if (key === firstSchemaKey) throw new Error("write boom");
+      return realSet(key, value, description, category);
+    };
+
+    const { updated, deleted, failed } = await resetConfigToDefaults(store);
+
+    expect(updated).toBe(schemaKeys.length - 1);
+    expect(deleted).toBe(1);
+    expect(failed).toEqual([{ key: firstSchemaKey, reason: "write boom" }]);
   });
 });

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -185,6 +185,10 @@ export interface SettingsProps extends CommonProps {
   textChannels: ChannelOption[];
   categoryChannels: ChannelOption[];
   roles: RoleOption[];
+  /** Guild id of the session, used as the reset-confirmation fallback. */
+  guildId: string;
+  /** Guild name (when fetchable); the preferred reset-confirmation phrase. */
+  guildName: string | null;
   flash?: FlashMessage | null;
 }
 
@@ -572,6 +576,27 @@ export function renderSettingsPage(props: SettingsProps): string {
   </form>
 </div>`;
 
+  // Two-step confirm: the JS confirm() guards the click, and the operator
+  // must additionally type the guild name (or guild id when the name can't
+  // be fetched) into the text field, which the server re-validates. The
+  // `required` attribute and `confirmTarget` keep the client and server in
+  // step. See `POST /admin/settings/reset-defaults` in write-routes.ts.
+  const confirmTarget = props.guildName ?? props.guildId;
+  const dangerSection = `
+<div id="danger-zone" class="card" style="border-color:#7f1d1d">
+  <h2>Danger zone</h2>
+  <p class="muted" style="margin:0 0 .75rem">Reset every setting to its built-in default. All keys in the schema are rewritten to their default value, and any orphaned keys left behind by removed features are deleted. Bootstrap / environment variables (Discord token, Mongo URI, WebUI session config) are <strong>not</strong> touched. You may need to <strong>Reload commands</strong> afterwards.</p>
+  <form method="POST" action="/admin/settings/reset-defaults" class="stack" onsubmit="return confirm('Reset ALL settings to their defaults? This cannot be undone.');">
+    <input type="hidden" name="_csrf" value="${csrf}">
+    <label>Type <code>${escapeHtml(confirmTarget)}</code> to confirm:
+      <input type="text" name="confirm" autocomplete="off" placeholder="${escapeHtml(confirmTarget)}" required>
+    </label>
+    <div>
+      <button type="submit" class="btn btn-danger">Reset all settings to defaults</button>
+    </div>
+  </form>
+</div>`;
+
   const body = `
 <h1>Settings</h1>
 <p class="subtitle">All DB-backed configuration, grouped by feature. Mirrors <code>SETTINGS.md</code> and <code>config-service.ts</code>.</p>
@@ -579,6 +604,7 @@ ${renderFlash(props.flash)}
 ${actionBar}
 ${sections}
 ${importSection}
+${dangerSection}
 `;
   return renderAdminPage({
     title: "Settings",

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -417,6 +417,17 @@ export function createReadOnlyRouter(
         roles: roleData.roles,
       }));
 
+      // Guild name backs the "type to confirm" step of the danger-zone
+      // reset. Best-effort: when the fetch fails the renderer falls back to
+      // the guild id, which the reset handler also accepts.
+      let guildName: string | null = null;
+      try {
+        const guild = await client.guilds.fetch(common.guildId);
+        guildName = guild.name;
+      } catch (err) {
+        logger.debug("settings guild fetch failed", err);
+      }
+
       res.type("text/html").send(
         renderSettingsPage({
           ...common,
@@ -424,6 +435,8 @@ export function createReadOnlyRouter(
           textChannels,
           categoryChannels,
           roles,
+          guildId: common.guildId,
+          guildName,
         }),
       );
     }),

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -265,6 +265,75 @@ function getCsrfFromReq(req: AuthenticatedRequest): string {
 }
 
 /**
+ * Minimal config-store surface the bulk reset needs. `ConfigService`
+ * satisfies it structurally; the narrow shape keeps the reset logic
+ * unit-testable against a fake store without Express or Mongo.
+ */
+export interface ResetConfigStore {
+  getAll(): Promise<Array<{ key: string }>>;
+  set(
+    key: string,
+    value: unknown,
+    description: string,
+    category: string,
+  ): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+/**
+ * Reset the live config back to `defaultConfig`:
+ *   - every key in the schema is rewritten to its default value;
+ *   - orphan DB rows (keys no longer in the schema) are deleted.
+ *
+ * Protected bootstrap keys never live in the `configs` collection, but are
+ * skipped on the delete pass defensively so a stray row can't be dropped
+ * here. Mirrors the partial-application semantics of the YAML import: a
+ * write/delete that throws is collected in `failed` and the rest continue.
+ */
+export async function resetConfigToDefaults(config: ResetConfigStore): Promise<{
+  updated: number;
+  deleted: number;
+  failed: Array<{ key: string; reason: string }>;
+}> {
+  const all = await config.getAll();
+  const failed: Array<{ key: string; reason: string }> = [];
+
+  let updated = 0;
+  for (const [key, value] of Object.entries(defaultConfig)) {
+    const meta = settingsMetadata[key as keyof typeof settingsMetadata];
+    try {
+      await config.set(
+        key,
+        value,
+        meta?.description ?? "",
+        meta?.category ?? key.split(".")[0],
+      );
+      updated++;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : "set failed";
+      logger.error("reset-defaults: failed to write setting", err);
+      failed.push({ key, reason });
+    }
+  }
+
+  let deleted = 0;
+  for (const entry of all) {
+    if (entry.key in defaultConfig) continue;
+    if (PROTECTED_KEYS.has(entry.key)) continue;
+    try {
+      await config.delete(entry.key);
+      deleted++;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : "delete failed";
+      logger.error("reset-defaults: failed to delete orphan key", err);
+      failed.push({ key: entry.key, reason });
+    }
+  }
+
+  return { updated, deleted, failed };
+}
+
+/**
  * Enabled-state of feature-gated nav items for the pages rendered by the
  * write router (wizard steps, import preview). Keeps their sidebar
  * consistent with the read-only pages.
@@ -409,6 +478,124 @@ export function createWriteRouter(
         flashRedirect(res, "/admin/settings", {
           type: "err",
           text: `Failed to reset ${key}: ${text}`,
+        });
+      }
+    }),
+  );
+
+  // Reset every setting to its schema default (issue #487). Two-step
+  // confirm: the page guards the click with a JS confirm() and requires the
+  // operator to type the guild name (the form field re-validated below).
+  router.post(
+    "/settings/reset-defaults",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const body = (req.body as Record<string, unknown> | undefined) ?? {};
+
+      // Defence-in-depth: this endpoint takes no per-key payload, but a
+      // crafted request that smuggles a protected bootstrap key (Discord
+      // token, Mongo URI, WebUI session config) is refused outright — those
+      // keys must never be touched by a settings reset.
+      const protectedHit = Object.keys(body).find((k) =>
+        PROTECTED_KEYS.has(k),
+      );
+      if (protectedHit) {
+        await recordAudit(session, {
+          action: "settings.reset-defaults",
+          result: "failure",
+          errorMessage: "protected key in payload",
+          details: { protectedKey: protectedHit },
+        });
+        flashRedirect(res, "/admin/settings", {
+          type: "err",
+          text: "Reset refused: request contained a protected bootstrap key.",
+        });
+        return;
+      }
+
+      // The operator must type the guild name (falling back to the guild id
+      // when Discord can't be reached) to commit. Accept either so a fetch
+      // failure between render and submit can't lock the operator out.
+      let guildName: string | null = null;
+      try {
+        const guild = await client.guilds.fetch(session.guildId);
+        guildName = guild.name;
+      } catch (err) {
+        logger.debug("reset-defaults guild fetch failed", err);
+      }
+      const expected = guildName ?? session.guildId;
+      const confirmText = getString(req, "confirm");
+      const confirmed =
+        confirmText.length > 0 &&
+        (confirmText === expected || confirmText === session.guildId);
+      if (!confirmed) {
+        await recordAudit(session, {
+          action: "settings.reset-defaults",
+          result: "failure",
+          errorMessage: "confirmation text did not match",
+        });
+        flashRedirect(res, "/admin/settings", {
+          type: "err",
+          text: `Reset cancelled — type "${expected}" exactly to confirm.`,
+        });
+        return;
+      }
+
+      const config = ConfigService.getInstance();
+      try {
+        const { updated, deleted, failed } =
+          await resetConfigToDefaults(config);
+        const landed = updated + deleted;
+        // Mirror the YAML-import audit: `result: "failure"` only when nothing
+        // landed, otherwise `success` with a `partial` flag for reporting.
+        const outcome: "ok" | "partial" | "failed" =
+          failed.length === 0 ? "ok" : landed > 0 ? "partial" : "failed";
+        await recordAudit(session, {
+          action: "settings.reset-defaults",
+          details: {
+            updated,
+            deleted,
+            failed,
+            failedCount: failed.length,
+            outcome,
+          },
+          result: outcome === "failed" ? "failure" : "success",
+          errorMessage:
+            failed.length > 0
+              ? failed
+                  .slice(0, 5)
+                  .map((f) => `${f.key}: ${f.reason}`)
+                  .join("; ")
+              : null,
+        });
+
+        const orphanNote =
+          deleted > 0
+            ? `, ${deleted} orphan key${deleted === 1 ? "" : "s"} removed`
+            : "";
+        const reloadNote = " You may need to Reload commands.";
+        if (failed.length === 0) {
+          flashRedirect(res, "/admin/settings", {
+            type: "ok",
+            text: `Settings reset to defaults — ${updated} key${updated === 1 ? "" : "s"} updated${orphanNote}.${reloadNote}`,
+          });
+          return;
+        }
+        flashRedirect(res, "/admin/settings", {
+          type: landed > 0 ? "warn" : "err",
+          text: `Reset ${landed > 0 ? "partially " : ""}failed — ${updated} key${updated === 1 ? "" : "s"} updated${orphanNote}, ${failed.length} failed (first: ${failed[0].key} — ${failed[0].reason}).${landed > 0 ? reloadNote : ""}`,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Reset to defaults failed", err);
+        await recordAudit(session, {
+          action: "settings.reset-defaults",
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/settings", {
+          type: "err",
+          text: `Reset failed: ${text}`,
         });
       }
     }),

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -496,9 +496,7 @@ export function createWriteRouter(
       // crafted request that smuggles a protected bootstrap key (Discord
       // token, Mongo URI, WebUI session config) is refused outright — those
       // keys must never be touched by a settings reset.
-      const protectedHit = Object.keys(body).find((k) =>
-        PROTECTED_KEYS.has(k),
-      );
+      const protectedHit = Object.keys(body).find((k) => PROTECTED_KEYS.has(k));
       if (protectedHit) {
         await recordAudit(session, {
           action: "settings.reset-defaults",


### PR DESCRIPTION
Closes #487.

Adds a **Danger zone** to the admin Settings page that wipes the live config back to the built-in `defaultConfig` (from `src/services/config-schema.ts`) in a single action — no more hand-editing each row or dropping rows in MongoDB.

## UI

- A "Danger zone" card at the bottom of `/admin/settings` with a `btn btn-danger` **Reset all settings to defaults** button.
- **Two-step confirm**: a JS `confirm()` guards the click, and the operator must additionally type the **guild name** (falling back to the guild id when the name can't be fetched) into a `required` text field, which the server re-validates.

## Behaviour — `POST /admin/settings/reset-defaults`

- **Defence-in-depth**: refuses outright if a `PROTECTED_KEYS` row appears in the request payload (the endpoint takes no per-key payload, but the principle stands).
- Rewrites every key in `defaultConfig` back to its default via `configService.set(...)`.
- **Orphan cleanup**: DB keys present but absent from `defaultConfig` are deleted. Protected bootstrap/env keys are skipped on the delete pass defensively (they don't live in the `configs` collection anyway).
- **Audit**: records a single `WebAuditLog` row with `action: "settings.reset-defaults"` and the count of keys touched, mirroring the YAML-import audit's tri-state (`failure` only when nothing landed; otherwise `success` with a `partial`/`outcome` flag).
- **Flash**: `Settings reset to defaults — N keys updated…` and suggests clicking **Reload commands**.

The reset logic is extracted into the unit-testable `resetConfigToDefaults(store)` helper, decoupled from Express/Mongo via a narrow `ResetConfigStore` interface that `ConfigService` satisfies structurally.

## Safety

- `WEBUI_*` env vars and bootstrap keys are untouched.
- The typed-confirmation step prevents an accidental click.

## Acceptance

- [x] New "Reset all settings" form on `/admin/settings` with two-step confirmation.
- [x] All keys in `defaultConfig` written back to defaults; orphan DB keys outside the schema deleted.
- [x] `WebAuditLog` records the reset with the actor and key count.
- [x] `SETTINGS.md` documents the action and its scope (also noted in `WEBUI.md`).
- [x] Unit tests cover reset, orphan deletion, protected-key safety, and partial-failure collection against a fixture store with non-default values and an orphan key.

## Testing

- `npm test` — 892 passing, 1 skipped (4 new tests for `resetConfigToDefaults`).
- `npm run lint` — 0 errors.
- `npx tsc --noEmit` — clean.

https://claude.ai/code/session_0155hEXpiywHvEm1d6KjtE35

---
_Generated by [Claude Code](https://claude.ai/code/session_0155hEXpiywHvEm1d6KjtE35)_