### PR TITLE
feat(quotes): backup/restore, channel reset, and persistent vote tallies

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -362,13 +362,59 @@ Edit an existing quote that you added.
 - You can only edit quotes that you added
 - At least one of `text` or `author` must be provided
 
+#### `/quote export` (admin)
+
+Download a JSON backup of every quote, including each quote's 👍/👎 vote
+tally. Requires the **Administrator** permission. The reply is ephemeral and
+includes the backup as a file attachment.
+
+```text
+/quote export
+```
+
+Keep the file safe — it is the durable source of truth for your quotes and
+can be restored with `/quote import`.
+
+#### `/quote import` (admin)
+
+Restore quotes from a backup file produced by `/quote export`. Requires the
+**Administrator** permission.
+
+```text
+/quote import file:<backup.json>
+/quote import file:<backup.json> rebuild:true
+```
+
+**Parameters:**
+
+- `file` (required) — A JSON backup from `/quote export`
+- `rebuild` (optional) — Also purge and rebuild the quote channel after
+  importing, restoring each quote's saved vote tally into its embed
+
+Entries whose original ID (or identical text + author) already exist are
+skipped, so a restore is idempotent and safe to re-run.
+
+#### `/quote reset` (admin)
+
+Purge the quote channel and rebuild it from the database: clears all
+messages, recreates a single header post, and re-posts every stored quote
+with its saved vote tally restored. Requires the **Administrator**
+permission. Useful for recovering a channel left in a bad state (for example
+after a bot reinstall duplicated the header or reset the vote counts).
+
+```text
+/quote reset
+```
+
 **How it works:**
 
 1. User submits a quote via `/quote add`
 2. Bot posts it as an embed in the configured quote channel
 3. Bot adds 👍 / 👎 reactions
 4. Users browse by scrolling the channel and vote with reactions
-5. Bot cleans up unauthorized messages every few minutes
+5. Vote tallies are saved to the database, so they survive a channel
+   re-sync or a bot reinstall (and are restored by `/quote reset`)
+6. Bot cleans up unauthorized messages every few minutes
 
 **Security:**
 

--- a/__tests__/services/quote-channel-manager-backup.test.ts
+++ b/__tests__/services/quote-channel-manager-backup.test.ts
@@ -6,6 +6,7 @@ import {
   beforeEach,
   afterEach,
 } from '@jest/globals';
+import { Collection } from 'discord.js';
 
 const mockRegisterReloadCallback = jest.fn();
 const mockGetBoolean = jest.fn();
@@ -147,6 +148,37 @@ describe('QuoteChannelManager - header idempotency & vote persistence', () => {
         expect.any(String),
         'quotes',
       );
+    });
+  });
+
+  describe('clearChannel', () => {
+    it('deletes messages bulkDelete skips (older than 14 days) individually', async () => {
+      const manager = await loadManager();
+
+      const m1: any = { id: 'm1', delete: jest.fn().mockResolvedValue(undefined) };
+      const m2: any = { id: 'm2', delete: jest.fn().mockResolvedValue(undefined) };
+      const firstBatch = new Collection<string, any>([
+        ['m1', m1],
+        ['m2', m2],
+      ]);
+      const empty = new Collection<string, any>();
+
+      const channel: any = {
+        messages: {
+          fetch: jest
+            .fn()
+            .mockResolvedValueOnce(firstBatch)
+            .mockResolvedValueOnce(empty),
+        },
+        // Both messages are >14 days old, so bulkDelete removes nothing.
+        bulkDelete: jest.fn().mockResolvedValue(new Collection<string, any>()),
+      };
+
+      const total = await (manager as any).clearChannel(channel);
+
+      expect(total).toBe(2);
+      expect(m1.delete).toHaveBeenCalledTimes(1);
+      expect(m2.delete).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/__tests__/services/quote-channel-manager-backup.test.ts
+++ b/__tests__/services/quote-channel-manager-backup.test.ts
@@ -1,0 +1,178 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from '@jest/globals';
+
+const mockRegisterReloadCallback = jest.fn();
+const mockGetBoolean = jest.fn();
+const mockGetString = jest.fn();
+const mockSet = jest.fn();
+
+const mockSetVoteCountsByMessageId = jest.fn();
+const mockListQuotes = jest.fn();
+const mockUpdateQuoteMessageId = jest.fn();
+
+jest.mock('../../src/utils/logger.js');
+jest.mock('cron');
+
+jest.unstable_mockModule('../../src/services/config-service.js', () => ({
+  ConfigService: {
+    getInstance: jest.fn(() => ({
+      registerReloadCallback: mockRegisterReloadCallback,
+      getBoolean: mockGetBoolean,
+      getString: mockGetString,
+      set: mockSet,
+    })),
+  },
+}));
+
+jest.unstable_mockModule('../../src/services/quote-service.js', () => ({
+  quoteService: {
+    setVoteCountsByMessageId: mockSetVoteCountsByMessageId,
+    listQuotes: mockListQuotes,
+    updateQuoteMessageId: mockUpdateQuoteMessageId,
+  },
+}));
+
+const HEADER_TITLE = '📝 Welcome to the Quote Channel!';
+const HEADER_FOOTER = 'KoolBot Quote System';
+
+function headerMessage(id: string) {
+  return {
+    id,
+    author: { id: 'bot123' },
+    embeds: [{ title: HEADER_TITLE, footer: { text: HEADER_FOOTER } }],
+  };
+}
+
+function userMessage(id: string) {
+  return {
+    id,
+    author: { id: 'user999' },
+    embeds: [{ title: 'something else', footer: { text: 'nope' } }],
+  };
+}
+
+const mockClient: any = {
+  isReady: jest.fn().mockReturnValue(true),
+  user: { id: 'bot123' },
+  channels: { fetch: jest.fn() },
+  on: jest.fn(),
+  removeListener: jest.fn(),
+};
+
+async function loadManager() {
+  const { QuoteChannelManager } = await import(
+    '../../src/services/quote-channel-manager.js'
+  );
+  return QuoteChannelManager.getInstance(mockClient);
+}
+
+describe('QuoteChannelManager - header idempotency & vote persistence', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSet.mockResolvedValue(undefined);
+  });
+
+  describe('findExistingHeader', () => {
+    it('finds a pinned bot header', async () => {
+      const manager = await loadManager();
+      const channel = {
+        messages: {
+          fetchPinned: jest
+            .fn()
+            .mockResolvedValue([userMessage('u1'), headerMessage('h1')]),
+          fetch: jest.fn().mockResolvedValue([]),
+        },
+      };
+      const result = await (manager as any).findExistingHeader(channel);
+      expect(result).toEqual({ id: 'h1' });
+      // Found in pins → no need to scan recent messages.
+      expect(channel.messages.fetch).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a recent-message scan when no pin matches', async () => {
+      const manager = await loadManager();
+      const channel = {
+        messages: {
+          fetchPinned: jest.fn().mockResolvedValue([userMessage('u1')]),
+          fetch: jest
+            .fn()
+            .mockResolvedValue([userMessage('u2'), headerMessage('h2')]),
+        },
+      };
+      const result = await (manager as any).findExistingHeader(channel);
+      expect(result).toEqual({ id: 'h2' });
+    });
+
+    it('returns null when no header exists anywhere', async () => {
+      const manager = await loadManager();
+      const channel = {
+        messages: {
+          fetchPinned: jest.fn().mockResolvedValue([userMessage('u1')]),
+          fetch: jest.fn().mockResolvedValue([userMessage('u2')]),
+        },
+      };
+      const result = await (manager as any).findExistingHeader(channel);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('ensureHeaderPost adoption', () => {
+    it('adopts an existing header instead of creating a duplicate', async () => {
+      // Header enabled, but the stored ID is gone (e.g. after a reinstall).
+      mockGetBoolean.mockResolvedValue(true);
+      mockGetString.mockResolvedValue(''); // no stored header id
+
+      const manager = await loadManager();
+      const channel = {
+        send: jest.fn(),
+        messages: {
+          fetchPinned: jest.fn().mockResolvedValue([headerMessage('existing')]),
+          fetch: jest.fn().mockResolvedValue([]),
+        },
+      };
+
+      await (manager as any).ensureHeaderPost(channel);
+
+      // Adopted the existing header id, did NOT post a second welcome message.
+      expect(channel.send).not.toHaveBeenCalled();
+      expect(mockSet).toHaveBeenCalledWith(
+        'quotes.header_message_id',
+        'existing',
+        expect.any(String),
+        'quotes',
+      );
+    });
+  });
+
+  describe('scheduleVotePersist (debounced)', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('coalesces a burst into a single write with the latest values', async () => {
+      const manager = await loadManager();
+      mockSetVoteCountsByMessageId.mockResolvedValue(undefined);
+
+      (manager as any).scheduleVotePersist('msg1', 1, 0);
+      (manager as any).scheduleVotePersist('msg1', 2, 0);
+      (manager as any).scheduleVotePersist('msg1', 3, 1);
+
+      expect(mockSetVoteCountsByMessageId).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(2000);
+      await Promise.resolve();
+
+      expect(mockSetVoteCountsByMessageId).toHaveBeenCalledTimes(1);
+      expect(mockSetVoteCountsByMessageId).toHaveBeenCalledWith('msg1', 3, 1);
+    });
+  });
+});

--- a/__tests__/services/quote-channel-manager.test.ts
+++ b/__tests__/services/quote-channel-manager.test.ts
@@ -56,8 +56,10 @@ describe('QuoteChannelManager', () => {
       expect(manager.initialize.length).toBe(0);
     });
 
-    it('postQuote should accept 4 parameters', () => {
-      expect(manager.postQuote.length).toBe(4);
+    it('postQuote should accept 4 required parameters (plus an optional votes arg)', () => {
+      // quoteId, content, authorId, addedById are required; the 5th `votes`
+      // param is optional and used when restoring tallies on re-sync.
+      expect(manager.postQuote.length).toBe(5);
     });
 
     it('deleteQuoteMessage should accept message ID', () => {

--- a/__tests__/services/quote-service-backup.test.ts
+++ b/__tests__/services/quote-service-backup.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { QuoteService } from '../../src/services/quote-service.js';
+
+jest.mock('mongoose');
+jest.mock('../../src/database/schema.js');
+jest.mock('../../src/services/config-service.js');
+jest.mock('../../src/services/cooldown-manager.js');
+jest.mock('../../src/utils/logger.js');
+
+const VALID_ID = '0123456789abcdef01234567';
+
+describe('QuoteService backup & vote persistence', () => {
+  let service: QuoteService;
+  let model: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new QuoteService();
+    model = {
+      find: jest.fn(),
+      findOne: jest.fn(),
+      findOneAndUpdate: jest.fn(),
+      create: jest.fn(),
+    };
+    // Replace the (mongoose-mocked) model with a controllable stub.
+    (service as any).model = model;
+  });
+
+  describe('setVoteCountsByMessageId', () => {
+    it('writes the tally keyed by messageId', async () => {
+      model.findOneAndUpdate.mockResolvedValue({});
+      await service.setVoteCountsByMessageId('msg1', 3, 1);
+      expect(model.findOneAndUpdate).toHaveBeenCalledWith(
+        { messageId: 'msg1' },
+        { likes: 3, dislikes: 1 },
+      );
+    });
+
+    it('clamps negative counts to zero', async () => {
+      model.findOneAndUpdate.mockResolvedValue({});
+      await service.setVoteCountsByMessageId('msg1', -2, -5);
+      expect(model.findOneAndUpdate).toHaveBeenCalledWith(
+        { messageId: 'msg1' },
+        { likes: 0, dislikes: 0 },
+      );
+    });
+
+    it('is a no-op when messageId is empty', async () => {
+      await service.setVoteCountsByMessageId('', 1, 1);
+      expect(model.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('exportQuotes', () => {
+    it('serialises quotes including vote tallies', async () => {
+      const docs = [
+        {
+          _id: { toString: () => VALID_ID },
+          content: 'hi',
+          authorId: 'a',
+          addedById: 'b',
+          channelId: 'c',
+          messageId: 'm',
+          likes: 2,
+          dislikes: 1,
+          createdAt: new Date('2020-01-01T00:00:00Z'),
+          addedAt: new Date('2020-01-02T00:00:00Z'),
+        },
+      ];
+      model.find.mockReturnValue({ sort: jest.fn().mockResolvedValue(docs) });
+
+      const out = await service.exportQuotes();
+
+      expect(out.version).toBe(1);
+      expect(out.quotes).toHaveLength(1);
+      expect(out.quotes[0]).toMatchObject({
+        id: VALID_ID,
+        content: 'hi',
+        likes: 2,
+        dislikes: 1,
+      });
+    });
+  });
+
+  describe('importQuotes', () => {
+    it('imports new entries and preserves id + votes', async () => {
+      model.findOne.mockResolvedValue(null);
+      model.create.mockResolvedValue({});
+
+      const res = await service.importQuotes({
+        version: 1,
+        exportedAt: 'x',
+        quotes: [
+          {
+            id: VALID_ID,
+            content: 'hi',
+            authorId: 'a',
+            addedById: 'b',
+            channelId: 'c',
+            messageId: 'm',
+            likes: 2,
+            dislikes: 1,
+          },
+        ],
+      });
+
+      expect(res.imported).toBe(1);
+      expect(res.skipped).toBe(0);
+      expect(model.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          _id: VALID_ID,
+          content: 'hi',
+          likes: 2,
+          dislikes: 1,
+        }),
+      );
+    });
+
+    it('round-trips an export back into an import', async () => {
+      const docs = [
+        {
+          _id: { toString: () => VALID_ID },
+          content: 'round trip',
+          authorId: 'a',
+          addedById: 'b',
+          channelId: 'c',
+          messageId: 'm',
+          likes: 5,
+          dislikes: 2,
+          createdAt: new Date('2021-01-01T00:00:00Z'),
+          addedAt: new Date('2021-01-01T00:00:00Z'),
+        },
+      ];
+      model.find.mockReturnValue({ sort: jest.fn().mockResolvedValue(docs) });
+      const exported = await service.exportQuotes();
+
+      model.findOne.mockResolvedValue(null);
+      model.create.mockResolvedValue({});
+      const res = await service.importQuotes(exported);
+
+      expect(res.imported).toBe(1);
+      expect(model.create).toHaveBeenCalledWith(
+        expect.objectContaining({ content: 'round trip', likes: 5, dislikes: 2 }),
+      );
+    });
+
+    it('skips an entry whose original id already exists', async () => {
+      model.findOne.mockResolvedValue({ _id: 'exists' });
+
+      const res = await service.importQuotes({
+        quotes: [
+          { id: VALID_ID, content: 'hi', authorId: 'a', addedById: 'b' },
+        ],
+      });
+
+      expect(res.imported).toBe(0);
+      expect(res.skipped).toBe(1);
+      expect(model.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects a structurally invalid payload', async () => {
+      const res = await service.importQuotes(null);
+      expect(res.imported).toBe(0);
+      expect(res.errors.length).toBeGreaterThan(0);
+    });
+
+    it('records an error for an entry missing content', async () => {
+      const res = await service.importQuotes({
+        quotes: [{ authorId: 'a', addedById: 'b' }],
+      });
+      expect(res.skipped).toBe(1);
+      expect(res.errors[0]).toMatch(/content/i);
+    });
+  });
+});

--- a/__tests__/services/quote-service-backup.test.ts
+++ b/__tests__/services/quote-service-backup.test.ts
@@ -158,6 +158,24 @@ describe('QuoteService backup & vote persistence', () => {
       expect(model.create).not.toHaveBeenCalled();
     });
 
+    it('dedups on content+author even when the entry has a valid id', async () => {
+      // A matching content+author already exists under a different id.
+      model.findOne.mockResolvedValue({ _id: 'someOtherId' });
+
+      const res = await service.importQuotes({
+        quotes: [
+          { id: VALID_ID, content: 'dup', authorId: 'a', addedById: 'b' },
+        ],
+      });
+
+      expect(res.skipped).toBe(1);
+      expect(model.create).not.toHaveBeenCalled();
+      // The dedup query must consider both the id AND content+author.
+      expect(model.findOne).toHaveBeenCalledWith({
+        $or: [{ _id: VALID_ID }, { content: 'dup', authorId: 'a' }],
+      });
+    });
+
     it('rejects a structurally invalid payload', async () => {
       const res = await service.importQuotes(null);
       expect(res.imported).toBe(0);

--- a/src/commands/quote.ts
+++ b/src/commands/quote.ts
@@ -370,15 +370,17 @@ async function handleImport(
     summary += ` First error: ${result.errors[0]}`;
   }
 
-  if (rebuild && result.imported > 0) {
+  // Rebuild whenever the admin asked for it — not just when something was
+  // imported. Imports are idempotent, so a valid re-run can legitimately report
+  // 0 imported + N skipped while the admin still wants the channel rebuilt.
+  if (rebuild) {
     try {
       const manager = QuoteChannelManager.getInstance(interaction.client);
       const { reposted } = await manager.resetChannel();
       summary += ` Rebuilt the quote channel (${reposted} quotes re-posted).`;
     } catch (error) {
       logger.error("Failed to rebuild quote channel after import:", error);
-      summary +=
-        " Import succeeded but the channel rebuild failed — run `/quote reset` to retry.";
+      summary += " The channel rebuild failed — run `/quote reset` to retry.";
     }
   }
 

--- a/src/commands/quote.ts
+++ b/src/commands/quote.ts
@@ -1,7 +1,17 @@
-import { SlashCommandBuilder, ChatInputCommandInteraction } from "discord.js";
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  GuildMember,
+  PermissionFlagsBits,
+  AttachmentBuilder,
+} from "discord.js";
 import { quoteService } from "../services/quote-service.js";
 import { QuoteChannelManager } from "../services/quote-channel-manager.js";
 import logger from "../utils/logger.js";
+
+// Hard cap on a restore upload. A quote backup is small text; this stops a
+// misclicked giant attachment from being streamed into memory.
+const MAX_IMPORT_BYTES = 5 * 1024 * 1024;
 
 /**
  * Normalize a Discord user ID from various formats to a clean numeric ID
@@ -69,7 +79,62 @@ export const data = new SlashCommandBuilder()
           .setDescription("The new author of the quote")
           .setRequired(false),
       ),
+  )
+  .addSubcommand((subcommand) =>
+    subcommand
+      .setName("export")
+      .setDescription("Admin: download a backup of all quotes (incl. votes)"),
+  )
+  .addSubcommand((subcommand) =>
+    subcommand
+      .setName("import")
+      .setDescription("Admin: restore quotes from a backup file")
+      .addAttachmentOption((option) =>
+        option
+          .setName("file")
+          .setDescription("A backup file produced by /quote export")
+          .setRequired(true),
+      )
+      .addBooleanOption((option) =>
+        option
+          .setName("rebuild")
+          .setDescription(
+            "Also purge and rebuild the quote channel after importing",
+          )
+          .setRequired(false),
+      ),
+  )
+  .addSubcommand((subcommand) =>
+    subcommand
+      .setName("reset")
+      .setDescription(
+        "Admin: purge the quote channel and rebuild it from the database",
+      ),
   );
+
+/**
+ * Whether the invoking guild member has the Administrator permission.
+ * Mirrors the gating used by `/config`; returns false defensively when the
+ * member object or permission bitfield is unavailable.
+ */
+function invokerIsAdmin(
+  member: ChatInputCommandInteraction["member"],
+): boolean {
+  if (!member) return false;
+  if (member instanceof GuildMember) {
+    return member.permissions.has(PermissionFlagsBits.Administrator);
+  }
+  const raw = (member as { permissions?: unknown }).permissions;
+  if (typeof raw !== "string") return false;
+  try {
+    return (
+      (BigInt(raw) & PermissionFlagsBits.Administrator) ===
+      PermissionFlagsBits.Administrator
+    );
+  } catch {
+    return false;
+  }
+}
 
 export async function execute(
   interaction: ChatInputCommandInteraction,
@@ -81,6 +146,12 @@ export async function execute(
       await handleAdd(interaction);
     } else if (subcommand === "edit") {
       await handleEdit(interaction);
+    } else if (subcommand === "export") {
+      await handleExport(interaction);
+    } else if (subcommand === "import") {
+      await handleImport(interaction);
+    } else if (subcommand === "reset") {
+      await handleReset(interaction);
     }
   } catch (error) {
     logger.error("Error executing quote command:", error);
@@ -223,4 +294,124 @@ async function handleEdit(
     content: "✅ Quote updated successfully!",
     ephemeral: true,
   });
+}
+
+async function handleExport(
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  if (!invokerIsAdmin(interaction.member)) {
+    await interaction.reply({
+      content: "❌ This command requires the Administrator permission.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  await interaction.deferReply({ ephemeral: true });
+
+  const backup = await quoteService.exportQuotes();
+  const json = JSON.stringify(backup, null, 2);
+  const file = new AttachmentBuilder(Buffer.from(json, "utf-8"), {
+    name: `quotes-backup-${new Date().toISOString().slice(0, 10)}.json`,
+  });
+
+  await interaction.editReply({
+    content: `✅ Exported ${backup.quotes.length} quote${
+      backup.quotes.length === 1 ? "" : "s"
+    }. Keep this file safe — you can restore it with \`/quote import\`.`,
+    files: [file],
+  });
+}
+
+async function handleImport(
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  if (!invokerIsAdmin(interaction.member)) {
+    await interaction.reply({
+      content: "❌ This command requires the Administrator permission.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const attachment = interaction.options.getAttachment("file", true);
+  const rebuild = interaction.options.getBoolean("rebuild") ?? false;
+
+  if (attachment.size > MAX_IMPORT_BYTES) {
+    await interaction.reply({
+      content: `❌ Backup file is too large (max ${MAX_IMPORT_BYTES / (1024 * 1024)} MB).`,
+      ephemeral: true,
+    });
+    return;
+  }
+
+  await interaction.deferReply({ ephemeral: true });
+
+  let payload: unknown;
+  try {
+    const response = await fetch(attachment.url);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    payload = JSON.parse(await response.text());
+  } catch (error) {
+    logger.error("Failed to read quote backup attachment:", error);
+    await interaction.editReply({
+      content:
+        "❌ Could not read the backup file. Make sure it's a valid JSON file produced by `/quote export`.",
+    });
+    return;
+  }
+
+  const result = await quoteService.importQuotes(payload);
+
+  let summary = `✅ Imported ${result.imported}, skipped ${result.skipped}.`;
+  if (result.errors.length > 0) {
+    summary += ` First error: ${result.errors[0]}`;
+  }
+
+  if (rebuild && result.imported > 0) {
+    try {
+      const manager = QuoteChannelManager.getInstance(interaction.client);
+      const { reposted } = await manager.resetChannel();
+      summary += ` Rebuilt the quote channel (${reposted} quotes re-posted).`;
+    } catch (error) {
+      logger.error("Failed to rebuild quote channel after import:", error);
+      summary +=
+        " Import succeeded but the channel rebuild failed — run `/quote reset` to retry.";
+    }
+  }
+
+  await interaction.editReply({ content: summary });
+}
+
+async function handleReset(
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  if (!invokerIsAdmin(interaction.member)) {
+    await interaction.reply({
+      content: "❌ This command requires the Administrator permission.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  await interaction.deferReply({ ephemeral: true });
+
+  try {
+    const manager = QuoteChannelManager.getInstance(interaction.client);
+    const { reposted } = await manager.resetChannel();
+    await interaction.editReply({
+      content: `✅ Quote channel rebuilt: ${reposted} quote${
+        reposted === 1 ? "" : "s"
+      } re-posted with their saved vote tallies.`,
+    });
+  } catch (error) {
+    logger.error("Failed to reset quote channel:", error);
+    await interaction.editReply({
+      content: `❌ Failed to rebuild the quote channel: ${
+        error instanceof Error ? error.message : "Unknown error"
+      }`,
+    });
+  }
 }

--- a/src/services/quote-channel-manager.ts
+++ b/src/services/quote-channel-manager.ts
@@ -18,6 +18,17 @@ import { quoteService } from "./quote-service.js";
 // detail of the channel-cleanup loop.
 const CLEANUP_INTERVAL_MINUTES = 5;
 
+// Reaction bursts (many users voting at once) would otherwise trigger a DB
+// write per reaction event. Coalesce writes per message into a single update
+// after this quiet window so a popular quote can't hammer Mongo.
+const VOTE_PERSIST_DEBOUNCE_MS = 2000;
+
+// Identifiers used to recognise an existing bot-authored header embed when the
+// stored message ID has been lost (e.g. after a reinstall wiped the config
+// row). Matching on these prevents the welcome post from being duplicated.
+const HEADER_TITLE = "📝 Welcome to the Quote Channel!";
+const HEADER_FOOTER = "KoolBot Quote System";
+
 /**
  * Normalize a Discord user ID from various formats to a clean numeric ID
  * Handles: <@123>, <@!123>, @username, or plain 123
@@ -48,6 +59,9 @@ export class QuoteChannelManager {
   private configService: ConfigService;
   private isInitialized: boolean = false;
   private cleanupJob: CronJob | null = null;
+  // Pending debounced vote-count writes, keyed by Discord message ID.
+  private voteWriteTimers: Map<string, ReturnType<typeof setTimeout>> =
+    new Map();
   private reactionAddHandler:
     | ((
         reaction: MessageReaction | PartialMessageReaction,
@@ -263,7 +277,6 @@ export class QuoteChannelManager {
       );
 
       // Try to fetch existing header message
-      let headerExists = false;
       if (storedHeaderId) {
         try {
           const existingMessage = await channel.messages.fetch(storedHeaderId);
@@ -271,7 +284,6 @@ export class QuoteChannelManager {
             existingMessage &&
             existingMessage.author.id === this.client.user?.id
           ) {
-            headerExists = true;
             logger.debug("Quote channel header post already exists");
             return;
           }
@@ -280,13 +292,72 @@ export class QuoteChannelManager {
         }
       }
 
-      // Create header post if it doesn't exist
-      if (!headerExists) {
-        await this.createHeaderPost(channel);
+      // The stored ID is missing or stale (common after a reinstall, which
+      // wipes the config row). Before creating a new header, scan the channel
+      // for an existing bot-authored header so we don't post a duplicate
+      // welcome message. If one is found, adopt its ID instead.
+      const existingHeader = await this.findExistingHeader(channel);
+      if (existingHeader) {
+        logger.info(
+          `Adopting existing quote channel header post: ${existingHeader.id}`,
+        );
+        await this.configService.set(
+          "quotes.header_message_id",
+          existingHeader.id,
+          "Message ID of the quote channel header post",
+          "quotes",
+        );
+        return;
       }
+
+      // No header anywhere — create one.
+      await this.createHeaderPost(channel);
     } catch (error) {
       logger.error("Error ensuring header post:", error);
     }
+  }
+
+  /**
+   * Locate an existing bot-authored header embed in the channel by matching
+   * the known title/footer, so a lost `quotes.header_message_id` doesn't cause
+   * a duplicate welcome post. Pinned messages are checked first (the header is
+   * pinned by default) before falling back to a recent-message scan.
+   */
+  private async findExistingHeader(
+    channel: TextChannel,
+  ): Promise<{ id: string } | null> {
+    const botId = this.client.user?.id;
+    if (!botId) return null;
+
+    const isHeader = (msg: {
+      author: { id: string };
+      embeds: { title?: string | null; footer?: { text?: string } | null }[];
+    }): boolean => {
+      if (msg.author.id !== botId) return false;
+      return msg.embeds.some(
+        (e) => e.title === HEADER_TITLE || e.footer?.text === HEADER_FOOTER,
+      );
+    };
+
+    try {
+      const pinned = await channel.messages.fetchPinned();
+      const pinnedHeader = pinned.find((m) => isHeader(m));
+      if (pinnedHeader) return { id: pinnedHeader.id };
+    } catch (error) {
+      logger.debug("Could not fetch pinned messages while scanning for header");
+      logger.debug(String(error));
+    }
+
+    try {
+      const recent = await channel.messages.fetch({ limit: 100 });
+      const recentHeader = recent.find((m) => isHeader(m));
+      if (recentHeader) return { id: recentHeader.id };
+    } catch (error) {
+      logger.debug("Could not fetch recent messages while scanning for header");
+      logger.debug(String(error));
+    }
+
+    return null;
   }
 
   /**
@@ -459,6 +530,13 @@ export class QuoteChannelManager {
       logger.info("Stopped quote channel cleanup job");
     }
 
+    // Flush/cancel any pending debounced vote writes so they don't fire after
+    // the manager has been torn down.
+    for (const timer of this.voteWriteTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.voteWriteTimers.clear();
+
     // Remove reaction handlers
     if (this.reactionAddHandler) {
       this.client.removeListener("messageReactionAdd", this.reactionAddHandler);
@@ -504,6 +582,7 @@ export class QuoteChannelManager {
     content: string,
     authorId: string,
     addedById: string,
+    votes?: { likes: number; dislikes: number },
   ): Promise<string | null> {
     try {
       const channel = await this.getQuoteChannel();
@@ -515,17 +594,29 @@ export class QuoteChannelManager {
       const normalizedAuthorId = normalizeUserId(authorId);
       const normalizedAddedById = normalizeUserId(addedById);
 
+      const fields = [
+        { name: "Author", value: `<@${normalizedAuthorId}>`, inline: true },
+        {
+          name: "Added by",
+          value: `<@${normalizedAddedById}>`,
+          inline: true,
+        },
+      ];
+      // When restoring from a backup the actual user reactions can't be
+      // recreated (a bot can't react on a user's behalf), so surface the
+      // historical tally in the embed itself instead of losing it.
+      if (votes && votes.likes + votes.dislikes > 0) {
+        fields.push({
+          name: "Votes",
+          value: `👍 ${votes.likes} · 👎 ${votes.dislikes}`,
+          inline: true,
+        });
+      }
+
       const embed = new EmbedBuilder()
         .setColor(0x0099ff)
         .setDescription(`"${content}"`)
-        .addFields(
-          { name: "Author", value: `<@${normalizedAuthorId}>`, inline: true },
-          {
-            name: "Added by",
-            value: `<@${normalizedAddedById}>`,
-            inline: true,
-          },
-        )
+        .addFields(fields)
         .setFooter({ text: `ID: ${quoteId}` })
         .setTimestamp();
 
@@ -626,15 +717,51 @@ export class QuoteChannelManager {
       const thumbsUp = message.reactions.cache.get("👍");
       const thumbsDown = message.reactions.cache.get("👎");
 
-      const likes = thumbsUp ? thumbsUp.count - 1 : 0; // -1 to exclude bot's reaction
-      const dislikes = thumbsDown ? thumbsDown.count - 1 : 0;
+      const likes = Math.max(0, thumbsUp ? thumbsUp.count - 1 : 0); // -1 to exclude bot's seed reaction
+      const dislikes = Math.max(0, thumbsDown ? thumbsDown.count - 1 : 0);
 
       logger.debug(
         `Quote message ${messageId}: ${likes} likes, ${dislikes} dislikes`,
       );
+
+      // Persist the tally so it survives a channel re-sync / reinstall.
+      this.scheduleVotePersist(messageId, likes, dislikes);
     } catch (error) {
       logger.error(`Error updating quote reactions for ${messageId}:`, error);
     }
+  }
+
+  /**
+   * Debounce vote-count writes per message so a burst of reactions collapses
+   * into a single DB update once the activity settles.
+   */
+  private scheduleVotePersist(
+    messageId: string,
+    likes: number,
+    dislikes: number,
+  ): void {
+    const existing = this.voteWriteTimers.get(messageId);
+    if (existing) {
+      clearTimeout(existing);
+    }
+
+    const timer = setTimeout(() => {
+      this.voteWriteTimers.delete(messageId);
+      quoteService
+        .setVoteCountsByMessageId(messageId, likes, dislikes)
+        .catch((error) =>
+          logger.error(
+            `Failed to persist vote counts for message ${messageId}:`,
+            error,
+          ),
+        );
+    }, VOTE_PERSIST_DEBOUNCE_MS);
+
+    // Don't keep the event loop alive solely for a pending vote write.
+    if (typeof timer.unref === "function") {
+      timer.unref();
+    }
+    this.voteWriteTimers.set(messageId, timer);
   }
 
   private setupReactionHandlers(): void {
@@ -704,50 +831,74 @@ export class QuoteChannelManager {
     this.client.on("messageReactionRemove", this.reactionRemoveHandler);
   }
 
-  private async syncExistingQuotes(): Promise<void> {
+  /**
+   * Bulk-delete every (recent) message in the channel. Discord's bulkDelete is
+   * capped at 100 messages per call and won't touch messages older than 14
+   * days, so we loop until the channel stops shrinking. Returns the number of
+   * messages deleted.
+   */
+  private async clearChannel(channel: TextChannel): Promise<number> {
+    let totalDeleted = 0;
+    // Discord bulkDelete is limited to 100 messages per call; loop until the channel is cleared.
+    // The `true` flag skips messages older than 14 days to avoid API errors.
+    // See: https://discord.js.org/#/docs/main/stable/class/TextChannel?scrollTo=bulkDelete
+    // Note: this will only delete messages that are not older than 14 days.
+    // Older messages (if any) will remain in the channel.
+    // If full historical clearing is required, they must be removed individually.
+    // This loop focuses on respecting the bulkDelete 100-message limitation.
+    while (true) {
+      const messages = await channel.messages.fetch({ limit: 100 });
+      if (messages.size === 0) {
+        break;
+      }
+      const deleted = await channel.bulkDelete(messages, true);
+      totalDeleted += deleted.size;
+      if (deleted.size === 0) {
+        // bulkDelete skips messages older than 14 days. If a full batch
+        // was fetched but nothing was deletable, every remaining message
+        // is too old to bulk-delete — stop instead of refetching the same
+        // 100 messages forever.
+        break;
+      }
+      if (messages.size < 100) {
+        // Fetched fewer than 100 messages, so there are no more recent messages to delete.
+        break;
+      }
+    }
+    logger.info(`Cleared ${totalDeleted} messages from quote channel`);
+    return totalDeleted;
+  }
+
+  /**
+   * Re-post every stored quote to the channel, restoring each quote's saved
+   * vote tally into its embed, and update the stored message IDs. When
+   * `clearFirst` is true the channel is wiped and the header re-created first —
+   * this is the "rebuild the channel from the database" path.
+   */
+  private async syncExistingQuotes(clearFirst = false): Promise<number> {
     try {
       logger.info("Syncing existing quotes to channel...");
 
       const channel = await this.getQuoteChannel();
       if (!channel) {
         logger.warn("Cannot sync quotes: channel not found");
-        return;
+        return 0;
       }
 
-      // Clear channel first (optional)
-      const clearChannel = await this.configService.getBoolean(
-        "quotes.clear_on_sync",
-        false,
-      );
-      if (clearChannel) {
-        let totalDeleted = 0;
-        // Discord bulkDelete is limited to 100 messages per call; loop until the channel is cleared.
-        // The `true` flag skips messages older than 14 days to avoid API errors.
-        // See: https://discord.js.org/#/docs/main/stable/class/TextChannel?scrollTo=bulkDelete
-        // Note: this will only delete messages that are not older than 14 days.
-        // Older messages (if any) will remain in the channel.
-        // If full historical clearing is required, they must be removed individually.
-        // This loop focuses on respecting the bulkDelete 100-message limitation.
-        while (true) {
-          const messages = await channel.messages.fetch({ limit: 100 });
-          if (messages.size === 0) {
-            break;
-          }
-          const deleted = await channel.bulkDelete(messages, true);
-          totalDeleted += deleted.size;
-          if (deleted.size === 0) {
-            // bulkDelete skips messages older than 14 days. If a full batch
-            // was fetched but nothing was deletable, every remaining message
-            // is too old to bulk-delete — stop instead of refetching the same
-            // 100 messages forever.
-            break;
-          }
-          if (messages.size < 100) {
-            // Fetched fewer than 100 messages, so there are no more recent messages to delete.
-            break;
-          }
-        }
-        logger.info(`Cleared ${totalDeleted} messages from quote channel`);
+      const shouldClear =
+        clearFirst ||
+        (await this.configService.getBoolean("quotes.clear_on_sync", false));
+      if (shouldClear) {
+        await this.clearChannel(channel);
+        // The header was just deleted; drop the stale stored ID so exactly one
+        // fresh header is created rather than a search turning up nothing.
+        await this.configService.set(
+          "quotes.header_message_id",
+          "",
+          "Message ID of the quote channel header post",
+          "quotes",
+        );
+        await this.ensureHeaderPost(channel);
       }
 
       // Get all quotes from database
@@ -759,6 +910,7 @@ export class QuoteChannelManager {
           quote.content,
           quote.authorId,
           quote.addedById,
+          { likes: quote.likes ?? 0, dislikes: quote.dislikes ?? 0 },
         );
 
         if (messageId) {
@@ -771,8 +923,25 @@ export class QuoteChannelManager {
       }
 
       logger.info(`Synced ${quotes.length} quotes to channel`);
+      return quotes.length;
     } catch (error) {
       logger.error("Error syncing quotes:", error);
+      return 0;
     }
+  }
+
+  /**
+   * Purge the quote channel and rebuild it from the database: clear all
+   * messages, re-create a single header post, and re-post every stored quote
+   * with its saved vote tally restored. Used by the admin `/quote reset`
+   * command to recover a channel left in a bad state (e.g. after a reinstall).
+   */
+  public async resetChannel(): Promise<{ reposted: number }> {
+    const channel = await this.getQuoteChannel();
+    if (!channel) {
+      throw new Error("Quote channel not configured or not found");
+    }
+    const reposted = await this.syncExistingQuotes(true);
+    return { reposted };
   }
 }

--- a/src/services/quote-channel-manager.ts
+++ b/src/services/quote-channel-manager.ts
@@ -832,36 +832,54 @@ export class QuoteChannelManager {
   }
 
   /**
-   * Bulk-delete every (recent) message in the channel. Discord's bulkDelete is
-   * capped at 100 messages per call and won't touch messages older than 14
-   * days, so we loop until the channel stops shrinking. Returns the number of
+   * Delete every message in the channel. Discord's bulkDelete is capped at 100
+   * messages per call and refuses messages older than 14 days, so anything it
+   * skips is removed individually — otherwise a rebuild would re-post quotes on
+   * top of surviving old messages and create duplicates. Returns the number of
    * messages deleted.
    */
   private async clearChannel(channel: TextChannel): Promise<number> {
     let totalDeleted = 0;
-    // Discord bulkDelete is limited to 100 messages per call; loop until the channel is cleared.
-    // The `true` flag skips messages older than 14 days to avoid API errors.
     // See: https://discord.js.org/#/docs/main/stable/class/TextChannel?scrollTo=bulkDelete
-    // Note: this will only delete messages that are not older than 14 days.
-    // Older messages (if any) will remain in the channel.
-    // If full historical clearing is required, they must be removed individually.
-    // This loop focuses on respecting the bulkDelete 100-message limitation.
     while (true) {
       const messages = await channel.messages.fetch({ limit: 100 });
       if (messages.size === 0) {
         break;
       }
-      const deleted = await channel.bulkDelete(messages, true);
-      totalDeleted += deleted.size;
-      if (deleted.size === 0) {
-        // bulkDelete skips messages older than 14 days. If a full batch
-        // was fetched but nothing was deletable, every remaining message
-        // is too old to bulk-delete — stop instead of refetching the same
-        // 100 messages forever.
-        break;
+
+      let deletedThisRound = 0;
+      let bulkDeletedIds: { has: (id: string) => boolean } = {
+        has: () => false,
+      };
+      try {
+        // The `true` flag tells bulkDelete to skip (rather than error on)
+        // messages older than 14 days.
+        const deleted = await channel.bulkDelete(messages, true);
+        deletedThisRound += deleted.size;
+        bulkDeletedIds = deleted;
+      } catch (error) {
+        logger.error("Error bulk-deleting quote channel messages:", error);
       }
-      if (messages.size < 100) {
-        // Fetched fewer than 100 messages, so there are no more recent messages to delete.
+
+      // Anything bulkDelete skipped (too old) must be removed individually so
+      // the channel is genuinely emptied before quotes are re-posted.
+      const remaining = messages.filter((m) => !bulkDeletedIds.has(m.id));
+      for (const message of remaining.values()) {
+        try {
+          await message.delete();
+          deletedThisRound++;
+        } catch (error) {
+          logger.error(
+            `Error deleting old quote channel message ${message.id}:`,
+            error,
+          );
+        }
+      }
+
+      totalDeleted += deletedThisRound;
+      if (deletedThisRound === 0) {
+        // Nothing in this batch could be deleted (e.g. missing permissions) —
+        // stop instead of refetching the same messages forever.
         break;
       }
     }
@@ -901,8 +919,9 @@ export class QuoteChannelManager {
         await this.ensureHeaderPost(channel);
       }
 
-      // Get all quotes from database
-      const { quotes } = await quoteService.listQuotes(1, 1000);
+      // Get every stored quote (unbounded): a rebuild must include all quotes,
+      // not just the first page.
+      const quotes = await quoteService.getAllQuotes();
 
       for (const quote of quotes) {
         const messageId = await this.postQuote(

--- a/src/services/quote-service.ts
+++ b/src/services/quote-service.ts
@@ -293,13 +293,17 @@ export class QuoteService {
 
       try {
         // Skip if the original id already exists (re-running a restore) or an
-        // identical quote (same text + author) is already stored.
+        // identical quote (same text + author) is already stored. When the id
+        // is valid we still also match on content+author so a re-import under a
+        // new id cannot duplicate an existing quote (the idempotency contract).
         const validId =
           Boolean(entry.id) && isValidObjectId(entry.id as string);
+        const contentMatch = {
+          content: entry.content,
+          authorId: entry.authorId,
+        };
         const duplicate = await this.model.findOne(
-          validId
-            ? { _id: entry.id }
-            : { content: entry.content, authorId: entry.authorId },
+          validId ? { $or: [{ _id: entry.id }, contentMatch] } : contentMatch,
         );
         if (duplicate) {
           result.skipped++;

--- a/src/services/quote-service.ts
+++ b/src/services/quote-service.ts
@@ -294,7 +294,8 @@ export class QuoteService {
       try {
         // Skip if the original id already exists (re-running a restore) or an
         // identical quote (same text + author) is already stored.
-        const validId = Boolean(entry.id) && isValidObjectId(entry.id as string);
+        const validId =
+          Boolean(entry.id) && isValidObjectId(entry.id as string);
         const duplicate = await this.model.findOne(
           validId
             ? { _id: entry.id }

--- a/src/services/quote-service.ts
+++ b/src/services/quote-service.ts
@@ -1,4 +1,11 @@
 import { Model, Document, model } from "mongoose";
+import logger from "../utils/logger.js";
+
+/** A Mongo ObjectId is a 24-character hex string. Matching with a regex avoids
+ * importing `mongoose.Types` (which the test suite's mongoose mock omits). */
+function isValidObjectId(id: string): boolean {
+  return /^[a-f\d]{24}$/i.test(id);
+}
 import { quoteSchema } from "../database/schema.js";
 import { ConfigService } from "./config-service.js";
 import { CooldownManager } from "./cooldown-manager.js";
@@ -39,6 +46,36 @@ export interface IQuote extends Document {
   addedAt: Date;
   likes: number;
   dislikes: number;
+}
+
+/** Bumped if the export shape ever changes in a backwards-incompatible way. */
+export const QUOTE_EXPORT_VERSION = 1;
+
+/** One quote in a backup file. `id` is the original Mongo `_id` so it can be
+ * preserved across a reinstall (it is what the quote embed footer shows). */
+export interface QuoteExportEntry {
+  id?: string;
+  content: string;
+  authorId: string;
+  addedById: string;
+  channelId: string;
+  messageId: string;
+  likes: number;
+  dislikes: number;
+  createdAt?: string;
+  addedAt?: string;
+}
+
+export interface QuoteExport {
+  version: number;
+  exportedAt: string;
+  quotes: QuoteExportEntry[];
+}
+
+export interface QuoteImportResult {
+  imported: number;
+  skipped: number;
+  errors: string[];
 }
 
 export class QuoteService {
@@ -180,6 +217,121 @@ export class QuoteService {
     messageId: string,
   ): Promise<void> {
     await this.model.findByIdAndUpdate(quoteId, { messageId });
+  }
+
+  /**
+   * Persist the live 👍/👎 tallies for the quote posted as `messageId`.
+   *
+   * The reaction handlers only ever know the Discord message ID, so the
+   * lookup is by `messageId` rather than `_id`. This is what makes votes
+   * "stick": without it the counts live only on the Discord message and are
+   * lost the moment the channel is re-synced (e.g. after a reinstall).
+   */
+  async setVoteCountsByMessageId(
+    messageId: string,
+    likes: number,
+    dislikes: number,
+  ): Promise<void> {
+    if (!messageId) return;
+    await this.model.findOneAndUpdate(
+      { messageId },
+      { likes: Math.max(0, likes), dislikes: Math.max(0, dislikes) },
+    );
+  }
+
+  /**
+   * Serialise every quote (including its vote tallies) into a backup
+   * structure suitable for JSON export. The original `_id` is preserved as
+   * `id` so a restore can reproduce the same quote IDs shown in embed footers.
+   */
+  async exportQuotes(): Promise<QuoteExport> {
+    const quotes = await this.model.find().sort({ createdAt: 1 });
+    return {
+      version: QUOTE_EXPORT_VERSION,
+      exportedAt: new Date().toISOString(),
+      quotes: quotes.map((q) => ({
+        id: q._id.toString(),
+        content: q.content,
+        authorId: q.authorId,
+        addedById: q.addedById,
+        channelId: q.channelId,
+        messageId: q.messageId,
+        likes: q.likes ?? 0,
+        dislikes: q.dislikes ?? 0,
+        createdAt: q.createdAt?.toISOString(),
+        addedAt: q.addedAt?.toISOString(),
+      })),
+    };
+  }
+
+  /**
+   * Ingest a backup produced by {@link exportQuotes}. Entries whose original
+   * `id` (or identical content+author) already exist are skipped, so a
+   * restore is idempotent and safe to re-run. Vote tallies are restored as-is.
+   */
+  async importQuotes(payload: unknown): Promise<QuoteImportResult> {
+    const result: QuoteImportResult = { imported: 0, skipped: 0, errors: [] };
+
+    const source = payload as Partial<QuoteExport> | null | undefined;
+    if (!source || !Array.isArray(source.quotes)) {
+      result.errors.push("Invalid backup: expected { quotes: [...] }");
+      return result;
+    }
+
+    for (let i = 0; i < source.quotes.length; i++) {
+      const entry = source.quotes[i];
+      if (!entry || typeof entry.content !== "string" || !entry.content) {
+        result.errors.push(`Quote ${i + 1}: missing content`);
+        result.skipped++;
+        continue;
+      }
+      if (!entry.authorId || !entry.addedById) {
+        result.errors.push(`Quote ${i + 1}: missing author or addedBy`);
+        result.skipped++;
+        continue;
+      }
+
+      try {
+        // Skip if the original id already exists (re-running a restore) or an
+        // identical quote (same text + author) is already stored.
+        const validId = Boolean(entry.id) && isValidObjectId(entry.id as string);
+        const duplicate = await this.model.findOne(
+          validId
+            ? { _id: entry.id }
+            : { content: entry.content, authorId: entry.authorId },
+        );
+        if (duplicate) {
+          result.skipped++;
+          continue;
+        }
+
+        await this.model.create({
+          // Preserve the original _id when valid so footer IDs survive a
+          // reinstall; otherwise let Mongo assign a fresh one.
+          ...(validId ? { _id: entry.id } : {}),
+          content: entry.content,
+          authorId: entry.authorId,
+          addedById: entry.addedById,
+          channelId: entry.channelId || "imported",
+          // messageId is required by the schema; the channel re-sync overwrites
+          // it with the real message ID once the quote is re-posted.
+          messageId: entry.messageId || `imported-${entry.id ?? i}`,
+          createdAt: entry.createdAt ? new Date(entry.createdAt) : new Date(),
+          addedAt: entry.addedAt ? new Date(entry.addedAt) : new Date(),
+          likes: Math.max(0, entry.likes ?? 0),
+          dislikes: Math.max(0, entry.dislikes ?? 0),
+        });
+        result.imported++;
+      } catch (error) {
+        logger.error(`Error importing quote ${i + 1}:`, error);
+        result.errors.push(
+          `Quote ${i + 1}: ${error instanceof Error ? error.message : "Unknown error"}`,
+        );
+        result.skipped++;
+      }
+    }
+
+    return result;
   }
 
   async editQuote(


### PR DESCRIPTION
Resolves #553 — fixes the quote channel falling into a bad state after a bot reinstall (duplicated header, vote counts wiped) and adds backup/restore + channel reset.

## What changed

### 1. Vote tallies now persist (the core bug)
`QuoteChannelManager.updateQuoteReactions()` previously only **logged** the 👍/👎 counts — they were never written to the `Quote` document, so any re-sync reset everyone to zero. Reaction add/remove now persist the live tally (debounced per message, 2s) via the new `QuoteService.setVoteCountsByMessageId()`.

### 2. Header idempotency
When `quotes.header_message_id` is lost (a reinstall wipes the config row), `ensureHeaderPost()` now scans pinned/recent messages for an existing bot-authored header and **adopts** it instead of posting a duplicate welcome message.

### 3. Backup / restore
- `QuoteService.exportQuotes()` / `importQuotes()` — JSON backup including vote tallies, preserving original quote IDs (the IDs shown in embed footers). Import is idempotent: entries whose original ID, or identical text+author, already exist are skipped.
- Surfaced as admin slash subcommands `/quote export` and `/quote import` (with an optional `rebuild:true` to re-post into the channel after importing).

### 4. Channel reset
`QuoteChannelManager.resetChannel()` clears the channel, recreates a **single** header, and re-posts every stored quote with its saved tally rendered into the embed (a bot can't recreate user reactions, so the historical count is shown as a `Votes` field instead of being lost). Exposed as `/quote reset`.

All three new subcommands are gated behind the **Administrator** permission (mirrors the `/config` gating pattern).

## Files
- `src/services/quote-service.ts` — `setVoteCountsByMessageId`, `exportQuotes`, `importQuotes`
- `src/services/quote-channel-manager.ts` — debounced vote persistence, `findExistingHeader`, `clearChannel`, `resetChannel`, vote rendering in `postQuote`
- `src/commands/quote.ts` — `export` / `import` / `reset` admin subcommands
- `COMMANDS.md` — docs for the new subcommands and vote persistence

## Testing
- New `__tests__/services/quote-service-backup.test.ts` — vote-count writes (incl. clamping/no-op), export serialisation, import dedup, and export→import round-trip.
- New `__tests__/services/quote-channel-manager-backup.test.ts` — header found in pins / recent / nowhere, header **adoption** (no duplicate post), and debounced vote write coalescing a burst into one write.
- Updated the `postQuote` signature test for the new optional `votes` arg.
- Full suite: **1035 passing, 1 skipped**; `tsc`, `eslint`, `markdownlint`, and `build` all clean.

## Acceptance criteria (from #553)
- [x] Reacting 👍/👎 updates `likes`/`dislikes` in MongoDB, not just a log line
- [x] After a simulated reinstall there is exactly one header and quotes show their previous tallies, not zero
- [x] Admin can export all quotes (incl. vote counts) and restore them
- [x] "Reset quote channel" clears, rebuilds, and restores votes in one action
- [x] Tests cover vote persistence on add/remove, header idempotency, export→import round-trip

## Notes
- Restoring **live** user reactions isn't possible (a bot can't react on a user's behalf), so the restored tally is rendered into the embed as a `Votes` field. This is called out in the issue as the intended approach.
- `/quote import` reads the attachment from Discord's CDN with a 5 MB cap.

https://claude.ai/code/session_01TX3WyM89nZwK6DHvVspjw6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TX3WyM89nZwK6DHvVspjw6)_