### PR TITLE
fix: validate Content-Type and cap size on poll import fetches

### DIFF
--- a/__tests__/services/poll-service.test.ts
+++ b/__tests__/services/poll-service.test.ts
@@ -61,7 +61,11 @@ describe("PollService", () => {
   it("rejects invalid URL formats before fetching", async () => {
     const service = PollService.getInstance({} as never);
 
-    const result = await service.importFromUrl("not-a-url", "guild-1", "user-1");
+    const result = await service.importFromUrl(
+      "not-a-url",
+      "guild-1",
+      "user-1",
+    );
 
     expect(result).toEqual({
       imported: 0,
@@ -107,7 +111,11 @@ describe("PollService", () => {
     ];
 
     for (const blockedUrl of blockedUrls) {
-      const result = await service.importFromUrl(blockedUrl, "guild-1", "user-1");
+      const result = await service.importFromUrl(
+        blockedUrl,
+        "guild-1",
+        "user-1",
+      );
 
       expect(result).toEqual({
         imported: 0,
@@ -137,15 +145,18 @@ describe("PollService", () => {
       "user-1",
     );
 
-    expect(mockAxiosGet).toHaveBeenCalledWith("https://example.com/polls.yaml", {
-      timeout: 10000,
-      maxContentLength: 2 * 1024 * 1024,
-      maxBodyLength: 2 * 1024 * 1024,
-      responseType: "text",
-      headers: {
-        "User-Agent": "KoolBot-PollService/1.0",
+    expect(mockAxiosGet).toHaveBeenCalledWith(
+      "https://example.com/polls.yaml",
+      {
+        timeout: 10000,
+        maxContentLength: 2 * 1024 * 1024,
+        maxBodyLength: 2 * 1024 * 1024,
+        responseType: "text",
+        headers: {
+          "User-Agent": "KoolBot-PollService/1.0",
+        },
       },
-    });
+    );
     expect(mockPollItemFindOne).toHaveBeenCalledWith({
       guildId: "guild-1",
       question: "Favorite color?",
@@ -190,11 +201,33 @@ describe("PollService", () => {
     expect(mockPollItemCreate).not.toHaveBeenCalled();
   });
 
+  it("reports an invalid-format error for an empty or non-object body", async () => {
+    mockAxiosGet.mockResolvedValue({
+      data: "",
+      headers: { "content-type": "text/plain" },
+    });
+
+    const service = PollService.getInstance({} as never);
+
+    const result = await service.importFromUrl(
+      "https://example.com/empty.yaml",
+      "guild-1",
+      "user-1",
+    );
+
+    expect(result).toEqual({
+      imported: 0,
+      skipped: 0,
+      errors: ["Invalid format: expected { polls: [...] }"],
+    });
+    expect(mockPollItemCreate).not.toHaveBeenCalled();
+  });
+
   it("reports a clear error when the payload exceeds the size cap", async () => {
     mockAxiosIsAxiosError.mockReturnValue(true);
     mockAxiosGet.mockRejectedValue({
-      code: "ERR_FR_MAX_CONTENT_LENGTH_EXCEEDED",
-      message: "maxContentLength size of 2097152 exceeded",
+      code: "ERR_FR_MAX_BODY_LENGTH_EXCEEDED",
+      message: "maxBodyLength size of 2097152 exceeded",
     });
 
     const service = PollService.getInstance({} as never);

--- a/__tests__/services/poll-service.test.ts
+++ b/__tests__/services/poll-service.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 
 const mockAxiosGet = jest.fn();
+const mockAxiosIsAxiosError = jest.fn();
 const mockPollItemFindOne = jest.fn();
 const mockPollItemCreate = jest.fn();
 const mockRegisterReloadCallback = jest.fn();
@@ -10,7 +11,7 @@ const mockConfigGetNumber = jest.fn();
 jest.unstable_mockModule("axios", () => ({
   default: {
     get: mockAxiosGet,
-    isAxiosError: jest.fn(() => false),
+    isAxiosError: mockAxiosIsAxiosError,
   },
 }));
 
@@ -50,6 +51,7 @@ describe("PollService", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (PollService as unknown as { instance: unknown }).instance = undefined;
+    mockAxiosIsAxiosError.mockReturnValue(false);
     mockConfigGetBoolean.mockResolvedValue(false);
     mockConfigGetNumber.mockResolvedValue(7);
     mockPollItemFindOne.mockResolvedValue(null);
@@ -124,6 +126,7 @@ describe("PollService", () => {
       - Blue
       - Green
 `,
+      headers: { "content-type": "text/yaml; charset=utf-8" },
     });
 
     const service = PollService.getInstance({} as never);
@@ -136,7 +139,9 @@ describe("PollService", () => {
 
     expect(mockAxiosGet).toHaveBeenCalledWith("https://example.com/polls.yaml", {
       timeout: 10000,
-      maxContentLength: 1024 * 1024,
+      maxContentLength: 2 * 1024 * 1024,
+      maxBodyLength: 2 * 1024 * 1024,
+      responseType: "text",
       headers: {
         "User-Agent": "KoolBot-PollService/1.0",
       },
@@ -159,5 +164,75 @@ describe("PollService", () => {
       skipped: 0,
       errors: [],
     });
+  });
+
+  it("rejects responses with a non-JSON/YAML Content-Type", async () => {
+    mockAxiosGet.mockResolvedValue({
+      data: "<!DOCTYPE html><html><body>Login required</body></html>",
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+
+    const service = PollService.getInstance({} as never);
+
+    const result = await service.importFromUrl(
+      "https://example.com/login",
+      "guild-1",
+      "user-1",
+    );
+
+    expect(result).toEqual({
+      imported: 0,
+      skipped: 0,
+      errors: [
+        'Unexpected Content-Type from import URL: "text/html". Expected JSON or YAML.',
+      ],
+    });
+    expect(mockPollItemCreate).not.toHaveBeenCalled();
+  });
+
+  it("reports a clear error when the payload exceeds the size cap", async () => {
+    mockAxiosIsAxiosError.mockReturnValue(true);
+    mockAxiosGet.mockRejectedValue({
+      code: "ERR_FR_MAX_CONTENT_LENGTH_EXCEEDED",
+      message: "maxContentLength size of 2097152 exceeded",
+    });
+
+    const service = PollService.getInstance({} as never);
+
+    const result = await service.importFromUrl(
+      "https://example.com/huge.yaml",
+      "guild-1",
+      "user-1",
+    );
+
+    expect(result).toEqual({
+      imported: 0,
+      skipped: 0,
+      errors: ["URL response too large (max 2 MB)"],
+    });
+    expect(mockPollItemCreate).not.toHaveBeenCalled();
+  });
+
+  it("reports a clear error when the request times out", async () => {
+    mockAxiosIsAxiosError.mockReturnValue(true);
+    mockAxiosGet.mockRejectedValue({
+      code: "ECONNABORTED",
+      message: "timeout of 10000ms exceeded",
+    });
+
+    const service = PollService.getInstance({} as never);
+
+    const result = await service.importFromUrl(
+      "https://example.com/slow.yaml",
+      "guild-1",
+      "user-1",
+    );
+
+    expect(result).toEqual({
+      imported: 0,
+      skipped: 0,
+      errors: ["Request timeout - URL took too long to respond"],
+    });
+    expect(mockPollItemCreate).not.toHaveBeenCalled();
   });
 });

--- a/src/services/poll-service.ts
+++ b/src/services/poll-service.ts
@@ -25,6 +25,30 @@ interface PollSource {
   polls: PollData[];
 }
 
+// Cap the size of an imported poll library. 2 MB comfortably holds thousands of
+// questions while preventing a malicious or misconfigured URL from streaming an
+// unbounded body into memory before parsing fails.
+const MAX_IMPORT_BYTES = 2 * 1024 * 1024;
+
+// Reject the request if it has not completed within this window so a slow or
+// unresponsive server cannot hang the import indefinitely.
+const IMPORT_TIMEOUT_MS = 10_000;
+
+// The importer accepts YAML or JSON, so we allow JSON, YAML, and generic
+// plain-text/octet-stream responses. Anything else (e.g. an HTML login,
+// redirect, or Cloudflare challenge page) is rejected before parsing so the
+// admin gets a clear error instead of a confusing parse failure.
+const ALLOWED_IMPORT_CONTENT_TYPES = [
+  "application/json",
+  "text/json",
+  "application/yaml",
+  "text/yaml",
+  "application/x-yaml",
+  "text/x-yaml",
+  "text/plain",
+  "application/octet-stream",
+];
+
 /**
  * Block obvious local/private destinations so poll imports cannot be used for
  * direct SSRF probes against loopback, link-local, RFC1918, or unique-local
@@ -455,14 +479,31 @@ export class PollService {
     }
 
     try {
-      // Fetch the content with timeout
+      // Fetch the content with timeout. Receive the body as raw text so we can
+      // inspect the Content-Type and parse it ourselves rather than letting
+      // Axios silently coerce a non-JSON response.
       const response = await axios.get(parsedUrl.toString(), {
-        timeout: 10000,
-        maxContentLength: 1024 * 1024, // 1MB max
+        timeout: IMPORT_TIMEOUT_MS,
+        maxContentLength: MAX_IMPORT_BYTES,
+        maxBodyLength: MAX_IMPORT_BYTES,
+        responseType: "text",
         headers: {
           "User-Agent": "KoolBot-PollService/1.0",
         },
       });
+
+      // Validate the Content-Type before parsing. An HTML login/redirect or
+      // challenge page would otherwise surface as a cryptic parse error.
+      const contentType = String(response.headers?.["content-type"] ?? "")
+        .split(";")[0]
+        .trim()
+        .toLowerCase();
+      if (contentType && !ALLOWED_IMPORT_CONTENT_TYPES.includes(contentType)) {
+        results.errors.push(
+          `Unexpected Content-Type from import URL: "${contentType}". Expected JSON or YAML.`,
+        );
+        return results;
+      }
 
       let pollData: PollSource;
 
@@ -541,6 +582,10 @@ export class PollService {
       if (axios.isAxiosError(error)) {
         if (error.code === "ECONNABORTED") {
           results.errors.push("Request timeout - URL took too long to respond");
+        } else if (error.code === "ERR_FR_MAX_CONTENT_LENGTH_EXCEEDED") {
+          results.errors.push(
+            `URL response too large (max ${MAX_IMPORT_BYTES / (1024 * 1024)} MB)`,
+          );
         } else if (error.response) {
           results.errors.push(
             `HTTP ${error.response.status}: ${error.response.statusText}`,

--- a/src/services/poll-service.ts
+++ b/src/services/poll-service.ts
@@ -515,7 +515,9 @@ export class PollService {
         pollData = JSON.parse(response.data);
       }
 
-      if (!pollData.polls || !Array.isArray(pollData.polls)) {
+      // yaml.load / JSON.parse can yield null, undefined, or a scalar for an
+      // empty or non-object body, so guard before dereferencing.
+      if (!pollData?.polls || !Array.isArray(pollData.polls)) {
         results.errors.push("Invalid format: expected { polls: [...] }");
         return results;
       }
@@ -582,7 +584,10 @@ export class PollService {
       if (axios.isAxiosError(error)) {
         if (error.code === "ECONNABORTED") {
           results.errors.push("Request timeout - URL took too long to respond");
-        } else if (error.code === "ERR_FR_MAX_CONTENT_LENGTH_EXCEEDED") {
+        } else if (
+          error.code === "ERR_FR_MAX_CONTENT_LENGTH_EXCEEDED" ||
+          error.code === "ERR_FR_MAX_BODY_LENGTH_EXCEEDED"
+        ) {
           results.errors.push(
             `URL response too large (max ${MAX_IMPORT_BYTES / (1024 * 1024)} MB)`,
           );


### PR DESCRIPTION
## Summary

Hardens `importFromUrl` in `src/services/poll-service.ts` against unreliable and oversized external responses, addressing #507.

The existing code already validated the URL scheme (`http`/`https`) and blocked private/local addresses, but it parsed the response without checking the `Content-Type` and capped the body at only 1 MB on `maxContentLength` alone. This PR adds the remaining safeguards.

## Changes

- **Content-Type validation** — responses whose `Content-Type` is not JSON, YAML, or plain text (e.g. an HTML login/redirect or Cloudflare challenge page) are rejected before parsing with a clear, user-facing error instead of a confusing parse failure.
- **Raw-text response** — fetch with `responseType: "text"` so the importer controls parsing rather than letting Axios silently coerce a non-JSON body.
- **Size cap** — both `maxContentLength` and `maxBodyLength` are set from a named `MAX_IMPORT_BYTES = 2 MB` constant (with a comment explaining the choice). When the cap is exceeded, a clear `URL response too large (max 2 MB)` message is surfaced.
- **Named timeout** — the 10 s timeout is extracted into `IMPORT_TIMEOUT_MS`.

## Acceptance criteria

- [x] Fetches to non-JSON URLs produce a clear user-facing error message, not a parse stack trace.
- [x] Response body is capped (2 MB, named constant with an explanatory comment).
- [x] A request timeout is set (10 s).
- [x] Non-`http(s)` URL schemes are rejected before the request is issued (pre-existing; covered by tests).
- [x] Unit tests cover non-JSON Content-Type, payload exceeding the cap, timeout, and invalid URL scheme.

## Testing

- `npm test` — 918 passed, 1 pre-existing skip (90 suites)
- `npm run build` — clean
- ESLint — no new errors; Prettier — clean

Closes #507

---
_Generated by [Claude Code](https://claude.ai/code/session_012UMbB6R39NUfsnpGBBacv4)_