### PR TITLE
feat(webui): keep scroll position when saving a settings section

### DIFF
--- a/__tests__/web/admin-layout.test.ts
+++ b/__tests__/web/admin-layout.test.ts
@@ -97,6 +97,25 @@ describe("renderAdminPage", () => {
     expect(html).toContain("keydown");
   });
 
+  it("ships the AJAX section-save script that posts via fetch (issue #555)", () => {
+    const html = renderAdminPage({
+      title: "Settings",
+      active: "/admin/settings",
+      body: "",
+      csrfToken: "",
+      remainingMs: 0,
+    });
+    // Progressive enhancement: the per-section Save submits via fetch() so the
+    // page no longer reloads and jumps to the top. The script targets the
+    // save-section form, advertises a JSON response, and renders an inline
+    // flash instead of redirecting.
+    expect(html).toContain('form[action="/admin/settings/save-section"]');
+    expect(html).toContain("'X-Requested-With':'fetch'");
+    expect(html).toContain("section-flash");
+    // Reset buttons (formaction) must still submit natively.
+    expect(html).toContain("getAttribute('formaction')");
+  });
+
   it("escapes the title", () => {
     const html = renderAdminPage({
       title: "<bad>",

--- a/__tests__/web/write-routes.test.ts
+++ b/__tests__/web/write-routes.test.ts
@@ -10,6 +10,8 @@ import {
   findSectionMasterKey,
   firstLengthError,
   resetConfigToDefaults,
+  truncateFlash,
+  wantsJson,
   TEXT_LIMITS,
   type ResetConfigStore,
 } from "../../src/web/write-routes.js";
@@ -85,6 +87,50 @@ describe("PROTECTED_KEYS", () => {
   it("excludes regular config keys", () => {
     expect(PROTECTED_KEYS.has("voicechannels.enabled")).toBe(false);
     expect(PROTECTED_KEYS.has("quotes.max_length")).toBe(false);
+  });
+});
+
+describe("wantsJson (issue #555)", () => {
+  const fakeReq = (headers: Record<string, string | string[]>) => ({
+    get: (name: string) => headers[name],
+  });
+
+  it("returns true when X-Requested-With is fetch (case-insensitive)", () => {
+    expect(wantsJson(fakeReq({ "X-Requested-With": "fetch" }))).toBe(true);
+    expect(wantsJson(fakeReq({ "X-Requested-With": "FETCH" }))).toBe(true);
+  });
+
+  it("returns true when Accept advertises application/json", () => {
+    expect(
+      wantsJson(fakeReq({ Accept: "application/json, text/plain, */*" })),
+    ).toBe(true);
+  });
+
+  it("returns false for a plain form POST (the no-JS fallback)", () => {
+    expect(
+      wantsJson(
+        fakeReq({ Accept: "text/html,application/xhtml+xml,application/xml" }),
+      ),
+    ).toBe(false);
+    expect(wantsJson(fakeReq({}))).toBe(false);
+  });
+
+  it("tolerates a header returned as an array", () => {
+    expect(wantsJson(fakeReq({ "X-Requested-With": ["fetch"] }))).toBe(true);
+  });
+});
+
+describe("truncateFlash (issue #555)", () => {
+  it("leaves short text untouched", () => {
+    expect(truncateFlash("Saved 3 settings in Polls.")).toBe(
+      "Saved 3 settings in Polls.",
+    );
+  });
+
+  it("caps overlong text at 500 chars with an ellipsis", () => {
+    const out = truncateFlash("x".repeat(600));
+    expect(out.length).toBe(500);
+    expect(out.endsWith("…")).toBe(true);
   });
 });
 

--- a/__tests__/web/write-routes.test.ts
+++ b/__tests__/web/write-routes.test.ts
@@ -106,6 +106,10 @@ describe("wantsJson (issue #555)", () => {
     ).toBe(true);
   });
 
+  it("matches application/json case-insensitively (media types per RFC 9110)", () => {
+    expect(wantsJson(fakeReq({ Accept: "Application/JSON" }))).toBe(true);
+  });
+
   it("returns false for a plain form POST (the no-JS fallback)", () => {
     expect(
       wantsJson(

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -371,6 +371,56 @@ const CASCADE_DISABLE_SCRIPT =
   "master.addEventListener('change',apply);apply()}" +
   "document.querySelectorAll('[data-cascade-master]').forEach(wire)})();";
 
+// AJAX section save (#555). Each Settings category is its own
+// `POST /admin/settings/save-section` form. A plain submit 303-redirects
+// back to /admin/settings, reloading the page and dropping the admin at the
+// top — annoying when you just saved a section near the bottom. This
+// progressively enhances the Save button: submit via fetch(), show the
+// server's flash inline inside the same card, and leave scroll position
+// untouched. The server returns JSON for these requests (Accept:
+// application/json) and keeps the redirect for the no-JS path, so browsers
+// without fetch/FormData fall back to the original full-page behaviour.
+//
+// Per-row Reset buttons retarget /admin/settings/reset via `formaction`;
+// those are left to submit natively (full reload). We track the clicked
+// submitter manually as well as via `SubmitEvent.submitter` so a Reset on an
+// older browser without `submitter` isn't mistakenly AJAX-posted to the
+// save-section route.
+const SETTINGS_SAVE_SCRIPT =
+  "(function(){" +
+  "var forms=document.querySelectorAll('form[action=\"/admin/settings/save-section\"]');" +
+  "if(!forms.length)return;" +
+  "function flashEl(form){var card=form.closest('.card');if(!card)return null;" +
+  "var n=card.querySelector('.section-flash');" +
+  "if(!n){n=document.createElement('div');n.className='notice section-flash';" +
+  "form.parentNode.insertBefore(n,form)}return n}" +
+  "function show(form,type,text){var n=flashEl(form);if(!n)return;" +
+  "var cls=type==='ok'?'ok':type==='warn'?'warn':'err';" +
+  "n.className='notice section-flash '+cls;n.textContent=text}" +
+  "function submit(e,submitter){var form=e.currentTarget;" +
+  // Reset buttons retarget via formaction — let those submit natively.
+  "if(submitter&&submitter.getAttribute('formaction'))return;" +
+  "if(typeof fetch!=='function'||typeof FormData!=='function')return;" +
+  "e.preventDefault();" +
+  "var save=form.querySelector('button[type=submit]:not([formaction])');" +
+  "if(save)save.disabled=true;" +
+  "fetch(form.action,{method:'POST',credentials:'same-origin',cache:'no-store'," +
+  "headers:{'Accept':'application/json','X-Requested-With':'fetch'}," +
+  "body:new FormData(form)})" +
+  ".then(function(res){if(res.status===401){window.location.href='/admin/';return null}" +
+  "return res.json().catch(function(){return null})})" +
+  ".then(function(d){if(save)save.disabled=false;" +
+  "if(!d){show(form,'err','Save failed — unexpected server response.');return}" +
+  "show(form,d.type||'ok',d.text||'Saved.')})" +
+  ".catch(function(){if(save)save.disabled=false;" +
+  "show(form,'err','Save failed — network error. Your changes were not saved.')})}" +
+  "function wire(form){var last=null;" +
+  "form.addEventListener('click',function(ev){var t=ev.target;" +
+  "if(t&&t.closest){var b=t.closest('button,input[type=submit]');" +
+  "if(b&&form.contains(b))last=b}});" +
+  "form.addEventListener('submit',function(e){submit(e,e.submitter||last);last=null})}" +
+  "forms.forEach(wire)})();";
+
 function renderNav(
   active: string,
   navFeatureStatus?: NavFeatureStatus,
@@ -423,6 +473,7 @@ export function renderAdminPage(opts: AdminPageOptions): string {
     `<script>${SCRIPT}</script>`,
     `<script>${CRON_PICKER_SCRIPT}</script>`,
     `<script>${CASCADE_DISABLE_SCRIPT}</script>`,
+    `<script>${SETTINGS_SAVE_SCRIPT}</script>`,
     "</body></html>",
   ].join("");
 }

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -595,7 +595,7 @@ export function renderSettingsPage(props: SettingsProps): string {
       // to retarget /admin/settings/reset for a single key (issue #433).
       const scopeAttr = cascadeMasterKey ? " data-cascade-scope" : "";
       return `
-<div class="card">
+<div class="card" id="section-${escapeHtml(g.category)}">
   <h2>${escapeHtml(meta.title)}</h2>
   ${descHtml}
   <form method="POST" action="/admin/settings/save-section"${scopeAttr}>

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -105,18 +105,56 @@ export function firstLengthError(
   return null;
 }
 
+export function truncateFlash(text: string): string {
+  return text.length > FLASH_MAX ? `${text.slice(0, FLASH_MAX - 1)}…` : text;
+}
+
 function flashRedirect(res: Response, path: string, flash: Flash): void {
   // Mirror the renderer's 500-char cap on the way out so the redirect
   // URL itself can't balloon to header/URI limits on a noisy failure.
-  const truncated =
-    flash.text.length > FLASH_MAX
-      ? `${flash.text.slice(0, FLASH_MAX - 1)}…`
-      : flash.text;
   const qs = new globalThis.URLSearchParams({
     flash: flash.type,
-    msg: truncated,
+    msg: truncateFlash(flash.text),
   }).toString();
   res.redirect(303, `${path}?${qs}`);
+}
+
+/**
+ * Whether the client wants a JSON reply instead of the usual 303 flash
+ * redirect. The Settings page's per-section Save is progressively enhanced to
+ * submit via `fetch()` (issue #555) so the page no longer reloads and jumps to
+ * the top; that request advertises itself with `X-Requested-With: fetch` (and
+ * `Accept: application/json`). A plain form POST — the no-JS fallback — sends
+ * neither and keeps the redirect path.
+ */
+export function wantsJson(req: {
+  get(name: string): string | string[] | undefined;
+}): boolean {
+  const header = (name: string): string => {
+    const raw = req.get(name);
+    return Array.isArray(raw) ? raw.join(",") : (raw ?? "");
+  };
+  if (header("X-Requested-With").toLowerCase() === "fetch") {
+    return true;
+  }
+  return header("Accept").includes("application/json");
+}
+
+/**
+ * Reply to a section-save with either an inline JSON flash (AJAX) or the
+ * legacy 303 redirect (no-JS). Always returns the same 500-char-capped flash
+ * the renderer would show, so both paths surface identical messages.
+ */
+function respondSectionFlash(
+  req: AuthenticatedRequest,
+  res: Response,
+  flash: Flash,
+): void {
+  if (wantsJson(req)) {
+    res.status(200).json({ type: flash.type, text: truncateFlash(flash.text) });
+    return;
+  }
+  flashRedirect(res, "/admin/settings", flash);
 }
 
 function getString(req: AuthenticatedRequest, name: string): string {
@@ -698,7 +736,7 @@ export function createWriteRouter(
           result: "failure",
           errorMessage: "no keys submitted",
         });
-        flashRedirect(res, "/admin/settings", {
+        respondSectionFlash(req, res, {
           type: "err",
           text: `No settings submitted for section ${category || "(unknown)"}.`,
         });
@@ -752,7 +790,7 @@ export function createWriteRouter(
           errorMessage: rejected.map((r) => `${r.key}: ${r.reason}`).join("; "),
         });
         const detail = rejected.map((r) => `${r.key} (${r.reason})`).join(", ");
-        flashRedirect(res, "/admin/settings", {
+        respondSectionFlash(req, res, {
           type: "err",
           text: `No changes saved — ${rejected.length} invalid value${rejected.length === 1 ? "" : "s"} in ${category || "section"}: ${detail}.`,
         });
@@ -817,14 +855,14 @@ export function createWriteRouter(
 
       const label = category || "section";
       if (failed.length === 0) {
-        flashRedirect(res, "/admin/settings", {
+        respondSectionFlash(req, res, {
           type: "ok",
           text: `Saved ${applied.length} setting${applied.length === 1 ? "" : "s"} in ${label}.`,
         });
         return;
       }
       const firstError = failed[0];
-      flashRedirect(res, "/admin/settings", {
+      respondSectionFlash(req, res, {
         type: applied.length > 0 ? "warn" : "err",
         text: `Saved ${applied.length}/${applied.length + failed.length} in ${label}. Failed: ${firstError.key} (${firstError.reason})${failed.length > 1 ? ` and ${failed.length - 1} more` : ""}.`,
       });

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -130,11 +130,14 @@ function flashRedirect(res: Response, path: string, flash: Flash): void {
 export function wantsJson(req: {
   get(name: string): string | string[] | undefined;
 }): boolean {
+  // Header values are compared case-insensitively: media types (RFC 9110)
+  // and our `fetch` sentinel are both case-insensitive, so a client sending
+  // `Accept: Application/JSON` must still get the JSON reply.
   const header = (name: string): string => {
     const raw = req.get(name);
-    return Array.isArray(raw) ? raw.join(",") : (raw ?? "");
+    return (Array.isArray(raw) ? raw.join(",") : (raw ?? "")).toLowerCase();
   };
-  if (header("X-Requested-With").toLowerCase() === "fetch") {
+  if (header("X-Requested-With") === "fetch") {
     return true;
   }
   return header("Accept").includes("application/json");


### PR DESCRIPTION
## Summary

Fixes #555. The Settings page renders one `<form>` per feature category, each posting to `POST /admin/settings/save-section`. On save the handler did a `303` redirect back to `/admin/settings?flash=…`, reloading the whole page and dropping the admin at the **top** — so after saving a section near the bottom (Polls, Achievements, …) you lost your place.

This implements **Option 1 (AJAX save)** from the issue, the recommended real fix, with the no-JS fallback intact.

## Changes

- **Progressive enhancement (`admin-layout.ts`)** — a new inline script intercepts the per-section Save, submits via `fetch()` (with `Accept: application/json` and `X-Requested-With: fetch`), and renders the server's flash inline inside the same card. Scroll position is never touched.
  - Disables the Save button while in-flight; re-enables on completion.
  - Network/parse errors surface an inline error (changes not saved).
  - A `401` redirects to `/admin/` (matches the existing session-expiry handling).
  - Per-row **Reset** buttons (`formaction`) still submit natively — detected via `SubmitEvent.submitter` with a manual click-tracking fallback for older browsers.
  - If `fetch`/`FormData` are unavailable, the script does nothing and the plain form POST proceeds.
- **Server (`write-routes.ts`)** — `save-section` now returns JSON `{ type, text }` for AJAX requests and keeps the `303` redirect for plain form POSTs. CSRF is unchanged (the token rides in the `FormData` body). Extracted `truncateFlash` and `wantsJson` helpers (both unit-tested).
- **Renderer (`admin-views.ts`)** — each section card gains `id="section-<category>"` (scopes the inline flash; also usable as an anchor).

## Success criteria (from the issue)

- ✅ Saving no longer scrolls to the page top
- ✅ Success/error messages remain visible (rendered inline in the card)
- ✅ No-JavaScript browsers still function (plain form POST → `303` redirect)
- ✅ CSRF protection persists

## Testing

- New unit tests for `wantsJson`, `truncateFlash`, and the embedded save script markup.
- `npm run build`, `npm run lint`, `npm run format:check`, and `npm test` (1028 passing) all green.

https://claude.ai/code/session_019PGemvVtaDf6oQ716tc5am

---
_Generated by [Claude Code](https://claude.ai/code/session_019PGemvVtaDf6oQ716tc5am)_