### PR TITLE
Fix unmanaged-channel scanner deleting renamed channels after ownership transfer (#542)

### DIFF
--- a/__tests__/services/voice-channel-manager-rename-cleanup.test.ts
+++ b/__tests__/services/voice-channel-manager-rename-cleanup.test.ts
@@ -151,4 +151,39 @@ describe("VoiceChannelManager - rename-safe unmanaged cleanup (issue #542)", () 
     expect(renamedChannel.delete).toHaveBeenCalled();
     expect((manager as any).userChannels.has("lonix-id")).toBe(false);
   });
+
+  it("reconciles all per-channel state when an empty owned channel is cleaned up", async () => {
+    // Empty owned channel that also has a waiting room, live status, an
+    // ownership queue entry and a pending transfer timer. Deleting it must not
+    // orphan any of that in-memory state (see Copilot review on #543).
+    Object.defineProperty(renamedChannel, "members", {
+      value: new Collection(),
+      writable: true,
+    });
+    const channelId = renamedChannel.id as string;
+    (manager as any).userChannels.set("lonix-id", renamedChannel);
+    (manager as any).waitingRooms.set(channelId, "waiting-room-id");
+    (manager as any).waitingRoomToMain.set("waiting-room-id", channelId);
+    (manager as any).liveChannels.add(channelId);
+    (manager as any).ownershipQueue.set(channelId, ["someone-id"]);
+    const timer = setTimeout(() => {}, 60_000);
+    (manager as any).ownershipTransferTimers.set(channelId, {
+      timer,
+      originalOwnerId: "lonix-id",
+    });
+
+    await manager.cleanupEmptyChannels();
+
+    expect(renamedChannel.delete).toHaveBeenCalled();
+    expect((manager as any).userChannels.has("lonix-id")).toBe(false);
+    expect((manager as any).waitingRooms.has(channelId)).toBe(false);
+    expect((manager as any).waitingRoomToMain.has("waiting-room-id")).toBe(
+      false,
+    );
+    expect((manager as any).liveChannels.has(channelId)).toBe(false);
+    expect((manager as any).ownershipQueue.has(channelId)).toBe(false);
+    expect((manager as any).ownershipTransferTimers.has(channelId)).toBe(false);
+
+    clearTimeout(timer);
+  });
 });

--- a/__tests__/services/voice-channel-manager-rename-cleanup.test.ts
+++ b/__tests__/services/voice-channel-manager-rename-cleanup.test.ts
@@ -137,6 +137,18 @@ describe("VoiceChannelManager - rename-safe unmanaged cleanup (issue #542)", () 
     expect(renamedChannel.delete).toHaveBeenCalled();
   });
 
+  it("protects a custom-named, occupied channel even without an ownership entry", async () => {
+    // Ownership tracking is missing but the channel still has a tracked custom
+    // name and a member inside. It must be treated as managed (consistent with
+    // cleanupEmptyChannel) and not deleted as unmanaged.
+    manager.setCustomChannelName(renamedChannel.id as string, "My Cool Room");
+
+    await manager.cleanupEmptyChannels();
+
+    expect(renamedChannel.delete).not.toHaveBeenCalled();
+    expect(foreignChannel.delete).toHaveBeenCalled();
+  });
+
   it("removes the ownership entry when an empty owned channel is cleaned up", async () => {
     // Owned but empty renamed channel: it should be deleted as an empty
     // managed channel and its ownership entry cleared.

--- a/__tests__/services/voice-channel-manager-rename-cleanup.test.ts
+++ b/__tests__/services/voice-channel-manager-rename-cleanup.test.ts
@@ -1,0 +1,154 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import {
+  ChannelType,
+  Collection,
+  type Client,
+  type Guild,
+  type VoiceChannel,
+} from "discord.js";
+
+// Mock dependencies before importing
+jest.mock("../../src/utils/logger.js");
+jest.mock("../../src/services/voice-channel-tracker.js");
+jest.mock("../../src/services/config-service.js");
+
+// Import after mocks
+import { VoiceChannelManager } from "../../src/services/voice-channel-manager.js";
+import { ConfigService } from "../../src/services/config-service.js";
+
+const mockConfigService =
+  ConfigService.getInstance() as jest.Mocked<ConfigService>;
+
+/**
+ * Regression coverage for issue #542: after an ownership transfer the channel
+ * is renamed from "🎮 X's Room" to "Y's Channel", dropping the managed prefix.
+ * The unmanaged-channel scanner must still recognise it as managed (by channel
+ * ID) so it isn't deleted out from under the members still inside.
+ */
+describe("VoiceChannelManager - rename-safe unmanaged cleanup (issue #542)", () => {
+  let manager: VoiceChannelManager;
+  let mockClient: Partial<Client>;
+  let renamedChannel: Partial<VoiceChannel>;
+  let foreignChannel: Partial<VoiceChannel>;
+  let category: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (VoiceChannelManager as any).instance = undefined;
+
+    mockConfigService.getBoolean = jest
+      .fn()
+      .mockImplementation((key: string, defaultValue?: boolean) => {
+        if (key === "voicechannels.enabled") return Promise.resolve(true);
+        return Promise.resolve(defaultValue ?? false);
+      });
+
+    mockConfigService.getString = jest
+      .fn()
+      .mockImplementation((key: string, defaultValue?: string) => {
+        switch (key) {
+          case "GUILD_ID":
+            return Promise.resolve("guild-id");
+          case "voicechannels.lobby.name":
+            return Promise.resolve("Lobby");
+          case "voicechannels.lobby.offlinename":
+            return Promise.resolve("Lobby (Offline)");
+          case "voicechannels.category_id":
+            return Promise.resolve("category-id");
+          case "voicechannels.channel.prefix":
+            return Promise.resolve("🎮");
+          default:
+            return Promise.resolve(defaultValue ?? "");
+        }
+      });
+
+    // A channel that has been renamed by an ownership transfer. It no longer
+    // matches the "🎮" prefix but is still owned (tracked in userChannels) and
+    // still has a member inside.
+    renamedChannel = {
+      id: "renamed-channel-id",
+      name: "lonix's Channel",
+      type: ChannelType.GuildVoice,
+      members: new Collection([["lonix-id", {} as any]]),
+      delete: jest.fn<any>().mockResolvedValue(undefined),
+    } as any;
+
+    // A genuinely foreign channel that the bot does not manage.
+    foreignChannel = {
+      id: "foreign-channel-id",
+      name: "Some Random Channel",
+      type: ChannelType.GuildVoice,
+      members: new Collection(),
+      delete: jest.fn<any>().mockResolvedValue(undefined),
+    } as any;
+
+    const channels = new Collection<string, VoiceChannel>();
+    channels.set(renamedChannel.id as string, renamedChannel as VoiceChannel);
+    channels.set(foreignChannel.id as string, foreignChannel as VoiceChannel);
+
+    category = {
+      id: "category-id",
+      type: ChannelType.GuildCategory,
+      children: { cache: channels },
+    };
+
+    const guild: Partial<Guild> = {
+      channels: {
+        cache: new Collection([["category-id", category]]),
+      } as any,
+    };
+
+    mockClient = {
+      guilds: {
+        fetch: jest.fn<any>().mockResolvedValue(guild),
+      } as any,
+    } as any;
+
+    manager = VoiceChannelManager.getInstance(mockClient as Client);
+  });
+
+  afterEach(() => {
+    (VoiceChannelManager as any).instance = undefined;
+  });
+
+  it("does not delete a renamed, occupied channel that is still owned", async () => {
+    // Owner registry tracks the renamed channel by its stable ID.
+    (manager as any).userChannels.set("lonix-id", renamedChannel);
+
+    await manager.cleanupEmptyChannels();
+
+    expect(renamedChannel.delete).not.toHaveBeenCalled();
+    // The foreign channel should still be cleaned up.
+    expect(foreignChannel.delete).toHaveBeenCalled();
+  });
+
+  it("deletes a renamed channel that is no longer tracked as owned", async () => {
+    // Nothing in userChannels: the renamed channel is now indistinguishable
+    // from a foreign channel and should be removed.
+    await manager.cleanupEmptyChannels();
+
+    expect(renamedChannel.delete).toHaveBeenCalled();
+  });
+
+  it("removes the ownership entry when an empty owned channel is cleaned up", async () => {
+    // Owned but empty renamed channel: it should be deleted as an empty
+    // managed channel and its ownership entry cleared.
+    Object.defineProperty(renamedChannel, "members", {
+      value: new Collection(),
+      writable: true,
+    });
+    (manager as any).userChannels.set("lonix-id", renamedChannel);
+
+    await manager.cleanupEmptyChannels();
+
+    expect(renamedChannel.delete).toHaveBeenCalled();
+    expect((manager as any).userChannels.has("lonix-id")).toBe(false);
+  });
+});

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -1253,6 +1253,46 @@ export class VoiceChannelManager {
   }
 
   /**
+   * Reconcile all in-memory tracking for a channel that has been deleted.
+   *
+   * The various cleanup paths (cleanupUserChannel, cleanupEmptyChannel and the
+   * periodic cleanupEmptyChannels scanner) all need to drop the same per-channel
+   * state once a channel is gone, otherwise maps such as waitingRoomToMain or
+   * ownershipTransferTimers are orphaned — e.g. a leftover waiting room would be
+   * skipped forever by the unmanaged-channel loop. This clears ownership,
+   * custom-name, ownership-queue, live-status and pending-transfer state, and
+   * removes any associated waiting room.
+   */
+  private async reconcileDeletedChannelState(channelId: string): Promise<void> {
+    // Drop ownership entry (userChannels is keyed by ownerId -> channel)
+    for (const [ownerId, userChannel] of this.userChannels.entries()) {
+      if (userChannel.id === channelId) {
+        this.userChannels.delete(ownerId);
+        break;
+      }
+    }
+
+    this.customChannelNames.delete(channelId);
+    this.ownershipQueue.delete(channelId);
+    this.liveChannels.delete(channelId);
+    // Cancel and drop any pending ownership-transfer timer for this channel
+    this.cancelOwnershipTransfer(channelId);
+
+    // Remove the associated waiting room, if any
+    const waitingRoomId = this.waitingRooms.get(channelId);
+    if (waitingRoomId) {
+      this.waitingRooms.delete(channelId);
+      this.waitingRoomToMain.delete(waitingRoomId);
+      try {
+        const waitingRoom = this.client.channels.cache.get(waitingRoomId);
+        if (waitingRoom) await waitingRoom.delete();
+      } catch {
+        // Ignore errors cleaning up waiting room
+      }
+    }
+  }
+
+  /**
    * Handle when a user joins a lobby channel - create a dynamic channel for them
    */
   public async handleLobbyJoin(
@@ -1771,8 +1811,8 @@ export class VoiceChannelManager {
 
           // Delete unmanaged channels (empty or not)
           await channel.delete("Bot cleanup - unmanaged channel");
-          // Clean up custom name tracking
-          this.customChannelNames.delete(channel.id);
+          // Reconcile any leftover in-memory tracking for this channel
+          await this.reconcileDeletedChannelState(channel.id);
           logger.info(`Deleted unmanaged channel: ${channel.name}`);
         } catch (error) {
           logger.error(`Error deleting channel ${channel.name}:`, error);
@@ -1794,14 +1834,8 @@ export class VoiceChannelManager {
       for (const channel of emptyManagedChannels.values()) {
         try {
           await channel.delete("Bot cleanup - empty managed channel");
-          // Clean up custom name tracking
-          this.customChannelNames.delete(channel.id);
-          // Clean up ownership tracking for the deleted channel
-          for (const [ownerId, userChannel] of this.userChannels.entries()) {
-            if (userChannel.id === channel.id) {
-              this.userChannels.delete(ownerId);
-            }
-          }
+          // Reconcile all in-memory tracking so no per-channel state is orphaned
+          await this.reconcileDeletedChannelState(channel.id);
           logger.info(`Deleted empty managed channel: ${channel.name}`);
         } catch (error) {
           logger.error(`Error deleting channel ${channel.name}:`, error);

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -1255,13 +1255,14 @@ export class VoiceChannelManager {
   /**
    * Reconcile all in-memory tracking for a channel that has been deleted.
    *
-   * The various cleanup paths (cleanupUserChannel, cleanupEmptyChannel and the
-   * periodic cleanupEmptyChannels scanner) all need to drop the same per-channel
-   * state once a channel is gone, otherwise maps such as waitingRoomToMain or
-   * ownershipTransferTimers are orphaned — e.g. a leftover waiting room would be
-   * skipped forever by the unmanaged-channel loop. This clears ownership,
-   * custom-name, ownership-queue, live-status and pending-transfer state, and
-   * removes any associated waiting room.
+   * Used by the periodic cleanupEmptyChannels() scanner after it deletes a
+   * channel: the same per-channel state must be dropped once a channel is gone,
+   * otherwise maps such as waitingRoomToMain or ownershipTransferTimers are
+   * orphaned — e.g. a leftover waiting room would be skipped forever by the
+   * unmanaged-channel loop. This clears ownership, custom-name, ownership-queue,
+   * live-status and pending-transfer state, and removes any associated waiting
+   * room. (cleanupUserChannel/cleanupEmptyChannel perform their own equivalent
+   * reconciliation inline.)
    */
   private async reconcileDeletedChannelState(channelId: string): Promise<void> {
     // Drop ownership entry (userChannels is keyed by ownerId -> channel)
@@ -1285,7 +1286,8 @@ export class VoiceChannelManager {
       this.waitingRoomToMain.delete(waitingRoomId);
       try {
         const waitingRoom = this.client.channels.cache.get(waitingRoomId);
-        if (waitingRoom) await waitingRoom.delete();
+        if (waitingRoom)
+          await waitingRoom.delete("Bot cleanup - parent channel removed");
       } catch {
         // Ignore errors cleaning up waiting room
       }

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -1740,11 +1740,25 @@ export class VoiceChannelManager {
         }
       }
 
+      // Build a set of managed channel IDs from the ownership registry.
+      // Channel IDs are stable across renames, whereas names are not: an
+      // ownership transfer renames "🎮 X's Room" -> "Y's Channel", dropping
+      // the prefix. Matching owned channels by ID keeps renamed channels
+      // protected from the unmanaged-channel scanner so members are not
+      // kicked out. See issue #542.
+      const managedChannelIds = new Set<string>();
+      for (const userChannel of this.userChannels.values()) {
+        managedChannelIds.add(userChannel.id);
+      }
+
       // Clean up channels the bot doesn't manage
       for (const channel of allChannels.values()) {
         try {
-          // Skip if it's a managed channel
-          if (managedChannelNames.has(channel.name)) {
+          // Skip if it's a managed channel (by name pattern or owned channel ID)
+          if (
+            managedChannelNames.has(channel.name) ||
+            managedChannelIds.has(channel.id)
+          ) {
             logger.debug(`Skipping managed channel: ${channel.name}`);
             continue;
           }
@@ -1765,10 +1779,13 @@ export class VoiceChannelManager {
         }
       }
 
-      // Also clean up empty managed channels (except lobby)
+      // Also clean up empty managed channels (except lobby). Match by name
+      // pattern or owned channel ID so renamed channels are cleaned up once
+      // they become empty.
       const emptyManagedChannels = allChannels.filter(
         (channel) =>
-          managedChannelNames.has(channel.name) &&
+          (managedChannelNames.has(channel.name) ||
+            managedChannelIds.has(channel.id)) &&
           channel.name !== lobbyChannelName &&
           channel.name !== offlineLobbyName &&
           channel.members.size === 0,
@@ -1779,6 +1796,12 @@ export class VoiceChannelManager {
           await channel.delete("Bot cleanup - empty managed channel");
           // Clean up custom name tracking
           this.customChannelNames.delete(channel.id);
+          // Clean up ownership tracking for the deleted channel
+          for (const [ownerId, userChannel] of this.userChannels.entries()) {
+            if (userChannel.id === channel.id) {
+              this.userChannels.delete(ownerId);
+            }
+          }
           logger.info(`Deleted empty managed channel: ${channel.name}`);
         } catch (error) {
           logger.error(`Error deleting channel ${channel.name}:`, error);

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -1786,9 +1786,19 @@ export class VoiceChannelManager {
       // the prefix. Matching owned channels by ID keeps renamed channels
       // protected from the unmanaged-channel scanner so members are not
       // kicked out. See issue #542.
+      //
+      // Also include channels with a tracked custom name so the predicate
+      // matches cleanupEmptyChannel()'s definition of "managed": if the
+      // ownership entry is ever missing while customChannelNames still holds
+      // the channel, it must not be misclassified as unmanaged and deleted.
       const managedChannelIds = new Set<string>();
       for (const userChannel of this.userChannels.values()) {
         managedChannelIds.add(userChannel.id);
+      }
+      for (const channel of allChannels.values()) {
+        if (this.hasCustomName(channel.id)) {
+          managedChannelIds.add(channel.id);
+        }
       }
 
       // Clean up channels the bot doesn't manage


### PR DESCRIPTION
## Summary

Fixes #542 — after an ownership transfer, the renamed channel was being deleted by the unmanaged-channel scanner, kicking out members who were still inside.

## Root cause

`cleanupEmptyChannels()` in `voice-channel-manager.ts` identified managed channels **purely by name pattern** — the configured prefix (default `🎮`) plus the lobby name. When an ownership transfer renames a channel from `🎮 X's Room` → `Y's Channel`, the prefix is dropped, so the renamed channel no longer matched. The scanner then treated it as a foreign/unmanaged channel and deleted it (the loop deletes unmanaged channels whether empty or not), force-disconnecting any remaining members.

Meanwhile the actual ownership registry (`userChannels`) already tracks each owned channel by its **stable channel ID**, which survives renames — but the scanner never consulted it.

## Fix

- The scanner now also treats any channel whose **ID** is present in the `userChannels` ownership registry as managed, in addition to the existing name-pattern match. Renamed channels stay protected for as long as they're owned.
- The empty-managed-channel cleanup likewise matches by ID, so renamed channels are still tidied up once they become empty — and the ownership entry is cleared when that happens.

This implements the issue's suggested fix: key the managed-channel check by channel ID (stable across renames) rather than name pattern.

## Tests

Added `__tests__/services/voice-channel-manager-rename-cleanup.test.ts` covering:
- A renamed, occupied, still-owned channel is **not** deleted (while a genuinely foreign channel still is).
- A renamed channel no longer tracked as owned **is** deleted.
- An empty owned channel is deleted and its ownership entry cleared.

`npm run build`, `eslint`, `prettier --check`, and the cleanup test suites all pass.

https://claude.ai/code/session_01LNgs1kBP9BT3wCQh6dsYuA

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNgs1kBP9BT3wCQh6dsYuA)_