### PR TITLE
Cancel pending ownership transfer when channel is cleaned up (#540)

### DIFF
--- a/__tests__/services/voice-channel-manager-cleanup.test.ts
+++ b/__tests__/services/voice-channel-manager-cleanup.test.ts
@@ -321,6 +321,64 @@ describe("VoiceChannelManager - Channel Cleanup with Custom Names", () => {
     });
   });
 
+  describe("pending ownership-transfer cleanup (issue #540)", () => {
+    function seedPendingTransfer(channelId: string): jest.Mock {
+      // Seed a pending ownership-transfer timer for the channel and return a
+      // spy standing in for the real timer handle so we can assert it's cleared.
+      const timer = setTimeout(() => {}, 60_000) as unknown as ReturnType<
+        typeof setTimeout
+      >;
+      (manager as any).ownershipTransferTimers.set(channelId, {
+        timer,
+        originalOwnerId: "owner-id",
+      });
+      return jest.fn();
+    }
+
+    it("cancels a pending ownership transfer when cleanupEmptyChannel deletes the channel", async () => {
+      manager.setCustomChannelName("channel-id", "Custom Channel Name");
+      (manager as any).userChannels.set("owner-id", mockChannel);
+      mockMembers.clear();
+      Object.defineProperty(mockChannel, "members", {
+        value: mockMembers as Collection<string, GuildMember>,
+        writable: true,
+      });
+
+      seedPendingTransfer("channel-id");
+      const clearSpy = jest.spyOn(global, "clearTimeout");
+
+      await (manager as any).cleanupEmptyChannel(mockChannel as VoiceChannel);
+
+      // The timer must be cancelled and dropped so it never fires on the
+      // now-deleted channel (DiscordAPIError 10003).
+      expect(clearSpy).toHaveBeenCalled();
+      expect((manager as any).ownershipTransferTimers.has("channel-id")).toBe(
+        false,
+      );
+      clearSpy.mockRestore();
+    });
+
+    it("cancels a pending ownership transfer when cleanupUserChannel deletes the channel", async () => {
+      (manager as any).userChannels.set("owner-id", mockChannel);
+      mockMembers.clear();
+      Object.defineProperty(mockChannel, "members", {
+        value: mockMembers as Collection<string, GuildMember>,
+        writable: true,
+      });
+
+      seedPendingTransfer("channel-id");
+      const clearSpy = jest.spyOn(global, "clearTimeout");
+
+      await (manager as any).cleanupUserChannel("owner-id");
+
+      expect(clearSpy).toHaveBeenCalled();
+      expect((manager as any).ownershipTransferTimers.has("channel-id")).toBe(
+        false,
+      );
+      clearSpy.mockRestore();
+    });
+  });
+
   describe("Custom name tracking cleanup", () => {
     it("should clean up custom name tracking when channel is deleted", async () => {
       // Setup: Channel has custom name

--- a/__tests__/services/voice-channel-manager-cleanup.test.ts
+++ b/__tests__/services/voice-channel-manager-cleanup.test.ts
@@ -322,17 +322,20 @@ describe("VoiceChannelManager - Channel Cleanup with Custom Names", () => {
   });
 
   describe("pending ownership-transfer cleanup (issue #540)", () => {
-    function seedPendingTransfer(channelId: string): jest.Mock {
-      // Seed a pending ownership-transfer timer for the channel and return a
-      // spy standing in for the real timer handle so we can assert it's cleared.
-      const timer = setTimeout(() => {}, 60_000) as unknown as ReturnType<
-        typeof setTimeout
-      >;
+    function seedPendingTransfer(
+      channelId: string,
+    ): ReturnType<typeof setTimeout> {
+      // Seed a pending ownership-transfer timer for the channel using a
+      // deterministic sentinel handle (no real setTimeout, so no open handle is
+      // left if a test fails early) and return it for assertions.
+      const timer = {
+        __sentinel: channelId,
+      } as unknown as ReturnType<typeof setTimeout>;
       (manager as any).ownershipTransferTimers.set(channelId, {
         timer,
         originalOwnerId: "owner-id",
       });
-      return jest.fn();
+      return timer;
     }
 
     it("cancels a pending ownership transfer when cleanupEmptyChannel deletes the channel", async () => {
@@ -344,14 +347,15 @@ describe("VoiceChannelManager - Channel Cleanup with Custom Names", () => {
         writable: true,
       });
 
-      seedPendingTransfer("channel-id");
+      const timer = seedPendingTransfer("channel-id");
       const clearSpy = jest.spyOn(global, "clearTimeout");
 
       await (manager as any).cleanupEmptyChannel(mockChannel as VoiceChannel);
 
-      // The timer must be cancelled and dropped so it never fires on the
-      // now-deleted channel (DiscordAPIError 10003).
-      expect(clearSpy).toHaveBeenCalled();
+      // The specific seeded timer must be cancelled and dropped so it never
+      // fires on the now-deleted channel (DiscordAPIError 10003).
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+      expect(clearSpy).toHaveBeenCalledWith(timer);
       expect((manager as any).ownershipTransferTimers.has("channel-id")).toBe(
         false,
       );
@@ -366,12 +370,13 @@ describe("VoiceChannelManager - Channel Cleanup with Custom Names", () => {
         writable: true,
       });
 
-      seedPendingTransfer("channel-id");
+      const timer = seedPendingTransfer("channel-id");
       const clearSpy = jest.spyOn(global, "clearTimeout");
 
       await (manager as any).cleanupUserChannel("owner-id");
 
-      expect(clearSpy).toHaveBeenCalled();
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+      expect(clearSpy).toHaveBeenCalledWith(timer);
       expect((manager as any).ownershipTransferTimers.has("channel-id")).toBe(
         false,
       );

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -542,7 +542,17 @@ export class VoiceChannelManager {
           // Clear the timer from the map
           this.ownershipTransferTimers.delete(channel.id);
         } catch (error) {
-          logger.error("Error during scheduled ownership transfer:", error);
+          // The channel may have been deleted during the grace period (e.g. the
+          // remaining members all left and cleanup removed it). channels.fetch
+          // throws DiscordAPIError 10003 rather than returning null, so handle
+          // that case as a no-op instead of an error (issue #540).
+          if (isUnknownChannelError(error)) {
+            logger.warn(
+              `Channel ${channel.id} no longer exists, skipping ownership transfer`,
+            );
+          } else {
+            logger.error("Error during scheduled ownership transfer:", error);
+          }
           this.ownershipTransferTimers.delete(channel.id);
         }
       }, OWNERSHIP_TRANSFER_GRACE_SECONDS * 1000);
@@ -1164,6 +1174,9 @@ export class VoiceChannelManager {
     this.userChannels.delete(userId);
     this.customChannelNames.delete(channelId);
     this.ownershipQueue.delete(channelId);
+    // Cancel any pending ownership-transfer timer so it doesn't fire on the
+    // now-deleted channel (issue #540).
+    this.cancelOwnershipTransfer(channelId);
   }
 
   /**
@@ -1229,6 +1242,10 @@ export class VoiceChannelManager {
 
       // Clean up live status
       this.liveChannels.delete(channel.id);
+
+      // Cancel any pending ownership-transfer timer so it doesn't fire on the
+      // now-deleted channel (issue #540).
+      this.cancelOwnershipTransfer(channel.id);
 
       // Clean up waiting room (fire-and-forget after channel deleted to avoid race conditions)
       const waitingRoomId = this.waitingRooms.get(channel.id);


### PR DESCRIPTION
## Summary

Fixes #540 — the deferred ownership-transfer timer fired on an already-deleted channel, throwing `DiscordAPIError[10003] Unknown Channel`.

### Was it already fixed?

Partially. The periodic cleanup scanner's `reconcileDeletedChannelState()` already cancels the pending timer — but the **realtime** cleanup paths did not. The issue's log (`Cleaned up empty voice channel ...`) comes from `cleanupEmptyChannel()`, which deleted the channel and cleared every other tracking map (`userChannels`, `customChannelNames`, `ownershipQueue`, `liveChannels`, `waitingRooms`) **except** `ownershipTransferTimers`. `cleanupUserChannel()` had the same gap. So the bug was still live on exactly the path the issue describes.

## Changes

- **`cleanupEmptyChannel()`** and **`cleanupUserChannel()`**: call `cancelOwnershipTransfer(channelId)` during inline reconciliation, so a pending transfer can't fire on a deleted channel (issue's preferred fix — option 1).
- **Timer handler** (defense in depth — option 2): `client.channels.fetch()` *throws* `DiscordAPIError 10003` for a deleted channel rather than returning `null`, so the existing `if (!channelNow)` guard never caught it. The `catch` now treats an Unknown Channel error as a `warn`-level no-op instead of an `error`.

## Tests

- Added two tests in `voice-channel-manager-cleanup.test.ts` asserting a seeded pending timer is cleared (`clearTimeout` called, map entry removed) when each cleanup path runs.
- Full `voice-channel-manager` suite: **53 passed, 1 skipped** (10 suites). Type-check, lint, and prettier all clean.

https://claude.ai/code/session_01A7vb2s4bsEsMoLBympTB1q

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7vb2s4bsEsMoLBympTB1q)_