### PR TITLE
Add per-user display timezone preference (#524)

### DIFF
--- a/__tests__/services/digest-service.test.ts
+++ b/__tests__/services/digest-service.test.ts
@@ -13,9 +13,11 @@ const mockTrackerGetInstance = jest.fn(() => ({
 
 const mockGetPrefs = jest.fn();
 const mockGetTimezone = jest.fn();
+const mockGetPrefsWithTimezone = jest.fn();
 const mockPrefsGetInstance = jest.fn(() => ({
   getPrefs: mockGetPrefs,
   getTimezone: mockGetTimezone,
+  getPrefsWithTimezone: mockGetPrefsWithTimezone,
 }));
 
 const mockAchievementsGetInstance = jest.fn(() => ({}));
@@ -129,6 +131,10 @@ describe("DigestService", () => {
       rewind: true,
     });
     mockGetTimezone.mockResolvedValue(null);
+    mockGetPrefsWithTimezone.mockResolvedValue({
+      prefs: { achievements: true, digest: true, rewind: true },
+      timezone: null,
+    });
     mockDigestStateFindOne.mockResolvedValue(null);
     mockDigestStateFindOneAndUpdate.mockResolvedValue({});
     mockUserAchievementsFindOne.mockResolvedValue(null);
@@ -188,10 +194,9 @@ describe("DigestService", () => {
         // 60 minutes — clears min_active_minutes=30
         { userId: "u1", username: "u1", totalTime: 60 * 60 },
       ]);
-      mockGetPrefs.mockResolvedValue({
-        achievements: true,
-        digest: false,
-        rewind: true,
+      mockGetPrefsWithTimezone.mockResolvedValue({
+        prefs: { achievements: true, digest: false, rewind: true },
+        timezone: null,
       });
 
       const svc: ServiceInstance = DigestService.getInstance(makeClient());
@@ -259,8 +264,8 @@ describe("DigestService", () => {
 
       expect(result!.qualifying).toBe(1);
       expect(result!.sent).toBe(1);
-      expect(mockGetPrefs).toHaveBeenCalledTimes(1);
-      expect(mockGetPrefs).toHaveBeenCalledWith("u1", "guild-1");
+      expect(mockGetPrefsWithTimezone).toHaveBeenCalledTimes(1);
+      expect(mockGetPrefsWithTimezone).toHaveBeenCalledWith("u1", "guild-1");
     });
   });
 });

--- a/__tests__/services/digest-service.test.ts
+++ b/__tests__/services/digest-service.test.ts
@@ -12,8 +12,10 @@ const mockTrackerGetInstance = jest.fn(() => ({
 }));
 
 const mockGetPrefs = jest.fn();
+const mockGetTimezone = jest.fn();
 const mockPrefsGetInstance = jest.fn(() => ({
   getPrefs: mockGetPrefs,
+  getTimezone: mockGetTimezone,
 }));
 
 const mockAchievementsGetInstance = jest.fn(() => ({}));
@@ -126,6 +128,7 @@ describe("DigestService", () => {
       digest: true,
       rewind: true,
     });
+    mockGetTimezone.mockResolvedValue(null);
     mockDigestStateFindOne.mockResolvedValue(null);
     mockDigestStateFindOneAndUpdate.mockResolvedValue({});
     mockUserAchievementsFindOne.mockResolvedValue(null);

--- a/__tests__/services/rewind-service.test.ts
+++ b/__tests__/services/rewind-service.test.ts
@@ -205,6 +205,29 @@ describe("RewindService pure helpers", () => {
     it("returns null on empty input", () => {
       expect(computePeakDay([])).toBeNull();
     });
+
+    it("buckets days in the supplied timezone (#524)", () => {
+      // 02:00 UTC on the 16th is still the 15th in New York, so both
+      // sessions fall on the same local day there but on different UTC days.
+      const sessions = [
+        {
+          startTime: new Date("2026-03-15T20:00:00Z"),
+          duration: 3600,
+          channelId: "a",
+        },
+        {
+          startTime: new Date("2026-03-16T02:00:00Z"),
+          duration: 3600,
+          channelId: "a",
+        },
+      ];
+      expect(computePeakDay(sessions, "America/New_York")).toEqual({
+        date: "2026-03-15",
+        totalSeconds: 7200,
+      });
+      // Without a zone, the two sessions land on separate UTC days.
+      expect(computePeakDay(sessions)?.totalSeconds).toBe(3600);
+    });
   });
 
   describe("computeLongestStreak", () => {

--- a/__tests__/services/user-notification-prefs-service.test.ts
+++ b/__tests__/services/user-notification-prefs-service.test.ts
@@ -136,6 +136,35 @@ describe('UserNotificationPrefsService', () => {
     });
   });
 
+  describe('getPrefsWithTimezone', () => {
+    it('returns prefs and timezone from a single read', async () => {
+      findOne.mockResolvedValueOnce({
+        achievements: false,
+        digest: true,
+        rewind: true,
+        timezone: 'Europe/Berlin',
+      });
+      const out = await UserNotificationPrefsService.getInstance().getPrefsWithTimezone('u1', 'g1');
+      expect(out).toEqual({
+        prefs: { achievements: false, digest: true, rewind: true },
+        timezone: 'Europe/Berlin',
+      });
+      expect(findOne).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns defaults + null timezone when no row exists', async () => {
+      findOne.mockResolvedValueOnce(null);
+      const out = await UserNotificationPrefsService.getInstance().getPrefsWithTimezone('u1', 'g1');
+      expect(out).toEqual({ prefs: DEFAULT_PREFS, timezone: null });
+    });
+
+    it('collapses to defaults + null timezone on DB error', async () => {
+      findOne.mockRejectedValueOnce(new Error('mongo down'));
+      const out = await UserNotificationPrefsService.getInstance().getPrefsWithTimezone('u1', 'g1');
+      expect(out).toEqual({ prefs: DEFAULT_PREFS, timezone: null });
+    });
+  });
+
   describe('getTimezone', () => {
     it('returns the stored zone when present', async () => {
       findOne.mockResolvedValueOnce({ timezone: 'Europe/Berlin' });

--- a/__tests__/services/user-notification-prefs-service.test.ts
+++ b/__tests__/services/user-notification-prefs-service.test.ts
@@ -136,6 +136,79 @@ describe('UserNotificationPrefsService', () => {
     });
   });
 
+  describe('getTimezone', () => {
+    it('returns the stored zone when present', async () => {
+      findOne.mockResolvedValueOnce({ timezone: 'Europe/Berlin' });
+      const tz = await UserNotificationPrefsService.getInstance().getTimezone('u1', 'g1');
+      expect(tz).toBe('Europe/Berlin');
+    });
+
+    it('returns null when unset or row missing', async () => {
+      findOne.mockResolvedValueOnce(null);
+      expect(await UserNotificationPrefsService.getInstance().getTimezone('u1', 'g1')).toBeNull();
+      findOne.mockResolvedValueOnce({ timezone: '' });
+      expect(await UserNotificationPrefsService.getInstance().getTimezone('u1', 'g1')).toBeNull();
+    });
+
+    it('returns null on DB error', async () => {
+      findOne.mockRejectedValueOnce(new Error('mongo down'));
+      expect(await UserNotificationPrefsService.getInstance().getTimezone('u1', 'g1')).toBeNull();
+    });
+
+    it('returns null for empty userId/guildId without touching the DB', async () => {
+      const svc = UserNotificationPrefsService.getInstance();
+      expect(await svc.getTimezone('', 'g1')).toBeNull();
+      expect(await svc.getTimezone('u1', '')).toBeNull();
+      expect(findOne).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setTimezone', () => {
+    it('validates and stores a recognized zone', async () => {
+      findOneAndUpdate.mockResolvedValueOnce({ timezone: 'America/New_York' });
+      const result = await UserNotificationPrefsService.getInstance().setTimezone(
+        'u1',
+        'g1',
+        'America/New_York',
+      );
+      expect(result).toBe('America/New_York');
+      const [filter, update] = findOneAndUpdate.mock.calls[0] as [
+        Record<string, unknown>,
+        { $set: Record<string, unknown> },
+      ];
+      expect(filter).toEqual({ userId: 'u1', guildId: 'g1' });
+      expect(update.$set).toHaveProperty('timezone', 'America/New_York');
+    });
+
+    it('rejects an invalid zone before hitting the DB', async () => {
+      await expect(
+        UserNotificationPrefsService.getInstance().setTimezone('u1', 'g1', 'Mars/Phobos'),
+      ).rejects.toThrow(/not a recognized IANA timezone/);
+      expect(findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it('clears the preference with $unset when passed null', async () => {
+      findOneAndUpdate.mockResolvedValueOnce({});
+      const result = await UserNotificationPrefsService.getInstance().setTimezone(
+        'u1',
+        'g1',
+        null,
+      );
+      expect(result).toBeNull();
+      const update = findOneAndUpdate.mock.calls[0][1] as {
+        $unset?: Record<string, unknown>;
+      };
+      expect(update.$unset).toHaveProperty('timezone');
+    });
+
+    it('throws on empty userId/guildId', async () => {
+      const svc = UserNotificationPrefsService.getInstance();
+      await expect(svc.setTimezone('', 'g1', 'UTC')).rejects.toThrow();
+      await expect(svc.setTimezone('u1', '', 'UTC')).rejects.toThrow();
+      expect(findOneAndUpdate).not.toHaveBeenCalled();
+    });
+  });
+
   it('exposes a stable list of known pref keys', () => {
     expect(NOTIFICATION_PREF_KEYS).toEqual(['achievements', 'digest', 'rewind']);
   });

--- a/__tests__/utils/timezone.test.ts
+++ b/__tests__/utils/timezone.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for the per-user timezone helpers (#524).
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import {
+  formatDateTimeInZone,
+  formatInZone,
+  getServerTimezone,
+  isValidTimezone,
+  isoDateInZone,
+  listSupportedTimezones,
+  resolveTimezone,
+} from "../../src/utils/timezone.js";
+
+describe("timezone utils", () => {
+  describe("isValidTimezone", () => {
+    it("accepts recognized IANA identifiers", () => {
+      expect(isValidTimezone("America/New_York")).toBe(true);
+      expect(isValidTimezone("Europe/London")).toBe(true);
+      expect(isValidTimezone("UTC")).toBe(true);
+    });
+
+    it("rejects unknown zones and non-strings", () => {
+      expect(isValidTimezone("Mars/Phobos")).toBe(false);
+      expect(isValidTimezone("America/Fakeville")).toBe(false);
+      expect(isValidTimezone("")).toBe(false);
+      expect(isValidTimezone("not a zone")).toBe(false);
+      expect(isValidTimezone(undefined)).toBe(false);
+      expect(isValidTimezone(null)).toBe(false);
+      expect(isValidTimezone(42)).toBe(false);
+    });
+  });
+
+  describe("listSupportedTimezones", () => {
+    it("returns a sorted, non-empty list of known zones", () => {
+      const zones = listSupportedTimezones();
+      expect(zones.length).toBeGreaterThan(0);
+      expect(zones).toContain("America/New_York");
+      const sorted = [...zones].sort();
+      expect(zones).toEqual(sorted);
+    });
+  });
+
+  describe("getServerTimezone", () => {
+    it("returns a usable IANA zone", () => {
+      expect(isValidTimezone(getServerTimezone())).toBe(true);
+    });
+  });
+
+  describe("resolveTimezone", () => {
+    it("returns the zone as-is when valid", () => {
+      expect(resolveTimezone("Europe/Berlin")).toBe("Europe/Berlin");
+    });
+
+    it("falls back to the server timezone when unset or invalid", () => {
+      const server = getServerTimezone();
+      expect(resolveTimezone(null)).toBe(server);
+      expect(resolveTimezone(undefined)).toBe(server);
+      expect(resolveTimezone("")).toBe(server);
+      expect(resolveTimezone("Nope/Nowhere")).toBe(server);
+    });
+  });
+
+  describe("formatInZone", () => {
+    it("formats a UTC instant in the requested zone", () => {
+      const d = new Date("2026-06-12T12:00:00Z");
+      expect(formatInZone(d, "UTC", "yyyy-MM-dd HH:mm")).toBe("2026-06-12 12:00");
+      // 12:00 UTC is 08:00 in New York (EDT, UTC-4) in June.
+      expect(formatInZone(d, "America/New_York", "yyyy-MM-dd HH:mm")).toBe(
+        "2026-06-12 08:00",
+      );
+    });
+  });
+
+  describe("isoDateInZone", () => {
+    it("buckets the calendar day in the given zone", () => {
+      // 02:00 UTC on Jan 1 is still Dec 31 in New York.
+      const d = new Date("2026-01-01T02:00:00Z");
+      expect(isoDateInZone(d, "UTC")).toBe("2026-01-01");
+      expect(isoDateInZone(d, "America/New_York")).toBe("2025-12-31");
+      // ...and already Jan 1 in Tokyo (UTC+9).
+      expect(isoDateInZone(d, "Asia/Tokyo")).toBe("2026-01-01");
+    });
+  });
+
+  describe("formatDateTimeInZone", () => {
+    it("includes the resolved zone name", () => {
+      const d = new Date("2026-06-12T12:00:00Z");
+      expect(formatDateTimeInZone(d, "UTC")).toBe("2026-06-12 12:00 (UTC)");
+    });
+
+    it("falls back to the server timezone for an unset value", () => {
+      const d = new Date("2026-06-12T12:00:00Z");
+      expect(formatDateTimeInZone(d, null)).toContain(
+        `(${getServerTimezone()})`,
+      );
+    });
+  });
+});

--- a/__tests__/web/user-routes.test.ts
+++ b/__tests__/web/user-routes.test.ts
@@ -607,6 +607,12 @@ describe("/me/rewind", () => {
       checkCommandPermission: async () => true,
     } as never);
 
+    const { UserNotificationPrefsService } =
+      await import("../../src/services/user-notification-prefs-service.js");
+    jest.spyOn(UserNotificationPrefsService, "getInstance").mockReturnValue({
+      getTimezone: async () => null,
+    } as never);
+
     const { RewindService } =
       await import("../../src/services/rewind-service.js");
     const getSummary = jest.fn().mockResolvedValue(opts.summary as never);
@@ -761,5 +767,236 @@ describe("/me/rewind", () => {
     });
     expect(out.statusCode).toBe(500);
     expect(out.body).toContain("Could not load your year-in-review");
+  });
+});
+
+describe("/me/timezone (#524)", () => {
+  beforeEach(() => {
+    process.env.WEBUI_SESSION_SECRET = SECRET;
+    process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES = "30";
+    (WebSessionService as unknown as { instance: unknown }).instance = null;
+  });
+
+  async function dispatch(opts: {
+    method: "GET" | "POST";
+    body?: Record<string, unknown>;
+    csrfHeader?: string;
+    stored?: string | null;
+    setTimezoneImpl?: jest.Mock;
+  }): Promise<{
+    statusCode: number;
+    body: string;
+    redirectedTo?: string;
+    audit?: Record<string, unknown>;
+  }> {
+    const now = Date.now();
+    const payload: CookiePayload = {
+      sid: "session-id",
+      uid: "user-1",
+      gid: "guild-1",
+      rol: "user",
+      iat: now - 60_000,
+      act: now - 60_000,
+    };
+    const cookie = `koolbot_session=${buildCookie(payload)}; koolbot_csrf=csrf-1`;
+
+    const svc = WebSessionService.getInstance();
+    jest.spyOn(svc, "findById").mockResolvedValue({
+      discordUserId: "user-1",
+      guildId: "guild-1",
+      role: "user",
+      scopes: [],
+      revokedAt: null,
+      expiresAt: new Date(now + 60 * 60 * 1000),
+    } as never);
+
+    const { PermissionsService } = await import(
+      "../../src/services/permissions-service.js"
+    );
+    jest.spyOn(PermissionsService, "getInstance").mockReturnValue({
+      checkCommandPermission: async () => true,
+    } as never);
+
+    const { UserNotificationPrefsService } = await import(
+      "../../src/services/user-notification-prefs-service.js"
+    );
+    const getTimezone = jest
+      .fn<() => Promise<string | null>>()
+      .mockResolvedValue(opts.stored ?? null);
+    const setTimezone =
+      opts.setTimezoneImpl ??
+      jest
+        .fn<
+          (
+            userId: string,
+            guildId: string,
+            tz: string | null,
+          ) => Promise<string | null>
+        >()
+        .mockImplementation(async (_u, _g, tz) => tz);
+    jest.spyOn(UserNotificationPrefsService, "getInstance").mockReturnValue({
+      getTimezone,
+      setTimezone,
+    } as never);
+
+    const { WebAuditLog } = await import("../../src/models/web-audit-log.js");
+    const createSpy = jest
+      .spyOn(WebAuditLog, "create")
+      .mockResolvedValue({} as never);
+
+    const mockClient = {} as never;
+    const { createSessionMiddleware } = await import("../../src/web/session.js");
+    const requireSession = createSessionMiddleware(mockClient);
+    const router = createUserRouter(mockClient, requireSession);
+
+    const headers: Record<string, unknown> = { cookie };
+    if (opts.method === "POST" && opts.csrfHeader) {
+      headers["x-csrf-token"] = opts.csrfHeader;
+    }
+
+    const captured: {
+      statusCode: number;
+      body: string;
+      redirectedTo?: string;
+    } = { statusCode: 200, body: "" };
+    const res = makeRes() as ReturnType<typeof makeRes> & {
+      redirect: jest.Mock;
+      header: jest.Mock;
+    };
+    res.status.mockImplementation((code: number) => {
+      captured.statusCode = code;
+      res.statusCode = code;
+      return res;
+    });
+    res.send.mockImplementation((body: unknown) => {
+      captured.body = typeof body === "string" ? body : String(body);
+      res.body = captured.body;
+      return res;
+    });
+    res.redirect = jest.fn((code: unknown, url?: unknown) => {
+      if (typeof code === "number") {
+        captured.statusCode = code;
+        captured.redirectedTo = String(url);
+      } else {
+        captured.statusCode = 302;
+        captured.redirectedTo = String(code);
+      }
+      return res;
+    });
+    res.header = jest.fn(() => res);
+
+    const req = {
+      method: opts.method,
+      url: "/timezone",
+      originalUrl: "/me/timezone",
+      path: "/timezone",
+      baseUrl: "/me",
+      headers,
+      body: opts.body ?? {},
+      query: {},
+      csrfToken: "csrf-1",
+      header: (name: string) => headers[name.toLowerCase()],
+    } as never as Parameters<typeof router>[0];
+
+    await new Promise<void>((resolve) => {
+      router(
+        req as never,
+        res as never,
+        (() => {
+          resolve();
+        }) as never,
+      );
+      setTimeout(resolve, 0);
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Spies accumulate across the suite, so read the most recent create
+    // call — the one this dispatch produced.
+    const auditCall = createSpy.mock.calls.at(-1)?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    return { ...captured, audit: auditCall };
+  }
+
+  it("renders the timezone selector with the server default option", async () => {
+    const out = await dispatch({ method: "GET" });
+    expect(out.body).toContain("Timezone");
+    expect(out.body).toContain('action="/me/timezone"');
+    expect(out.body).toContain('name="timezone"');
+    expect(out.body).toContain("Server default");
+    expect(out.body).toContain("America/New_York");
+  });
+
+  it("pre-selects the stored zone", async () => {
+    const out = await dispatch({ method: "GET", stored: "Europe/Berlin" });
+    expect(out.body).toContain(
+      '<option value="Europe/Berlin" selected>Europe/Berlin</option>',
+    );
+  });
+
+  it("saves a chosen timezone and redirects with a success flash", async () => {
+    const out = await dispatch({
+      method: "POST",
+      body: { _csrf: "csrf-1", timezone: "America/New_York" },
+      csrfHeader: "csrf-1",
+    });
+    expect(out.statusCode).toBe(303);
+    expect(out.redirectedTo).toMatch(/^\/me\/timezone\?/);
+    expect(out.audit).toMatchObject({
+      action: "user.timezone.set",
+      result: "success",
+    });
+  });
+
+  it("clears the timezone when an empty value is submitted", async () => {
+    let captured: { tz: string | null } | null = null;
+    const setTimezone = jest
+      .fn<
+        (u: string, g: string, tz: string | null) => Promise<string | null>
+      >()
+      .mockImplementation(async (_u, _g, tz) => {
+        captured = { tz };
+        return tz;
+      });
+    const out = await dispatch({
+      method: "POST",
+      body: { _csrf: "csrf-1", timezone: "" },
+      csrfHeader: "csrf-1",
+      stored: "Europe/Berlin",
+      setTimezoneImpl: setTimezone,
+    });
+    expect(out.statusCode).toBe(303);
+    expect(captured).not.toBeNull();
+    expect(captured!.tz).toBeNull();
+  });
+
+  it("surfaces a descriptive error when the service rejects an invalid zone", async () => {
+    const setTimezone = jest
+      .fn<
+        (u: string, g: string, tz: string | null) => Promise<string | null>
+      >()
+      .mockRejectedValue(
+        new Error('"Mars/Phobos" is not a recognized IANA timezone identifier'),
+      );
+    const out = await dispatch({
+      method: "POST",
+      body: { _csrf: "csrf-1", timezone: "Mars/Phobos" },
+      csrfHeader: "csrf-1",
+      setTimezoneImpl: setTimezone,
+    });
+    expect(out.statusCode).toBe(303);
+    expect(out.redirectedTo).toContain("flash=err");
+    expect(out.audit).toMatchObject({
+      action: "user.timezone.set",
+      result: "failure",
+    });
+  });
+
+  it("rejects POST without a CSRF token", async () => {
+    const out = await dispatch({
+      method: "POST",
+      body: { timezone: "UTC" },
+    });
+    expect(out.statusCode).toBe(403);
   });
 });

--- a/src/commands/voicestats.ts
+++ b/src/commands/voicestats.ts
@@ -4,6 +4,8 @@ import {
   TimePeriod,
 } from "../services/voice-channel-tracker.js";
 import { ConfigService } from "../services/config-service.js";
+import { UserNotificationPrefsService } from "../services/user-notification-prefs-service.js";
+import { formatDateTimeInZone } from "../utils/timezone.js";
 import logger from "../utils/logger.js";
 
 // Helper function to format time in hours and minutes
@@ -174,10 +176,19 @@ async function executeUser(
       return;
     }
 
+    // Render timestamps in the requesting user's stored timezone when set,
+    // falling back to the server timezone (#524).
+    const viewerTimezone = interaction.guildId
+      ? await UserNotificationPrefsService.getInstance().getTimezone(
+          interaction.user.id,
+          interaction.guildId,
+        )
+      : null;
+
     const response = [
       `**Voice Channel Statistics for ${user.username} (${period})**`,
       `Total Time: ${formatTime(stats.totalTime)}`,
-      `Last Seen: ${stats.lastSeen.toLocaleString()}`,
+      `Last Seen: ${formatDateTimeInZone(stats.lastSeen, viewerTimezone)}`,
       "",
       "**Recent Sessions:**",
       ...stats.sessions.slice(0, 5).map((session) => {

--- a/src/commands/voicestats.ts
+++ b/src/commands/voicestats.ts
@@ -176,19 +176,23 @@ async function executeUser(
       return;
     }
 
-    // Render timestamps in the requesting user's stored timezone when set,
-    // falling back to the server timezone (#524).
+    // Render the timestamp in the requesting user's stored timezone when
+    // set. When unset we keep the previous `toLocaleString()` output so
+    // users who never configured a zone see no change in behaviour (#524).
     const viewerTimezone = interaction.guildId
       ? await UserNotificationPrefsService.getInstance().getTimezone(
           interaction.user.id,
           interaction.guildId,
         )
       : null;
+    const lastSeen = viewerTimezone
+      ? formatDateTimeInZone(stats.lastSeen, viewerTimezone)
+      : stats.lastSeen.toLocaleString();
 
     const response = [
       `**Voice Channel Statistics for ${user.username} (${period})**`,
       `Total Time: ${formatTime(stats.totalTime)}`,
-      `Last Seen: ${formatDateTimeInZone(stats.lastSeen, viewerTimezone)}`,
+      `Last Seen: ${lastSeen}`,
       "",
       "**Recent Sessions:**",
       ...stats.sessions.slice(0, 5).map((session) => {

--- a/src/models/user-notification-prefs.ts
+++ b/src/models/user-notification-prefs.ts
@@ -9,6 +9,11 @@ import mongoose, { Document, Schema } from "mongoose";
  * The `digest` (#483) and `rewind` (#484) fields ship from day one with
  * defaulting writes so the schema is stable across all three sub-issues:
  * downstream PRs only have to read them in their own DM paths.
+ *
+ * `timezone` (#524) is the user's preferred IANA display zone for digest,
+ * rewind and voicestats time rendering. It is optional: a missing value
+ * means "use the server timezone" and is the default for every existing
+ * row, so unconfigured users see no change in behaviour.
  */
 export interface IUserNotificationPrefs extends Document {
   userId: string;
@@ -16,6 +21,7 @@ export interface IUserNotificationPrefs extends Document {
   achievements: boolean;
   digest: boolean;
   rewind: boolean;
+  timezone?: string;
   updatedAt: Date;
 }
 
@@ -26,6 +32,8 @@ const UserNotificationPrefsSchema = new Schema<IUserNotificationPrefs>(
     achievements: { type: Boolean, required: true, default: true },
     digest: { type: Boolean, required: true, default: true },
     rewind: { type: Boolean, required: true, default: true },
+    // Optional IANA zone (e.g. "Europe/Berlin"); absent → server timezone.
+    timezone: { type: String, required: false },
     updatedAt: { type: Date, required: true, default: Date.now },
   },
   { timestamps: false },

--- a/src/services/digest-service.ts
+++ b/src/services/digest-service.ts
@@ -285,15 +285,17 @@ export class DigestService {
 
       for (const user of qualifying) {
         try {
-          const prefs = await prefsService.getPrefs(user.userId, guildId);
+          // One read for both the opt-out flag and the display timezone
+          // (used for the week range), so the cron loop stays at a single
+          // prefs query per user even for large guilds (#524).
+          const { prefs, timezone } = await prefsService.getPrefsWithTimezone(
+            user.userId,
+            guildId,
+          );
           if (!prefs.digest) {
             summary.skippedOptOut += 1;
             continue;
           }
-
-          // Render the week range in the user's preferred timezone, or
-          // the server timezone when unset (#524).
-          const timezone = await prefsService.getTimezone(user.userId, guildId);
 
           const previousState = await DigestState.findOne({
             userId: user.userId,

--- a/src/services/digest-service.ts
+++ b/src/services/digest-service.ts
@@ -9,6 +9,7 @@ import { DigestState } from "../models/digest-state.js";
 import { UserAchievements } from "../models/user-achievements.js";
 import { ACCOLADE_METADATA, type AccoladeType } from "../content/accolades.js";
 import { ACHIEVEMENT_METADATA } from "../content/achievements.js";
+import { formatInZone } from "../utils/timezone.js";
 import logger from "../utils/logger.js";
 
 interface QualifyingUser {
@@ -290,6 +291,10 @@ export class DigestService {
             continue;
           }
 
+          // Render the week range in the user's preferred timezone, or
+          // the server timezone when unset (#524).
+          const timezone = await prefsService.getTimezone(user.userId, guildId);
+
           const previousState = await DigestState.findOne({
             userId: user.userId,
             guildId,
@@ -321,6 +326,8 @@ export class DigestService {
             streakWeeks,
             includeAchievements,
             weeklyAchievements,
+            ranAt: summary.ranAt,
+            timezone,
           });
 
           const delivered = await this.sendDigestDM(user.userId, embed);
@@ -447,6 +454,8 @@ export class DigestService {
       name: string;
       description: string;
     }>;
+    ranAt: Date;
+    timezone: string | null;
   }): EmbedBuilder {
     const {
       user,
@@ -454,6 +463,8 @@ export class DigestService {
       streakWeeks,
       includeAchievements,
       weeklyAchievements,
+      ranAt,
+      timezone,
     } = args;
     const previousTime = previousState?.lastWeekTotalTime ?? 0;
     const previousRank = previousState?.lastWeekRank ?? null;
@@ -504,11 +515,16 @@ export class DigestService {
 
     const footer = pickMotivationalFooter(user.userId.length + user.totalTime);
 
+    // "Week of <start> – <end>" in the user's timezone (server tz when
+    // unset) so the 7-day window reads in their local time (#524).
+    const weekStart = new Date(ranAt.getTime() - SECONDS_PER_WEEK * 1000);
+    const weekRange = `${formatInZone(weekStart, timezone, "MMM d")} – ${formatInZone(ranAt, timezone, "MMM d")}`;
+
     return new EmbedBuilder()
       .setTitle("📊 Your weekly voice digest")
       .setColor(EMBED_COLOR)
       .setDescription(
-        `Here's a snapshot of your last 7 days in voice, ${user.username}.`,
+        `Here's a snapshot of your last 7 days in voice (${weekRange}), ${user.username}.`,
       )
       .addFields(fields)
       .setFooter({

--- a/src/services/rewind-service.ts
+++ b/src/services/rewind-service.ts
@@ -231,7 +231,11 @@ export function computeTopTextChannels(
     .slice(0, limit);
 }
 
-/** The UTC day with the most messages, or null when there are none. */
+/**
+ * The day with the most messages, or null when there are none. Days are
+ * bucketed in UTC by default; passing a valid IANA `timeZone` buckets
+ * them in that zone instead (#524).
+ */
 export function computePeakMessageDay(
   messages: RawTextMessage[],
   timeZone?: string,
@@ -254,9 +258,11 @@ export function computePeakMessageDay(
 }
 
 /**
- * Longest run of consecutive UTC days that contain ≥1 session. Returns
- * the day count and the start/end ISO dates of the winning run. A single
- * day of activity counts as a streak of 1.
+ * Longest run of consecutive days that contain ≥1 session. Returns the
+ * day count and the start/end ISO dates of the winning run. A single day
+ * of activity counts as a streak of 1. Days are bucketed in UTC by
+ * default; passing a valid IANA `timeZone` buckets them in that zone
+ * instead, so the run reflects the user's local midnight (#524).
  */
 export function computeLongestStreak(
   sessions: RawSession[],

--- a/src/services/rewind-service.ts
+++ b/src/services/rewind-service.ts
@@ -5,6 +5,7 @@ import { MessageActivityTracking } from "../models/message-activity-tracking.js"
 import { ConfigService } from "./config-service.js";
 import { ACCOLADE_METADATA } from "../content/accolades.js";
 import { ACHIEVEMENT_METADATA } from "../content/achievements.js";
+import { isValidTimezone, isoDateInZone } from "../utils/timezone.js";
 import logger from "../utils/logger.js";
 
 /**
@@ -119,6 +120,16 @@ export function toIsoDate(date: Date): string {
   return `${y}-${m}-${d}`;
 }
 
+/**
+ * The calendar-day key for a timestamp (#524). Defaults to UTC so unset
+ * users keep the existing grouping; when a valid IANA `timeZone` is
+ * supplied, days are bucketed in that zone instead so "peak day" and
+ * streaks reflect the user's local midnight.
+ */
+function dayKey(date: Date, timeZone?: string): string {
+  return timeZone ? isoDateInZone(date, timeZone) : toIsoDate(date);
+}
+
 export function sessionSeconds(session: RawSession): number {
   if (typeof session.duration === "number" && session.duration > 0) {
     return Math.floor(session.duration);
@@ -166,12 +177,13 @@ export function computeTopChannels(
 
 export function computePeakDay(
   sessions: RawSession[],
+  timeZone?: string,
 ): { date: string; totalSeconds: number } | null {
   const byDay = new Map<string, number>();
   for (const s of sessions) {
     const seconds = sessionSeconds(s);
     if (seconds <= 0) continue;
-    const key = toIsoDate(s.startTime);
+    const key = dayKey(s.startTime, timeZone);
     byDay.set(key, (byDay.get(key) ?? 0) + seconds);
   }
   if (byDay.size === 0) return null;
@@ -222,10 +234,11 @@ export function computeTopTextChannels(
 /** The UTC day with the most messages, or null when there are none. */
 export function computePeakMessageDay(
   messages: RawTextMessage[],
+  timeZone?: string,
 ): { date: string; count: number } | null {
   const byDay = new Map<string, number>();
   for (const m of messages) {
-    const key = toIsoDate(m.sentAt);
+    const key = dayKey(m.sentAt, timeZone);
     byDay.set(key, (byDay.get(key) ?? 0) + 1);
   }
   if (byDay.size === 0) return null;
@@ -245,7 +258,10 @@ export function computePeakMessageDay(
  * the day count and the start/end ISO dates of the winning run. A single
  * day of activity counts as a streak of 1.
  */
-export function computeLongestStreak(sessions: RawSession[]): {
+export function computeLongestStreak(
+  sessions: RawSession[],
+  timeZone?: string,
+): {
   days: number;
   startDate: string | null;
   endDate: string | null;
@@ -253,7 +269,7 @@ export function computeLongestStreak(sessions: RawSession[]): {
   const days = new Set<string>();
   for (const s of sessions) {
     if (sessionSeconds(s) <= 0) continue;
-    days.add(toIsoDate(s.startTime));
+    days.add(dayKey(s.startTime, timeZone));
   }
   if (days.size === 0) return { days: 0, startDate: null, endDate: null };
   const sorted = [...days].sort();
@@ -352,9 +368,16 @@ export class RewindService {
     userId: string,
     guildId: string,
     year: number,
+    timeZone?: string | null,
   ): Promise<RewindSummary | null> {
     try {
       const { start, end } = yearBounds(year);
+
+      // Only bucket days in a user zone when one is actually set and
+      // valid; otherwise keep the existing UTC grouping so unconfigured
+      // users see no change (#524).
+      const dayZone =
+        timeZone && isValidTimezone(timeZone) ? timeZone : undefined;
 
       const [userDoc, achievementsDoc] = await Promise.all([
         VoiceChannelTracking.findOne({ userId }).lean<{
@@ -382,12 +405,12 @@ export class RewindService {
       const daysActive = new Set(
         sessions
           .filter((s) => sessionSeconds(s) > 0)
-          .map((s) => toIsoDate(s.startTime)),
+          .map((s) => dayKey(s.startTime, dayZone)),
       ).size;
 
       const topChannels = computeTopChannels(sessions, 3);
-      const peakDay = computePeakDay(sessions);
-      const streak = computeLongestStreak(sessions);
+      const peakDay = computePeakDay(sessions, dayZone);
+      const streak = computeLongestStreak(sessions, dayZone);
 
       const accolades = (achievementsDoc?.accolades ?? [])
         .filter((a) => a.earnedAt >= start && a.earnedAt < end)
@@ -414,7 +437,7 @@ export class RewindService {
       ] = await Promise.all([
         this.computeAnnualRank(userId, start, end, totalSeconds),
         this.computeWeeklyJourney(userId, start, end),
-        this.computeTextActivity(userId, guildId, start, end),
+        this.computeTextActivity(userId, guildId, start, end, dayZone),
       ]);
 
       // The picker should offer any year the user has either kind of data.
@@ -519,6 +542,7 @@ export class RewindService {
     guildId: string,
     start: Date,
     end: Date,
+    timeZone?: string,
   ): Promise<{
     messagesSent: number;
     topTextChannels: RewindTextChannel[];
@@ -561,7 +585,7 @@ export class RewindService {
       return {
         messagesSent: inYear.length,
         topTextChannels,
-        peakMessageDay: computePeakMessageDay(inYear),
+        peakMessageDay: computePeakMessageDay(inYear, timeZone),
         years,
       };
     } catch (error) {

--- a/src/services/user-notification-prefs-service.ts
+++ b/src/services/user-notification-prefs-service.ts
@@ -72,6 +72,34 @@ export class UserNotificationPrefsService {
   }
 
   /**
+   * Read prefs and timezone in a single query. Callers that need both —
+   * notably the weekly digest cron, which renders the week range in the
+   * user's zone — use this to avoid a second `findOne` per user. Same
+   * defaulting rules as `getPrefs`/`getTimezone` (missing row / error →
+   * all-defaults + null zone).
+   */
+  public async getPrefsWithTimezone(
+    userId: string,
+    guildId: string,
+  ): Promise<{ prefs: NotificationPrefs; timezone: string | null }> {
+    if (!userId || !guildId) {
+      return { prefs: { ...DEFAULT_PREFS }, timezone: null };
+    }
+    try {
+      const row = await UserNotificationPrefs.findOne({ userId, guildId });
+      if (!row) return { prefs: { ...DEFAULT_PREFS }, timezone: null };
+      const tz =
+        typeof row.timezone === "string" && row.timezone.length > 0
+          ? row.timezone
+          : null;
+      return { prefs: rowToPrefs(row), timezone: tz };
+    } catch (err) {
+      logger.error("Failed to load notification prefs + timezone", err);
+      return { prefs: { ...DEFAULT_PREFS }, timezone: null };
+    }
+  }
+
+  /**
    * Apply a partial update. Only keys present in `patch` are written;
    * absent keys keep their prior stored value (or default if no row
    * existed). The merged result is returned so callers can render the

--- a/src/services/user-notification-prefs-service.ts
+++ b/src/services/user-notification-prefs-service.ts
@@ -1,4 +1,5 @@
 import logger from "../utils/logger.js";
+import { isValidTimezone } from "../utils/timezone.js";
 import {
   UserNotificationPrefs,
   type IUserNotificationPrefs,
@@ -94,6 +95,66 @@ export class UserNotificationPrefsService {
       { new: true, upsert: true, setDefaultsOnInsert: true },
     );
     return row ? rowToPrefs(row) : { ...DEFAULT_PREFS, ...cleaned };
+  }
+
+  /**
+   * Read the user's preferred display timezone (#524). Returns the stored
+   * IANA identifier, or `null` when unset (or on any read error) so
+   * callers fall back to the server timezone without special-casing.
+   */
+  public async getTimezone(
+    userId: string,
+    guildId: string,
+  ): Promise<string | null> {
+    if (!userId || !guildId) return null;
+    try {
+      const row = await UserNotificationPrefs.findOne({ userId, guildId });
+      const tz = row?.timezone;
+      return typeof tz === "string" && tz.length > 0 ? tz : null;
+    } catch (err) {
+      logger.error("Failed to load user timezone", err);
+      return null;
+    }
+  }
+
+  /**
+   * Set or clear the user's preferred display timezone (#524).
+   *
+   * Passing `null`/empty clears the preference ($unset) so the user falls
+   * back to the server timezone. A non-empty value is validated against
+   * the runtime's IANA database BEFORE hitting MongoDB; an unrecognized
+   * zone throws a descriptive error. Returns the stored value (or `null`
+   * when cleared).
+   */
+  public async setTimezone(
+    userId: string,
+    guildId: string,
+    timezone: string | null,
+  ): Promise<string | null> {
+    if (!userId) throw new Error("userId required");
+    if (!guildId) throw new Error("guildId required");
+
+    if (timezone === null || timezone === "") {
+      await UserNotificationPrefs.findOneAndUpdate(
+        { userId, guildId },
+        { $set: { updatedAt: new Date() }, $unset: { timezone: "" } },
+        { new: true, upsert: true, setDefaultsOnInsert: true },
+      );
+      return null;
+    }
+
+    if (!isValidTimezone(timezone)) {
+      throw new Error(
+        `"${timezone}" is not a recognized IANA timezone identifier`,
+      );
+    }
+
+    const row = await UserNotificationPrefs.findOneAndUpdate(
+      { userId, guildId },
+      { $set: { timezone, updatedAt: new Date() } },
+      { new: true, upsert: true, setDefaultsOnInsert: true },
+    );
+    return row?.timezone ?? timezone;
   }
 }
 

--- a/src/utils/timezone.ts
+++ b/src/utils/timezone.ts
@@ -1,0 +1,102 @@
+/**
+ * Timezone helpers for the per-user display-timezone preference (#524).
+ *
+ * Validation leans on the runtime's own IANA database via
+ * `Intl.supportedValuesOf("timeZone")` (Node 22+) so we never bundle a
+ * timezone list. Formatting goes through `date-fns-tz` — already a
+ * production dependency — so call-sites can render a `Date` in an
+ * arbitrary zone without mutating global state.
+ *
+ * "Unset" always falls back to the host/server timezone, so users who
+ * never configure a zone see no change in behaviour.
+ */
+
+import { formatInTimeZone } from "date-fns-tz";
+import logger from "./logger.js";
+
+let cachedZones: Set<string> | null = null;
+
+/** All IANA zone identifiers known to this runtime, cached. */
+function supportedZones(): Set<string> {
+  if (cachedZones) return cachedZones;
+  try {
+    const values = (
+      Intl as unknown as { supportedValuesOf?: (key: string) => string[] }
+    ).supportedValuesOf?.("timeZone");
+    cachedZones = new Set(values ?? []);
+  } catch (err) {
+    logger.warn("Intl.supportedValuesOf('timeZone') unavailable", err);
+    cachedZones = new Set();
+  }
+  return cachedZones;
+}
+
+/** Sorted list of every IANA zone, for populating a `<select>`. */
+export function listSupportedTimezones(): string[] {
+  return [...supportedZones()].sort();
+}
+
+/**
+ * True when `tz` is a recognized IANA timezone identifier. Prefers the
+ * enumerated set; if that API is unavailable, falls back to probing the
+ * `Intl.DateTimeFormat` constructor (which throws on unknown zones).
+ */
+export function isValidTimezone(tz: unknown): tz is string {
+  if (typeof tz !== "string" || tz.length === 0) return false;
+  // Fast path: zones enumerated by the runtime. This set drives the
+  // dropdown but is not exhaustive — it omits a few valid aliases such
+  // as "UTC" / "GMT" — so fall through to the authoritative constructor
+  // probe, which throws a RangeError on an unknown zone.
+  if (supportedZones().has(tz)) return true;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** The host/server timezone — the fallback for users with no preference. */
+export function getServerTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+/**
+ * Resolve a possibly-unset/invalid user timezone to a usable IANA zone,
+ * falling back to the server timezone.
+ */
+export function resolveTimezone(tz?: string | null): string {
+  return tz && isValidTimezone(tz) ? tz : getServerTimezone();
+}
+
+/** Format `date` in the resolved zone with a `date-fns` format string. */
+export function formatInZone(
+  date: Date,
+  tz: string | null | undefined,
+  fmt: string,
+): string {
+  return formatInTimeZone(date, resolveTimezone(tz), fmt);
+}
+
+/**
+ * `YYYY-MM-DD` for `date` in an explicit zone. Used by the Rewind
+ * day-grouping helpers, which only call this when a zone is actually
+ * set — unset users keep the existing UTC grouping.
+ */
+export function isoDateInZone(date: Date, tz: string): string {
+  return formatInTimeZone(date, tz, "yyyy-MM-dd");
+}
+
+/**
+ * Render a date+time plus the resolved zone name, e.g.
+ * `2026-06-12 14:30 (Europe/London)`. Used where a bare timestamp would
+ * otherwise be ambiguous (e.g. `/voicestats user`).
+ */
+export function formatDateTimeInZone(date: Date, tz?: string | null): string {
+  const zone = resolveTimezone(tz);
+  return `${formatInTimeZone(date, zone, "yyyy-MM-dd HH:mm")} (${zone})`;
+}

--- a/src/web/user-layout.ts
+++ b/src/web/user-layout.ts
@@ -27,6 +27,7 @@ interface UserNavItem {
 export const USER_NAV_ITEMS: UserNavItem[] = [
   { href: "/me/", label: "Overview" },
   { href: "/me/notifications", label: "Notifications" },
+  { href: "/me/timezone", label: "Timezone" },
   { href: "/me/rewind", label: "Rewind" },
 ];
 
@@ -95,6 +96,9 @@ const STYLE = [
   ".prefs-table .toggle{display:flex;align-items:center;gap:.4rem;font-size:.85rem;color:#94a3b8}",
   ".prefs-table .pref-desc{color:#94a3b8;font-size:.85rem;margin-top:.15rem}",
   ".prefs-table .pref-soon{display:block;color:#f59e0b;font-size:.75rem;font-style:italic;margin-top:.15rem}",
+  "select.tz-select{width:100%;max-width:28rem;background:#0f1115;color:#e4e6eb;border:1px solid #2d3748;border-radius:4px;padding:.45rem .5rem;font-size:.9rem}",
+  ".tz-preview{margin-top:.75rem;font-size:.9rem;color:#cbd5e1}",
+  ".tz-preview .now{font-weight:600;color:#e4e6eb}",
   ".btn{background:#2563eb;color:#fff;border:0;padding:.45rem .9rem;border-radius:4px;cursor:pointer;font-weight:600;font-size:.9rem}",
   ".btn:hover{background:#1d4ed8}",
   ".form-actions{margin-top:1rem;display:flex;gap:.5rem;align-items:center}",
@@ -245,6 +249,8 @@ export function renderUserIndexBody(opts: {
     '<ul class="feature-list">',
     '<li><span class="feature-name"><a href="/me/notifications">Notifications</a></span>' +
       '<span class="feature-desc">Opt in or out of DM nudges from Koolbot.</span></li>',
+    '<li><span class="feature-name"><a href="/me/timezone">Timezone</a></span>' +
+      '<span class="feature-desc">Choose the timezone Koolbot uses when it shows you times in digests, Rewind, and voicestats.</span></li>',
     '<li><span class="feature-name"><a href="/me/rewind">Rewind</a></span>' +
       '<span class="feature-desc">Your personal year-in-review of voice activity, top channels, peak day, and badges earned.</span></li>',
     "</ul>",
@@ -507,6 +513,88 @@ export function renderUserRewindBody(opts: RewindBodyOptions): string {
     '<div class="card"><h2>Badges earned this year</h2>' +
       renderBadges([...opts.accolades, ...opts.achievements]) +
       "</div>",
+  ].join("");
+}
+
+// --------------------------------------------------------------------
+// Timezone page (#524)
+// --------------------------------------------------------------------
+
+export interface TimezonePageBodyOptions {
+  csrfToken: string;
+  /** Sorted IANA zone identifiers (from `Intl.supportedValuesOf`). */
+  zones: string[];
+  /** Currently stored zone, or null when unset (server default). */
+  selected: string | null;
+  /** Host/server timezone shown as the fallback in the preview. */
+  serverTimezone: string;
+}
+
+function renderTimezoneOptions(
+  zones: string[],
+  selected: string | null,
+): string {
+  // Group by the region prefix ("Europe/Berlin" → "Europe"); zones with
+  // no "/" (e.g. "UTC") land under "Other".
+  const groups = new Map<string, string[]>();
+  for (const zone of zones) {
+    const slash = zone.indexOf("/");
+    const region = slash === -1 ? "Other" : zone.slice(0, slash);
+    const list = groups.get(region) ?? [];
+    list.push(zone);
+    groups.set(region, list);
+  }
+  const regions = [...groups.keys()].sort();
+  const optgroups = regions
+    .map((region) => {
+      const opts = (groups.get(region) ?? [])
+        .map((zone) => {
+          const sel = zone === selected ? " selected" : "";
+          return `<option value="${escapeHtml(zone)}"${sel}>${escapeHtml(zone)}</option>`;
+        })
+        .join("");
+      return `<optgroup label="${escapeHtml(region)}">${opts}</optgroup>`;
+    })
+    .join("");
+  const serverSelected = selected === null ? " selected" : "";
+  return (
+    `<option value=""${serverSelected}>— Server default —</option>` + optgroups
+  );
+}
+
+// Live client-side preview: shows the current time in the selected zone
+// (or the server default when unset) so the user can confirm the right
+// zone before saving. No third-party date picker — just `Intl`.
+const TZ_PREVIEW_SCRIPT =
+  "(function(){var sel=document.getElementById('tz-select');" +
+  "var out=document.getElementById('tz-now');if(!sel||!out)return;" +
+  "var serverTz=out.getAttribute('data-server-tz')||'UTC';" +
+  "function render(){var tz=sel.value||serverTz;try{" +
+  "var s=new Intl.DateTimeFormat('en-GB',{timeZone:tz,dateStyle:'medium',timeStyle:'medium'}).format(new Date());" +
+  "out.textContent=s+' ('+tz+')'}catch(e){out.textContent='— invalid zone —'}}" +
+  "sel.addEventListener('change',render);render();setInterval(render,1000)})();";
+
+/**
+ * Inner HTML for `GET /me/timezone` (#524). One `<select>`, one POST.
+ * Choosing "Server default" and saving clears the stored preference.
+ */
+export function renderUserTimezoneBody(opts: TimezonePageBodyOptions): string {
+  return [
+    "<h1>Timezone</h1>",
+    `<p class="subtitle">Koolbot renders the times in your weekly digest, Rewind, and <code>/voicestats</code> in this zone. Leave it on <em>Server default</em> to use the server's timezone (<span class="mono">${escapeHtml(opts.serverTimezone)}</span>).</p>`,
+    '<form method="POST" action="/me/timezone">',
+    `<input type="hidden" name="_csrf" value="${escapeHtml(opts.csrfToken)}">`,
+    '<div class="card">',
+    '<label for="tz-select"><strong>Your timezone</strong></label>',
+    `<div style="margin-top:.5rem"><select id="tz-select" name="timezone" class="tz-select">${renderTimezoneOptions(opts.zones, opts.selected)}</select></div>`,
+    `<div class="tz-preview">Current time: <span id="tz-now" class="now" data-server-tz="${escapeHtml(opts.serverTimezone)}">—</span></div>`,
+    '<div class="form-actions">',
+    '<button class="btn" type="submit">Save timezone</button>',
+    '<span class="muted">Pick <em>Server default</em> and save to clear your preference.</span>',
+    "</div>",
+    "</div>",
+    "</form>",
+    `<script>${TZ_PREVIEW_SCRIPT}</script>`,
   ].join("");
 }
 

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -37,8 +37,13 @@ import {
   renderUserNotificationsBody,
   renderUserPage,
   renderUserRewindBody,
+  renderUserTimezoneBody,
   type UserFlashMessage,
 } from "./user-layout.js";
+import {
+  getServerTimezone,
+  listSupportedTimezones,
+} from "../utils/timezone.js";
 import {
   RewindService,
   formatFunComparison,
@@ -349,6 +354,106 @@ export function createUserRouter(
     }),
   );
 
+  // ---------- Timezone (#524) ----------
+  router.get(
+    "/timezone",
+    asyncHandler(async (req, res) => {
+      const session = req.webSession;
+      if (!session) {
+        res.status(500).type("text/plain").send("session missing");
+        return;
+      }
+      const { userId, guildId } = assertSelfScope(session, {
+        userId: session.discordUserId,
+        guildId: session.guildId,
+      });
+      const selected =
+        await UserNotificationPrefsService.getInstance().getTimezone(
+          userId,
+          guildId,
+        );
+      const flash = readFlashFromQuery(req);
+      res.type("text/html").send(
+        renderUserPage({
+          title: "Timezone",
+          active: "/me/timezone",
+          body: renderUserTimezoneBody({
+            csrfToken: getCsrfToken(req),
+            zones: listSupportedTimezones(),
+            selected,
+            serverTimezone: getServerTimezone(),
+          }),
+          csrfToken: getCsrfToken(req),
+          remainingMs: getDisplayedRemainingMs(session),
+          isAdmin: session.role === "admin",
+          flash,
+        }),
+      );
+    }),
+  );
+
+  router.post(
+    "/timezone",
+    requireCsrf,
+    asyncHandler(async (req, res) => {
+      const session = req.webSession;
+      if (!session) {
+        res.status(500).type("text/plain").send("session missing");
+        return;
+      }
+      const { userId, guildId } = assertSelfScope(session, {
+        userId: session.discordUserId,
+        guildId: session.guildId,
+      });
+
+      const body = (req.body as Record<string, unknown> | undefined) ?? {};
+      const raw = typeof body.timezone === "string" ? body.timezone.trim() : "";
+      const service = UserNotificationPrefsService.getInstance();
+      const before = await service.getTimezone(userId, guildId);
+
+      let result: "success" | "failure" = "success";
+      let errorMessage: string | null = null;
+      let after: string | null = before;
+      try {
+        after = await service.setTimezone(
+          userId,
+          guildId,
+          raw === "" ? null : raw,
+        );
+      } catch (err) {
+        result = "failure";
+        errorMessage = err instanceof Error ? err.message : String(err);
+        logger.error("Failed to save user timezone", err);
+      }
+
+      await recordAudit(session, {
+        action: "user.timezone.set",
+        targetId: userId,
+        details: result === "success" ? { before, after } : { attempted: raw },
+        result,
+        errorMessage,
+      });
+
+      let flash: UserFlashMessage;
+      if (result === "failure") {
+        flash = {
+          type: "err",
+          text: `Could not save your timezone: ${errorMessage ?? "unknown error"}.`,
+        };
+      } else if (before === after) {
+        flash = { type: "ok", text: "No change — timezone already set." };
+      } else if (after === null) {
+        flash = {
+          type: "ok",
+          text: "Cleared your timezone — Koolbot will use the server timezone.",
+        };
+      } else {
+        flash = { type: "ok", text: `Saved your timezone as ${after}.` };
+      }
+      res.redirect(303, flashUrl("/me/timezone", flash));
+    }),
+  );
+
   // ---------- Rewind (#484) ----------
   // `/me/rewind` defaults to the current calendar year (UTC); the
   // `/:year` variant lets users browse past years. Both gate on
@@ -366,10 +471,16 @@ export function createUserRouter(
     const currentYear = new Date().getUTCFullYear();
     const year = parseYearParam(req.params.year, currentYear);
 
+    const timezone =
+      await UserNotificationPrefsService.getInstance().getTimezone(
+        userId,
+        guildId,
+      );
     const summary = await RewindService.getInstance(client).getSummary(
       userId,
       guildId,
       year,
+      timezone,
     );
 
     if (!summary) {

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -407,7 +407,14 @@ export function createUserRouter(
       });
 
       const body = (req.body as Record<string, unknown> | undefined) ?? {};
-      const raw = typeof body.timezone === "string" ? body.timezone.trim() : "";
+      // Strip line breaks before the value reaches the service: it gets
+      // echoed back in `setTimezone`'s validation error (and from there
+      // into our logs), and a CR/LF could forge a log line. No valid IANA
+      // identifier contains a newline, so this never rejects a real zone.
+      const raw =
+        typeof body.timezone === "string"
+          ? body.timezone.replace(/[\r\n]+/g, "").trim()
+          : "";
       const service = UserNotificationPrefsService.getInstance();
       const before = await service.getTimezone(userId, guildId);
 


### PR DESCRIPTION
Closes #524.

Adds a per-user **display timezone** so voice stats, the weekly digest, and Rewind render times in the member's own local time instead of the server's. Unset = fall back to the server timezone, so nobody who never configures it sees a change.

## What changed

### Data model
- `UserNotificationPrefs` gains an optional `timezone?: string` (IANA id). Absent on every existing row → server timezone, no migration needed.

### Service (`UserNotificationPrefsService`)
- `getTimezone(userId, guildId)` → stored zone or `null` (null on error, never throws on read).
- `setTimezone(userId, guildId, tz | null)` → validates against the runtime's IANA database **before** touching MongoDB and throws a descriptive error on an unknown zone; an empty value clears the preference via `$unset`.

### Util (`src/utils/timezone.ts`)
- Validation via `Intl.supportedValuesOf("timeZone")` with a `DateTimeFormat` probe fallback (so aliases like `UTC`/`GMT` validate too), server-timezone resolution, and `date-fns-tz` formatting helpers. No bundled timezone database — `date-fns-tz` is already a production dependency.

### WebUI — `/me/timezone`
- Region-grouped `<select>` populated from `Intl.supportedValuesOf`, a **live client-side current-time preview** so users can confirm the zone before saving, and a "Server default" option that clears the stored value.
- CSRF-checked POST, audited through `WebAuditLog` as `user.timezone.set` (same pattern as the other `/me` writes). New nav + overview links.

### Render call-sites
- `/voicestats user`: "Last Seen" now renders in the requesting user's zone (server tz when unset).
- Rewind: peak-day, longest-streak, days-active, and peak-message-day are bucketed in the user's zone when one is set; unset users keep the existing UTC grouping.
- Weekly digest DM: the snapshot now shows the 7-day window as a "Week of …" range in the recipient's zone.

## Acceptance criteria
- ✅ A user can set and clear their timezone on `/me/timezone`.
- ✅ Invalid IANA identifiers are rejected with a descriptive error before hitting MongoDB.
- ✅ Weekly digest DMs to a user with a stored timezone use that zone for the week range.
- ✅ Users with no stored timezone see no change in behaviour.
- ✅ No server-side import of a timezone database (relies on `Intl` + `date-fns-tz`).

## Tests
New/extended coverage for the util helpers, the service get/set/validation/clear paths, timezone-aware Rewind day bucketing, and the `/me/timezone` routes. Full suite: 1001 passing, build/lint/format clean.

https://claude.ai/code/session_01QshnYa4uvntSAvitiseNe7

---
_Generated by [Claude Code](https://claude.ai/code/session_01QshnYa4uvntSAvitiseNe7)_