### PR TITLE
fix(web): bound long setting values within their cell on Settings page

### DIFF
--- a/__tests__/web/admin-layout.test.ts
+++ b/__tests__/web/admin-layout.test.ts
@@ -109,6 +109,25 @@ describe("renderAdminPage", () => {
     expect(html).not.toContain("<title><bad>");
   });
 
+  it("ships CSS that bounds long settings values within their cell (issue #489)", () => {
+    const html = renderAdminPage({
+      title: "Settings",
+      active: "/admin/settings",
+      body: "",
+      csrfToken: "",
+      remainingMs: 0,
+    });
+    // Editable controls are capped to the cell width so long channel/role
+    // lists or custom strings don't push the table past the page edge.
+    expect(html).toContain(
+      "td.settings-value input[type=text],td.settings-value select{width:100%;box-sizing:border-box}",
+    );
+    // The default-value cell wraps long content instead of forcing a wide row.
+    expect(html).toContain(
+      "td.settings-default{overflow-wrap:anywhere;word-break:break-word}",
+    );
+  });
+
   it("marks the active nav item", () => {
     const html = renderAdminPage({
       title: "Settings",

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -105,9 +105,7 @@ describe("renderSettingsPage", () => {
       ],
     });
     // Human label appears as bold primary text.
-    expect(html).toContain(
-      "<strong>Voice Channel Management enabled</strong>",
-    );
+    expect(html).toContain("<strong>Voice Channel Management enabled</strong>");
     // Raw dotted key still rendered, but de-emphasised as a small code ref.
     expect(html).toMatch(
       /<code class="mono muted"[^>]*>voicechannels\.enabled<\/code>/,
@@ -197,7 +195,9 @@ describe("renderSettingsPage", () => {
     // Single per-section save form (replaces the per-row "Set" button).
     expect(html).toContain('action="/admin/settings/save-section"');
     expect(html).toContain('name="category" value="quotes"');
-    expect(html).toContain('<button type="submit" class="btn btn-primary">Save</button>');
+    expect(html).toContain(
+      '<button type="submit" class="btn btn-primary">Save</button>',
+    );
     // Each row contributes its key via a hidden `keys` input so the
     // handler can enumerate the section without trusting `value_*` names.
     expect(html).toContain('name="keys" value="quotes.max_length"');
@@ -213,6 +213,36 @@ describe("renderSettingsPage", () => {
     expect(html).toContain('value="12345"');
     // No per-row "Set" submit survives.
     expect(html).not.toContain('action="/admin/settings/set"');
+  });
+
+  it("tags the value and default cells so long values stay bounded, not nowrap (issue #489)", () => {
+    const longTiers =
+      "role-aaaaaaaaaaaaaaaa:1000,role-bbbbbbbbbbbbbbbb:2500,role-cccccccccccccccc:5000,role-dddddddddddddddd:10000";
+    const html = renderSettingsPage({
+      ...COMMON,
+      groups: [
+        {
+          category: "leaderboard_roles",
+          rows: [
+            {
+              key: "leaderboard_roles.tiers",
+              current: longTiers,
+              defaultValue: longTiers,
+              type: "string",
+              description: "",
+              category: "leaderboard_roles",
+            },
+          ],
+        },
+      ],
+    });
+    // The editable value cell and the default cell carry the classes the
+    // stylesheet uses to bound long content within the column.
+    expect(html).toContain('<td class="settings-value">');
+    expect(html).toContain('<td class="settings-default">');
+    // The previous fixed `white-space:nowrap` on the default cell forced
+    // long values to push the table wide — it must be gone.
+    expect(html).not.toContain('<td style="white-space:nowrap">');
   });
 
   it("renders the action bar and import textarea", () => {
@@ -310,7 +340,9 @@ describe("renderSettingsPage", () => {
       '<select name="value_voicetracking.announcements.channel_id">',
     );
     expect(html).toContain('<option value="111">#general</option>');
-    expect(html).toContain('<option value="222" selected>#voice-stats</option>');
+    expect(html).toContain(
+      '<option value="222" selected>#voice-stats</option>',
+    );
   });
 
   it("renders a category-type setting from categoryChannels", () => {
@@ -432,9 +464,7 @@ describe("renderSettingsPage", () => {
         },
       ],
     });
-    expect(html).toMatch(
-      /<select name="value_quotes\.delete_roles" multiple/,
-    );
+    expect(html).toMatch(/<select name="value_quotes\.delete_roles" multiple/);
     expect(html).toContain('<option value="r1">@Admin</option>');
     expect(html).toContain('<option value="r2" selected>@Mod</option>');
   });
@@ -505,7 +535,6 @@ describe("renderSettingsPage", () => {
       '<option value="999-deleted" selected>(missing) 999-deleted</option>',
     );
   });
-
 });
 
 describe("renderPermissionsPage", () => {
@@ -1503,7 +1532,9 @@ describe("renderSettingsPage cron picker", () => {
     const html = withCron("30 8 * * *");
     expect(html).toContain('<div class="cron-picker" data-mode="daily">');
     expect(html).toContain('<option value="daily" selected>Daily</option>');
-    expect(html).toContain('<input type="time" class="cron-time" value="08:30">');
+    expect(html).toContain(
+      '<input type="time" class="cron-time" value="08:30">',
+    );
   });
 
   it("renders a monthly schedule with the day-of-month pre-populated", () => {

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -170,6 +170,11 @@ const STYLE = [
   "th,td{text-align:left;padding:.5rem .6rem;border-bottom:1px solid #2d3748;vertical-align:top}",
   "th{font-weight:600;color:#94a3b8;background:#1a1f2a}",
   "tr:hover td{background:#1a1f2a}",
+  // Settings page: keep editable controls inside their cell and let long
+  // current/default values wrap instead of pushing the table wide (issue #489).
+  "td.settings-value{min-width:12rem}",
+  "td.settings-value input[type=text],td.settings-value select{width:100%;box-sizing:border-box}",
+  "td.settings-default{overflow-wrap:anywhere;word-break:break-word}",
   ".muted{color:#94a3b8}",
   ".mono{font-family:ui-monospace,SFMono-Regular,SF Mono,Menlo,monospace;font-size:.85rem}",
   ".tag{display:inline-block;padding:.1rem .45rem;border-radius:4px;font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.04em}",

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -530,9 +530,9 @@ export function renderSettingsPage(props: SettingsProps): string {
   <code class="mono muted" style="font-size:.85em">${escapeHtml(r.key)}</code>
   <input type="hidden" name="keys" value="${escapeHtml(r.key)}">
 </td>
-<td>${renderSettingControl(r, pickers, r.key === cascadeMasterKey)}${renderResetButton(r.key)}</td>
+<td class="settings-value">${renderSettingControl(r, pickers, r.key === cascadeMasterKey)}${renderResetButton(r.key)}</td>
 <td><span class="tag tag-info">${escapeHtml(r.type)}</span></td>
-<td style="white-space:nowrap">${formatValue(r.defaultValue)}</td>
+<td class="settings-default">${formatValue(r.defaultValue)}</td>
 <td class="muted">${escapeHtml(r.description)}</td>
 </tr>`,
         )


### PR DESCRIPTION
Closes #489.

## Problem

On `/admin/settings`, long setting values (channel ID lists, comma-separated tier strings, long custom strings) overflowed the value column, pushing the table past the page edge and breaking the layout.

## Root cause

- The editable controls in the value (Edit) cell — `<input type="text">` and `<select>`/`<select multiple>` — had no width bound, so a `<select>` with long option labels sized to its widest option and a long string filled the cell unbounded.
- The **Default** column cell carried a fixed `white-space:nowrap`, so a long default value (its minimum content width = the full string) forced the whole table wider, causing horizontal page scroll.

## Fix (CSS / one-row, as scoped in the issue)

- Tag the editable value cell with `settings-value` and the default-value cell with `settings-default` so the fix is scoped to the Settings table (no impact on other admin tables).
- Cap text inputs and selects to the cell width: `width:100%;box-sizing:border-box`. Number inputs keep their inline `width:8rem`; long string values now scroll within the input rather than overflowing.
- Replace the default cell's `white-space:nowrap` with `overflow-wrap:anywhere;word-break:break-word` so long defaults wrap instead of forcing a wide row.

## Acceptance

- [x] Long values stay within the value container (text/selects bounded to cell; defaults wrap).
- [x] No regression on short values — cells stay `vertical-align:top`; label/value/metadata columns stay aligned.
- [x] Narrow viewport stays usable — a single long row no longer forces horizontal page scroll (the wrappable default column can shrink).

## Tests

- `renderSettingsPage` asserts the `settings-value`/`settings-default` cell classes and that the old `white-space:nowrap` cell is gone.
- `renderAdminPage` asserts the bounding CSS rules are shipped in the stylesheet.

All 139 web tests pass; `tsc` clean; ESLint 0 errors; Prettier clean.

https://claude.ai/code/session_019t6k4RU7HC6BHSMekDVqg7

---
_Generated by [Claude Code](https://claude.ai/code/session_019t6k4RU7HC6BHSMekDVqg7)_