### PR TITLE
Harden poll import against SSRF with configurable host allowlist

### DIFF
--- a/__tests__/services/poll-service.test.ts
+++ b/__tests__/services/poll-service.test.ts
@@ -1,4 +1,11 @@
-import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
 
 const mockFetch = jest.fn<typeof fetch>();
 const mockPollItemFindOne = jest.fn();
@@ -66,6 +73,13 @@ describe("PollService", () => {
     mockPollItemFindOne.mockResolvedValue(null);
     mockPollItemCreate.mockResolvedValue({});
     global.fetch = mockFetch as unknown as typeof fetch;
+    // The import host allowlist is server-controlled; allow the fixture host
+    // used throughout these tests via the configurable env var.
+    process.env.POLL_IMPORT_ALLOWED_HOSTS = "example.com";
+  });
+
+  afterEach(() => {
+    delete process.env.POLL_IMPORT_ALLOWED_HOSTS;
   });
 
   it("rejects invalid URL formats before fetching", async () => {
@@ -136,6 +150,67 @@ describe("PollService", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it("rejects hosts that are not on the import allowlist", async () => {
+    const service = PollService.getInstance({} as never);
+
+    const result = await service.importFromUrl(
+      "https://evil.example.org/polls.yaml",
+      "guild-1",
+      "user-1",
+    );
+
+    expect(result).toEqual({
+      imported: 0,
+      skipped: 0,
+      errors: ["URL host is not allowed for imports"],
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects look-alike hosts that only suffix an allowed host", async () => {
+    const service = PollService.getInstance({} as never);
+
+    const result = await service.importFromUrl(
+      "https://example.com.evil.org/polls.yaml",
+      "guild-1",
+      "user-1",
+    );
+
+    expect(result).toEqual({
+      imported: 0,
+      skipped: 0,
+      errors: ["URL host is not allowed for imports"],
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("allows GitHub raw hosts by default when no allowlist is configured", async () => {
+    delete process.env.POLL_IMPORT_ALLOWED_HOSTS;
+    mockFetch.mockResolvedValue(
+      makeResponse(
+        `polls:
+  - question: Default host?
+    answers:
+      - Yes
+      - No
+`,
+        "text/yaml",
+      ),
+    );
+
+    const service = PollService.getInstance({} as never);
+
+    const result = await service.importFromUrl(
+      "https://raw.githubusercontent.com/org/repo/main/polls.yaml",
+      "guild-1",
+      "user-1",
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result.imported).toBe(1);
+    expect(result.errors).toEqual([]);
+  });
+
   it("continues importing polls from allowed https URLs", async () => {
     mockFetch.mockResolvedValue(
       makeResponse(
@@ -160,7 +235,7 @@ describe("PollService", () => {
     expect(mockFetch).toHaveBeenCalledWith(
       "https://example.com/polls.yaml",
       expect.objectContaining({
-        redirect: "follow",
+        redirect: "error",
         headers: {
           "User-Agent": "KoolBot-PollService/1.0",
         },

--- a/src/services/poll-service.ts
+++ b/src/services/poll-service.ts
@@ -96,6 +96,47 @@ async function readBodyWithLimit(
   return Buffer.concat(chunks).toString("utf-8");
 }
 
+// Server-controlled allowlist of hosts that poll libraries may be imported from.
+// Restricting outbound requests to known-good hosts is the primary defense
+// against SSRF (CodeQL js/request-forgery): without it, an admin-supplied URL
+// can target arbitrary internal endpoints. Configurable via the
+// POLL_IMPORT_ALLOWED_HOSTS env var (comma-separated) so operators can widen
+// or change the destinations without a code change; defaults to GitHub's raw
+// content hosts.
+const DEFAULT_ALLOWED_IMPORT_HOSTS = [
+  "raw.githubusercontent.com",
+  "gist.githubusercontent.com",
+];
+
+function getAllowedImportHosts(): string[] {
+  const configured = process.env.POLL_IMPORT_ALLOWED_HOSTS;
+  if (!configured) {
+    return DEFAULT_ALLOWED_IMPORT_HOSTS;
+  }
+
+  const hosts = configured
+    .split(",")
+    .map((host) => host.trim().toLowerCase())
+    .filter((host) => host.length > 0);
+
+  return hosts.length > 0 ? hosts : DEFAULT_ALLOWED_IMPORT_HOSTS;
+}
+
+/**
+ * Returns true when the hostname exactly matches an allowed host or is a
+ * subdomain of one. The leading-dot check prevents a look-alike host such as
+ * "raw.githubusercontent.com.evil.com" from slipping through a naive
+ * `endsWith` comparison.
+ */
+function isAllowedImportHost(hostname: string): boolean {
+  const normalizedHostname = hostname.toLowerCase();
+  return getAllowedImportHosts().some(
+    (allowed) =>
+      normalizedHostname === allowed ||
+      normalizedHostname.endsWith(`.${allowed}`),
+  );
+}
+
 /**
  * Block obvious local/private destinations so poll imports cannot be used for
  * direct SSRF probes against loopback, link-local, RFC1918, or unique-local
@@ -525,6 +566,14 @@ export class PollService {
       return results;
     }
 
+    // Enforce the server-controlled host allowlist before making any request.
+    // This is the primary SSRF mitigation: it confines outbound traffic to
+    // trusted destinations regardless of what URL the admin supplies.
+    if (!isAllowedImportHost(parsedUrl.hostname)) {
+      results.errors.push("URL host is not allowed for imports");
+      return results;
+    }
+
     // Reject the request if it has not completed within IMPORT_TIMEOUT_MS so a
     // slow or unresponsive server cannot hang the import indefinitely. The same
     // signal aborts an in-flight body read, not just connection setup.
@@ -536,7 +585,11 @@ export class PollService {
       // Content-Type and parse it ourselves rather than trusting the server.
       const response = await fetch(parsedUrl.toString(), {
         signal: controller.signal,
-        redirect: "follow",
+        // Do not follow redirects: an allowed host could otherwise 3xx-redirect
+        // the request to an internal or cloud-metadata endpoint, bypassing the
+        // host allowlist. A redirect rejects the fetch and is surfaced as an
+        // error instead.
+        redirect: "error",
         headers: {
           "User-Agent": "KoolBot-PollService/1.0",
         },


### PR DESCRIPTION
## Summary

Addresses CodeQL `js/request-forgery` (code scanning alert #54) in `PollService.importFromUrl`, an alternative to the Copilot Autofix in #529.

CodeQL flags that the admin-supplied `url` flows directly into the outbound HTTP request. The existing protocol and private/local-host checks are real defenses, but CodeQL doesn't recognize a string hostname check as a sanitizer, and two genuine holes remain:

1. **Redirects** — following redirects means even a "safe" host can `3xx`-redirect the request to an internal or cloud-metadata endpoint (`169.254.169.254`), bypassing any front-door host check.
2. **DNS rebinding** — a public hostname can resolve to a private IP at request time, which a string-based check can't catch.

> Rebased onto `main` after #528 replaced axios with native `fetch`; the hardening below is applied on top of the fetch-based importer.

## Changes

- **Host allowlist** (the CodeQL-recognized barrier), but **configurable** via `POLL_IMPORT_ALLOWED_HOSTS` (comma-separated env var), defaulting to `raw.githubusercontent.com` and `gist.githubusercontent.com`. This closes the alert without permanently locking imports to GitHub — operators can widen destinations without a code change. This is the key difference from #529's hardcoded list, which would silently break imports from any other host.
- **Leading-dot subdomain match** so look-alikes like `raw.githubusercontent.com.evil.com` are rejected.
- **`redirect: "error"`** on the fetch call so an allowed host can't redirect the request to an internal target; a redirect rejects the request instead of being followed.
- Existing protocol and private/local-host checks retained as defense in depth.

## Tests

- New: rejects disallowed hosts, rejects look-alike suffix hosts, allows the default GitHub raw hosts when no env var is set.
- Updated the existing import tests to configure the allowlist via env and assert `redirect: "error"` on the request.
- All 14 tests in `__tests__/services/poll-service.test.ts` pass; lint clean (no new warnings).

Closes the concern behind #529 — that PR can be closed in favor of this one.

https://claude.ai/code/session_01RLuoa1GAQmGReEZ8WSttdQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLuoa1GAQmGReEZ8WSttdQ)_