### PR TITLE
feat(webui): collapse VC cleanup buttons to single "Force VC cleanup"

### DIFF
--- a/WEBUI.md
+++ b/WEBUI.md
@@ -659,7 +659,7 @@ side effect, since the HMAC key changes.
 | **Polls**          | `/poll create`, `list`, `add-item`, `import-url`, `delete`, `delete-item`, `test`, `list-items`     |
 | **Reaction Roles** | `/reactrole create`, `archive`, `unarchive`, `delete`, `list`, `status`                             |
 | **Notices**        | `/notice add`, `edit`, `delete`, `sync`                                                             |
-| **Voice Channels** | `/vc reload`, `/vc force-reload`                                                                    |
+| **Voice Channels** | `/vc force-reload` (single **Force VC cleanup** button)                                             |
 | **Database**       | `/dbtrunk status`, `/dbtrunk run`                                                                   |
 | **Command Audit**  | (new — read-only Discord slash-command audit log)                                                   |
 | **Bootstrap**      | (new — read-only env diagnostics)                                                                   |

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -1091,8 +1091,8 @@ describe("renderVoiceChannelsPage", () => {
     expect(html).toContain('class="tag tag-warn">dynamic');
     expect(html).toContain('class="tag tag-warn">LIVE');
     expect(html).toContain("Friday night");
-    expect(html).toContain("/admin/voice-channels/reload");
     expect(html).toContain("/admin/voice-channels/force-reload");
+    expect(html).not.toContain('action="/admin/voice-channels/reload"');
   });
 
   it("disables cleanup actions when the feature is off or the category is missing", () => {
@@ -1110,11 +1110,9 @@ describe("renderVoiceChannelsPage", () => {
       categoryFound: false,
     });
     expect(html).toMatch(
-      /<button[^>]*type="submit"[^>]*disabled[^>]*>Clean up empty channels<\/button>/,
+      /<button[^>]*type="submit"[^>]*disabled[^>]*>Force VC cleanup<\/button>/,
     );
-    expect(html).toMatch(
-      /<button[^>]*type="submit"[^>]*disabled[^>]*>Force cleanup/,
-    );
+    expect(html).not.toContain("Clean up empty channels");
   });
 });
 

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -1858,15 +1858,10 @@ ${renderFlash(props.flash)}
 </div>
 <div class="card">
   <h2>Cleanup actions</h2>
-  <form method="POST" action="/admin/voice-channels/reload" class="inline-form" onsubmit="return confirm('Clean up empty dynamic voice channels now?');">
-    ${csrfInput}
-    <button type="submit" class="btn btn-primary"${reloadDisabled ? " disabled" : ""}>Clean up empty channels</button>
-    <span class="muted">Same effect as <code>/vc reload</code>.</span>
-  </form>
   <form method="POST" action="/admin/voice-channels/force-reload" class="inline-form" onsubmit="return confirm('Force cleanup of ALL unmanaged channels in the category and re-create lobby channels?');">
     ${csrfInput}
-    <button type="submit" class="btn btn-danger"${reloadDisabled ? " disabled" : ""}>Force cleanup &amp; ensure lobby</button>
-    <span class="muted">Same effect as <code>/vc force-reload</code>.</span>
+    <button type="submit" class="btn btn-danger"${reloadDisabled ? " disabled" : ""}>Force VC cleanup</button>
+    <span class="muted">Removes ALL unmanaged channels in the category and re-creates the lobby. Same effect as <code>/vc force-reload</code>.</span>
   </form>
   ${reloadHint ? `<p class="muted">${reloadHint}</p>` : ""}
 </div>

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -1841,7 +1841,7 @@ export function renderVoiceChannelsPage(props: VoiceChannelsProps): string {
 
   const body = `
 <h1>Voice Channels</h1>
-<p class="subtitle">Voice-channel category contents and live state. Replaces <code>/vc reload|force-reload</code>; the slash commands still work in parallel during migration.</p>
+<p class="subtitle">Voice-channel category contents and live state. Replaces <code>/vc force-reload</code>; for the gentler empty-channel cleanup use <code>/vc reload</code>. The slash commands still work in parallel during migration.</p>
 ${renderFlash(props.flash)}
 <div class="card">
   <h2>Status</h2>

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -2780,37 +2780,6 @@ export function createWriteRouter(
   // ============================================================
 
   router.post(
-    "/voice-channels/reload",
-    asyncHandler(async (req, res) => {
-      const session = requireSessionContext(req);
-      const manager = VoiceChannelManager.getInstance(client);
-      try {
-        await manager.cleanupEmptyChannels();
-        await recordAudit(session, {
-          action: "voicechannels.reload",
-          result: "success",
-        });
-        flashRedirect(res, "/admin/voice-channels", {
-          type: "ok",
-          text: "Cleaned up empty voice channels.",
-        });
-      } catch (err) {
-        const text = err instanceof Error ? err.message : "Unknown error";
-        logger.error("VC reload failed", err);
-        await recordAudit(session, {
-          action: "voicechannels.reload",
-          result: "failure",
-          errorMessage: text,
-        });
-        flashRedirect(res, "/admin/voice-channels", {
-          type: "err",
-          text: `Cleanup failed: ${text}`,
-        });
-      }
-    }),
-  );
-
-  router.post(
     "/voice-channels/force-reload",
     asyncHandler(async (req, res) => {
       const session = requireSessionContext(req);


### PR DESCRIPTION
## Summary

Closes #490.

The admin **Voice Channels** page (`/admin/voice-channels`) previously had two cleanup buttons that confused operators about which to use. This collapses them into a single aggressive **Force VC cleanup** button.

## Changes

- **`src/web/admin-views.ts`** — Removed the gentle "Clean up empty channels" form (`POST /admin/voice-channels/reload`). Renamed the remaining force-cleanup button to **"Force VC cleanup"** and updated its helper text to spell out the aggressive behaviour. The confirm dialog wording is unchanged: _"Force cleanup of ALL unmanaged channels in the category and re-create lobby channels?"_
- **`src/web/write-routes.ts`** — Removed the `/voice-channels/reload` route handler. Kept `/voice-channels/force-reload` as the single canonical path; its `WebAuditLog` recording (`voicechannels.force-reload`) is unchanged, so audit-log entries are unaffected.
- **`WEBUI.md`** — Updated the admin-pages table so the Voice Channels row reflects the single button.
- **`__tests__/web/admin-views.test.ts`** — Updated assertions to expect the single "Force VC cleanup" button and to verify the old route/button are gone.

## Acceptance

- [x] Single "Force VC cleanup" button on the Voice Channels page.
- [x] Old "Clean up empty channels" route + button removed.
- [x] Confirm dialog clearly states the aggressive behaviour.
- [x] No regressions in audit-log entries (remaining action records via `WebAuditLog`).
- [x] `WEBUI.md` updated to reflect the single button.

## Testing

- `jest __tests__/web/admin-views.test.ts` — 75 passed
- `jest __tests__/web/write-routes.test.ts` — 26 passed
- `tsc --noEmit` — clean for changed files
- `eslint` — no new errors

Note: The `/vc reload` slash command still exists and works in parallel; only the WebUI gentle path was removed, as specified in the issue.

https://claude.ai/code/session_01BBtYohuJsYfqFg9w2vKaYX

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBtYohuJsYfqFg9w2vKaYX)_