### PR TITLE
feat: resolve emoji shortcodes in VC name config values (#558)

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,13 @@ The lobby automatically renames based on bot status:
 - **"🟢 Lobby"** — Bot online and ready
 - **"🔴 Lobby"** — Bot offline
 
+> **Emoji in channel names:** these name fields accept emoji shortcodes such
+> as `:green_circle:` or `:video_game:` — they're converted to the actual
+> emoji (🟢, 🎮) when you save. You can also paste the emoji directly.
+> Unrecognised shortcodes are kept as typed. Custom/server emoji
+> (`:myserveremoji:`) **can't** appear in channel names — that's a Discord
+> limitation, not the bot's, so they'll show as literal text.
+
 ### Voice activity tracking
 
 Track how much time users spend in voice channels:

--- a/__tests__/utils/emoji-shortcodes.test.ts
+++ b/__tests__/utils/emoji-shortcodes.test.ts
@@ -53,6 +53,21 @@ describe("resolveEmojiShortcodes (#558)", () => {
     expect(resolveEmojiShortcodes("a :: b")).toBe("a :: b");
   });
 
+  it("treats inherited Object.prototype names as unknown (no prototype-chain collision)", () => {
+    // Without an own-property check these would resolve to a function's
+    // source / [object Object] instead of being left as typed.
+    for (const token of [
+      ":constructor:",
+      ":toString:",
+      ":hasOwnProperty:",
+      ":valueOf:",
+      ":__proto__:",
+      ":__defineGetter__:",
+    ]) {
+      expect(resolveEmojiShortcodes(token)).toBe(token);
+    }
+  });
+
   it("matches shortcode names case-insensitively", () => {
     expect(resolveEmojiShortcodes(":GREEN_CIRCLE:")).toBe("🟢");
     expect(resolveEmojiShortcodes(":Green_Circle:")).toBe("🟢");
@@ -91,5 +106,12 @@ describe("findUnknownShortcodes (#558)", () => {
 
   it("preserves the original token casing in the result", () => {
     expect(findUnknownShortcodes(":Bogus:")).toEqual([":Bogus:"]);
+  });
+
+  it("reports inherited Object.prototype names as unknown", () => {
+    expect(findUnknownShortcodes(":constructor: :toString:")).toEqual([
+      ":constructor:",
+      ":toString:",
+    ]);
   });
 });

--- a/__tests__/utils/emoji-shortcodes.test.ts
+++ b/__tests__/utils/emoji-shortcodes.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  resolveEmojiShortcodes,
+  findUnknownShortcodes,
+  EMOJI_SHORTCODES,
+} from "../../src/utils/emoji-shortcodes.js";
+
+describe("resolveEmojiShortcodes (#558)", () => {
+  it("resolves a known shortcode to its Unicode emoji", () => {
+    expect(resolveEmojiShortcodes(":green_circle:")).toBe("🟢");
+    expect(resolveEmojiShortcodes(":red_circle:")).toBe("🔴");
+    expect(resolveEmojiShortcodes(":video_game:")).toBe("🎮");
+  });
+
+  it("resolves a shortcode embedded in surrounding text", () => {
+    expect(resolveEmojiShortcodes(":green_circle: Lobby")).toBe("🟢 Lobby");
+    expect(resolveEmojiShortcodes("Lobby :red_circle:")).toBe("Lobby 🔴");
+  });
+
+  it("resolves multiple shortcodes in one value", () => {
+    expect(resolveEmojiShortcodes(":green_circle: and :red_circle:")).toBe(
+      "🟢 and 🔴",
+    );
+  });
+
+  it("leaves unknown shortcodes untouched (no data loss)", () => {
+    expect(resolveEmojiShortcodes(":not_a_real_emoji:")).toBe(
+      ":not_a_real_emoji:",
+    );
+    // Custom/server emoji can't appear in channel names — passed through.
+    expect(resolveEmojiShortcodes(":myserveremoji:")).toBe(":myserveremoji:");
+  });
+
+  it("resolves only the known token in a mixed string", () => {
+    expect(resolveEmojiShortcodes(":green_circle: :unknown:")).toBe(
+      "🟢 :unknown:",
+    );
+  });
+
+  it("returns a value with no shortcode unchanged", () => {
+    expect(resolveEmojiShortcodes("Lobby")).toBe("Lobby");
+    expect(resolveEmojiShortcodes("")).toBe("");
+    expect(resolveEmojiShortcodes("🟢 Lobby")).toBe("🟢 Lobby");
+  });
+
+  it("does not treat colon-delimited non-emoji text as a shortcode", () => {
+    // A time like 12:34 has no surrounding word boundary the regex would
+    // misread, and `http://` / bare colons stay intact.
+    expect(resolveEmojiShortcodes("12:34")).toBe("12:34");
+    expect(resolveEmojiShortcodes("https://example.com")).toBe(
+      "https://example.com",
+    );
+    expect(resolveEmojiShortcodes("a :: b")).toBe("a :: b");
+  });
+
+  it("matches shortcode names case-insensitively", () => {
+    expect(resolveEmojiShortcodes(":GREEN_CIRCLE:")).toBe("🟢");
+    expect(resolveEmojiShortcodes(":Green_Circle:")).toBe("🟢");
+  });
+
+  it("coerces non-string input to a string", () => {
+    expect(resolveEmojiShortcodes(undefined)).toBe("");
+    expect(resolveEmojiShortcodes(null)).toBe("");
+    expect(resolveEmojiShortcodes(42)).toBe("42");
+  });
+
+  it("every mapped value is a non-empty string", () => {
+    for (const [name, glyph] of Object.entries(EMOJI_SHORTCODES)) {
+      expect(typeof glyph).toBe("string");
+      expect(glyph.length).toBeGreaterThan(0);
+      expect(name).toMatch(/^[a-z0-9_+-]+$/);
+    }
+  });
+});
+
+describe("findUnknownShortcodes (#558)", () => {
+  it("returns an empty array when there are no shortcodes", () => {
+    expect(findUnknownShortcodes("Lobby")).toEqual([]);
+    expect(findUnknownShortcodes("")).toEqual([]);
+  });
+
+  it("returns an empty array when every shortcode is known", () => {
+    expect(findUnknownShortcodes(":green_circle: :red_circle:")).toEqual([]);
+  });
+
+  it("lists unknown shortcodes in order, deduplicated", () => {
+    expect(
+      findUnknownShortcodes(":green_circle: :bogus: :bogus: :nope:"),
+    ).toEqual([":bogus:", ":nope:"]);
+  });
+
+  it("preserves the original token casing in the result", () => {
+    expect(findUnknownShortcodes(":Bogus:")).toEqual([":Bogus:"]);
+  });
+});

--- a/__tests__/web/write-routes.test.ts
+++ b/__tests__/web/write-routes.test.ts
@@ -262,6 +262,58 @@ describe("coerceConfigValue", () => {
         expect(String(r.value).length).toBeGreaterThan(TEXT_LIMITS.configValue);
     });
   });
+
+  describe("emoji shortcode resolution (#558)", () => {
+    it("resolves a known shortcode to Unicode for name-style keys", () => {
+      expect(
+        coerceConfigValue("voicechannels.channel.prefix", ":green_circle:"),
+      ).toEqual({ ok: true, value: "🟢" });
+      expect(
+        coerceConfigValue("voicechannels.lobby.name", ":green_circle: Lobby"),
+      ).toEqual({ ok: true, value: "🟢 Lobby" });
+      expect(
+        coerceConfigValue(
+          "voicechannels.lobby.offlinename",
+          ":red_circle: Lobby",
+        ),
+      ).toEqual({ ok: true, value: "🔴 Lobby" });
+      expect(
+        coerceConfigValue("voicechannels.channel.suffix", ":sparkles:"),
+      ).toEqual({ ok: true, value: "✨" });
+    });
+
+    it("passes unknown shortcodes through untouched (no data loss)", () => {
+      expect(
+        coerceConfigValue("voicechannels.lobby.name", ":myserveremoji: Lobby"),
+      ).toEqual({ ok: true, value: ":myserveremoji: Lobby" });
+    });
+
+    it("leaves a name value with no shortcode unchanged", () => {
+      expect(
+        coerceConfigValue("voicechannels.lobby.name", "Lobby"),
+      ).toEqual({ ok: true, value: "Lobby" });
+      // Raw Unicode the admin pasted directly must survive verbatim.
+      expect(
+        coerceConfigValue("voicechannels.channel.prefix", "🎮"),
+      ).toEqual({ ok: true, value: "🎮" });
+    });
+
+    it("does not resolve shortcodes for non-name string keys", () => {
+      // Only the channel-name keys opt in; other free-text keys are verbatim
+      // so a stray `:colon:` elsewhere isn't reinterpreted as an emoji.
+      const nameResult = coerceConfigValue(
+        "voicechannels.lobby.name",
+        ":green_circle:",
+      );
+      expect(nameResult.ok && nameResult.value).toBe("🟢");
+      // A non-name string key is left as-typed.
+      const r = coerceConfigValue(
+        "leaderboard_roles.tiers",
+        ":green_circle:",
+      );
+      expect(r).toEqual({ ok: true, value: ":green_circle:" });
+    });
+  });
 });
 
 describe("firstLengthError (#508)", () => {

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -412,26 +412,28 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
   "voicechannels.lobby.name": {
     label: "Lobby channel display name",
     description:
-      "Display name of the lobby channel users join to spawn a personal channel. Cosmetic; the bot sets this on the managed channel rather than looking it up by name.",
+      "Display name of the lobby channel users join to spawn a personal channel. Cosmetic; the bot sets this on the managed channel rather than looking it up by name. Emoji shortcodes like :green_circle: are converted to the emoji on save (custom server emoji aren't supported in channel names).",
     category: "voicechannels",
     type: "string",
   },
   "voicechannels.lobby.offlinename": {
     label: "Lobby display name (bot offline)",
     description:
-      "Display name shown on the lobby channel while the bot is offline. Cosmetic.",
+      "Display name shown on the lobby channel while the bot is offline. Cosmetic. Emoji shortcodes like :red_circle: are converted to the emoji on save (custom server emoji aren't supported in channel names).",
     category: "voicechannels",
     type: "string",
   },
   "voicechannels.channel.prefix": {
     label: "Per-user channel name prefix",
-    description: "Prefix prepended to dynamically created voice channel names.",
+    description:
+      "Prefix prepended to dynamically created voice channel names. Emoji shortcodes like :video_game: are converted to the emoji on save (custom server emoji aren't supported in channel names).",
     category: "voicechannels",
     type: "string",
   },
   "voicechannels.channel.suffix": {
     label: "Per-user channel name suffix",
-    description: "Suffix appended to dynamically created voice channel names.",
+    description:
+      "Suffix appended to dynamically created voice channel names. Emoji shortcodes like :sparkles: are converted to the emoji on save (custom server emoji aren't supported in channel names).",
     category: "voicechannels",
     type: "string",
   },

--- a/src/utils/emoji-shortcodes.ts
+++ b/src/utils/emoji-shortcodes.ts
@@ -140,6 +140,23 @@ export const EMOJI_SHORTCODES: Readonly<Record<string, string>> = {
 const SHORTCODE_RE = /:([a-z0-9_+-]+):/gi;
 
 /**
+ * Look up a shortcode name (case-insensitive) in the map, returning its
+ * Unicode emoji or `undefined` when the name isn't a recognised shortcode.
+ *
+ * Uses an *own-property* check rather than a bare index/`in`, so inherited
+ * `Object.prototype` members can't masquerade as known shortcodes: without
+ * it, `:constructor:`, `:toString:`, `:__proto__:` etc. would hit the
+ * prototype chain and resolve to a function's source (or `[object Object]`)
+ * instead of being treated as unknown and left as typed.
+ */
+function lookupShortcode(name: string): string | undefined {
+  const key = name.toLowerCase();
+  return Object.prototype.hasOwnProperty.call(EMOJI_SHORTCODES, key)
+    ? EMOJI_SHORTCODES[key]
+    : undefined;
+}
+
+/**
  * Replace every recognised `:shortcode:` in `input` with its Unicode emoji.
  * Unknown shortcodes are returned untouched (no data loss). Lookup is
  * case-insensitive on the shortcode name. A non-string input is coerced to
@@ -149,8 +166,7 @@ export function resolveEmojiShortcodes(input: unknown): string {
   const str = typeof input === "string" ? input : String(input ?? "");
   if (!str.includes(":")) return str;
   return str.replace(SHORTCODE_RE, (match, name: string) => {
-    const unicode = EMOJI_SHORTCODES[name.toLowerCase()];
-    return unicode ?? match;
+    return lookupShortcode(name) ?? match;
   });
 }
 
@@ -169,8 +185,7 @@ export function findUnknownShortcodes(input: unknown): string[] {
   const seen = new Set<string>();
   for (const m of str.matchAll(SHORTCODE_RE)) {
     const token = m[0];
-    const name = m[1].toLowerCase();
-    if (name in EMOJI_SHORTCODES) continue;
+    if (lookupShortcode(m[1]) !== undefined) continue;
     if (seen.has(token)) continue;
     seen.add(token);
     unknown.push(token);

--- a/src/utils/emoji-shortcodes.ts
+++ b/src/utils/emoji-shortcodes.ts
@@ -1,0 +1,179 @@
+/**
+ * Resolve emoji *shortcodes* (e.g. `:green_circle:`) to their Unicode
+ * codepoints (🟢) for config values that feed Discord channel names
+ * (issue #558).
+ *
+ * Discord only converts `:shortcode:` → emoji inside user-typed messages in
+ * its own client; it does **not** convert shortcodes in channel names or in
+ * names the bot sets via the API. So a prefix/lobby name typed as
+ * `:green_circle:` would otherwise be stored and applied verbatim, producing
+ * a channel literally named `:green_circle: Lobby` instead of `🟢 Lobby`.
+ *
+ * This module covers the common standard-Unicode shortcodes (status dots,
+ * squares, and the handful of voice/gaming-flavoured emoji a server admin is
+ * likely to reach for). It deliberately does **not** bundle the full emoji
+ * set — unknown shortcodes are left untouched so nothing is silently blanked.
+ *
+ * LIMITATION: Discord **custom/server** emoji (`:myserveremoji:`) cannot
+ * appear in channel names at all — they render as literal `:name:` text even
+ * for Discord itself. This resolver only handles standard Unicode shortcodes;
+ * an unrecognised `:name:` is passed through unchanged.
+ */
+
+/**
+ * Static `shortcode` → Unicode map. Keys are the bare shortcode name without
+ * the surrounding colons. Aliases (multiple names for the same glyph) are
+ * intentional — admins reach for different spellings.
+ */
+export const EMOJI_SHORTCODES: Readonly<Record<string, string>> = {
+  // Status dots — the primary motivation for this feature.
+  red_circle: "🔴",
+  orange_circle: "🟠",
+  yellow_circle: "🟡",
+  green_circle: "🟢",
+  blue_circle: "🔵",
+  purple_circle: "🟣",
+  brown_circle: "🟤",
+  black_circle: "⚫",
+  white_circle: "⚪",
+
+  // Squares.
+  red_square: "🟥",
+  orange_square: "🟧",
+  yellow_square: "🟨",
+  green_square: "🟩",
+  blue_square: "🟦",
+  purple_square: "🟪",
+  brown_square: "🟫",
+  black_large_square: "⬛",
+  white_large_square: "⬜",
+  black_medium_square: "◼️",
+  white_medium_square: "◻️",
+  black_small_square: "▪️",
+  white_small_square: "▫️",
+
+  // Diamonds / shapes.
+  large_blue_diamond: "🔷",
+  large_orange_diamond: "🔶",
+  small_blue_diamond: "🔹",
+  small_orange_diamond: "🔸",
+
+  // Stars / sparkle.
+  star: "⭐",
+  star2: "🌟",
+  sparkles: "✨",
+  dizzy: "💫",
+
+  // Voice / gaming flavour (matches the raw-Unicode defaults in code).
+  video_game: "🎮",
+  joystick: "🕹️",
+  microphone: "🎤",
+  studio_microphone: "🎙️",
+  headphones: "🎧",
+  musical_note: "🎵",
+  notes: "🎶",
+  speaker: "🔈",
+  sound: "🔉",
+  loud_sound: "🔊",
+  mute: "🔇",
+  bell: "🔔",
+  no_bell: "🔕",
+
+  // Locks / privacy.
+  lock: "🔒",
+  unlock: "🔓",
+  key: "🔑",
+
+  // Common decorative.
+  fire: "🔥",
+  zap: "⚡",
+  high_voltage: "⚡",
+  boom: "💥",
+  rocket: "🚀",
+  tada: "🎉",
+  confetti_ball: "🎊",
+  crown: "👑",
+  trophy: "🏆",
+  medal: "🏅",
+  gem: "💎",
+  heart: "❤️",
+  green_heart: "💚",
+  blue_heart: "💙",
+  purple_heart: "💜",
+  yellow_heart: "💛",
+  orange_heart: "🧡",
+  black_heart: "🖤",
+  white_heart: "🤍",
+  eyes: "👀",
+  wave: "👋",
+  robot: "🤖",
+  ghost: "👻",
+  skull: "💀",
+  alien: "👽",
+  gear: "⚙️",
+  wrench: "🔧",
+  hammer: "🔨",
+  shield: "🛡️",
+  crossed_swords: "⚔️",
+  dart: "🎯",
+  game_die: "🎲",
+  hourglass: "⌛",
+  hourglass_flowing_sand: "⏳",
+  warning: "⚠️",
+  no_entry: "⛔",
+  no_entry_sign: "🚫",
+  white_check_mark: "✅",
+  heavy_check_mark: "✔️",
+  x: "❌",
+  question: "❓",
+  exclamation: "❗",
+  hash: "#️⃣",
+  hourglass_done: "⏳",
+} as const;
+
+/**
+ * Matches a `:shortcode:` token. The inner name is `[a-z0-9_+-]+` — the
+ * character class used by standard emoji shortcode sets — so arbitrary text
+ * between colons (URLs, timestamps like `12:34`, `::`) is not treated as a
+ * candidate and is left exactly as typed.
+ */
+const SHORTCODE_RE = /:([a-z0-9_+-]+):/gi;
+
+/**
+ * Replace every recognised `:shortcode:` in `input` with its Unicode emoji.
+ * Unknown shortcodes are returned untouched (no data loss). Lookup is
+ * case-insensitive on the shortcode name. A non-string input is coerced to
+ * a string so callers can pass raw config values directly.
+ */
+export function resolveEmojiShortcodes(input: unknown): string {
+  const str = typeof input === "string" ? input : String(input ?? "");
+  if (!str.includes(":")) return str;
+  return str.replace(SHORTCODE_RE, (match, name: string) => {
+    const unicode = EMOJI_SHORTCODES[name.toLowerCase()];
+    return unicode ?? match;
+  });
+}
+
+/**
+ * Return the list of `:shortcode:` tokens in `input` that did **not** resolve
+ * to a known emoji, in order of appearance (deduplicated). Lets a caller
+ * surface a "these weren't recognised" hint — e.g. a typo'd `:greencircle:`
+ * or a custom server emoji that can't appear in channel names — without
+ * blocking the save. Returns an empty array when everything resolved (or
+ * there were no shortcodes at all).
+ */
+export function findUnknownShortcodes(input: unknown): string[] {
+  const str = typeof input === "string" ? input : String(input ?? "");
+  if (!str.includes(":")) return [];
+  const unknown: string[] = [];
+  const seen = new Set<string>();
+  for (const m of str.matchAll(SHORTCODE_RE)) {
+    const token = m[0];
+    const name = m[1].toLowerCase();
+    if (name in EMOJI_SHORTCODES) continue;
+    if (seen.has(token)) continue;
+    seen.add(token);
+    unknown.push(token);
+  }
+  return unknown;
+}

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -43,6 +43,10 @@ import {
 } from "./session.js";
 import { recordAudit } from "./audit.js";
 import {
+  resolveEmojiShortcodes,
+  findUnknownShortcodes,
+} from "../utils/emoji-shortcodes.js";
+import {
   getDisplayedRemainingMs,
   resolveNavFeatureStatus,
 } from "./admin-layout.js";
@@ -235,6 +239,21 @@ const WIZARD_FEATURE_ORDER = [
 ];
 
 /**
+ * Config keys whose string value is set directly as a Discord channel name
+ * (or part of one). For these, `:shortcode:` emoji are resolved to Unicode at
+ * the write boundary (issue #558) so admins can type `:green_circle:` and get
+ * 🟢 in the channel name. Other free-text keys (headers, message templates,
+ * etc.) are left verbatim — a stray `:colon:` there is not necessarily an
+ * emoji, and Discord renders shortcodes itself inside message content.
+ */
+export const EMOJI_NAME_KEYS: ReadonlySet<string> = new Set([
+  "voicechannels.lobby.name",
+  "voicechannels.lobby.offlinename",
+  "voicechannels.channel.prefix",
+  "voicechannels.channel.suffix",
+]);
+
+/**
  * Coerce a raw form value to match the expected type of `key` in
  * `defaultConfig`. Returns the coerced value on success, or a typed
  * failure describing why coercion was refused.
@@ -282,7 +301,17 @@ export function coerceConfigValue(
     if (!Number.isFinite(n)) return { ok: false, reason: "invalid number" };
     return { ok: true, value: n };
   }
-  const value = String(raw ?? "");
+  let value = String(raw ?? "");
+  // Emoji shortcode resolution (#558). For the name-style keys that feed
+  // Discord channel names, convert any recognised `:shortcode:` (e.g.
+  // `:green_circle:`) to its Unicode codepoint at the write boundary, so the
+  // DB stores 🟢 and every downstream name-construction site "just works"
+  // without a per-call-site transform. Unknown shortcodes pass through
+  // untouched. Done before the length cap so the resolved (shorter) form is
+  // what gets measured and stored.
+  if (EMOJI_NAME_KEYS.has(key)) {
+    value = resolveEmojiShortcodes(value);
+  }
   // Cap free-text setting values so an oversized string can't be stored and
   // then overflow the Settings display or a downstream Discord payload (#508).
   // List keys are handled in the array branch above and are bounded by their
@@ -473,9 +502,20 @@ export function createWriteRouter(
           details: { before, after: coerced.value },
           result: "success",
         });
+        // For the channel-name keys, surface any `:shortcode:` that wasn't
+        // recognised so the admin learns it stayed as literal text rather
+        // than silently wondering why their emoji didn't appear (#558). The
+        // resolved value is already echoed back in the message above.
+        const unknown = EMOJI_NAME_KEYS.has(key)
+          ? findUnknownShortcodes(coerced.value)
+          : [];
+        const hint =
+          unknown.length > 0
+            ? ` Note: ${unknown.join(", ")} ${unknown.length === 1 ? "is not a" : "are not"} recognised emoji shortcode${unknown.length === 1 ? "" : "s"} (kept as typed; custom server emoji can't appear in channel names).`
+            : "";
         flashRedirect(res, "/admin/settings", {
-          type: "ok",
-          text: `Set ${key} = ${String(coerced.value)}.`,
+          type: unknown.length > 0 ? "warn" : "ok",
+          text: `Set ${key} = ${String(coerced.value)}.${hint}`,
         });
       } catch (err) {
         const text = err instanceof Error ? err.message : "Unknown error";


### PR DESCRIPTION
## Summary

Closes #558.

Admins typing an emoji **shortcode** such as `:green_circle:` into a name-style config value previously had the literal text stored and applied verbatim, so a channel ended up named `:green_circle: Lobby` instead of `🟢 Lobby`. Discord only converts `:shortcode:` → emoji inside user-typed messages in its own client — not in channel names the bot sets via the API.

This implements **Option A** from the issue: resolve recognised shortcodes to their Unicode codepoint **at the config write boundary** (`coerceConfigValue`), so the DB stores the emoji and every downstream name-construction site in `voice-channel-manager.ts` "just works" without a per-call-site transform.

## Changes

- **New `src/utils/emoji-shortcodes.ts`** — a static `shortcode → Unicode` map (common status dots, squares, and voice/gaming-flavoured emoji) plus:
  - `resolveEmojiShortcodes(str)` — replaces recognised `:shortcode:` tokens; leaves unknown ones untouched (no data loss).
  - `findUnknownShortcodes(str)` — lists tokens that didn't resolve, for the UI hint.
- **`write-routes.ts`** — resolution is gated to the four channel-name keys via `EMOJI_NAME_KEYS` (`voicechannels.lobby.name`, `lobby.offlinename`, `channel.prefix`, `channel.suffix`). Other free-text keys (headers, templates) are left verbatim. The single-key **Set** flash echoes the resolved value back and adds a `warn` hint listing any unrecognised shortcodes. Because the resolution lives in `coerceConfigValue`, it also applies on the save-section, wizard, and YAML-import write paths.
- **Docs** — the schema field descriptions and the README note the shortcode support and the documented limitation that **custom/server emoji can't appear in channel names** (a Discord constraint).

## Acceptance criteria

- [x] `:green_circle:` (and other common shortcodes) in the VC name fields resolve to the actual emoji in the channel name.
- [x] Unrecognised shortcodes are left as typed, with a UI hint on the Set flash.
- [x] The admin sees the resolved value after saving (echoed in the flash).
- [x] Documented limitation: custom/server emoji not supported in channel names.
- [x] Tests cover: known shortcode → Unicode, unknown passthrough, no-shortcode unchanged (plus the non-name-key opt-out and the `findUnknownShortcodes` hint helper).

## Testing

- `npx tsc --noEmit` — clean
- `eslint` on changed files — clean
- `jest __tests__/utils/emoji-shortcodes.test.ts __tests__/web/write-routes.test.ts` — 51 passed

https://claude.ai/code/session_01FvkMoy5TnZYbGnT7UNBRdc

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvkMoy5TnZYbGnT7UNBRdc)_