### PR TITLE
feat: expose opt-in Prometheus/OpenMetrics endpoint (#509)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,21 @@ WEBUI_INACTIVITY_TIMEOUT_MINUTES=30
 # WEBUI_TRUST_PROXY=1
 
 # =============================================================================
+# Prometheus / OpenMetrics (Optional)
+# =============================================================================
+# Exposes GET /metrics on port 3000 (alongside /health) for Prometheus or any
+# OpenMetrics-compatible collector. Disabled by default — the endpoint returns
+# 404 until METRICS_ENABLED=true. See WEBUI.md for the metric list, a scrape
+# config, and suggested Grafana panels.
+METRICS_ENABLED=false
+
+# Optional bearer token. When set, every scrape must send
+# `Authorization: Bearer <token>` or it receives 401. Leave blank to rely on
+# network-level ACLs (e.g. only your Prometheus host can reach port 3000).
+# Generate one with: openssl rand -base64 32
+# METRICS_TOKEN=
+
+# =============================================================================
 # How to get your Discord credentials:
 # =============================================================================
 # 1. Go to https://discord.com/developers/applications

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -93,6 +93,22 @@ WEBUI_INACTIVITY_TIMEOUT_MINUTES=30
 See [WEBUI.md → Bootstrap environment variables](WEBUI.md#bootstrap-environment-variables)
 for full descriptions and threat-model notes.
 
+### Prometheus metrics (optional)
+
+```env
+# Master switch — when true, GET /metrics is served on port 3000.
+# Disabled by default (the endpoint is 404 until set to true).
+METRICS_ENABLED=false
+
+# Optional bearer token. When set, scrapes must send
+# `Authorization: Bearer <token>` or receive 401. Leave blank to rely on
+# network-level ACLs instead.
+# METRICS_TOKEN=replace-with-a-long-random-string
+```
+
+See [WEBUI.md → Prometheus / OpenMetrics endpoint](WEBUI.md#prometheus--openmetrics-endpoint)
+for the metric list, a Prometheus scrape config, and suggested Grafana panels.
+
 ### How to get Discord credentials
 
 1. Go to [Discord Developer Portal](https://discord.com/developers/applications)

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -29,6 +29,7 @@ This document explains how to enable it, expose it, and operate it.
 - [Public-internet exposure](#public-internet-exposure)
 - [DM-closed fallback](#dm-closed-fallback)
 - [Session lifecycle and revocation](#session-lifecycle-and-revocation)
+- [Prometheus / OpenMetrics endpoint](#prometheus--openmetrics-endpoint)
 - [What the Web UI lets you do](#what-the-web-ui-lets-you-do)
 - [Troubleshooting](#troubleshooting)
 
@@ -242,6 +243,18 @@ Generate a strong secret:
 ```bash
 openssl rand -base64 32
 ```
+
+### Prometheus metrics (optional)
+
+These two vars are independent of the Web UI — the `/metrics` endpoint is
+served on the same port (3000) as `/health` whether or not the Web UI is
+enabled. See [Prometheus / OpenMetrics endpoint](#prometheus--openmetrics-endpoint)
+below for the full rundown.
+
+| Variable          | Required | Default | Notes                                                                 |
+| ----------------- | -------- | ------- | --------------------------------------------------------------------- |
+| `METRICS_ENABLED` | no       | `false` | `true` mounts `/metrics`; anything else leaves it 404.                |
+| `METRICS_TOKEN`   | no       | (empty) | When set, requests must send `Authorization: Bearer <token>` or 401.  |
 
 ---
 
@@ -642,6 +655,80 @@ docker compose exec mongodb mongosh koolbot --eval '
 Or rotate `WEBUI_SESSION_SECRET` in `.env` and restart — that
 invalidates every signed cookie and every outstanding magic link as a
 side effect, since the HMAC key changes.
+
+---
+
+## Prometheus / OpenMetrics endpoint
+
+KoolBot can expose a pull-based `/metrics` endpoint for Prometheus (or any
+OpenMetrics-compatible collector). It lives on the same Express server as
+`/health` — port 3000 — so no new process, container, or port is needed.
+
+It is **opt-in and disabled by default**:
+
+```env
+# Turn it on
+METRICS_ENABLED=true
+
+# Optional: require a bearer token on every scrape. Leave blank to rely
+# on network-level ACLs instead (e.g. only your Prometheus host can reach
+# port 3000).
+METRICS_TOKEN=replace-with-a-long-random-string
+```
+
+- When `METRICS_ENABLED` is anything other than `true`, the route is never
+  registered and `/metrics` returns **404**.
+- When `METRICS_TOKEN` is set, a scrape without a matching
+  `Authorization: Bearer <token>` header receives **401**. The comparison
+  is constant-time.
+
+Verify it locally:
+
+```bash
+# Without a token
+curl -s http://localhost:3000/metrics | head
+
+# With a token
+curl -s -H "Authorization: Bearer $METRICS_TOKEN" http://localhost:3000/metrics | head
+```
+
+A matching Prometheus scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: koolbot
+    metrics_path: /metrics
+    authorization:
+      type: Bearer
+      credentials: "replace-with-METRICS_TOKEN" # omit when no token is set
+    static_configs:
+      - targets: ["koolbot:3000"]
+```
+
+### Exposed metrics
+
+| Metric                              | Type    | Description                                                            |
+| ----------------------------------- | ------- | ---------------------------------------------------------------------- |
+| `koolbot_command_invocations_total` | Counter | Slash commands run, labelled by `command` and `status` (`ok`/`error`). |
+| `koolbot_discord_events_total`      | Counter | Discord gateway events received, labelled by `event`.                  |
+| `koolbot_voice_sessions_active`     | Gauge   | Current number of active managed voice channels.                       |
+| `koolbot_up`                        | Gauge   | `1` while connected to Discord, `0` after a disconnect or shutdown.    |
+| `process_*` / `nodejs_*`            | various | Node.js process metrics provided automatically by `prom-client`.       |
+
+### Suggested Grafana panels
+
+No dashboard JSON ships with the bot — wire these up to taste:
+
+- **Commands per minute** — `rate(koolbot_command_invocations_total[5m])`.
+- **Command error rate** — `sum(rate(koolbot_command_invocations_total{status="error"}[5m])) / sum(rate(koolbot_command_invocations_total[5m]))`.
+- **Active voice sessions** — Gauge panel on `koolbot_voice_sessions_active`.
+- **Connectivity** — Stat/State-timeline panel on `koolbot_up` (alert when `koolbot_up == 0`).
+- **Event throughput** — `sum by (event) (rate(koolbot_discord_events_total[5m]))`.
+- **Memory usage** — `process_resident_memory_bytes`.
+
+> ⚠️ **Don't expose `/metrics` to the public internet unprotected.** Set
+> `METRICS_TOKEN`, restrict port 3000 to your monitoring host, or both. The
+> same reverse-proxy guidance that applies to `/admin` applies here.
 
 ---
 

--- a/__tests__/web/metrics.test.ts
+++ b/__tests__/web/metrics.test.ts
@@ -1,0 +1,163 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+import type { NextFunction, Request, Response } from "express";
+import {
+  createMetricsRouter,
+  isMetricsEnabled,
+  metricsAuth,
+  metricsHandler,
+  recordCommandInvocation,
+  registry,
+  setVoiceSessionsProvider,
+} from "../../src/web/metrics.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+/** Minimal Express Response double that records what handlers set. */
+function mockResponse(): Response & {
+  statusCode: number;
+  headers: Record<string, string>;
+  body?: unknown;
+} {
+  const res = {
+    statusCode: 200,
+    headers: {} as Record<string, string>,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    set(field: string, value: string) {
+      this.headers[field.toLowerCase()] = value;
+      return this;
+    },
+    type(value: string) {
+      this.headers["content-type"] = value;
+      return this;
+    },
+    send(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    end(payload?: unknown) {
+      if (payload !== undefined) this.body = payload;
+      return this;
+    },
+  };
+  return res as unknown as Response & {
+    statusCode: number;
+    headers: Record<string, string>;
+    body?: unknown;
+  };
+}
+
+/** Express Request double exposing only the `get(header)` accessor. */
+function mockRequest(headers: Record<string, string> = {}): Request {
+  const lower: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v;
+  return {
+    get(name: string): string | undefined {
+      return lower[name.toLowerCase()];
+    },
+  } as unknown as Request;
+}
+
+describe("web/metrics", () => {
+  beforeEach(() => {
+    delete process.env.METRICS_ENABLED;
+    delete process.env.METRICS_TOKEN;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  describe("isMetricsEnabled / createMetricsRouter", () => {
+    it("is disabled by default and mounts no router", () => {
+      expect(isMetricsEnabled()).toBe(false);
+      expect(createMetricsRouter()).toBeNull();
+    });
+
+    it("mounts a router when METRICS_ENABLED=true", () => {
+      process.env.METRICS_ENABLED = "true";
+      expect(isMetricsEnabled()).toBe(true);
+      expect(createMetricsRouter()).not.toBeNull();
+    });
+  });
+
+  describe("metricsAuth", () => {
+    it("returns 401 when a token is configured and the header is absent", () => {
+      process.env.METRICS_TOKEN = "s3cret";
+      const req = mockRequest();
+      const res = mockResponse();
+      const next = jest.fn() as unknown as NextFunction;
+
+      metricsAuth(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(401);
+      expect(res.headers["www-authenticate"]).toBe("Bearer");
+    });
+
+    it("returns 401 when the bearer token does not match", () => {
+      process.env.METRICS_TOKEN = "s3cret";
+      const req = mockRequest({ authorization: "Bearer wrong" });
+      const res = mockResponse();
+      const next = jest.fn() as unknown as NextFunction;
+
+      metricsAuth(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(401);
+    });
+
+    it("calls next() when the bearer token matches", () => {
+      process.env.METRICS_TOKEN = "s3cret";
+      const req = mockRequest({ authorization: "Bearer s3cret" });
+      const res = mockResponse();
+      const next = jest.fn() as unknown as NextFunction;
+
+      metricsAuth(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.statusCode).toBe(200);
+    });
+
+    it("calls next() with no auth when no token is configured", () => {
+      const req = mockRequest();
+      const res = mockResponse();
+      const next = jest.fn() as unknown as NextFunction;
+
+      metricsAuth(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("metricsHandler", () => {
+    it("renders OpenMetrics text including required series", async () => {
+      setVoiceSessionsProvider(() => 3);
+      recordCommandInvocation("ping", "ok");
+
+      const req = mockRequest();
+      const res = mockResponse();
+      await metricsHandler(req, res);
+
+      const body = String(res.body);
+      expect(res.headers["content-type"]).toBe(registry.contentType);
+      expect(body).toContain("koolbot_command_invocations_total");
+      expect(body).toContain('command="ping"');
+      expect(body).toContain('status="ok"');
+      expect(body).toContain("koolbot_voice_sessions_active 3");
+      expect(body).toContain("koolbot_up");
+      // Default process metrics from prom-client.
+      expect(body).toContain("process_cpu_user_seconds_total");
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "express": "^5.2.1",
         "js-yaml": "^4.1.1",
         "mongoose": "^9.6.2",
+        "prom-client": "^15.1.3",
         "winston": "^3.19.0"
       },
       "devDependencies": {
@@ -1677,6 +1678,15 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3000,6 +3010,12 @@
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -7323,6 +7339,19 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -8059,6 +8088,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/test-exclude": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "express": "^5.2.1",
     "js-yaml": "^4.1.1",
     "mongoose": "^9.6.2",
+    "prom-client": "^15.1.3",
     "winston": "^3.19.0"
   },
   "devDependencies": {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -114,4 +114,16 @@ export const env = Object.freeze({
       return process.env.WEBUI_TRUST_PROXY;
     },
   }),
+  metrics: Object.freeze({
+    get enabled(): boolean {
+      return (process.env.METRICS_ENABLED || "").toLowerCase() === "true";
+    },
+    // Returns the configured bearer token, trimmed, or undefined when the
+    // var is unset/blank. A blank token means "no auth required" so we
+    // never treat whitespace as a real credential.
+    get token(): string | undefined {
+      const raw = (process.env.METRICS_TOKEN || "").trim();
+      return raw ? raw : undefined;
+    },
+  }),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,12 @@ import {
   getMissingWebUIEnvVars,
   isWebUIEnabled,
 } from "./web/index.js";
+import {
+  createMetricsRouter,
+  recordDiscordEvent,
+  setBotUp,
+  setVoiceSessionsProvider,
+} from "./web/metrics.js";
 import mongoose from "mongoose";
 
 dotenvConfig();
@@ -171,6 +177,14 @@ function startHealthServer(): void {
     logger.debug("WEBUI_ENABLED is not true; /admin routes not mounted");
   }
 
+  // Prometheus/OpenMetrics scrape endpoint (#509). Mounted only when
+  // METRICS_ENABLED=true; otherwise nothing is registered and /metrics
+  // stays 404. Optionally bearer-token protected via METRICS_TOKEN.
+  const metricsRouter = createMetricsRouter();
+  if (metricsRouter) {
+    healthApp.use(metricsRouter);
+  }
+
   healthApp.listen(3000, () => {
     logger.info("Healthcheck server running on port 3000");
   });
@@ -179,6 +193,9 @@ function startHealthServer(): void {
 // Add health server startup to main ready handler
 client.once(Events.ClientReady, async (readyClient) => {
   logger.info(`Ready! Logged in as ${readyClient.user.tag}`);
+
+  // koolbot_up = 1: connected to Discord (#509).
+  setBotUp(true);
 
   // Set connecting status (yellow) immediately when Discord is ready
   botStatusService.setConnectingStatus();
@@ -296,6 +313,9 @@ async function gracefulShutdown(signal: string): Promise<void> {
 
   isShuttingDown = true;
   const startTime = Date.now();
+
+  // koolbot_up = 0: no longer serving (#509).
+  setBotUp(false);
 
   try {
     logger.info(`🔄 Received ${signal}, starting graceful shutdown...`);
@@ -491,6 +511,8 @@ try {
   configService = ConfigService.getInstance();
   commandManager = CommandManager.getInstance(client);
   voiceChannelManager = VoiceChannelManager.getInstance(client);
+  // Feed the koolbot_voice_sessions_active gauge (#509) at scrape time.
+  setVoiceSessionsProvider(() => voiceChannelManager.getActiveSessionCount());
   voiceChannelTracker = VoiceChannelTracker.getInstance(client);
   voiceChannelAnnouncer = VoiceChannelAnnouncer.getInstance(client);
   voiceChannelTruncation = VoiceChannelTruncationService.getInstance(client);
@@ -639,7 +661,19 @@ async function initializeServices(): Promise<void> {
   }
 }
 
+// Track Discord connectivity for koolbot_up (#509). ClientReady flips it
+// to 1; a shard dropping flips it to 0, and a resume brings it back.
+client.on(Events.ShardDisconnect, () => {
+  recordDiscordEvent("shardDisconnect");
+  setBotUp(false);
+});
+client.on(Events.ShardResume, () => {
+  recordDiscordEvent("shardResume");
+  setBotUp(true);
+});
+
 client.on(Events.InteractionCreate, async (interaction) => {
+  recordDiscordEvent("interactionCreate");
   // Handle autocomplete interactions
   if (interaction.isAutocomplete()) {
     try {
@@ -780,6 +814,7 @@ client.on(Events.InteractionCreate, async (interaction) => {
 });
 
 client.on(Events.VoiceStateUpdate, async (oldState, newState) => {
+  recordDiscordEvent("voiceStateUpdate");
   try {
     const member = newState.member || oldState.member;
     if (member) {
@@ -804,6 +839,7 @@ client.on(Events.VoiceStateUpdate, async (oldState, newState) => {
 // Handle text messages for per-user/per-channel activity tracking (#495).
 // Gating (enabled, bot/DM, excluded channels) lives in the tracker.
 client.on(Events.MessageCreate, async (message) => {
+  recordDiscordEvent("messageCreate");
   try {
     await messageActivityTracker.handleMessageCreate(message);
   } catch (error) {

--- a/src/services/command-manager.ts
+++ b/src/services/command-manager.ts
@@ -14,6 +14,7 @@ import { getErrorMessage } from "../utils/error-guards.js";
 import { recordCommandAudit } from "../utils/record-command-audit.js";
 import { ConfigService } from "./config-service.js";
 import { MonitoringService } from "./monitoring-service.js";
+import { recordCommandInvocation } from "../web/metrics.js";
 import { CooldownManager } from "./cooldown-manager.js";
 import { PermissionsService } from "./permissions-service.js";
 
@@ -557,6 +558,7 @@ export class CommandManager {
         startTime,
         true,
       );
+      recordCommandInvocation(commandName, "ok");
       await recordAudit("success", null);
     } catch (error) {
       monitoringService.trackCommandEnd(
@@ -566,6 +568,7 @@ export class CommandManager {
         false,
       );
       monitoringService.trackError(commandName, error as Error);
+      recordCommandInvocation(commandName, "error");
       await recordAudit("error", getErrorMessage(error).slice(0, 500));
       throw error;
     }

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -115,6 +115,15 @@ export class VoiceChannelManager {
   }
 
   /**
+   * Number of currently active managed voice channels. One entry exists
+   * per owned dynamic channel, so the map size is the live session count
+   * surfaced by the koolbot_voice_sessions_active metric (#509).
+   */
+  public getActiveSessionCount(): number {
+    return this.userChannels.size;
+  }
+
+  /**
    * Mark a channel as having a custom name
    */
   public setCustomChannelName(channelId: string, name: string): void {

--- a/src/web/metrics.ts
+++ b/src/web/metrics.ts
@@ -1,0 +1,188 @@
+/**
+ * Prometheus / OpenMetrics instrumentation (issue #509).
+ *
+ * Exposes a single pull-based `/metrics` endpoint that an operator can
+ * scrape with Prometheus (or any OpenMetrics-compatible collector). The
+ * endpoint lives on the same Express server as `/health` (port 3000) and
+ * is entirely opt-in:
+ *
+ *   - `METRICS_ENABLED=false` (default) → the route is never registered,
+ *     so the server returns 404 exactly as before.
+ *   - `METRICS_TOKEN=<secret>` → requests must carry a matching
+ *     `Authorization: Bearer <secret>` header or they get 401.
+ *
+ * Both vars are bootstrap config read from `.env` via `config/env.ts`;
+ * nothing here touches MongoDB.
+ *
+ * The module owns a private registry (rather than the prom-client global
+ * default) so importing it has no global side effects and tests can reason
+ * about exactly which series exist.
+ */
+import { NextFunction, Request, Response, Router } from "express";
+import { Buffer } from "node:buffer";
+import { timingSafeEqual } from "node:crypto";
+import { Counter, Gauge, Registry, collectDefaultMetrics } from "prom-client";
+import { env } from "../config/env.js";
+import logger from "../utils/logger.js";
+
+export const registry = new Registry();
+
+// Node.js process metrics (process_cpu_*, process_resident_memory_bytes,
+// nodejs_*, etc.) — provided automatically by prom-client.
+collectDefaultMetrics({ register: registry });
+
+/**
+ * Slash commands invoked, labelled by `command` and `status` (`ok`/`error`).
+ */
+export const commandInvocations = new Counter({
+  name: "koolbot_command_invocations_total",
+  help: "Slash commands invoked, labelled by command and status",
+  labelNames: ["command", "status"] as const,
+  registers: [registry],
+});
+
+/**
+ * Discord.js gateway events received, labelled by `event`.
+ */
+export const discordEvents = new Counter({
+  name: "koolbot_discord_events_total",
+  help: "Discord.js events received, labelled by event",
+  labelNames: ["event"] as const,
+  registers: [registry],
+});
+
+/**
+ * `1` while the bot is connected to Discord, `0` after disconnect.
+ */
+export const botUp = new Gauge({
+  name: "koolbot_up",
+  help: "1 while the bot is connected to Discord, 0 after disconnect",
+  registers: [registry],
+});
+
+// Pull-based gauge: the current value is read at scrape time from a
+// provider registered by the bot (see setVoiceSessionsProvider). Keeping
+// the data source behind a callback avoids a hard import cycle between this
+// module and the VoiceChannelManager singleton.
+let voiceSessionsProvider: (() => number) | null = null;
+
+export const voiceSessionsActive = new Gauge({
+  name: "koolbot_voice_sessions_active",
+  help: "Current number of active managed voice channels",
+  registers: [registry],
+  collect(): void {
+    if (!voiceSessionsProvider) return;
+    try {
+      this.set(voiceSessionsProvider());
+    } catch (err) {
+      logger.error("Error reading active voice session count for metrics", err);
+    }
+  },
+});
+
+/**
+ * Register the callback used to populate `koolbot_voice_sessions_active`
+ * at scrape time. Called once during bot initialization.
+ */
+export function setVoiceSessionsProvider(provider: () => number): void {
+  voiceSessionsProvider = provider;
+}
+
+/** Record a single slash-command invocation outcome. */
+export function recordCommandInvocation(
+  command: string,
+  status: "ok" | "error",
+): void {
+  commandInvocations.inc({ command, status });
+}
+
+/** Record a received Discord gateway event by name. */
+export function recordDiscordEvent(event: string): void {
+  discordEvents.inc({ event });
+}
+
+/** Set the `koolbot_up` gauge to reflect Discord connectivity. */
+export function setBotUp(up: boolean): void {
+  botUp.set(up ? 1 : 0);
+}
+
+export function isMetricsEnabled(): boolean {
+  return env.metrics.enabled;
+}
+
+/**
+ * Constant-time comparison of two strings that first guards on length.
+ * `timingSafeEqual` throws when the buffers differ in length, so we check
+ * that up front (the length of a secret is not itself sensitive here).
+ */
+function safeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
+}
+
+/**
+ * Express middleware enforcing the optional bearer token. When
+ * `METRICS_TOKEN` is unset the endpoint is open (operators are expected to
+ * gate it with network ACLs in that case); when set, a missing or
+ * mismatched `Authorization: Bearer <token>` header yields 401.
+ */
+export function metricsAuth(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const token = env.metrics.token;
+  if (!token) {
+    next();
+    return;
+  }
+
+  const header = req.get("authorization") || "";
+  const expected = `Bearer ${token}`;
+  if (safeEqual(header, expected)) {
+    next();
+    return;
+  }
+
+  res
+    .status(401)
+    .set("WWW-Authenticate", "Bearer")
+    .type("text/plain")
+    .send("Unauthorized");
+}
+
+/** Express handler that renders the registry in OpenMetrics text format. */
+export async function metricsHandler(
+  _req: Request,
+  res: Response,
+): Promise<void> {
+  try {
+    const body = await registry.metrics();
+    res.set("Content-Type", registry.contentType);
+    res.send(body);
+  } catch (err) {
+    logger.error("Error rendering metrics", err);
+    res.status(500).type("text/plain").send("Internal Server Error");
+  }
+}
+
+/**
+ * Build the `/metrics` router. Returns `null` when metrics are disabled so
+ * the caller mounts nothing and unknown paths stay 404.
+ */
+export function createMetricsRouter(): Router | null {
+  if (!isMetricsEnabled()) {
+    logger.debug("METRICS_ENABLED is not true; /metrics not mounted");
+    return null;
+  }
+  const router = Router();
+  router.get("/metrics", metricsAuth, metricsHandler);
+  logger.info(
+    `Metrics endpoint mounted at /metrics${
+      env.metrics.token ? " (bearer-token protected)" : ""
+    }`,
+  );
+  return router;
+}


### PR DESCRIPTION
## Summary

Adds a pull-based `/metrics` endpoint for Prometheus (or any OpenMetrics-compatible collector), served on the **existing health server** (port 3000) alongside `/health` — no new process, container, or port. Closes #509.

The endpoint is **opt-in and disabled by default**, and optionally protected by a static bearer token, exactly as the issue specified.

## What's included

- **`src/web/metrics.ts`** — owns a private `prom-client` registry (no global side effects) with:
  - `prom-client` default process metrics (`process_*`, `nodejs_*`)
  - `koolbot_command_invocations_total{command,status}`
  - `koolbot_discord_events_total{event}`
  - `koolbot_voice_sessions_active`
  - `koolbot_up`
- **Gating & auth** — `METRICS_ENABLED` (default `false` → route never mounted → 404). `METRICS_TOKEN`, when set, requires `Authorization: Bearer <token>`; missing/mismatched → 401 via a constant-time comparison.
- **Wiring**
  - `CommandManager.executeCommand` records `ok`/`error` outcomes.
  - `index.ts` records gateway events and drives `koolbot_up` from `ClientReady` (1), `ShardDisconnect` (0), `ShardResume` (1), and graceful shutdown (0); mounts the metrics router on the health server.
  - `koolbot_voice_sessions_active` is populated at scrape time via a provider backed by a new `VoiceChannelManager.getActiveSessionCount()`.
- **Config** — `METRICS_ENABLED` / `METRICS_TOKEN` added to `config/env.ts` (the single sanctioned `process.env` reader).
- **Docs** — both env vars + the metric list, a Prometheus scrape config, and suggested Grafana panels documented in `WEBUI.md` and `SETTINGS.md`; added to `.env.example`.

## Acceptance criteria

- [x] `/metrics` returns OpenMetrics-compatible text when `METRICS_ENABLED=true`.
- [x] Endpoint is absent (404) when `METRICS_ENABLED=false` (default — no router mounted).
- [x] When `METRICS_TOKEN` is set, requests without the correct `Authorization: Bearer` header receive 401.
- [x] `koolbot_command_invocations_total`, `koolbot_voice_sessions_active`, and `koolbot_up` implemented (plus `koolbot_discord_events_total`).
- [x] `prom-client` default process metrics included.
- [x] `SETTINGS.md` / `WEBUI.md` document the two new env vars.
- [x] A unit test asserts the endpoint returns 401 when a token is configured and the header is absent.

## Testing

- New `__tests__/web/metrics.test.ts` (7 tests): 401-without-token, 401-on-mismatch, next() on match, open when no token, disabled-default (null router), and rendered-output assertions.
- Full suite green: **945 passing, 1 skipped, 92 suites**.
- `npm run check` (build + lint + format) passes; `markdownlint-cli2` clean on the changed docs.

## Out of scope (per issue)

Built-in Grafana dashboard JSON (panels documented instead), Pushgateway, and per-user metrics.

https://claude.ai/code/session_01C7bz8XJtAuRW8c52uqDccj

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7bz8XJtAuRW8c52uqDccj)_