### PR TITLE
ci: surface OCI description on GHCR and fix release-triggered image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,6 +85,12 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6
+        env:
+          # Emit OCI annotations on both the per-platform manifests and the
+          # image index. GHCR reads the package description from the index
+          # annotation for multi-arch images, so "index" is required for the
+          # description to show up on the GitHub Packages page.
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -110,6 +116,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -106,6 +106,15 @@ jobs:
             org.opencontainers.image.description=A Discord bot with various features
             maintainer=lonix
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          # metadata-action builds the annotations output from the
+          # `annotations` input (not `labels`), so the custom description must
+          # be repeated here to land in steps.meta.outputs.annotations — which
+          # is what gets attached to the manifest index and read by GHCR.
+          annotations: |
+            org.opencontainers.image.title=koolbot
+            org.opencontainers.image.description=A Discord bot with various features
+            maintainer=lonix
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
 
       - name: Build and push Docker image
         id: build

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,14 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT / GitHub App token (not the default GITHUB_TOKEN) so the
+          # tag and release this action creates can trigger downstream
+          # workflows — notably docker.yml's `on: push: tags`, which publishes
+          # the semver-tagged container image. Tags pushed with the default
+          # GITHUB_TOKEN are deliberately blocked from triggering other
+          # workflows, which is why v1.0.0 shipped without a 1.0.0 image.
+          # Falls back to GITHUB_TOKEN if the secret is unset (release still
+          # works, but won't auto-build the image).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Why

Two related gaps in the container release flow:

1. **The GHCR package page shows no description.** `docker.yml` already sets `org.opencontainers.image.description` as a **label**, but the image is multi-arch (`linux/amd64,linux/arm64`). For multi-arch images GHCR reads the description from the OCI **annotation on the manifest index**, not from per-platform config labels — so the description never appeared.

2. **`v1.0.0` shipped without a `1.0.0` container tag.** release-please created the `v1.0.0` tag, but every `docker.yml` run is an `event: push` on `main` — no run was ever triggered by the tag. This is the documented GitHub behavior: **tags/releases created with the default `GITHUB_TOKEN` cannot trigger other workflows**, so `docker.yml`'s `on: push: tags` never fired and the `type=semver` tags (`1.0.0`/`1.0`/`1`) were never published.

## Changes

- **`docker.yml`**
  - Set `DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index` on the metadata step so annotations are emitted at the index level.
  - Pass `annotations: ${{ steps.meta.outputs.annotations }}` to `build-push-action`. The description (and other OCI annotations) now land on the manifest index and surface on the GitHub Packages page.

- **`release-please.yml`**
  - Use `token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}`. A PAT/App token lets the created tag trigger `docker.yml`, so future releases auto-publish the semver-tagged image. Falls back to `GITHUB_TOKEN` if the secret is unset (release still works, image just won't auto-build).

## Required follow-up (repo admin)

- **Add a `RELEASE_PLEASE_TOKEN` secret** — a PAT with `contents: write` + `pull-requests: write` (or a GitHub App token). Without it, the fallback keeps releases working but won't trigger the image build.
- **Publish `1.0.0` now (one-time):** Actions → **Docker Build and Push** → **Run workflow** → select the **`v1.0.0` tag** as the ref. Running on the tag is what makes `type=semver` emit `1.0.0`/`1.0`/`1`. (I couldn't dispatch this from here — the integration token lacks `actions: write`.)

https://claude.ai/code/session_01RsXybwn9g47mC2XjTLXiRu

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsXybwn9g47mC2XjTLXiRu)_