### PR TITLE
fix(webui): drop "currently" prefix from wizard ON/OFF indicator

### DIFF
--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -1188,7 +1188,7 @@ describe("renderWizardPage", () => {
     expect(html).toContain('action="/admin/wizard/start"');
   });
 
-  it('shows "currently ON/OFF" indicator next to each feature label', () => {
+  it("shows ON/OFF indicator next to each feature label", () => {
     const html = renderWizardPage({
       ...COMMON,
       featureOrder: ["voicechannels", "polls"],
@@ -1196,11 +1196,11 @@ describe("renderWizardPage", () => {
     });
     // voicechannels is currently enabled → tag-on.
     expect(html).toMatch(
-      /Voice Channels\s*<span class="fc-current">currently <span class="tag tag-on">ON<\/span><\/span>/,
+      /Voice Channels\s*<span class="fc-current"><span class="tag tag-on">ON<\/span><\/span>/,
     );
     // polls is currently disabled → tag-off.
     expect(html).toMatch(
-      /Polls\s*<span class="fc-current">currently <span class="tag tag-off">OFF<\/span><\/span>/,
+      /Polls\s*<span class="fc-current"><span class="tag tag-off">OFF<\/span><\/span>/,
     );
   });
 });

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -906,7 +906,7 @@ export function renderWizardPage(props: WizardPageProps): string {
     .map((fk) => {
       const info = WIZARD_FEATURE_LABELS[fk] ?? { name: fk, desc: "" };
       const currentlyOn = Boolean(props.featureStatus[fk]);
-      const indicator = `<span class="fc-current">currently ${tagOnOff(currentlyOn)}</span>`;
+      const indicator = `<span class="fc-current">${tagOnOff(currentlyOn)}</span>`;
       const id = `feat-${fk}`;
       return `<div class="feature-card">
   <input type="checkbox" name="features" value="${escapeHtml(fk)}" id="${escapeHtml(id)}">

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -900,7 +900,7 @@ export function renderWizardPage(props: WizardPageProps): string {
   // Checkboxes always render unchecked, regardless of `featureStatus`. The
   // wizard treats each run as a fresh declaration of which features should be
   // on — admins re-tick what they want, untick what they don't. `featureStatus`
-  // only feeds the "currently: ON/OFF" indicator so the admin can see what
+  // only feeds the ON/OFF indicator so the admin can see what
   // state they're about to override.
   const cards = props.featureOrder
     .map((fk) => {


### PR DESCRIPTION
## Summary

The Setup Wizard feature cards showed each feature's present state as `currently ON` / `currently OFF`. The word "currently" added length without meaning next to the feature name, so the indicator now renders just the `ON` / `OFF` chip.

So a card now reads **Voice Channels `ON`** instead of **Voice Channels `currently ON`**.

## Changes

- `src/web/admin-views.ts` — removed the literal `currently ` prefix from the `renderWizardPage` indicator. `tagOnOff()` still renders the ON/OFF chip and the `.fc-current` span wrapper is unchanged.
- `__tests__/web/admin-views.test.ts` — updated the wizard indicator test (and its name) to assert the new wording.

Purely cosmetic — no behaviour change. The checkbox semantics (each wizard run is a fresh re-declaration of which features to enable) are unchanged.

## Testing

- `npm test -- __tests__/web/admin-views.test.ts` → 75 passed.

Closes #554

https://claude.ai/code/session_01QGZ5PQZkoiH8iTvF8TUsxw

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGZ5PQZkoiH8iTvF8TUsxw)_