### PR TITLE
fix(shutdown): avoid configService race in gracefulShutdown (#520)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -346,13 +346,19 @@ async function gracefulShutdown(signal: string): Promise<void> {
     // 1. Switch lobby to offline mode (priority 1) - 5 second timeout
     await runWithTimeout(
       async () => {
-        const guildId = await configService.getString("GUILD_ID", "");
+        // GUILD_ID is a bootstrap value read directly from the environment
+        // (see env.ts), so we don't depend on configService here — that
+        // keeps this path working even if a signal arrives before the
+        // ConfigService singleton has been wired up.
+        const guildId = env.guildId ?? "";
         if (guildId) {
           const guild = await client.guilds.fetch(guildId);
-          const offlineLobbyName = await configService.getString(
-            "voicechannels.lobby.offlinename",
-            "🔴 Lobby",
-          );
+          const offlineLobbyName = configService
+            ? await configService.getString(
+                "voicechannels.lobby.offlinename",
+                "🔴 Lobby",
+              )
+            : "🔴 Lobby";
 
           // Find the lobby channel and rename it
           const lobbyChannel = guild.channels.cache.find(
@@ -385,7 +391,7 @@ async function gracefulShutdown(signal: string): Promise<void> {
     // 3. Deregister commands (no wait needed) - 5 second timeout
     await runWithTimeout(
       async () => {
-        const guildId = await configService.getString("GUILD_ID", "");
+        const guildId = env.guildId ?? "";
         if (guildId) {
           const rest = new REST({ version: "10" }).setToken(env.discordToken!);
           await rest.put(
@@ -482,10 +488,6 @@ async function gracefulShutdown(signal: string): Promise<void> {
   }
 }
 
-// Handle process termination
-process.on("SIGINT", () => gracefulShutdown("SIGINT"));
-process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
-
 // Service instances (declared outside try-catch for proper scoping)
 let configService: ConfigService;
 let commandManager: CommandManager;
@@ -533,6 +535,14 @@ try {
   logger.error("❌ Fatal error during service instantiation:", error);
   process.exit(1);
 }
+
+// Handle process termination. Registered AFTER service instantiation so the
+// singletons gracefulShutdown() relies on (e.g. configService, the timer-owning
+// services) are guaranteed to exist by the time a SIGINT/SIGTERM can invoke it.
+// Service instantiation above is synchronous, so this does not widen any
+// meaningful window during which signals would go unhandled.
+process.on("SIGINT", () => gracefulShutdown("SIGINT"));
+process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
 
 // Bot status service is already initialized above
 


### PR DESCRIPTION
## Summary

Fixes #520.

`gracefulShutdown()` referenced the module-level `configService`, which is only **assigned** inside the `try` block that runs *after* the `SIGINT`/`SIGTERM` handlers were registered. If a signal arrived in that small window, `configService` was still `undefined`, so `configService.getString(...)` threw a `TypeError` and crashed the shutdown handler — leaving the lobby stuck in its "online" state instead of being flipped offline.

This combines the issue's preferred fixes (Option B + Option C, with a defensive guard):

- **Register the `SIGINT`/`SIGTERM` handlers after service instantiation** so the singletons `gracefulShutdown` relies on are guaranteed to exist by the time a signal can invoke it. Service instantiation is synchronous, so this doesn't widen any meaningful unhandled-signal window.
- **Read `GUILD_ID` directly from `env`** (a bootstrap value that lives in `.env`) instead of going through `configService` for the shutdown lobby-rename and command-deregistration steps, removing the dependency entirely there.
- **Guard the remaining `configService` read** (the offline lobby name) with a `"🔴 Lobby"` fallback so the rename still proceeds even if `configService` is somehow unset.

## Testing

- `npx tsc --noEmit` — passes
- `npx eslint src/index.ts` — passes
- `npx prettier --check src/index.ts` — passes

There is no test harness around the `index.ts` entry point, so this is verified via type-check/lint/format plus code review of the shutdown path.

https://claude.ai/code/session_016bcX3vvwKDrEhfV4sX5pQ3

---
_Generated by [Claude Code](https://claude.ai/code/session_016bcX3vvwKDrEhfV4sX5pQ3)_