### PR TITLE
Potential fix for code scanning alert no. 54: Server-side request forgery

### DIFF
--- a/src/services/poll-service.ts
+++ b/src/services/poll-service.ts
@@ -478,6 +478,18 @@ export class PollService {
       return results;
     }
 
+    // Restrict imports to trusted hosts to prevent SSRF via arbitrary destinations.
+    // Keep this list server-controlled; users may provide only the path/query on these hosts.
+    const ALLOWED_IMPORT_HOSTS = ["raw.githubusercontent.com", "gist.githubusercontent.com"];
+    const hostname = parsedUrl.hostname.toLowerCase();
+    const isAllowedHost = ALLOWED_IMPORT_HOSTS.some(
+      (allowed) => hostname === allowed || hostname.endsWith(`.${allowed}`),
+    );
+    if (!isAllowedHost) {
+      results.errors.push("URL host is not allowed for imports");
+      return results;
+    }
+
     try {
       // Fetch the content with timeout. Receive the body as raw text so we can
       // inspect the Content-Type and parse it ourselves rather than letting


### PR DESCRIPTION
Potential fix for [https://github.com/lonix/koolbot/security/code-scanning/54](https://github.com/lonix/koolbot/security/code-scanning/54)

Best fix: keep current behavior (URL-based import) but restrict outbound requests to a **server-controlled allowlist of trusted hostnames** before calling `axios.get(...)`.

In `src/services/poll-service.ts`, inside `importFromUrl` right after current protocol/private checks and before `axios.get`, add a hostname allowlist validation (exact host match and optional subdomain match of trusted domains). If hostname is not allowed, return an error and do not perform request. This preserves existing functionality for approved sources while eliminating arbitrary-host SSRF.

No changes are required in `src/web/write-routes.ts` for this fix; input can remain user-provided, but must select from trusted destinations enforced server-side.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
