### PR TITLE
Remove redundant dotenvConfig() calls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,6 @@ import {
   Partials,
   AuditLogEvent,
 } from "discord.js";
-import { config as dotenvConfig } from "dotenv";
 import { env, getMissingRequiredEnv } from "./config/env.js";
 import logger, { isDebugMode } from "./utils/logger.js";
 import { ConfigService } from "./services/config-service.js";
@@ -57,8 +56,6 @@ import {
   setVoiceSessionsProvider,
 } from "./web/metrics.js";
 import mongoose from "mongoose";
-
-dotenvConfig();
 
 // Validate critical environment variables
 const missingVars = getMissingRequiredEnv();

--- a/src/services/command-manager.ts
+++ b/src/services/command-manager.ts
@@ -8,7 +8,6 @@ import {
   DiscordAPIError,
   HTTPError,
 } from "discord.js";
-import { config as dotenvConfig } from "dotenv";
 import logger, { isDebugMode } from "../utils/logger.js";
 import { getErrorMessage } from "../utils/error-guards.js";
 import { recordCommandAudit } from "../utils/record-command-audit.js";
@@ -17,8 +16,6 @@ import { MonitoringService } from "./monitoring-service.js";
 import { recordCommandInvocation } from "../web/metrics.js";
 import { CooldownManager } from "./cooldown-manager.js";
 import { PermissionsService } from "./permissions-service.js";
-
-dotenvConfig();
 
 interface CommandModule {
   data: SlashCommandBuilder;


### PR DESCRIPTION
## Summary

Removes the two redundant `dotenvConfig()` calls flagged in #537.

`src/config/env.ts` is the canonical (and documented "only") module permitted to read `process.env`. It calls `dotenvConfig()` eagerly at import time, so every downstream importer observes a populated environment. The calls in `src/index.ts` and `src/services/command-manager.ts` were redundant no-ops that:

- relied implicitly on import order (`env.ts` is already imported above the call in `index.ts`), and
- could mask `.env` discrepancies when loaded from a different working directory (test harnesses / monorepos), since `dotenv` never overwrites already-set vars.

## Changes

- **`src/index.ts`** — removed `dotenvConfig()` call and the now-unused `import { config as dotenvConfig } from "dotenv"`.
- **`src/services/command-manager.ts`** — same removal.

`env.ts` remains unchanged and is sufficient; all other modules continue to rely on it implicitly through the `import { env } from "../config/env.js"` chain.

## Verification

- `npx tsc --noEmit` — passes
- `npm run lint` — passes

Closes #537

https://claude.ai/code/session_015W7GbNyo2fN5onrZFgoY3n

---
_Generated by [Claude Code](https://claude.ai/code/session_015W7GbNyo2fN5onrZFgoY3n)_