### PR TITLE
fix: bound unbounded `.find({})` service queries to avoid scale regression (#505)

### DIFF
--- a/__tests__/services/achievements-service.test.ts
+++ b/__tests__/services/achievements-service.test.ts
@@ -37,6 +37,20 @@ import { UserAchievements } from '../../src/models/user-achievements.js';
 import { VoiceChannelTracking, type IVoiceChannelTracking } from '../../src/models/voice-channel-tracking.js';
 import { UserNotificationPrefsService } from '../../src/services/user-notification-prefs-service.js';
 
+// Helper that mimics a Mongoose query cursor over a fixed set of docs, so
+// tests can exercise the streaming `.find({}).cursor()` path.
+function mockFindCursor(docs: unknown[]) {
+  return {
+    cursor: () => ({
+      async *[Symbol.asyncIterator]() {
+        for (const doc of docs) {
+          yield doc;
+        }
+      },
+    }),
+  };
+}
+
 // Helper to create an AchievementsService with injected config
 function createAchievementsService(mockClient: Partial<Client>) {
   const service = AchievementsService.getInstance(mockClient as Client);
@@ -61,7 +75,7 @@ describe('AchievementsService', () => {
   beforeEach(() => {
     // Reconfigure mock methods for each test
     (UserAchievements.findOne as jest.Mock).mockResolvedValue(null);
-    (UserAchievements.find as jest.Mock).mockResolvedValue([]);
+    (UserAchievements.find as jest.Mock).mockReturnValue(mockFindCursor([]));
     (VoiceChannelTracking.findOne as jest.Mock).mockResolvedValue(null);
 
     mockClient = { users: { fetch: jest.fn() } as any };
@@ -389,20 +403,22 @@ describe('AchievementsService', () => {
   describe('getNewAccoladesSinceLastWeek', () => {
     it('should return empty array when no recent accolades', async () => {
       const { service } = createAchievementsService(mockClient);
-      (UserAchievements.find as jest.Mock).mockResolvedValue([]);
+      (UserAchievements.find as jest.Mock).mockReturnValue(mockFindCursor([]));
       expect(await service.getNewAccoladesSinceLastWeek()).toEqual([]);
     });
 
     it('should return users with accolades earned in the past week', async () => {
       const { service } = createAchievementsService(mockClient);
       const recentDate = new Date();
-      (UserAchievements.find as jest.Mock).mockResolvedValue([
-        {
-          userId: 'user1',
-          username: 'User1',
-          accolades: [{ type: 'first_hour', earnedAt: recentDate, metadata: {} }],
-        },
-      ]);
+      (UserAchievements.find as jest.Mock).mockReturnValue(
+        mockFindCursor([
+          {
+            userId: 'user1',
+            username: 'User1',
+            accolades: [{ type: 'first_hour', earnedAt: recentDate, metadata: {} }],
+          },
+        ]),
+      );
 
       const result = await service.getNewAccoladesSinceLastWeek();
       expect(result).toHaveLength(1);
@@ -411,7 +427,9 @@ describe('AchievementsService', () => {
 
     it('should handle database errors gracefully', async () => {
       const { service } = createAchievementsService(mockClient);
-      (UserAchievements.find as jest.Mock).mockRejectedValue(new Error('DB error'));
+      (UserAchievements.find as jest.Mock).mockImplementation(() => {
+        throw new Error('DB error');
+      });
       expect(await service.getNewAccoladesSinceLastWeek()).toEqual([]);
     });
   });

--- a/__tests__/services/achievements-service.test.ts
+++ b/__tests__/services/achievements-service.test.ts
@@ -40,15 +40,15 @@ import { UserNotificationPrefsService } from '../../src/services/user-notificati
 // Helper that mimics a Mongoose query cursor over a fixed set of docs, so
 // tests can exercise the streaming `.find({}).cursor()` path.
 function mockFindCursor(docs: unknown[]) {
-  return {
-    cursor: () => ({
-      async *[Symbol.asyncIterator]() {
-        for (const doc of docs) {
-          yield doc;
-        }
-      },
-    }),
-  };
+  const cursor = () => ({
+    async *[Symbol.asyncIterator]() {
+      for (const doc of docs) {
+        yield doc;
+      }
+    },
+  });
+  // Mirrors the `.select(...).lean().cursor()` chain the service uses.
+  return { select: () => ({ lean: () => ({ cursor }) }) };
 }
 
 // Helper to create an AchievementsService with injected config

--- a/__tests__/services/message-activity-cleanup.test.ts
+++ b/__tests__/services/message-activity-cleanup.test.ts
@@ -22,6 +22,22 @@ import { MessageActivityTracking } from "../../src/models/message-activity-track
 (MessageActivityTracking as unknown as { updateOne: jest.Mock }).updateOne =
   jest.fn();
 
+// Mimics the streaming `find({}).lean(false).cursor()` chain the cleanup
+// service uses, yielding each doc one at a time.
+function findCursor(docs: unknown[]) {
+  return {
+    lean: () => ({
+      cursor: () => ({
+        async *[Symbol.asyncIterator]() {
+          for (const doc of docs) {
+            yield doc;
+          }
+        },
+      }),
+    }),
+  };
+}
+
 function createService() {
   const service = MessageActivityCleanupService.getInstance({} as Client);
 
@@ -77,7 +93,7 @@ describe("MessageActivityCleanupService", () => {
       recentMessages: [oldEntry, recentEntry],
     };
 
-    find.mockReturnValue({ exec: jest.fn().mockResolvedValue([userDoc]) });
+    find.mockReturnValue(findCursor([userDoc]));
 
     const stats = await service.runCleanup();
 
@@ -102,8 +118,8 @@ describe("MessageActivityCleanupService", () => {
       sentAt: new Date(Date.now() - 5 * DAY_MS),
       channelId: "c1",
     };
-    find.mockReturnValue({
-      exec: jest.fn().mockResolvedValue([
+    find.mockReturnValue(
+      findCursor([
         {
           _id: "id1",
           username: "User1",
@@ -112,13 +128,31 @@ describe("MessageActivityCleanupService", () => {
           recentMessages: [recentEntry],
         },
       ]),
-    });
+    );
 
     const stats = await service.runCleanup();
 
     expect(stats.messagesPruned).toBe(0);
     expect(stats.usersProcessed).toBe(0);
     expect(updateOne).not.toHaveBeenCalled();
+  });
+
+  it("streams via a cursor and never materialises the whole collection", async () => {
+    const { service } = createService();
+
+    const cursor = jest.fn(() => ({
+      async *[Symbol.asyncIterator]() {},
+    }));
+    const lean = jest.fn(() => ({ cursor }));
+    find.mockReturnValue({ lean });
+
+    await service.runCleanup();
+
+    // The cleanup must page through the collection with a cursor rather than
+    // awaiting an unbounded `.find({}).exec()` that loads every document.
+    expect(find).toHaveBeenCalledTimes(1);
+    expect(cursor).toHaveBeenCalledTimes(1);
+    expect(find.mock.results[0].value).not.toHaveProperty("exec");
   });
 
   it("skips when the cleanup job is disabled", async () => {

--- a/__tests__/services/voice-channel-tracker.test.ts
+++ b/__tests__/services/voice-channel-tracker.test.ts
@@ -265,6 +265,48 @@ describe('VoiceChannelTracker', () => {
       (VoiceChannelTracking.aggregate as jest.Mock).mockRejectedValue(new Error('DB error'));
       expect(await tracker.getTopUsers()).toEqual([]);
     });
+
+    it('reads the cap from the leaderboard_max_results config key', async () => {
+      const { tracker, mockConfigService } = createTracker(mockClient);
+      (VoiceChannelTracking.aggregate as jest.Mock).mockResolvedValue([]);
+
+      await tracker.getTopUsers(10, 'alltime');
+
+      expect(mockConfigService.getNumber).toHaveBeenCalledWith(
+        'voicetracking.stats.leaderboard_max_results',
+        50,
+      );
+    });
+
+    it('clamps a large requested limit to the configurable cap', async () => {
+      const { tracker, mockConfigService } = createTracker(mockClient);
+      mockConfigService.getNumber.mockResolvedValue(5);
+      (VoiceChannelTracking.aggregate as jest.Mock).mockClear();
+      (VoiceChannelTracking.aggregate as jest.Mock).mockResolvedValue([]);
+
+      await tracker.getTopUsers(1000, 'alltime');
+
+      const pipeline = (VoiceChannelTracking.aggregate as jest.Mock).mock.calls[0][0];
+      const limitStage = pipeline.find(
+        (stage: Record<string, unknown>) => '$limit' in stage,
+      );
+      expect(limitStage).toEqual({ $limit: 5 });
+    });
+
+    it('keeps every row for the "all" sentinel (non-positive limit)', async () => {
+      const { tracker, mockConfigService } = createTracker(mockClient);
+      mockConfigService.getNumber.mockResolvedValue(5);
+      (VoiceChannelTracking.aggregate as jest.Mock).mockClear();
+      (VoiceChannelTracking.aggregate as jest.Mock).mockResolvedValue([]);
+
+      await tracker.getTopUsers(0, 'week');
+
+      const pipeline = (VoiceChannelTracking.aggregate as jest.Mock).mock.calls[0][0];
+      const limitStage = pipeline.find(
+        (stage: Record<string, unknown>) => '$limit' in stage,
+      );
+      expect(limitStage).toBeUndefined();
+    });
   });
 
   describe('getUserLastSeen', () => {

--- a/__tests__/services/voice-channel-truncation-methods.test.ts
+++ b/__tests__/services/voice-channel-truncation-methods.test.ts
@@ -8,8 +8,11 @@ jest.mock('../../src/models/voice-channel-tracking.js', () => ({
   VoiceChannelTracking: {
     find: jest.fn().mockResolvedValue([]),
     findOne: jest.fn().mockResolvedValue(null),
+    updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }),
   },
 }));
+
+import { VoiceChannelTracking } from '../../src/models/voice-channel-tracking.js';
 
 describe('VoiceChannelTruncationService Methods', () => {
   let mockClient: Partial<Client>;
@@ -49,9 +52,29 @@ describe('VoiceChannelTruncationService Methods', () => {
 
   it('should have getStatus method', async () => {
     const { VoiceChannelTruncationService } = await import('../../src/services/voice-channel-truncation.js');
-    
+
     const instance = VoiceChannelTruncationService.getInstance(mockClient as Client);
 
     expect(typeof instance.getStatus).toBe('function');
+  });
+
+  it('streams the tracking collection via a cursor, not an unbounded find', async () => {
+    const { VoiceChannelTruncationService } = await import('../../src/services/voice-channel-truncation.js');
+    const instance = VoiceChannelTruncationService.getInstance(mockClient as Client);
+
+    const cursor = jest.fn(() => ({
+      async *[Symbol.asyncIterator]() {},
+    }));
+    const lean = jest.fn(() => ({ cursor }));
+    const find = VoiceChannelTracking.find as jest.Mock;
+    find.mockReturnValue({ lean });
+
+    // performCleanup is the private worker that the cron tick invokes.
+    await (instance as unknown as { performCleanup: () => Promise<unknown> }).performCleanup();
+
+    expect(find).toHaveBeenCalledTimes(1);
+    expect(cursor).toHaveBeenCalledTimes(1);
+    // The unbounded materialisation path (.exec()) must never be used.
+    expect(find.mock.results[0].value).not.toHaveProperty('exec');
   });
 });

--- a/src/services/achievements-service.ts
+++ b/src/services/achievements-service.ts
@@ -1250,10 +1250,14 @@ export class AchievementsService {
 
       // Stream matching documents via a cursor rather than materialising the
       // whole result set, so this stays bounded as the achievements
-      // collection grows.
+      // collection grows. Only the three fields read below are projected, and
+      // `.lean()` avoids hydrating full Mongoose documents.
       const cursor = UserAchievements.find({
         "accolades.earnedAt": { $gte: oneWeekAgo },
-      }).cursor();
+      })
+        .select("userId username accolades")
+        .lean()
+        .cursor();
 
       const result: Array<{
         userId: string;

--- a/src/services/achievements-service.ts
+++ b/src/services/achievements-service.ts
@@ -1248,17 +1248,33 @@ export class AchievementsService {
 
       const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
 
-      const users = await UserAchievements.find({
+      // Stream matching documents via a cursor rather than materialising the
+      // whole result set, so this stays bounded as the achievements
+      // collection grows.
+      const cursor = UserAchievements.find({
         "accolades.earnedAt": { $gte: oneWeekAgo },
-      });
+      }).cursor();
 
-      return users
-        .map((user) => ({
-          userId: user.userId,
-          username: user.username,
-          accolades: user.accolades.filter((a) => a.earnedAt >= oneWeekAgo),
-        }))
-        .filter((u) => u.accolades.length > 0);
+      const result: Array<{
+        userId: string;
+        username: string;
+        accolades: IAccolade[];
+      }> = [];
+
+      for await (const user of cursor) {
+        const accolades = user.accolades.filter(
+          (a) => a.earnedAt >= oneWeekAgo,
+        );
+        if (accolades.length > 0) {
+          result.push({
+            userId: user.userId,
+            username: user.username,
+            accolades,
+          });
+        }
+      }
+
+      return result;
     } catch (error) {
       logger.error("Error getting new accolades since last week:", error);
       return [];

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -14,6 +14,7 @@ export interface ConfigSchema {
   "voicetracking.enabled": boolean;
   "voicetracking.stats.top.enabled": boolean; // Enable /voicestats top subcommand
   "voicetracking.stats.user.enabled": boolean; // Enable /voicestats user subcommand
+  "voicetracking.stats.leaderboard_max_results": number; // Server-side cap on /voicestats top rows
   "voicetracking.seen.enabled": boolean;
   "voicetracking.excluded_channels": string; // Comma-separated channel IDs
   "voicetracking.announcements.enabled": boolean;
@@ -147,6 +148,7 @@ export const defaultConfig: ConfigSchema = {
   "voicetracking.enabled": false,
   "voicetracking.stats.top.enabled": false,
   "voicetracking.stats.user.enabled": false,
+  "voicetracking.stats.leaderboard_max_results": 50,
   "voicetracking.seen.enabled": false,
   "voicetracking.excluded_channels": "",
   "voicetracking.announcements.enabled": false,
@@ -472,6 +474,13 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
     description: "Enable the /voicestats user personal-stats subcommand.",
     category: "voicetracking",
     type: "boolean",
+  },
+  "voicetracking.stats.leaderboard_max_results": {
+    label: "Leaderboard max results",
+    description:
+      "Server-side cap on how many ranked users the /voicestats top leaderboard returns. Bounds the aggregation pipeline so a single request can never materialise the whole collection.",
+    category: "voicetracking",
+    type: "number",
   },
   "voicetracking.seen.enabled": {
     label: "/seen command enabled",

--- a/src/services/message-activity-cleanup.ts
+++ b/src/services/message-activity-cleanup.ts
@@ -301,9 +301,9 @@ export class MessageActivityCleanupService {
       cutoffDate.setDate(cutoffDate.getDate() - retentionDays);
 
       // Stream users one at a time via a cursor instead of loading the whole
-      // (append-heavy) collection into memory. Each document is processed and
-      // updated independently, so we never materialise more than one row.
-      const cursor = MessageActivityTracking.find({}).lean(false).cursor();
+      // (append-heavy) collection into memory. The loop only reads fields and
+      // writes back via `updateOne`, so `.lean()` avoids hydration overhead.
+      const cursor = MessageActivityTracking.find({}).lean().cursor();
 
       for await (const user of cursor) {
         try {

--- a/src/services/message-activity-cleanup.ts
+++ b/src/services/message-activity-cleanup.ts
@@ -300,9 +300,12 @@ export class MessageActivityCleanupService {
       const cutoffDate = new Date();
       cutoffDate.setDate(cutoffDate.getDate() - retentionDays);
 
-      const users = await MessageActivityTracking.find({}).exec();
+      // Stream users one at a time via a cursor instead of loading the whole
+      // (append-heavy) collection into memory. Each document is processed and
+      // updated independently, so we never materialise more than one row.
+      const cursor = MessageActivityTracking.find({}).lean(false).cursor();
 
-      for (const user of users) {
+      for await (const user of cursor) {
         try {
           if (user.recentMessages && user.recentMessages.length > 0) {
             const recent = user.recentMessages.filter(

--- a/src/services/voice-channel-tracker.ts
+++ b/src/services/voice-channel-tracker.ts
@@ -462,6 +462,20 @@ export class VoiceChannelTracker {
       let startDate: Date;
       let users;
 
+      // Server-side safety cap. A positive `limit` (e.g. the user-supplied
+      // `/voicestats top` count) is clamped to the configurable maximum so a
+      // single request can never materialise an unbounded result set. A
+      // non-positive `limit` is the documented "all ranked users" sentinel
+      // used by internal aggregation consumers (weekly digest fan-out,
+      // leaderboard-role reconcile), which still receive every row.
+      const maxResults = await this.configService.getNumber(
+        "voicetracking.stats.leaderboard_max_results",
+        50,
+      );
+      const effectiveLimit =
+        limit > 0 ? Math.min(limit, Math.max(1, maxResults)) : 0;
+      const limitStage = effectiveLimit > 0 ? [{ $limit: effectiveLimit }] : [];
+
       switch (timePeriod) {
         case "week":
           startDate = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
@@ -476,7 +490,7 @@ export class VoiceChannelTracker {
               },
             },
             { $sort: { totalTime: -1 } },
-            ...(limit > 0 ? [{ $limit: limit }] : []),
+            ...limitStage,
           ]);
           break;
         case "month":
@@ -492,7 +506,7 @@ export class VoiceChannelTracker {
               },
             },
             { $sort: { totalTime: -1 } },
-            ...(limit > 0 ? [{ $limit: limit }] : []),
+            ...limitStage,
           ]);
           break;
         case "alltime":
@@ -505,7 +519,7 @@ export class VoiceChannelTracker {
               },
             },
             { $sort: { totalTime: -1 } },
-            ...(limit > 0 ? [{ $limit: limit }] : []),
+            ...limitStage,
           ]);
           break;
       }

--- a/src/services/voice-channel-tracker.ts
+++ b/src/services/voice-channel-tracker.ts
@@ -468,12 +468,19 @@ export class VoiceChannelTracker {
       // non-positive `limit` is the documented "all ranked users" sentinel
       // used by internal aggregation consumers (weekly digest fan-out,
       // leaderboard-role reconcile), which still receive every row.
-      const maxResults = await this.configService.getNumber(
+      //
+      // Both values are sanitised to a finite positive integer: `$limit` must
+      // be an integer, and a fractional/NaN/Infinity config value would
+      // otherwise produce an invalid stage or silently disable the cap.
+      const rawMax = await this.configService.getNumber(
         "voicetracking.stats.leaderboard_max_results",
         50,
       );
+      const maxResults =
+        Number.isFinite(rawMax) && rawMax >= 1 ? Math.floor(rawMax) : 50;
+      const requestedLimit = Number.isFinite(limit) ? Math.floor(limit) : 0;
       const effectiveLimit =
-        limit > 0 ? Math.min(limit, Math.max(1, maxResults)) : 0;
+        requestedLimit > 0 ? Math.min(requestedLimit, maxResults) : 0;
       const limitStage = effectiveLimit > 0 ? [{ $limit: effectiveLimit }] : [];
 
       switch (timePeriod) {

--- a/src/services/voice-channel-truncation.ts
+++ b/src/services/voice-channel-truncation.ts
@@ -341,10 +341,12 @@ export class VoiceChannelTruncationService {
       // Get retention configuration
       const retentionConfig = await this.getRetentionConfig();
 
-      // Get all users with voice tracking data
-      const users = await VoiceChannelTracking.find({}).exec();
+      // Stream users one at a time via a cursor instead of loading the whole
+      // (append-heavy) collection into memory. Each document is processed and
+      // updated independently, so we never materialise more than one row.
+      const cursor = VoiceChannelTracking.find({}).lean(false).cursor();
 
-      for (const user of users) {
+      for await (const user of cursor) {
         try {
           if (user.sessions && user.sessions.length > 0) {
             const cutoffDate = new Date();

--- a/src/services/voice-channel-truncation.ts
+++ b/src/services/voice-channel-truncation.ts
@@ -342,9 +342,9 @@ export class VoiceChannelTruncationService {
       const retentionConfig = await this.getRetentionConfig();
 
       // Stream users one at a time via a cursor instead of loading the whole
-      // (append-heavy) collection into memory. Each document is processed and
-      // updated independently, so we never materialise more than one row.
-      const cursor = VoiceChannelTracking.find({}).lean(false).cursor();
+      // (append-heavy) collection into memory. The loop only reads fields and
+      // writes back via `updateOne`, so `.lean()` avoids hydration overhead.
+      const cursor = VoiceChannelTracking.find({}).lean().cursor();
 
       for await (const user of cursor) {
         try {


### PR DESCRIPTION
Closes #505.

## Problem

Several service methods loaded entire append-heavy MongoDB collections into memory (`.find({}).exec()` with no `limit()`/cursor), and the leaderboard aggregation was only bounded when a positive `limit` was passed. At scale (thousands of sessions/month) this risks latency spikes and OOM.

## Changes

**Cleanup passes — stream via cursor instead of materialising the whole collection**
- `src/services/voice-channel-truncation.ts` — the cron cleanup now iterates `VoiceChannelTracking.find({}).lean(false).cursor()` one document at a time.
- `src/services/message-activity-cleanup.ts` — same cursor treatment for `MessageActivityTracking`.
- `src/services/achievements-service.ts` — the weekly-accolade scan (`getNewAccoladesSinceLastWeek`) now streams matching docs through a cursor instead of building the full array.

**Leaderboard aggregation — configurable cap**
- `src/services/voice-channel-tracker.ts` `getTopUsers()` clamps a positive requested size to a new config key and always emits the `$limit` stage for it.
- New setting `voicetracking.stats.leaderboard_max_results` (number, default `50`) added to `config-schema.ts` (type, default, and WebUI metadata).
- The non-positive `limit` value remains the documented "all ranked users" sentinel used by the weekly digest fan-out and leaderboard-role reconcile — those legitimately need the full ranked set, so they are intentionally **not** capped (capping them would silently drop qualifying users on large servers).

## Tests
- `voice-channel-truncation-methods.test.ts` and `message-activity-cleanup.test.ts` assert the cleanup services call `.cursor()` and never expose the unbounded `.exec()` path.
- `voice-channel-tracker.test.ts` asserts the cap is read from `voicetracking.stats.leaderboard_max_results`, that an oversized request is clamped to the cap, and that the "all" sentinel keeps every row.
- `achievements-service.test.ts` updated to the cursor-based mock.

Full suite: **920 passing, 1 skipped**. `tsc --noEmit` clean; lint reports 0 errors (only pre-existing warnings).

## Acceptance criteria
- [x] Unbounded `.find({})` cleanup/scan calls now use a cursor.
- [x] Leaderboard pipeline has a `$limit` stage with a configurable cap.
- [x] Unit tests assert the cleanup services do not issue an unbounded `.find`.

### Note on remaining `.find({})` calls
`config-service.ts` reads `Config.find({})` (bounded by the number of config keys, not user data) and `notices-channel-manager.ts` reads all notices (admin-authored, small). These collections are inherently bounded and intentionally need every row, so they were left as-is rather than risk silently truncating configuration/notices. The append-heavy collections the issue targets are all addressed.

https://claude.ai/code/session_011b543LwbpDuwyrMSx5hiyS

---
_Generated by [Claude Code](https://claude.ai/code/session_011b543LwbpDuwyrMSx5hiyS)_