### PR TITLE
Replace axios with native fetch in poll-service

### DIFF
--- a/__tests__/services/poll-service.test.ts
+++ b/__tests__/services/poll-service.test.ts
@@ -1,19 +1,11 @@
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 
-const mockAxiosGet = jest.fn();
-const mockAxiosIsAxiosError = jest.fn();
+const mockFetch = jest.fn<typeof fetch>();
 const mockPollItemFindOne = jest.fn();
 const mockPollItemCreate = jest.fn();
 const mockRegisterReloadCallback = jest.fn();
 const mockConfigGetBoolean = jest.fn();
 const mockConfigGetNumber = jest.fn();
-
-jest.unstable_mockModule("axios", () => ({
-  default: {
-    get: mockAxiosGet,
-    isAxiosError: mockAxiosIsAxiosError,
-  },
-}));
 
 jest.unstable_mockModule("../../src/services/config-service.js", () => ({
   ConfigService: {
@@ -47,15 +39,29 @@ jest.unstable_mockModule("../../src/utils/logger.js", () => ({
 
 const { PollService } = await import("../../src/services/poll-service.js");
 
+// Build a real fetch Response so the service exercises the genuine
+// Headers/ReadableStream plumbing it relies on at runtime (Node 22+).
+function makeResponse(
+  body: BodyInit | null,
+  contentType: string,
+  init: ResponseInit = {},
+): Response {
+  const headers = new Headers(init.headers);
+  if (contentType) {
+    headers.set("content-type", contentType);
+  }
+  return new Response(body, { status: 200, ...init, headers });
+}
+
 describe("PollService", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (PollService as unknown as { instance: unknown }).instance = undefined;
-    mockAxiosIsAxiosError.mockReturnValue(false);
     mockConfigGetBoolean.mockResolvedValue(false);
     mockConfigGetNumber.mockResolvedValue(7);
     mockPollItemFindOne.mockResolvedValue(null);
     mockPollItemCreate.mockResolvedValue({});
+    global.fetch = mockFetch as unknown as typeof fetch;
   });
 
   it("rejects invalid URL formats before fetching", async () => {
@@ -72,7 +78,7 @@ describe("PollService", () => {
       skipped: 0,
       errors: ["Invalid URL format. Please provide a valid HTTP or HTTPS URL."],
     });
-    expect(mockAxiosGet).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("rejects non-http protocols before fetching", async () => {
@@ -89,7 +95,7 @@ describe("PollService", () => {
       skipped: 0,
       errors: ["URL must use the http or https protocol"],
     });
-    expect(mockAxiosGet).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("rejects private and local destinations before fetching", async () => {
@@ -123,19 +129,21 @@ describe("PollService", () => {
         errors: ["URL must not point to a private or local address"],
       });
     }
-    expect(mockAxiosGet).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("continues importing polls from allowed https URLs", async () => {
-    mockAxiosGet.mockResolvedValue({
-      data: `polls:
+    mockFetch.mockResolvedValue(
+      makeResponse(
+        `polls:
   - question: Favorite color?
     answers:
       - Blue
       - Green
 `,
-      headers: { "content-type": "text/yaml; charset=utf-8" },
-    });
+        "text/yaml; charset=utf-8",
+      ),
+    );
 
     const service = PollService.getInstance({} as never);
 
@@ -145,17 +153,15 @@ describe("PollService", () => {
       "user-1",
     );
 
-    expect(mockAxiosGet).toHaveBeenCalledWith(
+    expect(mockFetch).toHaveBeenCalledWith(
       "https://example.com/polls.yaml",
-      {
-        timeout: 10000,
-        maxContentLength: 2 * 1024 * 1024,
-        maxBodyLength: 2 * 1024 * 1024,
-        responseType: "text",
+      expect.objectContaining({
+        redirect: "follow",
         headers: {
           "User-Agent": "KoolBot-PollService/1.0",
         },
-      },
+        signal: expect.any(AbortSignal),
+      }),
     );
     expect(mockPollItemFindOne).toHaveBeenCalledWith({
       guildId: "guild-1",
@@ -177,11 +183,37 @@ describe("PollService", () => {
     });
   });
 
-  it("rejects responses with a non-JSON/YAML Content-Type", async () => {
-    mockAxiosGet.mockResolvedValue({
-      data: "<!DOCTYPE html><html><body>Login required</body></html>",
-      headers: { "content-type": "text/html; charset=utf-8" },
+  it("reports an HTTP error for a non-2xx response", async () => {
+    mockFetch.mockResolvedValue(
+      makeResponse("Not found", "text/plain", {
+        status: 404,
+        statusText: "Not Found",
+      }),
+    );
+
+    const service = PollService.getInstance({} as never);
+
+    const result = await service.importFromUrl(
+      "https://example.com/missing.yaml",
+      "guild-1",
+      "user-1",
+    );
+
+    expect(result).toEqual({
+      imported: 0,
+      skipped: 0,
+      errors: ["HTTP 404: Not Found"],
     });
+    expect(mockPollItemCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects responses with a non-JSON/YAML Content-Type", async () => {
+    mockFetch.mockResolvedValue(
+      makeResponse(
+        "<!DOCTYPE html><html><body>Login required</body></html>",
+        "text/html; charset=utf-8",
+      ),
+    );
 
     const service = PollService.getInstance({} as never);
 
@@ -202,10 +234,7 @@ describe("PollService", () => {
   });
 
   it("reports an invalid-format error for an empty or non-object body", async () => {
-    mockAxiosGet.mockResolvedValue({
-      data: "",
-      headers: { "content-type": "text/plain" },
-    });
+    mockFetch.mockResolvedValue(makeResponse("", "text/plain"));
 
     const service = PollService.getInstance({} as never);
 
@@ -223,12 +252,12 @@ describe("PollService", () => {
     expect(mockPollItemCreate).not.toHaveBeenCalled();
   });
 
-  it("reports a clear error when the payload exceeds the size cap", async () => {
-    mockAxiosIsAxiosError.mockReturnValue(true);
-    mockAxiosGet.mockRejectedValue({
-      code: "ERR_FR_MAX_BODY_LENGTH_EXCEEDED",
-      message: "maxBodyLength size of 2097152 exceeded",
-    });
+  it("reports a clear error when a declared Content-Length exceeds the cap", async () => {
+    mockFetch.mockResolvedValue(
+      makeResponse("", "text/yaml", {
+        headers: { "content-length": String(2 * 1024 * 1024 + 1) },
+      }),
+    );
 
     const service = PollService.getInstance({} as never);
 
@@ -246,12 +275,34 @@ describe("PollService", () => {
     expect(mockPollItemCreate).not.toHaveBeenCalled();
   });
 
-  it("reports a clear error when the request times out", async () => {
-    mockAxiosIsAxiosError.mockReturnValue(true);
-    mockAxiosGet.mockRejectedValue({
-      code: "ECONNABORTED",
-      message: "timeout of 10000ms exceeded",
+  it("enforces the size cap while streaming a body with no Content-Length", async () => {
+    const oversized = "x".repeat(2 * 1024 * 1024 + 10);
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(oversized));
+        controller.close();
+      },
     });
+    mockFetch.mockResolvedValue(makeResponse(stream, "text/yaml"));
+
+    const service = PollService.getInstance({} as never);
+
+    const result = await service.importFromUrl(
+      "https://example.com/streamed.yaml",
+      "guild-1",
+      "user-1",
+    );
+
+    expect(result).toEqual({
+      imported: 0,
+      skipped: 0,
+      errors: ["URL response too large (max 2 MB)"],
+    });
+    expect(mockPollItemCreate).not.toHaveBeenCalled();
+  });
+
+  it("reports a clear error when the request times out", async () => {
+    mockFetch.mockRejectedValue(new DOMException("The operation was aborted", "AbortError"));
 
     const service = PollService.getInstance({} as never);
 
@@ -265,6 +316,25 @@ describe("PollService", () => {
       imported: 0,
       skipped: 0,
       errors: ["Request timeout - URL took too long to respond"],
+    });
+    expect(mockPollItemCreate).not.toHaveBeenCalled();
+  });
+
+  it("reports a network error when fetch fails to connect", async () => {
+    mockFetch.mockRejectedValue(new TypeError("fetch failed"));
+
+    const service = PollService.getInstance({} as never);
+
+    const result = await service.importFromUrl(
+      "https://example.com/unreachable.yaml",
+      "guild-1",
+      "user-1",
+    );
+
+    expect(result).toEqual({
+      imported: 0,
+      skipped: 0,
+      errors: ["No response from URL - check if URL is accessible"],
     });
     expect(mockPollItemCreate).not.toHaveBeenCalled();
   });

--- a/__tests__/services/poll-service.test.ts
+++ b/__tests__/services/poll-service.test.ts
@@ -42,9 +42,13 @@ const { PollService } = await import("../../src/services/poll-service.js");
 // Build a real fetch Response so the service exercises the genuine
 // Headers/ReadableStream plumbing it relies on at runtime (Node 22+).
 function makeResponse(
-  body: BodyInit | null,
+  body: string | ReadableStream<Uint8Array> | null,
   contentType: string,
-  init: ResponseInit = {},
+  init: {
+    status?: number;
+    statusText?: string;
+    headers?: Record<string, string>;
+  } = {},
 ): Response {
   const headers = new Headers(init.headers);
   if (contentType) {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,7 +26,24 @@ export default [
         '__filename': 'readonly',
         'console': 'readonly',
         'module': 'readonly',
-        'require': 'readonly'
+        'require': 'readonly',
+        'global': 'readonly',
+        'Buffer': 'readonly',
+        // Web platform globals available in Node.js 22+
+        'fetch': 'readonly',
+        'Request': 'readonly',
+        'Response': 'readonly',
+        'Headers': 'readonly',
+        'AbortController': 'readonly',
+        'AbortSignal': 'readonly',
+        'ReadableStream': 'readonly',
+        'TextEncoder': 'readonly',
+        'TextDecoder': 'readonly',
+        'DOMException': 'readonly',
+        'URL': 'readonly',
+        'BodyInit': 'readonly',
+        'ResponseInit': 'readonly',
+        'RequestInit': 'readonly'
       }
     },
     plugins: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,10 +40,7 @@ export default [
         'TextEncoder': 'readonly',
         'TextDecoder': 'readonly',
         'DOMException': 'readonly',
-        'URL': 'readonly',
-        'BodyInit': 'readonly',
-        'ResponseInit': 'readonly',
-        'RequestInit': 'readonly'
+        'URL': 'readonly'
       }
     },
     plugins: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.9.0",
       "dependencies": {
         "@discordjs/builders": "^1.14.1",
-        "axios": "^1.16.1",
         "cron": "^4.4.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
@@ -3111,18 +3110,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -3224,24 +3211,6 @@
     "node_modules/async": {
       "version": "3.2.6",
       "license": "MIT"
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
-      }
     },
     "node_modules/babel-jest": {
       "version": "30.4.1",
@@ -3760,18 +3729,6 @@
         "node": ">=12.20"
       }
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -3961,15 +3918,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -4190,21 +4138,6 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4722,26 +4655,6 @@
       "version": "1.1.0",
       "license": "MIT"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -4757,22 +4670,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -5011,21 +4908,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
@@ -5063,19 +4945,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {
@@ -7070,27 +6939,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -7711,15 +7559,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@discordjs/builders": "^1.14.1",
-    "axios": "^1.16.1",
     "cron": "^4.4.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",

--- a/src/services/poll-service.ts
+++ b/src/services/poll-service.ts
@@ -543,6 +543,9 @@ export class PollService {
       });
 
       if (!response.ok) {
+        // Cancel the unconsumed body so undici can release the socket instead
+        // of holding it open until garbage collection.
+        await response.body?.cancel().catch(() => {});
         results.errors.push(`HTTP ${response.status}: ${response.statusText}`);
         return results;
       }
@@ -554,6 +557,7 @@ export class PollService {
         .trim()
         .toLowerCase();
       if (contentType && !ALLOWED_IMPORT_CONTENT_TYPES.includes(contentType)) {
+        await response.body?.cancel().catch(() => {});
         results.errors.push(
           `Unexpected Content-Type from import URL: "${contentType}". Expected JSON or YAML.`,
         );
@@ -569,6 +573,7 @@ export class PollService {
         Number.isFinite(declaredLength) &&
         declaredLength > MAX_IMPORT_BYTES
       ) {
+        await response.body?.cancel().catch(() => {});
         results.errors.push(
           `URL response too large (max ${MAX_IMPORT_BYTES / (1024 * 1024)} MB)`,
         );

--- a/src/services/poll-service.ts
+++ b/src/services/poll-service.ts
@@ -6,7 +6,6 @@ import logger from "../utils/logger.js";
 import { PollSchedule, IPollSchedule } from "../models/poll-schedule.js";
 import { PollItem, IPollItem } from "../models/poll-item.js";
 import { sanitizeForLog } from "../utils/log-sanitize.js";
-import axios from "axios";
 import yaml from "js-yaml";
 
 interface ScheduledPollJob {
@@ -48,6 +47,54 @@ const ALLOWED_IMPORT_CONTENT_TYPES = [
   "text/plain",
   "application/octet-stream",
 ];
+
+// Raised by the import body reader when a response streams more than
+// MAX_IMPORT_BYTES. fetch has no built-in equivalent of Axios's
+// maxContentLength, so we enforce the cap ourselves while consuming the body.
+class ImportSizeExceededError extends Error {
+  constructor() {
+    super("Import payload exceeded the maximum allowed size");
+    this.name = "ImportSizeExceededError";
+  }
+}
+
+// Read a response body as UTF-8 text while enforcing a hard byte cap. The
+// stream is abandoned as soon as the cap is crossed so a malicious or
+// misconfigured server cannot push an unbounded body into memory.
+async function readBodyWithLimit(
+  response: Response,
+  maxBytes: number,
+): Promise<string> {
+  const body = response.body;
+  if (!body) {
+    return "";
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (value) {
+        total += value.length;
+        if (total > maxBytes) {
+          throw new ImportSizeExceededError();
+        }
+        chunks.push(value);
+      }
+    }
+  } finally {
+    // Release the stream; cancel() is a no-op once the body is fully read.
+    await reader.cancel().catch(() => {});
+  }
+
+  return Buffer.concat(chunks).toString("utf-8");
+}
 
 /**
  * Block obvious local/private destinations so poll imports cannot be used for
@@ -478,23 +525,31 @@ export class PollService {
       return results;
     }
 
+    // Reject the request if it has not completed within IMPORT_TIMEOUT_MS so a
+    // slow or unresponsive server cannot hang the import indefinitely. The same
+    // signal aborts an in-flight body read, not just connection setup.
+    const controller = new globalThis.AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), IMPORT_TIMEOUT_MS);
+
     try {
-      // Fetch the content with timeout. Receive the body as raw text so we can
-      // inspect the Content-Type and parse it ourselves rather than letting
-      // Axios silently coerce a non-JSON response.
-      const response = await axios.get(parsedUrl.toString(), {
-        timeout: IMPORT_TIMEOUT_MS,
-        maxContentLength: MAX_IMPORT_BYTES,
-        maxBodyLength: MAX_IMPORT_BYTES,
-        responseType: "text",
+      // Fetch the content. The body is read as raw text so we can inspect the
+      // Content-Type and parse it ourselves rather than trusting the server.
+      const response = await fetch(parsedUrl.toString(), {
+        signal: controller.signal,
+        redirect: "follow",
         headers: {
           "User-Agent": "KoolBot-PollService/1.0",
         },
       });
 
+      if (!response.ok) {
+        results.errors.push(`HTTP ${response.status}: ${response.statusText}`);
+        return results;
+      }
+
       // Validate the Content-Type before parsing. An HTML login/redirect or
       // challenge page would otherwise surface as a cryptic parse error.
-      const contentType = String(response.headers?.["content-type"] ?? "")
+      const contentType = (response.headers.get("content-type") ?? "")
         .split(";")[0]
         .trim()
         .toLowerCase();
@@ -505,14 +560,31 @@ export class PollService {
         return results;
       }
 
+      // Reject early on an oversized declared length, then enforce the cap
+      // again while streaming in case the server lied about (or omitted) it.
+      const declaredLength = Number(
+        response.headers.get("content-length") ?? "",
+      );
+      if (
+        Number.isFinite(declaredLength) &&
+        declaredLength > MAX_IMPORT_BYTES
+      ) {
+        results.errors.push(
+          `URL response too large (max ${MAX_IMPORT_BYTES / (1024 * 1024)} MB)`,
+        );
+        return results;
+      }
+
+      const rawBody = await readBodyWithLimit(response, MAX_IMPORT_BYTES);
+
       let pollData: PollSource;
 
       // Try to parse as YAML first (also works for JSON)
       try {
-        pollData = yaml.load(response.data) as PollSource;
+        pollData = yaml.load(rawBody) as PollSource;
       } catch {
         // If YAML fails, try JSON
-        pollData = JSON.parse(response.data);
+        pollData = JSON.parse(rawBody);
       }
 
       // yaml.load / JSON.parse can yield null, undefined, or a scalar for an
@@ -581,32 +653,25 @@ export class PollService {
         }
       }
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        if (error.code === "ECONNABORTED") {
-          results.errors.push("Request timeout - URL took too long to respond");
-        } else if (
-          error.code === "ERR_FR_MAX_CONTENT_LENGTH_EXCEEDED" ||
-          error.code === "ERR_FR_MAX_BODY_LENGTH_EXCEEDED"
-        ) {
-          results.errors.push(
-            `URL response too large (max ${MAX_IMPORT_BYTES / (1024 * 1024)} MB)`,
-          );
-        } else if (error.response) {
-          results.errors.push(
-            `HTTP ${error.response.status}: ${error.response.statusText}`,
-          );
-        } else if (error.request) {
-          results.errors.push(
-            "No response from URL - check if URL is accessible",
-          );
-        } else {
-          results.errors.push(`Request error: ${error.message}`);
-        }
+      if (error instanceof DOMException && error.name === "AbortError") {
+        results.errors.push("Request timeout - URL took too long to respond");
+      } else if (error instanceof ImportSizeExceededError) {
+        results.errors.push(
+          `URL response too large (max ${MAX_IMPORT_BYTES / (1024 * 1024)} MB)`,
+        );
+      } else if (error instanceof TypeError) {
+        // fetch rejects with a TypeError for network-level failures (DNS,
+        // connection refused, TLS errors) where no response was received.
+        results.errors.push(
+          "No response from URL - check if URL is accessible",
+        );
       } else {
         results.errors.push(
           `Error: ${error instanceof Error ? error.message : "Unknown error"}`,
         );
       }
+    } finally {
+      clearTimeout(timeoutId);
     }
 
     return results;


### PR DESCRIPTION
## Summary

Removes `axios` — the only production dependency used solely for a single HTTP GET in `src/services/poll-service.ts` (importing poll items from a URL). The project already requires **Node.js ≥ 22.0.0**, where `fetch` is a stable global, so no polyfill or replacement package is needed.

Closes #523.

## Changes

- **`src/services/poll-service.ts`**
  - Rewrote `importFromUrl` to use the global `fetch` with an `AbortController`-based 10s timeout (`IMPORT_TIMEOUT_MS`).
  - Replaced axios `maxContentLength`/`maxBodyLength` with an explicit 2 MB cap: an early `Content-Length` header check, plus a streaming byte counter (`readBodyWithLimit`) that abandons the body the moment the cap is crossed — so a server that lies about or omits `Content-Length` can't stream an unbounded body into memory.
  - Kept the same `Content-Type` allow-list validation, `User-Agent` header, and YAML-then-JSON parsing.
  - Mapped fetch failure modes to the **same user-facing error messages** as before:
    - `AbortError` → "Request timeout - URL took too long to respond"
    - oversized body → "URL response too large (max 2 MB)"
    - network `TypeError` → "No response from URL - check if URL is accessible"
    - non-2xx → "HTTP `{status}`: `{statusText}`"
- **`package.json` / `package-lock.json`** — removed `axios` from dependencies.
- **`eslint.config.js`** — added Node 22 web-platform globals (`fetch`, `Response`, `Headers`, `Buffer`, `DOMException`, etc.) so `no-undef` is satisfied without `globalThis.` workarounds.
- **`__tests__/services/poll-service.test.ts`** — replaced the axios mock with a `fetch` mock that returns real `Response` objects, and added coverage for the streaming size cap, HTTP errors, and network failures.

## Verification

- `npm run build` ✅
- `npm run lint` ✅ (0 errors)
- `npm run format:check` ✅
- `npm run test:ci` ✅ — 964 passed / 1 skipped; poll-service suite: 11 passed
- `grep` confirms no remaining `axios` imports anywhere in `src`/`__tests__`.

## Notes

Redirect handling (`redirect: "follow"`) preserves the prior axios behavior of transparently following redirects; the existing initial-host SSRF check is unchanged, so there is no regression.

https://claude.ai/code/session_01W3XCgQDUds2vJQmChFdPe8

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3XCgQDUds2vJQmChFdPe8)_