### PR TITLE
ci: enforce conventional-commit PR titles so release-please sees every change

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,62 @@
+name: PR Title Lint
+
+# This repository squash-merges pull requests, using the PR title as the
+# resulting commit subject. release-please only counts commits whose subject
+# follows Conventional Commits, so a non-conforming PR title becomes a commit
+# that is silently dropped from the changelog and version bump. This workflow
+# rejects PR titles that are not valid Conventional Commits, keeping the
+# squashed history machine-readable for release-please.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  conventional-title:
+    name: Conventional Commit title
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate PR title
+        env:
+          # Passed via env (never interpolated into the script) to avoid
+          # template/script injection from untrusted PR titles.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          # Types kept in sync with changelog-sections in release-please-config.json.
+          types='feat|fix|perf|revert|refactor|docs|deps|test|build|ci|chore'
+
+          # Conventional Commit subject: type, optional scope(s), optional '!', ': ', subject.
+          # The scope group is repeated ('*') so dependabot's double scopes
+          # (e.g. "chore(deps)(deps): ...") are also accepted.
+          pattern="^(${types})(\([a-z0-9 ,./_-]+\))*!?: .+"
+
+          if printf '%s' "$PR_TITLE" | grep -Eq "$pattern"; then
+            echo "✅ Valid Conventional Commit title: $PR_TITLE"
+            exit 0
+          fi
+
+          echo "::error title=Invalid PR title::PR title must follow Conventional Commits."
+          {
+            echo "## ❌ PR title is not a valid Conventional Commit"
+            echo
+            echo "This repo squash-merges using the PR title as the commit subject, and"
+            echo "release-please drops any commit that does not parse as a Conventional"
+            echo "Commit — so a bad title means your change vanishes from the changelog."
+            echo
+            echo "**Got:** \`$PR_TITLE\`"
+            echo
+            echo "**Expected:** \`<type>(<optional scope>): <subject>\`, e.g. \`fix: …\` or \`feat(webui): …\`"
+            echo
+            echo "**Allowed types:** ${types//|/, }"
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -420,6 +420,15 @@ Add detailed section on writing tests and test coverage expectations.
 - **Reference issues** - Use `Closes #123`, `Fixes #456`, or `Refs #789`
 - **Keep commits focused** - Don't mix refactoring with bug fixes
 
+### PR titles must be conventional commits too
+
+This project **squash-merges** pull requests, so the **PR title** becomes the
+commit subject on `main`. release-please reads those subjects to build the
+changelog and pick the next version — and it silently ignores any subject that
+is not a valid conventional commit. A title like `Fix memory leak` is dropped
+from the release entirely; `fix: prevent memory leak in CooldownManager` is
+not. The `PR Title Lint` workflow enforces this on every PR.
+
 ## Pull Request Process
 
 ### Before Submitting


### PR DESCRIPTION
## Why

The pending release PR #545 (`chore(main): release 1.0.1`) contains **only one change** — the `ci:` commit from #541 — even though **eight** PRs have merged since `v1.0.0`.

Root cause: release-please only counts commits whose subject is a valid [Conventional Commit](https://www.conventionalcommits.org). This repo **squash-merges PRs using the PR title as the commit subject**, and seven of the eight titles were plain English with no type prefix:

| Commit | Title | Result |
|---|---|---|
| `4c37477` | **`ci:`** surface OCI description… (#541) | ✅ the only entry in 1.0.1 |
| `90291c0` | `Fix memory leak in CooldownManager…` (#544) | ❌ dropped (should be `fix:`) |
| `9535f2b` | `Fix unmanaged-channel scanner…` (#543) | ❌ dropped (should be `fix:`) |
| `c786f60` | `Remove redundant dotenvConfig() calls` (#546) | ❌ dropped (`refactor:`) |
| `2ff71ec` | `Enforce minimum entropy for WEBUI_SESSION_SECRET…` (#548) | ❌ dropped (security `fix:`) |
| `254580a` | `Cancel pending ownership transfer…` (#547) | ❌ dropped (should be `fix:`) |
| `97c2f50` | `Add per-user display timezone preference` (#549) | ❌ dropped (should be `feat:`) |
| `e0f28cc` | `Add example poll libraries…` (#550) | ❌ dropped (`docs:`) |

Because a feature (`97c2f50`) and four bug/security fixes were dropped, the pending bump is also **wrong**: it should be **1.1.0**, not 1.0.1.

## What this PR does (recurrence prevention)

- Adds a **`PR Title Lint`** workflow that rejects any PR title that isn't a valid conventional commit, so a malformed title can never again be squashed into `main` and silently dropped. Implemented inline (no third-party action) to satisfy the repo's zizmor `hash-pin` policy; the PR title is passed via `env` to avoid script injection. Allowed types are kept in sync with `release-please-config.json`.
- Documents the requirement in `CONTRIBUTING.md` (the existing guidance covered commit messages but not PR titles, which is what actually matters under squash-merge).

## Follow-up (not in this PR)

The already-merged squash commits can't be retroactively re-typed, so the **1.0.1 → 1.1.0 release correction is handled directly on release PR #545** (version files + changelog). That edit must land before any further push to `main`, or release-please will regenerate #545 and overwrite it.

https://claude.ai/code/session_01GHCRAFmmUEg6LTLnPiYusd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GHCRAFmmUEg6LTLnPiYusd)_