### PR TITLE
Fix memory leak in CooldownManager by evicting expired entries

### DIFF
--- a/__tests__/services/cooldown-manager.test.ts
+++ b/__tests__/services/cooldown-manager.test.ts
@@ -5,11 +5,12 @@ describe('CooldownManager', () => {
   let cooldownManager: CooldownManager;
 
   beforeEach(() => {
-    cooldownManager = new CooldownManager();
     jest.useFakeTimers();
+    cooldownManager = new CooldownManager();
   });
 
   afterEach(() => {
+    cooldownManager.destroy();
     jest.useRealTimers();
   });
 
@@ -262,9 +263,99 @@ describe('CooldownManager', () => {
     it('should handle very short time intervals', () => {
       cooldownManager.setCooldown('user1', 'command1');
       jest.advanceTimersByTime(1); // 1ms
-      
+
       const result = cooldownManager.getRemainingCooldown('user1', 'command1', 1);
       expect(result).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('memory management', () => {
+    const cooldownsOf = (m: CooldownManager): Map<string, Map<string, number>> =>
+      (m as unknown as { cooldowns: Map<string, Map<string, number>> }).cooldowns;
+    const rateLimitsOf = (m: CooldownManager): Map<string, number[]> =>
+      (m as unknown as { rateLimits: Map<string, number[]> }).rateLimits;
+
+    it('evicts an expired cooldown entry when read via isOnCooldown', () => {
+      cooldownManager.setCooldown('user1', 'command1');
+      expect(cooldownsOf(cooldownManager).has('user1')).toBe(true);
+
+      jest.advanceTimersByTime(61000);
+      expect(cooldownManager.isOnCooldown('user1', 'command1', 60)).toBe(false);
+      expect(cooldownsOf(cooldownManager).has('user1')).toBe(false);
+    });
+
+    it('evicts an expired cooldown entry when read via getRemainingCooldown', () => {
+      cooldownManager.setCooldown('user1', 'command1');
+
+      jest.advanceTimersByTime(61000);
+      expect(cooldownManager.getRemainingCooldown('user1', 'command1', 60)).toBe(0);
+      expect(cooldownsOf(cooldownManager).has('user1')).toBe(false);
+    });
+
+    it('keeps the user bucket while another command is still active', () => {
+      cooldownManager.setCooldown('user1', 'command1');
+      cooldownManager.setCooldown('user1', 'command2');
+
+      jest.advanceTimersByTime(61000);
+      cooldownManager.setCooldown('user1', 'command2'); // refresh command2
+
+      expect(cooldownManager.isOnCooldown('user1', 'command1', 60)).toBe(false);
+      const bucket = cooldownsOf(cooldownManager).get('user1');
+      expect(bucket?.has('command1')).toBe(false);
+      expect(bucket?.has('command2')).toBe(true);
+    });
+
+    it('evicts the rate-limit key on read once the window has fully expired', () => {
+      cooldownManager.trackCommandExecution('user1', 60);
+      expect(rateLimitsOf(cooldownManager).has('user1')).toBe(true);
+
+      jest.advanceTimersByTime(61000);
+      expect(cooldownManager.isRateLimited('user1', 3, 60)).toBe(false);
+      expect(rateLimitsOf(cooldownManager).has('user1')).toBe(false);
+    });
+
+    it('periodically sweeps cooldown entries for inactive users', () => {
+      cooldownManager.setCooldown('user1', 'command1');
+      // Observe the cooldown window so the sweep knows the cutoff.
+      cooldownManager.isOnCooldown('user1', 'command1', 60);
+      expect(cooldownsOf(cooldownManager).has('user1')).toBe(true);
+
+      // Advance past the 5-minute sweep interval without further reads.
+      jest.advanceTimersByTime(5 * 60 * 1000 + 1);
+      expect(cooldownsOf(cooldownManager).has('user1')).toBe(false);
+    });
+
+    it('periodically sweeps rate-limit entries for inactive users', () => {
+      cooldownManager.trackCommandExecution('user1', 60);
+      expect(rateLimitsOf(cooldownManager).has('user1')).toBe(true);
+
+      jest.advanceTimersByTime(5 * 60 * 1000 + 1);
+      expect(rateLimitsOf(cooldownManager).has('user1')).toBe(false);
+    });
+
+    it('does not sweep entries whose window is still active', () => {
+      cooldownManager.trackCommandExecution('user1', 3600); // 1 hour window
+      jest.advanceTimersByTime(5 * 60 * 1000 + 1);
+      expect(rateLimitsOf(cooldownManager).has('user1')).toBe(true);
+    });
+
+    it('destroy clears the cleanup interval and is idempotent', () => {
+      const clearIntervalSpy = jest.spyOn(globalThis, 'clearInterval');
+      const handle = (
+        cooldownManager as unknown as {
+          cleanupInterval: ReturnType<typeof setInterval> | null;
+        }
+      ).cleanupInterval;
+      expect(handle).not.toBeNull();
+
+      cooldownManager.destroy();
+      expect(clearIntervalSpy).toHaveBeenCalledWith(handle);
+      expect(
+        (cooldownManager as unknown as { cleanupInterval: unknown }).cleanupInterval,
+      ).toBeNull();
+      expect(() => cooldownManager.destroy()).not.toThrow();
+
+      clearIntervalSpy.mockRestore();
     });
   });
 });

--- a/__tests__/services/cooldown-manager.test.ts
+++ b/__tests__/services/cooldown-manager.test.ts
@@ -314,6 +314,20 @@ describe('CooldownManager', () => {
       expect(rateLimitsOf(cooldownManager).has('user1')).toBe(false);
     });
 
+    it('prunes expired timestamps in-place on isRateLimited without trackCommandExecution', () => {
+      cooldownManager.trackCommandExecution('user1', 60); // t=0
+      jest.advanceTimersByTime(40000);
+      cooldownManager.trackCommandExecution('user1', 60); // t=40s
+      expect(rateLimitsOf(cooldownManager).get('user1')).toHaveLength(2);
+
+      // Advance so only the second timestamp remains in the window.
+      jest.advanceTimersByTime(30000); // t=70s, window cutoff = 10s
+      expect(cooldownManager.isRateLimited('user1', 5, 60)).toBe(false);
+
+      // The expired first timestamp must have been written back out.
+      expect(rateLimitsOf(cooldownManager).get('user1')).toHaveLength(1);
+    });
+
     it('periodically sweeps cooldown entries for inactive users', () => {
       cooldownManager.setCooldown('user1', 'command1');
       // Observe the cooldown window so the sweep knows the cutoff.

--- a/src/services/cooldown-manager.ts
+++ b/src/services/cooldown-manager.ts
@@ -2,21 +2,106 @@ export class CooldownManager {
   private cooldowns: Map<string, Map<string, number>> = new Map();
   private rateLimits: Map<string, number[]> = new Map();
 
+  // Largest windows observed across calls. Used by the periodic sweep so it
+  // can safely evict entries that are guaranteed to be expired even though
+  // the per-call cooldown/window durations are not stored on each entry.
+  private maxCooldownMs = 0;
+  private maxRateWindowMs = 0;
+
+  // Run a safety-net sweep every 5 minutes to evict entries belonging to
+  // users who went inactive and will never trigger lazy eviction on read.
+  private static readonly CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
+  private cleanupInterval: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    this.startCleanupInterval();
+  }
+
+  private startCleanupInterval(): void {
+    this.cleanupInterval = setInterval(() => {
+      this.sweepExpiredEntries();
+    }, CooldownManager.CLEANUP_INTERVAL_MS);
+
+    // Don't keep the event loop alive solely for this background sweep.
+    this.cleanupInterval.unref?.();
+  }
+
+  /**
+   * Evict entries that are guaranteed to be expired. Inner cooldown entries
+   * older than the largest observed cooldown window are removed, and rate
+   * limit arrays that no longer contain any in-window timestamps are dropped.
+   * Empty user buckets are deleted entirely so neither Map grows with the
+   * total number of distinct users/commands ever seen.
+   */
+  private sweepExpiredEntries(): void {
+    const now = Date.now();
+
+    if (this.maxCooldownMs > 0) {
+      const cooldownCutoff = now - this.maxCooldownMs;
+      for (const [userId, userCooldowns] of this.cooldowns) {
+        for (const [command, lastUsed] of userCooldowns) {
+          if (lastUsed <= cooldownCutoff) {
+            userCooldowns.delete(command);
+          }
+        }
+        if (userCooldowns.size === 0) {
+          this.cooldowns.delete(userId);
+        }
+      }
+    }
+
+    if (this.maxRateWindowMs > 0) {
+      const rateCutoff = now - this.maxRateWindowMs;
+      for (const [userId, timestamps] of this.rateLimits) {
+        const recent = timestamps.filter((time) => time > rateCutoff);
+        if (recent.length === 0) {
+          this.rateLimits.delete(userId);
+        } else if (recent.length !== timestamps.length) {
+          this.rateLimits.set(userId, recent);
+        }
+      }
+    }
+  }
+
+  /**
+   * Stop the background cleanup sweep. Safe to call multiple times.
+   */
+  public destroy(): void {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+      this.cleanupInterval = null;
+    }
+  }
+
   public isOnCooldown(
     userId: string,
     command: string,
     cooldownSeconds: number,
   ): boolean {
-    const now = Date.now();
-    const userCooldowns = this.cooldowns.get(userId) || new Map();
-    const lastUsed = userCooldowns.get(command);
+    this.trackCooldownWindow(cooldownSeconds);
 
-    if (!lastUsed) {
+    const now = Date.now();
+    const userCooldowns = this.cooldowns.get(userId);
+    if (!userCooldowns) {
+      return false;
+    }
+
+    const lastUsed = userCooldowns.get(command);
+    if (lastUsed === undefined) {
       return false;
     }
 
     const cooldownTime = lastUsed + cooldownSeconds * 1000;
-    return now < cooldownTime;
+    if (now < cooldownTime) {
+      return true;
+    }
+
+    // Expired — evict lazily so stale entries don't accumulate.
+    userCooldowns.delete(command);
+    if (userCooldowns.size === 0) {
+      this.cooldowns.delete(userId);
+    }
+    return false;
   }
 
   public setCooldown(userId: string, command: string): void {
@@ -31,19 +116,30 @@ export class CooldownManager {
     command: string,
     cooldownSeconds: number,
   ): number {
+    this.trackCooldownWindow(cooldownSeconds);
+
     const userCooldowns = this.cooldowns.get(userId);
     if (!userCooldowns) {
       return 0;
     }
 
     const lastUsed = userCooldowns.get(command);
-    if (!lastUsed) {
+    if (lastUsed === undefined) {
       return 0;
     }
 
     const cooldownTime = lastUsed + cooldownSeconds * 1000;
     const remaining = Math.ceil((cooldownTime - Date.now()) / 1000);
-    return remaining > 0 ? remaining : 0;
+    if (remaining > 0) {
+      return remaining;
+    }
+
+    // Expired — evict lazily so stale entries don't accumulate.
+    userCooldowns.delete(command);
+    if (userCooldowns.size === 0) {
+      this.cooldowns.delete(userId);
+    }
+    return 0;
   }
 
   public clearCooldown(userId: string, command: string): void {
@@ -72,13 +168,26 @@ export class CooldownManager {
     maxCommands: number,
     windowSeconds: number,
   ): boolean {
+    this.trackRateWindow(windowSeconds);
+
     const now = Date.now();
-    const userCommands = this.rateLimits.get(userId) || [];
+    const userCommands = this.rateLimits.get(userId);
+    if (!userCommands) {
+      return false;
+    }
+
     const windowMs = windowSeconds * 1000;
     const cutoffTime = now - windowMs;
 
     // Filter out commands outside the time window
     const recentCommands = userCommands.filter((time) => time > cutoffTime);
+
+    // Evict the user key once their window has fully expired so the Map does
+    // not retain an entry for every user who ever ran a command.
+    if (recentCommands.length === 0) {
+      this.rateLimits.delete(userId);
+      return false;
+    }
 
     return recentCommands.length >= maxCommands;
   }
@@ -89,6 +198,8 @@ export class CooldownManager {
    * @param windowSeconds - Time window in seconds (used for cleanup)
    */
   public trackCommandExecution(userId: string, windowSeconds: number): void {
+    this.trackRateWindow(windowSeconds);
+
     const now = Date.now();
     const userCommands = this.rateLimits.get(userId) || [];
     const windowMs = windowSeconds * 1000;
@@ -107,6 +218,8 @@ export class CooldownManager {
    * @returns number of commands executed
    */
   public getCommandCount(userId: string, windowSeconds: number): number {
+    this.trackRateWindow(windowSeconds);
+
     const now = Date.now();
     const userCommands = this.rateLimits.get(userId) || [];
     const windowMs = windowSeconds * 1000;
@@ -127,6 +240,8 @@ export class CooldownManager {
     maxCommands: number,
     windowSeconds: number,
   ): number {
+    this.trackRateWindow(windowSeconds);
+
     const now = Date.now();
     const userCommands = this.rateLimits.get(userId) || [];
     const windowMs = windowSeconds * 1000;
@@ -160,5 +275,19 @@ export class CooldownManager {
    */
   public clearAllRateLimits(): void {
     this.rateLimits.clear();
+  }
+
+  private trackCooldownWindow(cooldownSeconds: number): void {
+    const ms = cooldownSeconds * 1000;
+    if (ms > this.maxCooldownMs) {
+      this.maxCooldownMs = ms;
+    }
+  }
+
+  private trackRateWindow(windowSeconds: number): void {
+    const ms = windowSeconds * 1000;
+    if (ms > this.maxRateWindowMs) {
+      this.maxRateWindowMs = ms;
+    }
   }
 }

--- a/src/services/cooldown-manager.ts
+++ b/src/services/cooldown-manager.ts
@@ -189,6 +189,13 @@ export class CooldownManager {
       return false;
     }
 
+    // Persist the pruned array when some timestamps expired so a user who
+    // keeps hitting the limit (and never calls trackCommandExecution) doesn't
+    // accumulate stale timestamps until the periodic sweep runs.
+    if (recentCommands.length !== userCommands.length) {
+      this.rateLimits.set(userId, recentCommands);
+    }
+
     return recentCommands.length >= maxCommands;
   }
 


### PR DESCRIPTION
Closes #536.

## Problem

`CooldownManager` (`src/services/cooldown-manager.ts`) maintained two in-memory Maps — `cooldowns` and `rateLimits` — that grew unboundedly because expired entries were never evicted:

- **`cooldowns`**: once a cooldown expired, the `(userId, command)` entry was left in place forever. Only the never-auto-called `clearCooldown`/`clearAllCooldowns` removed entries.
- **`rateLimits`**: `trackCommandExecution` pruned the per-user timestamp array, but the user key itself was never removed, so the Map grew to O(distinct-users-ever).

On long-running instances heap usage grew with the *total* number of distinct users/commands ever seen rather than the *active* set.

## Fix

Following the issue's recommendation (Option A for cooldowns + Option B for rate limits), the entire fix lives in `cooldown-manager.ts`:

- **Lazy eviction (cooldowns)** — `isOnCooldown` and `getRemainingCooldown` delete the entry when they observe it expired, dropping the user bucket once empty.
- **Lazy eviction (rate limits)** — `isRateLimited` deletes the user key once its window has fully expired.
- **Periodic safety-net sweep** — a 5-minute `setInterval` (created in the constructor, `unref()`'d so it never keeps the event loop alive) evicts entries for users who went inactive and will never trigger a lazy read. The sweep uses the largest cooldown / rate window observed across calls as its cutoff, so it only removes entries that are guaranteed to be expired. A `destroy()` method stops the interval.

The data model is unchanged, so all existing call sites (`command-manager`, `quote-service`) and tests keep working.

## Tests

Extended `__tests__/services/cooldown-manager.test.ts` with a `memory management` block asserting:

- expired cooldown / rate-limit entries are evicted on read,
- the user bucket survives while another command is still active,
- the periodic sweep evicts inactive users but keeps users whose window is still active,
- `destroy()` clears the interval and is idempotent.

All 40 tests pass; `tsc --noEmit`, ESLint, and Prettier are clean.

https://claude.ai/code/session_015Wf1xBivhNCPbmxHnTWg23

---
_Generated by [Claude Code](https://claude.ai/code/session_015Wf1xBivhNCPbmxHnTWg23)_