### PR TITLE
Start health server before login to prevent startup death-loops

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,11 @@ EXPOSE 3000
 # Drop root privileges — run as the built-in node user (uid 1000)
 USER node
 
-# Health check
+# Health check — uses the readiness endpoint (/ready, gated on Discord +
+# MongoDB). Kubernetes deployments should point a livenessProbe at /live
+# (always 200 once listening) and a readinessProbe at /ready.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/health || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/ready || exit 1
 
 # Start the application
 CMD ["npm", "start"]

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -575,10 +575,15 @@ That said:
 - **Always run behind HTTPS.** The session cookie is HMAC-signed but
   cleartext, and the magic link itself is a bearer token. TLS is
   non-negotiable on the public internet.
-- **The healthcheck endpoint (`/health`) is unauthenticated.** It is
-  intentionally minimal (returns `OK` or `Service Unavailable`) but it
-  *does* report whether MongoDB and Discord are reachable. Restrict it
-  to your monitoring system if you'd rather not advertise that.
+- **The health endpoints are unauthenticated.** The server exposes
+  `/live` (liveness — always `OK` once the process is up), `/ready`
+  (readiness — `OK` only when MongoDB and Discord are reachable, `503`
+  otherwise), and `/health` (a backward-compatible alias of `/ready`).
+  They are intentionally minimal, but `/ready`/`/health` *do* report
+  whether MongoDB and Discord are reachable. Restrict them to your
+  monitoring system if you'd rather not advertise that. Kubernetes
+  deployments should use `/live` for the livenessProbe and `/ready` for
+  the readinessProbe.
 - **Mind the magic-link TTL.** A leaked link is useless after redemption
   or expiry, but if the admin who ran `/config` shares the URL before
   redeeming it, anyone with the URL becomes that admin until the TTL

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,44 +115,67 @@ client.commands = new Collection();
 
 let isShuttingDown = false;
 // Flipped to true once initializeServices() completes (#521). Until then the
-// /health endpoint reports 503 "Starting" rather than refusing connections,
-// so orchestrators can tell "still booting" apart from "crashed".
+// readiness endpoints (/ready, /health) report 503 instead of refusing the
+// connection, which surfaces a slow startup as an observable HTTP response.
 let isReady = false;
 let discordLogger: DiscordLogger;
 const botStatusService: BotStatusService = BotStatusService.getInstance(client);
 
-// Healthcheck endpoint for Docker/Kubernetes. The server starts listening
+// HTTP health server for Docker/Kubernetes. The server starts listening
 // immediately at process startup — before client.login() — so the port is
-// always open (#521). While the bot is still booting it returns 503
-// "Starting"; only once initializeServices() finishes (isReady) does it run
-// the Discord + MongoDB readiness checks and return 200.
+// always open (#521), and exposes separate liveness and readiness probes:
+//
+//   /live   liveness  — 200 as soon as the process is up and the event loop
+//                       is responsive. Point a Kubernetes livenessProbe here
+//                       so a slow Discord/MongoDB startup never triggers a
+//                       restart.
+//   /ready  readiness — 200 only once initialization has finished and Discord
+//                       and MongoDB are connected; 503 otherwise. Point a
+//                       readinessProbe / load-balancer check here.
+//   /health           — backward-compatible alias of /ready (Docker
+//                       HEALTHCHECK and existing setups). Same semantics.
+
+// Readiness gate shared by /ready and /health. Returns true only once
+// initialization has completed and both Discord and MongoDB are connected.
+function isAppReady(): boolean {
+  if (!isReady) {
+    return false;
+  }
+  let discordReady = false;
+  let mongoReady = false;
+  try {
+    discordReady =
+      typeof client.isReady === "function" ? client.isReady() : false;
+  } catch {
+    discordReady = false;
+  }
+  try {
+    mongoReady = mongoose.connection.readyState === 1;
+  } catch {
+    mongoReady = false;
+  }
+  return discordReady && mongoReady;
+}
 
 function startHealthServer(): void {
   const healthApp = express();
-  healthApp.get("/health", (_req: Request, res: Response) => {
-    if (!isReady) {
-      res.status(503).send("Starting");
-      return;
-    }
-    let discordReady = false;
-    let mongoReady = false;
-    try {
-      discordReady =
-        typeof client.isReady === "function" ? client.isReady() : false;
-    } catch {
-      discordReady = false;
-    }
-    try {
-      mongoReady = mongoose.connection.readyState === 1;
-    } catch {
-      mongoReady = false;
-    }
-    if (discordReady && mongoReady) {
+
+  // Liveness: the process is running. Always 200 once the server is listening.
+  healthApp.get("/live", (_req: Request, res: Response) => {
+    res.status(200).send("OK");
+  });
+
+  // Readiness: ready to serve only when fully initialized and connected.
+  const readinessHandler = (_req: Request, res: Response): void => {
+    if (isAppReady()) {
       res.status(200).send("OK");
     } else {
-      res.status(503).send("Service Unavailable");
+      res.status(503).send(isReady ? "Service Unavailable" : "Starting");
     }
-  });
+  };
+  healthApp.get("/ready", readinessHandler);
+  // /health is retained as a backward-compatible alias of /ready.
+  healthApp.get("/health", readinessHandler);
 
   // Mount the WebUI behind the feature flag. When disabled, no /admin/*
   // route is registered, so the server responds 404 for those paths

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,14 +114,26 @@ const client = new Client({
 client.commands = new Collection();
 
 let isShuttingDown = false;
+// Flipped to true once initializeServices() completes (#521). Until then the
+// /health endpoint reports 503 "Starting" rather than refusing connections,
+// so orchestrators can tell "still booting" apart from "crashed".
+let isReady = false;
 let discordLogger: DiscordLogger;
 const botStatusService: BotStatusService = BotStatusService.getInstance(client);
 
-// Healthcheck endpoint for Docker (start only after bot is ready)
+// Healthcheck endpoint for Docker/Kubernetes. The server starts listening
+// immediately at process startup — before client.login() — so the port is
+// always open (#521). While the bot is still booting it returns 503
+// "Starting"; only once initializeServices() finishes (isReady) does it run
+// the Discord + MongoDB readiness checks and return 200.
 
 function startHealthServer(): void {
   const healthApp = express();
   healthApp.get("/health", (_req: Request, res: Response) => {
+    if (!isReady) {
+      res.status(503).send("Starting");
+      return;
+    }
     let discordReady = false;
     let mongoReady = false;
     try {
@@ -190,7 +202,6 @@ function startHealthServer(): void {
   });
 }
 
-// Add health server startup to main ready handler
 client.once(Events.ClientReady, async (readyClient) => {
   logger.info(`Ready! Logged in as ${readyClient.user.tag}`);
 
@@ -202,8 +213,10 @@ client.once(Events.ClientReady, async (readyClient) => {
 
   await initializeServices();
 
-  // Start healthcheck server after all other initialization
-  startHealthServer();
+  // Flip the health flag so /health switches from 503 "Starting" to its
+  // normal Discord + MongoDB readiness checks (#521). The server itself is
+  // already listening — it was started before client.login() below.
+  isReady = true;
 });
 
 async function cleanupGlobalCommands(): Promise<void> {
@@ -915,6 +928,10 @@ client.on(Events.GuildMemberAdd, async (member) => {
     }
   }
 });
+
+// Start the healthcheck server immediately so port 3000 is listening before
+// Discord/MongoDB are up (#521). It reports 503 "Starting" until isReady.
+startHealthServer();
 
 // Login to Discord (errors will be caught by global error handlers)
 client.login(env.discordToken).catch((error) => {


### PR DESCRIPTION
## Summary

Fixes #521. The health/metrics server now starts listening **before** `client.login()`, instead of only after `initializeServices()` finishes inside the `ClientReady` handler.

Previously, port 3000 didn't open until Discord connected, MongoDB connected (up to a 10s timeout), and every service initialized. During that whole window a `HEALTHCHECK` got **connection refused** rather than a response — which can trigger restarts/unhealthy status under orchestrators (Kubernetes liveness probes have no equivalent of Docker's `--start-period`).

## Changes

- Added a module-level `isReady` flag (default `false`).
- `/health` now returns `503 "Starting"` while `isReady` is false; once flipped it runs the existing Discord + MongoDB readiness checks (`200 OK` / `503 Service Unavailable`).
- `startHealthServer()` is now called immediately before `client.login()`, so the port is always listening.
- The `ClientReady` handler flips `isReady = true` after `initializeServices()` instead of starting the server.

## Impact

- Compatible with Kubernetes liveness probes out of the box.
- No longer relies on Docker's `--start-period` as the only safety net.
- A slow MongoDB connection is now observable as sustained `503`s instead of silent connection refused.

## Verification

- `tsc --noEmit` passes
- `eslint src/index.ts` passes
- `prettier --check` passes

https://claude.ai/code/session_01RST7BYBS39E9vnBv79TCpT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RST7BYBS39E9vnBv79TCpT)_