### PR TITLE
fix: enforce server-side length validation on WebUI write routes (#508)

### DIFF
--- a/__tests__/web/write-routes.test.ts
+++ b/__tests__/web/write-routes.test.ts
@@ -8,7 +8,9 @@ import { describe, it, expect } from "@jest/globals";
 import {
   coerceConfigValue,
   findSectionMasterKey,
+  firstLengthError,
   resetConfigToDefaults,
+  TEXT_LIMITS,
   type ResetConfigStore,
 } from "../../src/web/write-routes.js";
 import {
@@ -137,14 +139,16 @@ describe("coerceConfigValue", () => {
       ok: true,
       value: "Lobby",
     });
-    expect(
-      coerceConfigValue("voicechannels.lobby.name", 123),
-    ).toEqual({ ok: true, value: "123" });
+    expect(coerceConfigValue("voicechannels.lobby.name", 123)).toEqual({
+      ok: true,
+      value: "123",
+    });
     // null / undefined become an empty string rather than the literal
     // "null" / "undefined", which is what an unset string field should be.
-    expect(
-      coerceConfigValue("voicechannels.lobby.name", null),
-    ).toEqual({ ok: true, value: "" });
+    expect(coerceConfigValue("voicechannels.lobby.name", null)).toEqual({
+      ok: true,
+      value: "",
+    });
   });
 
   it("joins array input into a comma-separated string for *_list keys", () => {
@@ -169,9 +173,10 @@ describe("coerceConfigValue", () => {
   });
 
   it("yields an empty string when nothing is selected in a multi-select", () => {
-    expect(
-      coerceConfigValue("voicetracking.excluded_channels", []),
-    ).toEqual({ ok: true, value: "" });
+    expect(coerceConfigValue("voicetracking.excluded_channels", [])).toEqual({
+      ok: true,
+      value: "",
+    });
   });
 
   it("rejects an array payload for a non-list string key", () => {
@@ -194,15 +199,18 @@ describe("coerceConfigValue", () => {
     // leaderboard_roles.period is a string key with an `options` whitelist
     // (week / month / alltime); values outside it must be refused.
     it("accepts a value in the options whitelist", () => {
-      expect(
-        coerceConfigValue("leaderboard_roles.period", "week"),
-      ).toEqual({ ok: true, value: "week" });
-      expect(
-        coerceConfigValue("leaderboard_roles.period", "month"),
-      ).toEqual({ ok: true, value: "month" });
-      expect(
-        coerceConfigValue("leaderboard_roles.period", "alltime"),
-      ).toEqual({ ok: true, value: "alltime" });
+      expect(coerceConfigValue("leaderboard_roles.period", "week")).toEqual({
+        ok: true,
+        value: "week",
+      });
+      expect(coerceConfigValue("leaderboard_roles.period", "month")).toEqual({
+        ok: true,
+        value: "month",
+      });
+      expect(coerceConfigValue("leaderboard_roles.period", "alltime")).toEqual({
+        ok: true,
+        value: "alltime",
+      });
     });
 
     it("rejects a value outside the options whitelist with an enumerated reason", () => {
@@ -221,6 +229,71 @@ describe("coerceConfigValue", () => {
       const r = coerceConfigValue("leaderboard_roles.period", "");
       expect(r.ok).toBe(false);
     });
+  });
+
+  describe("free-text length cap (#508)", () => {
+    it("accepts a string value at the configValue limit", () => {
+      const atLimit = "x".repeat(TEXT_LIMITS.configValue);
+      expect(coerceConfigValue("voicechannels.lobby.name", atLimit)).toEqual({
+        ok: true,
+        value: atLimit,
+      });
+    });
+
+    it("rejects a string value one character over the configValue limit", () => {
+      const tooLong = "x".repeat(TEXT_LIMITS.configValue + 1);
+      const r = coerceConfigValue("voicechannels.lobby.name", tooLong);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toMatch(/too long/i);
+    });
+
+    it("does not cap *_list CSV values (bounded by entity IDs, not text)", () => {
+      // A long multi-select selection collapses to CSV in the array branch,
+      // which must not be rejected by the scalar free-text cap.
+      // 150 snowflake-length IDs collapse to a CSV well over the 2000-char
+      // scalar cap; the *_list branch must still accept it.
+      const manyIds = Array.from(
+        { length: 150 },
+        (_, i) => `1000000000000000${String(i).padStart(3, "0")}`,
+      );
+      const r = coerceConfigValue("voicetracking.excluded_channels", manyIds);
+      expect(r.ok).toBe(true);
+      if (r.ok)
+        expect(String(r.value).length).toBeGreaterThan(TEXT_LIMITS.configValue);
+    });
+  });
+});
+
+describe("firstLengthError (#508)", () => {
+  it("returns null when every field is within its limit", () => {
+    expect(
+      firstLengthError([
+        { label: "Title", value: "short", max: 256 },
+        { label: "Content", value: "also short", max: 4000 },
+      ]),
+    ).toBeNull();
+  });
+
+  it("accepts a value exactly at its limit (boundary)", () => {
+    expect(
+      firstLengthError([{ label: "Title", value: "x".repeat(256), max: 256 }]),
+    ).toBeNull();
+  });
+
+  it("reports the first oversized field with its cap", () => {
+    const err = firstLengthError([
+      { label: "Title", value: "ok", max: 256 },
+      { label: "Content", value: "x".repeat(4001), max: 4000 },
+    ]);
+    expect(err).toBe("Content must be 4000 characters or fewer.");
+  });
+
+  it("stops at the first failing field even when several exceed", () => {
+    const err = firstLengthError([
+      { label: "Message", value: "x".repeat(3000), max: 2000 },
+      { label: "Embed description", value: "x".repeat(5000), max: 4000 },
+    ]);
+    expect(err).toBe("Message must be 2000 characters or fewer.");
   });
 });
 

--- a/src/models/poll-item.ts
+++ b/src/models/poll-item.ts
@@ -23,10 +23,14 @@ const PollItemSchema = new Schema<IPollItem>(
       type: [String],
       required: true,
       validate: {
+        // 2–10 answers, each within Discord's 55-char poll-option cap (#508).
         validator: function (v: string[]) {
-          return v.length >= 2 && v.length <= 10;
+          return (
+            v.length >= 2 && v.length <= 10 && v.every((a) => a.length <= 55)
+          );
         },
-        message: "Poll must have between 2 and 10 answers",
+        message:
+          "Poll must have between 2 and 10 answers, each 55 characters or fewer",
       },
     },
     multiSelect: { type: Boolean, default: false },

--- a/src/models/scheduled-announcement.ts
+++ b/src/models/scheduled-announcement.ts
@@ -33,11 +33,13 @@ const ScheduledAnnouncementSchema = new Schema<IScheduledAnnouncement>(
     guildId: { type: String, required: true, index: true },
     channelId: { type: String, required: true },
     cronSchedule: { type: String, required: true },
-    message: { type: String, required: true },
+    // Discord message content cap (#508).
+    message: { type: String, required: true, maxlength: 2000 },
     embedData: {
       type: {
-        title: { type: String },
-        description: { type: String },
+        // Discord embed title / description caps (#508).
+        title: { type: String, maxlength: 256 },
+        description: { type: String, maxlength: 4000 },
         color: { type: Number },
         fields: [
           {

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -517,8 +517,10 @@ function renderSettingControl(
   if (r.type === "cron") {
     return renderCronPicker(currentStr, settingValueFieldName(r.key));
   }
-  // string or unknown type → plain text input.
-  return `<input type="text" name="${valueName}" value="${escapeHtml(primitive)}">`;
+  // string or unknown type → plain text input. The maxlength mirrors the
+  // server-side `TEXT_LIMITS.configValue` cap in write-routes (#508) — kept as
+  // a literal here to avoid a circular import (write-routes imports this file).
+  return `<input type="text" name="${valueName}" maxlength="2000" value="${escapeHtml(primitive)}">`;
 }
 
 /**
@@ -1001,7 +1003,8 @@ export function renderWizardStepPage(props: WizardStepPageProps): string {
       } else if (type === "number") {
         control = `<input type="number" id="${escapeHtml(inputId)}" name="${escapeHtml(k)}" value="${escapeHtml(display)}">`;
       } else {
-        control = `<input type="text" id="${escapeHtml(inputId)}" name="${escapeHtml(k)}" value="${escapeHtml(display)}">`;
+        // maxlength mirrors TEXT_LIMITS.configValue in write-routes (#508).
+        control = `<input type="text" id="${escapeHtml(inputId)}" name="${escapeHtml(k)}" maxlength="2000" value="${escapeHtml(display)}">`;
       }
 
       return `<div class="field-row">
@@ -1413,8 +1416,8 @@ ${renderFlash(props.flash)}
     <label>Question
       <input type="text" name="question" maxlength="300" required>
     </label>
-    <label>Answers (comma-separated, 2–10 options)
-      <input type="text" name="answers" placeholder="Yes, No, Maybe" required>
+    <label>Answers (comma-separated, 2–10 options, ≤55 chars each)
+      <input type="text" name="answers" maxlength="600" placeholder="Yes, No, Maybe" required>
     </label>
     <label>Tags (comma-separated, optional)
       <input type="text" name="tags" placeholder="icebreaker, funny">

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -59,6 +59,52 @@ type Flash = { type: "ok" | "warn" | "err"; text: string };
 
 const FLASH_MAX = 500;
 
+/**
+ * Maximum lengths for user-supplied free text (issue #508). Each cap is
+ * derived from the real-world constraint the value eventually hits — a
+ * Discord embed/message/poll limit, or a sane ceiling for a stored setting.
+ * Server-side validation uses these so an oversized payload is rejected with
+ * a clean flash *before* it reaches MongoDB or the Discord API, rather than
+ * surfacing later as an opaque Mongoose `ValidationError` (formatted as a 500)
+ * or a silent Discord rejection at send time. The matching schema `maxlength`
+ * constraints are defence-in-depth for non-route writers.
+ */
+export const TEXT_LIMITS = {
+  /** Discord embed title cap — notice titles render as the embed title. */
+  noticeTitle: 256,
+  /** Discord embed description (body) cap — notices render as embeds. */
+  noticeContent: 4000,
+  /** Discord message content cap. */
+  announcementMessage: 2000,
+  /** Discord embed title cap. */
+  embedTitle: 256,
+  /** Discord embed description cap. */
+  embedDescription: 4000,
+  /** Discord poll question cap. */
+  pollQuestion: 300,
+  /** Discord poll answer (option) cap. */
+  pollAnswer: 55,
+  /** Ceiling for any single free-text setting value. */
+  configValue: 2000,
+} as const;
+
+/**
+ * Validate a labelled set of strings against their maximum lengths. Returns a
+ * human-readable error for the first field that exceeds its cap, or null when
+ * everything fits. Pure and exported so the route-layer length checks can be
+ * unit-tested without Express or Mongo.
+ */
+export function firstLengthError(
+  fields: Array<{ label: string; value: string; max: number }>,
+): string | null {
+  for (const { label, value, max } of fields) {
+    if (value.length > max) {
+      return `${label} must be ${max} characters or fewer.`;
+    }
+  }
+  return null;
+}
+
 function flashRedirect(res: Response, path: string, flash: Flash): void {
   // Mirror the renderer's 500-char cap on the way out so the redirect
   // URL itself can't balloon to header/URI limits on a noisy failure.
@@ -237,6 +283,16 @@ export function coerceConfigValue(
     return { ok: true, value: n };
   }
   const value = String(raw ?? "");
+  // Cap free-text setting values so an oversized string can't be stored and
+  // then overflow the Settings display or a downstream Discord payload (#508).
+  // List keys are handled in the array branch above and are bounded by their
+  // entity IDs, so the cap only applies to scalar string values here.
+  if (value.length > TEXT_LIMITS.configValue) {
+    return {
+      ok: false,
+      reason: `too long (max ${TEXT_LIMITS.configValue} characters)`,
+    };
+  }
   // Fixed-options keys carry an `options` whitelist in their metadata. Any
   // value outside it (mistyped form field, crafted POST, stale YAML import)
   // is refused with a clear, enumerated error rather than silently stored.
@@ -1510,6 +1566,32 @@ export function createWriteRouter(
         });
         return;
       }
+      // Reject oversized text up front so the operator gets a readable flash
+      // rather than a Discord rejection at send time or a Mongoose error (#508).
+      const lengthError = firstLengthError([
+        {
+          label: "Message",
+          value: message,
+          max: TEXT_LIMITS.announcementMessage,
+        },
+        {
+          label: "Embed title",
+          value: embedTitle,
+          max: TEXT_LIMITS.embedTitle,
+        },
+        {
+          label: "Embed description",
+          value: embedDescription,
+          max: TEXT_LIMITS.embedDescription,
+        },
+      ]);
+      if (lengthError) {
+        flashRedirect(res, "/admin/announcements", {
+          type: "err",
+          text: lengthError,
+        });
+        return;
+      }
 
       let embedData: IScheduledAnnouncement["embedData"] | undefined;
       if (embedTitle || embedDescription || embedColorHex) {
@@ -1902,10 +1984,10 @@ export function createWriteRouter(
         });
         return;
       }
-      if (question.length > 300) {
+      if (question.length > TEXT_LIMITS.pollQuestion) {
         flashRedirect(res, "/admin/polls", {
           type: "err",
-          text: "Question must be 300 characters or fewer.",
+          text: `Question must be ${TEXT_LIMITS.pollQuestion} characters or fewer.`,
         });
         return;
       }
@@ -1917,6 +1999,16 @@ export function createWriteRouter(
         flashRedirect(res, "/admin/polls", {
           type: "err",
           text: "Provide 2–10 comma-separated answers.",
+        });
+        return;
+      }
+      // Discord caps each poll answer (option) at 55 characters; reject an
+      // oversized one here so it fails with a clean flash rather than being
+      // stored and only rejected when Discord receives the payload (#508).
+      if (answers.some((a) => a.length > TEXT_LIMITS.pollAnswer)) {
+        flashRedirect(res, "/admin/polls", {
+          type: "err",
+          text: `Each answer must be ${TEXT_LIMITS.pollAnswer} characters or fewer.`,
         });
         return;
       }
@@ -2354,17 +2446,14 @@ export function createWriteRouter(
         });
         return;
       }
-      if (title.length > 256) {
+      const lengthError = firstLengthError([
+        { label: "Title", value: title, max: TEXT_LIMITS.noticeTitle },
+        { label: "Content", value: content, max: TEXT_LIMITS.noticeContent },
+      ]);
+      if (lengthError) {
         flashRedirect(res, "/admin/notices", {
           type: "err",
-          text: "Title must be 256 characters or fewer.",
-        });
-        return;
-      }
-      if (content.length > 4000) {
-        flashRedirect(res, "/admin/notices", {
-          type: "err",
-          text: "Content must be 4000 characters or fewer.",
+          text: lengthError,
         });
         return;
       }
@@ -2464,6 +2553,20 @@ export function createWriteRouter(
         flashRedirect(res, "/admin/notices", {
           type: "err",
           text: "Title, content, and category are all required.",
+        });
+        return;
+      }
+      // Mirror the create-route length checks: `notice.save()` would otherwise
+      // reject the oversized field as a Mongoose ValidationError surfaced as a
+      // 500-style flash instead of this readable message (#508).
+      const lengthError = firstLengthError([
+        { label: "Title", value: title, max: TEXT_LIMITS.noticeTitle },
+        { label: "Content", value: content, max: TEXT_LIMITS.noticeContent },
+      ]);
+      if (lengthError) {
+        flashRedirect(res, "/admin/notices", {
+          type: "err",
+          text: lengthError,
         });
         return;
       }


### PR DESCRIPTION
## Summary

Fixes #508. Several admin write handlers in `src/web/write-routes.ts` wrote user-supplied free text straight to MongoDB with no server-side length cap. Mongoose `maxlength` only fires on `save()` — not on `findOneAndUpdate`/`updateOne` (the pattern `ConfigService.set` uses) — so oversized values could be stored and then fail silently in Discord embeds (4096-char cap), overflow the Settings display, or surface as opaque Mongoose `ValidationError`s formatted as a 500.

## Changes

- **Shared limits + helper** — added an exported `TEXT_LIMITS` table (each cap derived from the real-world Discord/storage constraint) and a pure, exported `firstLengthError()` helper so the route-layer checks are unit-testable without Express/Mongo.
- **Route-layer pre-validation** (clean redirect-with-error, not a 500):
  - **Announcements/create** — message (≤2000), embed title (≤256), embed description (≤4000). *(Previously unvalidated.)*
  - **Notices/create** — refactored to the shared helper.
  - **Notices/:id/update** — **now validates title/content** (this path previously had no length check — the clearest gap).
  - **Polls/items/create** — added a per-answer length check (Discord's 55-char option cap); question now uses the shared constant.
  - **Settings** — `coerceConfigValue` now caps scalar free-text values at 2000 chars. `*_list` CSV values are left uncapped (bounded by entity IDs, not free text).
- **Schema `maxlength` (defence-in-depth)** — added to `scheduled-announcement` (message / embed title / description) and a per-answer length check to the `poll-item` validator.
- **HTML `maxlength`** — added to the poll answers input and the settings/wizard free-text inputs (most other forms already had matching attributes).
- **Tests** — added coverage for the `coerceConfigValue` length cap (including the boundary and the `*_list` exemption) and the `firstLengthError` helper.

## Acceptance criteria

- [x] Write-route `findOneAndUpdate`/`save` calls touching user strings now have explicit pre-validation in the handler.
- [x] Mongoose `maxlength` present on free-text fields, derived from real-world constraints.
- [x] Oversized values produce a clear redirect-with-error, not a 500.
- [x] Form inputs/textareas have matching `maxlength` HTML attributes.
- [x] Unit tests assert oversized payloads are rejected at the route layer.

## Verification

- `npx tsc --noEmit` — clean
- `npm test` — 91 suites / 945 passing (1 skipped)
- `eslint` — 0 errors; `prettier --check` — clean

https://claude.ai/code/session_01Hg1xF9a6RrZMpfBEzEbjmT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hg1xF9a6RrZMpfBEzEbjmT)_