### PR TITLE
feat(web): let admins paste a poll library to import without hosting it

### DIFF
--- a/__tests__/services/poll-service.test.ts
+++ b/__tests__/services/poll-service.test.ts
@@ -381,7 +381,9 @@ describe("PollService", () => {
   });
 
   it("reports a clear error when the request times out", async () => {
-    mockFetch.mockRejectedValue(new DOMException("The operation was aborted", "AbortError"));
+    mockFetch.mockRejectedValue(
+      new DOMException("The operation was aborted", "AbortError"),
+    );
 
     const service = PollService.getInstance({} as never);
 
@@ -497,9 +499,26 @@ describe("PollService", () => {
 
       expect(result.imported).toBe(0);
       expect(result.skipped).toBe(1);
-      expect(result.errors).toEqual([
-        "Poll 1: Answer too long (max 55 chars)",
-      ]);
+      expect(result.errors).toEqual(["Poll 1: Answer too long (max 55 chars)"]);
+      expect(mockPollItemCreate).not.toHaveBeenCalled();
+    });
+
+    it("rejects a non-string question instead of querying with it (NoSQL injection guard)", async () => {
+      const service = PollService.getInstance({} as never);
+
+      const result = await service.importFromString(
+        JSON.stringify({
+          polls: [{ question: { $ne: null }, answers: ["A", "B"] }],
+        }),
+        "guild-1",
+        "user-1",
+      );
+
+      expect(result.imported).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(result.errors).toEqual(["Poll 1: Missing question or answers"]);
+      // The operator object must never reach the duplicate-check query.
+      expect(mockPollItemFindOne).not.toHaveBeenCalled();
       expect(mockPollItemCreate).not.toHaveBeenCalled();
     });
 

--- a/__tests__/services/poll-service.test.ts
+++ b/__tests__/services/poll-service.test.ts
@@ -417,4 +417,106 @@ describe("PollService", () => {
     });
     expect(mockPollItemCreate).not.toHaveBeenCalled();
   });
+
+  describe("importFromString (paste path)", () => {
+    it("imports a valid pasted YAML library without any network call", async () => {
+      const service = PollService.getInstance({} as never);
+
+      const result = await service.importFromString(
+        `polls:
+  - question: Favorite color?
+    answers:
+      - Blue
+      - Green
+    tags: [fun]
+`,
+        "guild-1",
+        "user-1",
+      );
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(mockPollItemFindOne).toHaveBeenCalledWith({
+        guildId: "guild-1",
+        question: "Favorite color?",
+      });
+      expect(mockPollItemCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          guildId: "guild-1",
+          question: "Favorite color?",
+          answers: ["Blue", "Green"],
+          tags: ["fun"],
+          createdBy: "user-1",
+          source: "paste",
+        }),
+      );
+      expect(result).toEqual({ imported: 1, skipped: 0, errors: [] });
+    });
+
+    it("imports a valid pasted JSON library", async () => {
+      const service = PollService.getInstance({} as never);
+
+      const result = await service.importFromString(
+        JSON.stringify({
+          polls: [{ question: "Tea or coffee?", answers: ["Tea", "Coffee"] }],
+        }),
+        "guild-1",
+        "user-1",
+      );
+
+      expect(mockPollItemCreate).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ imported: 1, skipped: 0, errors: [] });
+    });
+
+    it("reports an invalid-format error for malformed YAML", async () => {
+      const service = PollService.getInstance({} as never);
+
+      const result = await service.importFromString(
+        "polls:\n  - question: 'unterminated\n",
+        "guild-1",
+        "user-1",
+      );
+
+      expect(result.imported).toBe(0);
+      expect(result.errors).toEqual([
+        "Invalid format: could not parse content as YAML or JSON",
+      ]);
+      expect(mockPollItemCreate).not.toHaveBeenCalled();
+    });
+
+    it("skips a poll whose answer exceeds the 55-character cap", async () => {
+      const service = PollService.getInstance({} as never);
+      const longAnswer = "a".repeat(56);
+
+      const result = await service.importFromString(
+        JSON.stringify({
+          polls: [{ question: "Too long?", answers: ["Yes", longAnswer] }],
+        }),
+        "guild-1",
+        "user-1",
+      );
+
+      expect(result.imported).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(result.errors).toEqual([
+        "Poll 1: Answer too long (max 55 chars)",
+      ]);
+      expect(mockPollItemCreate).not.toHaveBeenCalled();
+    });
+
+    it("skips a duplicate question that already exists", async () => {
+      mockPollItemFindOne.mockResolvedValue({ _id: "existing" });
+      const service = PollService.getInstance({} as never);
+
+      const result = await service.importFromString(
+        JSON.stringify({
+          polls: [{ question: "Existing?", answers: ["A", "B"] }],
+        }),
+        "guild-1",
+        "user-1",
+      );
+
+      expect(result).toEqual({ imported: 0, skipped: 1, errors: [] });
+      expect(mockPollItemCreate).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/__tests__/services/poll-service.test.ts
+++ b/__tests__/services/poll-service.test.ts
@@ -469,6 +469,24 @@ describe("PollService", () => {
       expect(result).toEqual({ imported: 1, skipped: 0, errors: [] });
     });
 
+    it("rejects content larger than the import size cap before parsing", async () => {
+      const service = PollService.getInstance({} as never);
+      const oversized = "x".repeat(2 * 1024 * 1024 + 1);
+
+      const result = await service.importFromString(
+        oversized,
+        "guild-1",
+        "user-1",
+      );
+
+      expect(result).toEqual({
+        imported: 0,
+        skipped: 0,
+        errors: ["Content too large (max 2 MB)"],
+      });
+      expect(mockPollItemCreate).not.toHaveBeenCalled();
+    });
+
     it("reports an invalid-format error for malformed YAML", async () => {
       const service = PollService.getInstance({} as never);
 

--- a/src/services/poll-service.ts
+++ b/src/services/poll-service.ts
@@ -29,6 +29,13 @@ interface PollSource {
 // unbounded body into memory before parsing fails.
 const MAX_IMPORT_BYTES = 2 * 1024 * 1024;
 
+// Discord caps each poll answer (option) at 55 characters and a poll question at
+// 300. Imported libraries are validated against the same limits so an oversized
+// entry fails cleanly at import time rather than when Discord rejects the poll
+// payload (#508).
+const MAX_POLL_ANSWER_LENGTH = 55;
+const MAX_POLL_QUESTION_LENGTH = 300;
+
 // Reject the request if it has not completed within this window so a slow or
 // unresponsive server cannot hang the import indefinitely.
 const IMPORT_TIMEOUT_MS = 10_000;
@@ -635,81 +642,13 @@ export class PollService {
 
       const rawBody = await readBodyWithLimit(response, MAX_IMPORT_BYTES);
 
-      let pollData: PollSource;
-
-      // Try to parse as YAML first (also works for JSON)
-      try {
-        pollData = yaml.load(rawBody) as PollSource;
-      } catch {
-        // If YAML fails, try JSON
-        pollData = JSON.parse(rawBody);
-      }
-
-      // yaml.load / JSON.parse can yield null, undefined, or a scalar for an
-      // empty or non-object body, so guard before dereferencing.
-      if (!pollData?.polls || !Array.isArray(pollData.polls)) {
-        results.errors.push("Invalid format: expected { polls: [...] }");
-        return results;
-      }
-
-      // Process each poll
-      for (let i = 0; i < pollData.polls.length; i++) {
-        const poll = pollData.polls[i];
-
-        // Validate poll data
-        if (!poll.question || !poll.answers || !Array.isArray(poll.answers)) {
-          results.errors.push(`Poll ${i + 1}: Missing question or answers`);
-          results.skipped++;
-          continue;
-        }
-
-        if (poll.answers.length < 2 || poll.answers.length > 10) {
-          results.errors.push(`Poll ${i + 1}: Must have 2-10 answers`);
-          results.skipped++;
-          continue;
-        }
-
-        if (poll.question.length > 300) {
-          results.errors.push(
-            `Poll ${i + 1}: Question too long (max 300 chars)`,
-          );
-          results.skipped++;
-          continue;
-        }
-
-        // Check if this poll already exists (by question)
-        const existing = await PollItem.findOne({
-          guildId,
-          question: poll.question,
-        });
-
-        if (existing) {
-          results.skipped++;
-          continue;
-        }
-
-        // Create new poll item
-        try {
-          await PollItem.create({
-            guildId,
-            question: poll.question,
-            answers: poll.answers,
-            multiSelect: poll.multiselect ?? false,
-            tags: poll.tags ?? [],
-            usageCount: 0,
-            lastUsed: null,
-            enabled: true,
-            createdBy: userId,
-            source: url,
-          });
-          results.imported++;
-        } catch (error) {
-          results.errors.push(
-            `Poll ${i + 1}: ${error instanceof Error ? error.message : "Unknown error"}`,
-          );
-          results.skipped++;
-        }
-      }
+      // The fetch + SSRF guards above are the only part that is URL-specific.
+      // Parsing, validation, dedup and persistence are shared with the paste
+      // path, so delegate to importFromString and fold its counts in.
+      const parsed = await this.importFromString(rawBody, guildId, userId, url);
+      results.imported += parsed.imported;
+      results.skipped += parsed.skipped;
+      results.errors.push(...parsed.errors);
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") {
         results.errors.push("Request timeout - URL took too long to respond");
@@ -730,6 +669,121 @@ export class PollService {
       }
     } finally {
       clearTimeout(timeoutId);
+    }
+
+    return results;
+  }
+
+  /**
+   * Parse, validate, dedup and persist a poll library from a raw YAML/JSON
+   * string. This is the shared core of both the import-by-URL flow (after the
+   * SSRF-guarded fetch) and the admin paste/upload flow, where the bytes come
+   * straight from the authenticated admin's browser and there is no outbound
+   * request to forge. Callers that fetch a URL pass that URL as `source`; the
+   * paste path passes "paste".
+   */
+  public async importFromString(
+    raw: string,
+    guildId: string,
+    userId: string,
+    source = "paste",
+  ): Promise<{ imported: number; skipped: number; errors: string[] }> {
+    const results = {
+      imported: 0,
+      skipped: 0,
+      errors: [] as string[],
+    };
+
+    let pollData: PollSource;
+
+    // Try to parse as YAML first (also accepts JSON). yaml.load is permissive,
+    // so a JSON.parse fallback only matters for the rare body it rejects; both
+    // failing surfaces a clean error rather than throwing to the caller.
+    try {
+      pollData = yaml.load(raw) as PollSource;
+    } catch {
+      try {
+        pollData = JSON.parse(raw);
+      } catch {
+        results.errors.push(
+          "Invalid format: could not parse content as YAML or JSON",
+        );
+        return results;
+      }
+    }
+
+    // yaml.load / JSON.parse can yield null, undefined, or a scalar for an
+    // empty or non-object body, so guard before dereferencing.
+    if (!pollData?.polls || !Array.isArray(pollData.polls)) {
+      results.errors.push("Invalid format: expected { polls: [...] }");
+      return results;
+    }
+
+    // Process each poll
+    for (let i = 0; i < pollData.polls.length; i++) {
+      const poll = pollData.polls[i];
+
+      // Validate poll data
+      if (!poll.question || !poll.answers || !Array.isArray(poll.answers)) {
+        results.errors.push(`Poll ${i + 1}: Missing question or answers`);
+        results.skipped++;
+        continue;
+      }
+
+      if (poll.answers.length < 2 || poll.answers.length > 10) {
+        results.errors.push(`Poll ${i + 1}: Must have 2-10 answers`);
+        results.skipped++;
+        continue;
+      }
+
+      if (poll.question.length > MAX_POLL_QUESTION_LENGTH) {
+        results.errors.push(
+          `Poll ${i + 1}: Question too long (max ${MAX_POLL_QUESTION_LENGTH} chars)`,
+        );
+        results.skipped++;
+        continue;
+      }
+
+      if (poll.answers.some((a) => a.length > MAX_POLL_ANSWER_LENGTH)) {
+        results.errors.push(
+          `Poll ${i + 1}: Answer too long (max ${MAX_POLL_ANSWER_LENGTH} chars)`,
+        );
+        results.skipped++;
+        continue;
+      }
+
+      // Check if this poll already exists (by question)
+      const existing = await PollItem.findOne({
+        guildId,
+        question: poll.question,
+      });
+
+      if (existing) {
+        results.skipped++;
+        continue;
+      }
+
+      // Create new poll item
+      try {
+        await PollItem.create({
+          guildId,
+          question: poll.question,
+          answers: poll.answers,
+          multiSelect: poll.multiselect ?? false,
+          tags: poll.tags ?? [],
+          usageCount: 0,
+          lastUsed: null,
+          enabled: true,
+          createdBy: userId,
+          source,
+        });
+        results.imported++;
+      } catch (error) {
+        results.errors.push(
+          `Poll ${i + 1}: ${error instanceof Error ? error.message : "Unknown error"}`,
+        );
+        results.skipped++;
+      }
     }
 
     return results;

--- a/src/services/poll-service.ts
+++ b/src/services/poll-service.ts
@@ -723,8 +723,18 @@ export class PollService {
     for (let i = 0; i < pollData.polls.length; i++) {
       const poll = pollData.polls[i];
 
-      // Validate poll data
-      if (!poll.question || !poll.answers || !Array.isArray(poll.answers)) {
+      // Validate poll data. The question and every answer must be plain
+      // strings: the parsed body is untrusted, and a non-string question (e.g.
+      // a YAML/JSON object like `{ $ne: null }`) would otherwise flow into the
+      // `PollItem.findOne` duplicate check as a query operator — a NoSQL
+      // injection sink (CodeQL js/sql-injection). The typeof guards confine it
+      // to primitive strings before it ever reaches the query.
+      if (
+        typeof poll.question !== "string" ||
+        !poll.question ||
+        !Array.isArray(poll.answers) ||
+        !poll.answers.every((a) => typeof a === "string")
+      ) {
         results.errors.push(`Poll ${i + 1}: Missing question or answers`);
         results.skipped++;
         continue;

--- a/src/services/poll-service.ts
+++ b/src/services/poll-service.ts
@@ -694,6 +694,17 @@ export class PollService {
       errors: [] as string[],
     };
 
+    // Apply the same size cap the URL path enforces while streaming. The paste
+    // route is already bounded by the WebUI's body-parser limit, but guarding
+    // here keeps importFromString safe for any caller (and future limit
+    // changes) rather than parsing an unbounded string into memory.
+    if (raw.length > MAX_IMPORT_BYTES) {
+      results.errors.push(
+        `Content too large (max ${MAX_IMPORT_BYTES / (1024 * 1024)} MB)`,
+      );
+      return results;
+    }
+
     let pollData: PollSource;
 
     // Try to parse as YAML first (also accepts JSON). yaml.load is permissive,

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -1441,6 +1441,17 @@ ${renderFlash(props.flash)}
     <button type="submit" class="btn btn-primary">Import</button>
   </form>
 </div>
+<div class="card">
+  <h2>Paste import</h2>
+  <p class="muted">Paste a YAML or JSON document shaped as <code>{ polls: [{ question, answers, multiselect?, tags? }] }</code> directly — no hosting required. Same validation and duplicate-skipping as the URL import; nothing is fetched from the network.</p>
+  <form method="POST" action="/admin/polls/items/import-text" class="stack">
+    ${csrfInput}
+    <label>Poll library (YAML or JSON)
+      <textarea name="content" rows="10" placeholder="polls:&#10;  - question: Favourite colour?&#10;    answers: [Red, Green, Blue]&#10;    multiselect: false&#10;    tags: [fun]" required></textarea>
+    </label>
+    <button type="submit" class="btn btn-primary">Import</button>
+  </form>
+</div>
 `;
   return renderAdminPage({
     title: "Polls",

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -1447,7 +1447,7 @@ ${renderFlash(props.flash)}
   <form method="POST" action="/admin/polls/items/import-text" class="stack">
     ${csrfInput}
     <label>Poll library (YAML or JSON)
-      <textarea name="content" rows="10" placeholder="polls:&#10;  - question: Favourite colour?&#10;    answers: [Red, Green, Blue]&#10;    multiselect: false&#10;    tags: [fun]" required></textarea>
+      <textarea name="content" rows="10" maxlength="200000" placeholder="polls:&#10;  - question: Favourite colour?&#10;    answers: [Red, Green, Blue]&#10;    multiselect: false&#10;    tags: [fun]" required></textarea>
     </label>
     <button type="submit" class="btn btn-primary">Import</button>
   </form>

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -2246,6 +2246,75 @@ export function createWriteRouter(
     }),
   );
 
+  // Paste-a-blob import (#552). Unlike /polls/items/import this makes no
+  // outbound request — the YAML/JSON comes straight from the authenticated
+  // admin's browser, so the SSRF allowlist/redirect/private-IP guards that the
+  // URL path needs do not apply here. The parse/validate/dedup loop is shared
+  // via PollService.importFromString.
+  router.post(
+    "/polls/items/import-text",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const content = getString(req, "content");
+      if (!content) {
+        flashRedirect(res, "/admin/polls", {
+          type: "err",
+          text: "Paste some YAML or JSON poll content to import.",
+        });
+        return;
+      }
+      const service = PollService.getInstance(client);
+      try {
+        const results = await service.importFromString(
+          content,
+          session.guildId,
+          session.discordUserId,
+          "paste",
+        );
+        const errCount = results.errors.length;
+        const type: Flash["type"] =
+          results.imported > 0 && errCount === 0
+            ? "ok"
+            : results.imported > 0
+              ? "warn"
+              : "err";
+        const summary = `Imported ${results.imported}, skipped ${results.skipped}, errors ${errCount}.`;
+        const firstError =
+          errCount > 0 ? ` First error: ${results.errors[0]}` : "";
+        await recordAudit(session, {
+          action: "poll-item.import",
+          details: {
+            source: "paste",
+            imported: results.imported,
+            skipped: results.skipped,
+            errors: errCount,
+          },
+          result:
+            errCount > 0 && results.imported === 0 ? "failure" : "success",
+          errorMessage:
+            errCount > 0 ? results.errors.slice(0, 5).join("; ") : null,
+        });
+        flashRedirect(res, "/admin/polls", {
+          type,
+          text: `${summary}${firstError}`,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Poll paste import failed", err);
+        await recordAudit(session, {
+          action: "poll-item.import",
+          details: { source: "paste" },
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/polls", {
+          type: "err",
+          text: `Import failed: ${text}`,
+        });
+      }
+    }),
+  );
+
   // ============================================================
   // Reaction Roles (issue #384)
   // ============================================================


### PR DESCRIPTION
## Summary

Closes #552. Today the only way to bulk-load poll questions in the WebUI is import-from-URL, which forces an admin to first host the YAML/JSON somewhere on the SSRF allowlist (`raw.githubusercontent.com` etc.) just so the bot can fetch it back. This adds a **paste** import alongside it: the bytes come straight from the already-authenticated admin's browser, so there is no server-side request to forge and none of the URL hardening applies.

## What changed

- **`src/services/poll-service.ts`** — extracted the parse → validate → dedup → persist half of `importFromUrl` into a shared `importFromString(raw, guildId, userId, source = "paste")`. `importFromUrl` now does "fetch + SSRF guard, then delegate". Parse failures (malformed YAML *and* JSON) now surface a clean error instead of throwing. Added a `≤55 chars/answer` check (matching the manual create path / #508) and named constants for the answer/question caps.
- **`src/web/write-routes.ts`** — new `POST /admin/polls/items/import-text` route next to the existing import handler. Same `poll-item.import` audit action with `source: "paste"`, same `imported / skipped / errors` flash summary. No outbound request.
- **`src/web/admin-views.ts`** — new "Paste import" card with a `<textarea>` on `/admin/polls`, mirroring the existing settings-import paste pattern.

The SSRF allowlist / redirect / private-IP logic is untouched and still only guards the URL path.

## Tests

Added an `importFromString (paste path)` describe block covering the acceptance criteria: valid YAML paste (asserts no network call + `source: "paste"`), valid JSON paste, malformed YAML, oversized answer (>55), and duplicate-question skip.

```
Test Suites: 98 passed, 98 total
Tests:       1 skipped, 1062 passed, 1063 total
```

`npm run check:all` (build + lint + format:check + test) is green.

## Acceptance criteria

- [x] Admin can paste YAML/JSON and import without hosting it
- [x] Pasted import reuses identical validation + duplicate-skipping and returns the same summary
- [x] Paste path makes no outbound HTTP request and is not subject to `POLL_IMPORT_ALLOWED_HOSTS`
- [x] CSRF-protected and audit-logged like the existing import
- [x] Unit tests cover valid paste, malformed YAML, oversized answer (>55), duplicate question

https://claude.ai/code/session_011ggoVWZRYkQer4BkBu192m

---
_Generated by [Claude Code](https://claude.ai/code/session_011ggoVWZRYkQer4BkBu192m)_