### PR TITLE
feat(webui): DB-backed, editable bot status message pools (#557)

### DIFF
--- a/WEBUI.md
+++ b/WEBUI.md
@@ -751,10 +751,25 @@ No dashboard JSON ships with the bot — wire these up to taste:
 | **Polls**          | `/poll create`, `list`, `add-item`, `import-url`, `delete`, `delete-item`, `test`, `list-items`     |
 | **Reaction Roles** | `/reactrole create`, `archive`, `unarchive`, `delete`, `list`, `status`                             |
 | **Notices**        | `/notice add`, `edit`, `delete`, `sync`                                                             |
+| **Bot Status**     | (new — edit the "Watching …" presence message pools)                                                |
 | **Voice Channels** | `/vc force-reload` (single **Force VC cleanup** button)                                             |
 | **Database**       | `/dbtrunk status`, `/dbtrunk run`                                                                   |
 | **Command Audit**  | (new — read-only Discord slash-command audit log)                                                   |
 | **Bootstrap**      | (new — read-only env diagnostics)                                                                   |
+
+The **Bot Status** page (`/admin/bot-status`) edits the three "Watching …"
+presence message pools the bot rotates through, picked by how many users
+are in voice: the *empty*, *one user*, and *multiple users* pools. Each
+pool has an add / edit / remove / reorder list plus a paste-a-list
+import/export box (newline- or JSON-encoded), built on a reusable
+string-array editor. Entries are stored per-guild in MongoDB and take
+effect immediately — no redeploy or `/config reload` needed. A pool with
+no stored rows falls back to the built-in defaults in
+`src/content/statuses.ts`, so behaviour is unchanged on a fresh install;
+use **Seed defaults into store** to start editing from those defaults.
+Entries in the *multiple users* pool must contain the `{count}`
+placeholder (replaced with the live user count); the editor rejects saves
+that omit it.
 
 ### User self-service (`/me/*`, both admin and user roles)
 

--- a/__tests__/content/statuses.test.ts
+++ b/__tests__/content/statuses.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  BOT_STATUS_POOLS,
+  BOT_STATUS_POOL_META,
+  STATUS_POOL_DEFAULTS,
+  STATUS_TEXT_MAX,
+  isBotStatusPool,
+  validateStatusEntry,
+  multipleUsersStatuses,
+} from "../../src/content/statuses.js";
+
+describe("isBotStatusPool", () => {
+  it("accepts the three known pools", () => {
+    for (const pool of BOT_STATUS_POOLS) {
+      expect(isBotStatusPool(pool)).toBe(true);
+    }
+  });
+
+  it("rejects unknown values", () => {
+    expect(isBotStatusPool("bogus")).toBe(false);
+    expect(isBotStatusPool("")).toBe(false);
+  });
+});
+
+describe("validateStatusEntry", () => {
+  it("rejects empty / whitespace-only text", () => {
+    expect(validateStatusEntry("lonely", "")).toMatch(/cannot be empty/);
+    expect(validateStatusEntry("lonely", "   ")).toMatch(/cannot be empty/);
+  });
+
+  it("rejects text longer than the cap", () => {
+    const tooLong = "x".repeat(STATUS_TEXT_MAX + 1);
+    expect(validateStatusEntry("lonely", tooLong)).toMatch(/characters or fewer/);
+  });
+
+  it("accepts a plain entry for non-count pools", () => {
+    expect(validateStatusEntry("lonely", "the void")).toBeNull();
+    expect(validateStatusEntry("single", "a lone wanderer")).toBeNull();
+  });
+
+  it("requires the {count} placeholder for the multiple pool", () => {
+    expect(validateStatusEntry("multiple", "lots of nerds")).toMatch(
+      /\{count\} placeholder/,
+    );
+  });
+
+  it("accepts a multiple-pool entry that contains {count}", () => {
+    expect(validateStatusEntry("multiple", "{count} nerds")).toBeNull();
+  });
+});
+
+describe("pool defaults and metadata", () => {
+  it("has defaults and metadata for every pool", () => {
+    for (const pool of BOT_STATUS_POOLS) {
+      expect(STATUS_POOL_DEFAULTS[pool].length).toBeGreaterThan(0);
+      expect(BOT_STATUS_POOL_META[pool].pool).toBe(pool);
+    }
+  });
+
+  it("only flags the multiple pool as requiring {count}", () => {
+    expect(BOT_STATUS_POOL_META.multiple.requiresCount).toBe(true);
+    expect(BOT_STATUS_POOL_META.lonely.requiresCount).toBe(false);
+    expect(BOT_STATUS_POOL_META.single.requiresCount).toBe(false);
+  });
+
+  it("ships multiple-pool defaults that all satisfy their own validation", () => {
+    for (const entry of multipleUsersStatuses) {
+      expect(validateStatusEntry("multiple", entry)).toBeNull();
+    }
+  });
+});

--- a/__tests__/services/bot-status-pools.test.ts
+++ b/__tests__/services/bot-status-pools.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+
+// The model is mocked so the service's DB reads can be controlled without
+// a live Mongo. ConfigService is auto-mocked; we point its getInstance at a
+// controllable fake so refreshStatusPools() sees a bound GUILD_ID.
+jest.mock("../../src/utils/logger.js");
+jest.mock("../../src/services/config-service.js", () => {
+  // Plain stable singleton; its methods are installed as jest mocks in the
+  // test scope below (factory-scope jest.fn() is brittle under ESM hoisting).
+  const instance = {};
+  return { ConfigService: { getInstance: () => instance } };
+});
+jest.mock("../../src/models/bot-status-message.js", () => ({
+  BotStatusMessage: {
+    find: jest.fn(),
+  },
+}));
+
+import { BotStatusService } from "../../src/services/bot-status-service.js";
+import { ConfigService } from "../../src/services/config-service.js";
+import { BotStatusMessage } from "../../src/models/bot-status-message.js";
+import {
+  STATUS_POOL_DEFAULTS,
+  type BotStatusPool,
+} from "../../src/content/statuses.js";
+
+interface StoredRow {
+  pool: BotStatusPool;
+  text: string;
+  order: number;
+}
+
+const configInstance = ConfigService.getInstance() as unknown as {
+  getString: jest.Mock;
+  getBoolean: jest.Mock;
+  registerReloadCallback: jest.Mock;
+};
+configInstance.getString = jest.fn();
+configInstance.getBoolean = jest.fn();
+configInstance.registerReloadCallback = jest.fn();
+
+/** Wire `BotStatusMessage.find().sort().lean()` to resolve to `rows`. */
+function setStoredRows(rows: StoredRow[]): void {
+  (BotStatusMessage.find as jest.Mock).mockReturnValue({
+    sort: () => ({
+      lean: () => Promise.resolve(rows),
+    }),
+  });
+}
+
+// The service is a singleton that captures its client on first construction,
+// so the presence spy must be stable across tests — recreating it per test
+// would leave it unwired from the already-built singleton.
+const setPresence: jest.Mock = jest.fn();
+const service = BotStatusService.getInstance({
+  user: { setPresence },
+} as never);
+
+describe("BotStatusService status pools", () => {
+  const presenceName = (): string | undefined => {
+    const calls = setPresence.mock.calls;
+    const last = calls[calls.length - 1]?.[0] as
+      | { activities?: Array<{ name?: string }> }
+      | undefined;
+    return last?.activities?.[0]?.name;
+  };
+
+  beforeEach(async () => {
+    configInstance.getString.mockResolvedValue("guild-1");
+    setStoredRows([]);
+    // Mark the service operational (the only path that flips isInitialized),
+    // then flush its background refresh so later assertions are deterministic.
+    service.setOperationalStatus();
+    await Promise.resolve();
+    await Promise.resolve();
+    setPresence.mockClear();
+  });
+
+  it("falls back to the built-in defaults when the store is empty", async () => {
+    setStoredRows([]);
+    await service.refreshStatusPools();
+
+    // count 0 → lonely pool; with an empty store this is the default list.
+    service.updateVcUserCount(7);
+    service.updateVcUserCount(0);
+    expect(STATUS_POOL_DEFAULTS.lonely).toContain(presenceName());
+  });
+
+  it("uses stored entries in place of the defaults for a populated pool", async () => {
+    setStoredRows([{ pool: "single", text: "CUSTOM SOLO STATUS", order: 0 }]);
+    await service.refreshStatusPools();
+
+    service.updateVcUserCount(0);
+    service.updateVcUserCount(1);
+    expect(presenceName()).toBe("CUSTOM SOLO STATUS");
+  });
+
+  it("substitutes {count} for the live user count in the multiple pool", async () => {
+    setStoredRows([{ pool: "multiple", text: "{count} folks online", order: 0 }]);
+    await service.refreshStatusPools();
+
+    service.updateVcUserCount(0);
+    service.updateVcUserCount(4);
+    expect(presenceName()).toBe("4 folks online");
+  });
+
+  it("keeps defaults for pools with no stored rows while overriding others", async () => {
+    // Only the single pool is customised; lonely should stay on defaults.
+    setStoredRows([{ pool: "single", text: "ONLY SINGLE", order: 0 }]);
+    await service.refreshStatusPools();
+
+    service.updateVcUserCount(1);
+    expect(presenceName()).toBe("ONLY SINGLE");
+
+    service.updateVcUserCount(0);
+    expect(STATUS_POOL_DEFAULTS.lonely).toContain(presenceName());
+  });
+
+  it("keeps the previous cache when GUILD_ID is unbound", async () => {
+    // Populate the cache from a real guild first.
+    setStoredRows([{ pool: "single", text: "BOUND STATUS", order: 0 }]);
+    await service.refreshStatusPools();
+
+    // Now simulate an unbound guild: refresh resets to defaults rather than
+    // querying the store.
+    configInstance.getString.mockResolvedValueOnce("");
+    await service.refreshStatusPools();
+
+    service.updateVcUserCount(0);
+    service.updateVcUserCount(1);
+    expect(STATUS_POOL_DEFAULTS.single).toContain(presenceName());
+  });
+});

--- a/__tests__/services/bot-status-pools.test.ts
+++ b/__tests__/services/bot-status-pools.test.ts
@@ -116,7 +116,7 @@ describe("BotStatusService status pools", () => {
     expect(STATUS_POOL_DEFAULTS.lonely).toContain(presenceName());
   });
 
-  it("keeps the previous cache when GUILD_ID is unbound", async () => {
+  it("resets to defaults when GUILD_ID is unbound", async () => {
     // Populate the cache from a real guild first.
     setStoredRows([{ pool: "single", text: "BOUND STATUS", order: 0 }]);
     await service.refreshStatusPools();

--- a/__tests__/web/write-routes.test.ts
+++ b/__tests__/web/write-routes.test.ts
@@ -9,6 +9,7 @@ import {
   coerceConfigValue,
   findSectionMasterKey,
   firstLengthError,
+  parseStringListImport,
   resetConfigToDefaults,
   TEXT_LIMITS,
   type ResetConfigStore,
@@ -18,6 +19,42 @@ import {
   PROTECTED_KEYS,
 } from "../../src/web/bootstrap-vars.js";
 import { defaultConfig } from "../../src/services/config-schema.js";
+
+describe("parseStringListImport", () => {
+  it("splits a newline-separated list, trimming and dropping blanks", () => {
+    expect(parseStringListImport("a\n  b  \n\n c \n")).toEqual(["a", "b", "c"]);
+  });
+
+  it("handles CRLF line endings", () => {
+    expect(parseStringListImport("x\r\ny\r\n")).toEqual(["x", "y"]);
+  });
+
+  it("parses a JSON array of strings", () => {
+    expect(parseStringListImport('["{count} nerds", "  spaced  "]')).toEqual([
+      "{count} nerds",
+      "spaced",
+    ]);
+  });
+
+  it("drops non-string and empty members of a JSON array", () => {
+    expect(parseStringListImport('["a", 1, "", null, "b"]')).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("falls back to newline parsing on malformed JSON", () => {
+    // Opening bracket but not valid JSON → treat as plain text lines.
+    expect(parseStringListImport("[not json\nstill a line")).toEqual([
+      "[not json",
+      "still a line",
+    ]);
+  });
+
+  it("returns an empty array for blank input", () => {
+    expect(parseStringListImport("   \n  \n")).toEqual([]);
+  });
+});
 
 /**
  * In-memory `ResetConfigStore` seeded from `initial` rows. Records every

--- a/src/content/statuses.ts
+++ b/src/content/statuses.ts
@@ -40,3 +40,95 @@ export const multipleUsersStatuses = [
   "{count} conversing about nothing",
   "{count} people that need to get a life",
 ] as const satisfies readonly `${string}{count}${string}`[];
+
+/**
+ * The three presence pools, in display/iteration order. Used as the
+ * `pool` discriminator on stored `BotStatusMessage` rows and as the
+ * collection id in the WebUI editor routes.
+ */
+export const BOT_STATUS_POOLS = ["lonely", "single", "multiple"] as const;
+
+export type BotStatusPool = (typeof BOT_STATUS_POOLS)[number];
+
+/**
+ * Built-in seed values for each pool. When the DB store for a pool is
+ * empty the bot falls back to these, so behaviour is unchanged out of the
+ * box and an operator can "seed defaults" to start editing from them.
+ */
+export const STATUS_POOL_DEFAULTS: Record<BotStatusPool, readonly string[]> = {
+  lonely: lonelyStatuses,
+  single: singleUserStatuses,
+  multiple: multipleUsersStatuses,
+};
+
+export interface BotStatusPoolMeta {
+  pool: BotStatusPool;
+  /** Human-readable name shown as the editor section heading. */
+  label: string;
+  /** One-line explanation of when this pool is used. */
+  description: string;
+  /**
+   * Whether every entry must contain the literal `{count}` placeholder.
+   * True only for the `multiple` pool — the placeholder is substituted
+   * with the live voice-channel user count at pick time. This preserves
+   * the invariant the `satisfies` template-literal type guarantees for
+   * the hardcoded defaults, which the DB cannot enforce by type alone.
+   */
+  requiresCount: boolean;
+}
+
+export const BOT_STATUS_POOL_META: Record<BotStatusPool, BotStatusPoolMeta> = {
+  lonely: {
+    pool: "lonely",
+    label: "Empty — nobody in voice",
+    description: "Shown when no users are in a tracked voice channel.",
+    requiresCount: false,
+  },
+  single: {
+    pool: "single",
+    label: "One user in voice",
+    description: "Shown when exactly one user is in voice.",
+    requiresCount: false,
+  },
+  multiple: {
+    pool: "multiple",
+    label: "Multiple users in voice",
+    description:
+      "Shown when two or more users are in voice. Each entry must contain the {count} placeholder, replaced with the live user count.",
+    requiresCount: true,
+  },
+};
+
+/** Maximum length of a single status entry (Discord activity name cap). */
+export const STATUS_TEXT_MAX = 128;
+
+/** Narrowing type guard for a raw string that may name a pool. */
+export function isBotStatusPool(value: string): value is BotStatusPool {
+  return (BOT_STATUS_POOLS as readonly string[]).includes(value);
+}
+
+/**
+ * Validate a single status entry for the given pool. Returns a
+ * human-readable error string, or `null` when the entry is valid. Pure
+ * and exported so both the write-route layer and the unit tests can share
+ * one source of truth for the `{count}` invariant.
+ */
+export function validateStatusEntry(
+  pool: BotStatusPool,
+  text: string,
+): string | null {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return "Status text cannot be empty.";
+  }
+  if (trimmed.length > STATUS_TEXT_MAX) {
+    return `Status text must be ${STATUS_TEXT_MAX} characters or fewer.`;
+  }
+  if (
+    BOT_STATUS_POOL_META[pool].requiresCount &&
+    !trimmed.includes("{count}")
+  ) {
+    return "Entries in the multiple-users pool must contain the {count} placeholder.";
+  }
+  return null;
+}

--- a/src/models/bot-status-message.ts
+++ b/src/models/bot-status-message.ts
@@ -1,0 +1,62 @@
+import mongoose, { Document, Schema } from "mongoose";
+import {
+  BOT_STATUS_POOLS,
+  STATUS_TEXT_MAX,
+  type BotStatusPool,
+} from "../content/statuses.js";
+
+/**
+ * A single DB-backed bot presence status entry (issue #557). Each row is
+ * one line in one of the three pools (`lonely` / `single` / `multiple`)
+ * for a guild. `BotStatusService` reads the live rows at pick time and
+ * falls back to the hardcoded `src/content/statuses.ts` defaults when a
+ * pool has no rows, so behaviour is unchanged on a fresh install.
+ */
+export interface IBotStatusMessage extends Document {
+  guildId: string;
+  pool: BotStatusPool;
+  text: string;
+  order: number;
+  createdBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const BotStatusMessageSchema = new Schema<IBotStatusMessage>(
+  {
+    guildId: { type: String, required: true, index: true },
+    pool: {
+      type: String,
+      required: true,
+      enum: [...BOT_STATUS_POOLS],
+    },
+    text: {
+      type: String,
+      required: true,
+      maxlength: STATUS_TEXT_MAX,
+    },
+    order: {
+      type: Number,
+      required: true,
+      default: 0,
+    },
+    createdBy: {
+      type: String,
+      required: true,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+// One compound index serves both the per-guild/per-pool ordered reads the
+// service does and the guild-scoped listing the WebUI renders.
+BotStatusMessageSchema.index({ guildId: 1, pool: 1, order: 1 });
+
+export const BotStatusMessage = mongoose.model<IBotStatusMessage>(
+  "BotStatusMessage",
+  BotStatusMessageSchema,
+);
+
+export default BotStatusMessage;

--- a/src/services/bot-status-service.ts
+++ b/src/services/bot-status-service.ts
@@ -1,11 +1,23 @@
 import { Client, ActivityType } from "discord.js";
 import { ConfigService } from "./config-service.js";
 import logger from "../utils/logger.js";
+import { BotStatusMessage } from "../models/bot-status-message.js";
 import {
-  lonelyStatuses,
-  singleUserStatuses,
-  multipleUsersStatuses,
+  STATUS_POOL_DEFAULTS,
+  BOT_STATUS_POOLS,
+  type BotStatusPool,
 } from "../content/statuses.js";
+
+type StatusPools = Record<BotStatusPool, string[]>;
+
+/** Fresh, mutable copy of the hardcoded defaults for every pool. */
+function defaultStatusPools(): StatusPools {
+  return {
+    lonely: [...STATUS_POOL_DEFAULTS.lonely],
+    single: [...STATUS_POOL_DEFAULTS.single],
+    multiple: [...STATUS_POOL_DEFAULTS.multiple],
+  };
+}
 
 export class BotStatusService {
   private static instance: BotStatusService;
@@ -15,10 +27,63 @@ export class BotStatusService {
   private currentVcUserCount = 0;
   // Username tracking removed for simplified status logic (field deleted)
   private statusUpdateInterval: ReturnType<typeof setInterval> | null = null;
+  /**
+   * In-memory copy of the live status pools, seeded with the hardcoded
+   * defaults so `getRandomStatusMessage()` (which is synchronous, called
+   * from presence updates) always has something to pick from — even
+   * before the first DB read or when the store is empty. Refreshed from
+   * the DB at startup, on `/config reload`, and after every WebUI edit.
+   */
+  private statusPools: StatusPools = defaultStatusPools();
 
   private constructor(client: Client) {
     this.client = client;
     this.configService = ConfigService.getInstance();
+
+    // Re-read the pools when configuration is reloaded so a `/config
+    // reload` picks up store changes without a redeploy, mirroring the
+    // reload-callback pattern used by the other services.
+    this.configService.registerReloadCallback(async () => {
+      await this.refreshStatusPools();
+    });
+  }
+
+  /**
+   * Reload the status pools from the DB store, falling back to the
+   * hardcoded defaults for any pool with no stored rows. Safe to call
+   * repeatedly; never throws — on error the existing cached pools are
+   * kept so presence updates keep working.
+   */
+  public async refreshStatusPools(): Promise<void> {
+    try {
+      const guildId = await this.configService.getString("GUILD_ID", "");
+      if (!guildId) {
+        // No guild bound yet (e.g. early startup / tests): keep defaults.
+        this.statusPools = defaultStatusPools();
+        return;
+      }
+      const rows = await BotStatusMessage.find({ guildId })
+        .sort({ pool: 1, order: 1 })
+        .lean();
+
+      const next = defaultStatusPools();
+      const stored: Partial<Record<BotStatusPool, string[]>> = {};
+      for (const row of rows) {
+        const pool = row.pool as BotStatusPool;
+        (stored[pool] ??= []).push(row.text);
+      }
+      for (const pool of BOT_STATUS_POOLS) {
+        const list = stored[pool];
+        // Empty store for a pool → keep that pool's built-in defaults.
+        if (list && list.length > 0) {
+          next[pool] = list;
+        }
+      }
+      this.statusPools = next;
+      logger.debug("Bot status pools refreshed from store");
+    } catch (error) {
+      logger.error("Failed to refresh bot status pools:", error);
+    }
   }
 
   /**
@@ -26,18 +91,16 @@ export class BotStatusService {
    */
   private getRandomStatusMessage(): string {
     // Simplified: only differentiate between 0, 1, and many users; no name interpolation
+    const pickFrom = (list: string[]): string =>
+      list[Math.floor(Math.random() * list.length)];
+
     if (this.currentVcUserCount <= 0) {
-      return lonelyStatuses[Math.floor(Math.random() * lonelyStatuses.length)];
+      return pickFrom(this.statusPools.lonely);
     }
     if (this.currentVcUserCount === 1) {
-      return singleUserStatuses[
-        Math.floor(Math.random() * singleUserStatuses.length)
-      ];
+      return pickFrom(this.statusPools.single);
     }
-    const template =
-      multipleUsersStatuses[
-        Math.floor(Math.random() * multipleUsersStatuses.length)
-      ];
+    const template = pickFrom(this.statusPools.multiple);
     return template.replace("{count}", this.currentVcUserCount.toString());
   }
 
@@ -74,6 +137,12 @@ export class BotStatusService {
   public setOperationalStatus(): void {
     try {
       this.isInitialized = true;
+      // Load the live pools from the store in the background; the cache is
+      // already seeded with defaults so presence works immediately, and a
+      // later refresh swaps in any operator-curated lists.
+      void this.refreshStatusPools().then(() =>
+        this.updateActivityBasedOnVcUsers(),
+      );
       this.updateActivityBasedOnVcUsers();
       logger.info("Bot status set to: Fully Operational (Green)");
     } catch (error) {

--- a/src/services/bot-status-service.ts
+++ b/src/services/bot-status-service.ts
@@ -58,29 +58,33 @@ export class BotStatusService {
     try {
       const guildId = await this.configService.getString("GUILD_ID", "");
       if (!guildId) {
-        // No guild bound yet (e.g. early startup / tests): keep defaults.
+        // No guild bound (e.g. early startup / tests): reset to defaults.
         this.statusPools = defaultStatusPools();
-        return;
-      }
-      const rows = await BotStatusMessage.find({ guildId })
-        .sort({ pool: 1, order: 1 })
-        .lean();
+      } else {
+        const rows = await BotStatusMessage.find({ guildId })
+          .sort({ pool: 1, order: 1 })
+          .lean();
 
-      const next = defaultStatusPools();
-      const stored: Partial<Record<BotStatusPool, string[]>> = {};
-      for (const row of rows) {
-        const pool = row.pool as BotStatusPool;
-        (stored[pool] ??= []).push(row.text);
-      }
-      for (const pool of BOT_STATUS_POOLS) {
-        const list = stored[pool];
-        // Empty store for a pool → keep that pool's built-in defaults.
-        if (list && list.length > 0) {
-          next[pool] = list;
+        const next = defaultStatusPools();
+        const stored: Partial<Record<BotStatusPool, string[]>> = {};
+        for (const row of rows) {
+          const pool = row.pool;
+          (stored[pool] ??= []).push(row.text);
         }
+        for (const pool of BOT_STATUS_POOLS) {
+          const list = stored[pool];
+          // Empty store for a pool → keep that pool's built-in defaults.
+          if (list && list.length > 0) {
+            next[pool] = list;
+          }
+        }
+        this.statusPools = next;
+        logger.debug("Bot status pools refreshed from store");
       }
-      this.statusPools = next;
-      logger.debug("Bot status pools refreshed from store");
+      // Re-render the presence now so a WebUI edit or `/config reload`
+      // takes effect immediately instead of waiting for the next VC
+      // count change. No-op until the service is operational.
+      this.updateActivityBasedOnVcUsers();
     } catch (error) {
       logger.error("Failed to refresh bot status pools:", error);
     }
@@ -137,13 +141,11 @@ export class BotStatusService {
   public setOperationalStatus(): void {
     try {
       this.isInitialized = true;
-      // Load the live pools from the store in the background; the cache is
-      // already seeded with defaults so presence works immediately, and a
-      // later refresh swaps in any operator-curated lists.
-      void this.refreshStatusPools().then(() =>
-        this.updateActivityBasedOnVcUsers(),
-      );
+      // Render immediately from the seeded defaults so presence works at
+      // once, then load the live pools from the store in the background
+      // (refreshStatusPools re-renders once the curated lists arrive).
       this.updateActivityBasedOnVcUsers();
+      void this.refreshStatusPools();
       logger.info("Bot status set to: Fully Operational (Green)");
     } catch (error) {
       logger.error("Failed to set operational status:", error);

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -97,6 +97,7 @@ export const NAV_ITEMS: NavItem[] = [
     label: "Voice Channels",
     featureKey: "voicechannels.enabled",
   },
+  { href: "/admin/bot-status", label: "Bot Status" },
   { href: "/admin/database", label: "Database" },
   { href: "/admin/audit/commands", label: "Command Audit" },
   { href: "/admin/bootstrap", label: "Bootstrap" },

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -14,6 +14,7 @@ import {
   categoryMetadata,
   type SettingOption,
 } from "../services/config-schema.js";
+import type { BotStatusPool } from "../content/statuses.js";
 
 interface CommonProps {
   csrfToken: string;
@@ -1780,6 +1781,172 @@ ${renderFlash(props.flash)}
   return renderAdminPage({
     title: "Database",
     active: "/admin/database",
+    body,
+    csrfToken: props.csrfToken,
+    remainingMs: props.remainingMs,
+    navFeatureStatus: props.navFeatureStatus,
+  });
+}
+
+// ---------- Reusable string-array editor (issue #557) ----------
+
+export interface StringArrayEditorItem {
+  id: string;
+  order: number;
+  text: string;
+}
+
+/**
+ * Options driving the reusable add / edit / remove / reorder / import /
+ * export editor for an arbitrary array of strings. Kept free of any
+ * bot-status-specific knowledge so the same partial can be dropped onto
+ * accolades / notice-categories / etc. later (the "array of data"
+ * generalisation in #557). The route handlers own validation; this only
+ * renders the controls.
+ */
+export interface StringArrayEditorOptions {
+  csrfToken: string;
+  /** Section heading. */
+  title: string;
+  /** Optional one-line explanation under the heading. */
+  description?: string;
+  /**
+   * Path prefix the CRUD/import forms post to, e.g. `/admin/bot-status`.
+   * Per-entry routes use `${basePath}/entry/:id/...`; collection routes
+   * use `${basePath}/pool/:collectionId/...`.
+   */
+  basePath: string;
+  /** Identifier of this array within `basePath` (e.g. the pool name). */
+  collectionId: string;
+  /** Current stored entries, already in display order. */
+  items: StringArrayEditorItem[];
+  /** Maximum length accepted for a single entry (drives `maxlength`). */
+  maxLength: number;
+  /** Optional hint shown beside the add input (e.g. the `{count}` rule). */
+  inputHint?: string;
+  /** Newline-joined effective list, shown in the export/import textarea. */
+  exportText: string;
+  /**
+   * When set, a banner explains the store is empty and the built-in
+   * defaults are in use, alongside a "seed defaults" button.
+   */
+  defaultsNotice?: string;
+}
+
+export function renderStringArrayEditor(
+  opts: StringArrayEditorOptions,
+): string {
+  const csrfInput = `<input type="hidden" name="_csrf" value="${escapeHtml(opts.csrfToken)}">`;
+  const poolPath = `${opts.basePath}/pool/${encodeURIComponent(opts.collectionId)}`;
+  const entryPath = (id: string): string =>
+    `${opts.basePath}/entry/${encodeURIComponent(id)}`;
+
+  const rows =
+    opts.items.length === 0
+      ? `<tr><td colspan="3"><span class="muted">No entries stored.</span></td></tr>`
+      : opts.items
+          .map(
+            (item) => `<tr>
+<td><form method="POST" action="${entryPath(item.id)}/order" class="inline-order">${csrfInput}<input type="number" name="order" value="${item.order}" min="-1000" max="10000" required><button type="submit" class="btn">Save</button></form></td>
+<td>
+  <details class="helper edit-details"><summary>${escapeHtml(item.text)}</summary>
+    <form method="POST" action="${entryPath(item.id)}/update" class="stack">${csrfInput}
+      <label>Text<input type="text" name="text" maxlength="${opts.maxLength}" value="${escapeHtml(item.text)}" required></label>
+      <button type="submit" class="btn btn-primary">Save changes</button>
+    </form>
+  </details>
+  <div class="muted mono">id: ${escapeHtml(item.id)}</div>
+</td>
+<td class="actions"><form method="POST" action="${entryPath(item.id)}/delete" onsubmit="return confirm('Delete this entry?');">${csrfInput}<button type="submit" class="btn btn-danger">Delete</button></form></td>
+</tr>`,
+          )
+          .join("");
+
+  const defaultsBanner = opts.defaultsNotice
+    ? `<div class="notice warn">${escapeHtml(opts.defaultsNotice)}
+  <form method="POST" action="${poolPath}/seed" class="inline-form">${csrfInput}<button type="submit" class="btn">Seed defaults into store</button></form>
+</div>`
+    : "";
+
+  const hint = opts.inputHint
+    ? `<span class="muted">${escapeHtml(opts.inputHint)}</span>`
+    : "";
+
+  return `<div class="card">
+  <h2>${escapeHtml(opts.title)} <span class="muted">(${opts.items.length})</span></h2>
+  ${opts.description ? `<p class="subtitle">${escapeHtml(opts.description)}</p>` : ""}
+  ${defaultsBanner}
+  <table><thead><tr><th>Order</th><th>Text</th><th>Actions</th></tr></thead><tbody>${rows}</tbody></table>
+  <form method="POST" action="${poolPath}/add" class="stack">
+    ${csrfInput}
+    <label>Add entry<input type="text" name="text" maxlength="${opts.maxLength}" required></label>
+    ${hint}
+    <label>Order<input type="number" name="order" min="-1000" max="10000" value="0" required></label>
+    <button type="submit" class="btn btn-primary">Add</button>
+  </form>
+  <details class="helper">
+    <summary>Import / export</summary>
+    <form method="POST" action="${poolPath}/import" class="stack">
+      ${csrfInput}
+      <p class="muted">Paste one entry per line, or a JSON array of strings. Exporting: the textarea below shows the current effective list — copy it to back up.</p>
+      <label>Entries<textarea name="items" rows="8">${escapeHtml(opts.exportText)}</textarea></label>
+      <label class="inline-form"><input type="radio" name="mode" value="replace" checked> Replace pool</label>
+      <label class="inline-form"><input type="radio" name="mode" value="append"> Append to pool</label>
+      <button type="submit" class="btn btn-primary">Import</button>
+    </form>
+  </details>
+</div>`;
+}
+
+// ---------- Bot Status (issue #557) ----------
+
+export interface BotStatusPoolView {
+  pool: BotStatusPool;
+  label: string;
+  description: string;
+  requiresCount: boolean;
+  items: StringArrayEditorItem[];
+  usingDefaults: boolean;
+  exportText: string;
+}
+
+export interface BotStatusProps extends CommonProps {
+  maxLength: number;
+  pools: BotStatusPoolView[];
+  flash?: FlashMessage | null;
+}
+
+export function renderBotStatusPage(props: BotStatusProps): string {
+  const editors = props.pools
+    .map((p) =>
+      renderStringArrayEditor({
+        csrfToken: props.csrfToken,
+        title: p.label,
+        description: p.description,
+        basePath: "/admin/bot-status",
+        collectionId: p.pool,
+        items: p.items,
+        maxLength: props.maxLength,
+        inputHint: p.requiresCount
+          ? "Must contain the {count} placeholder."
+          : undefined,
+        exportText: p.exportText,
+        defaultsNotice: p.usingDefaults
+          ? "This pool has no stored entries — the bot is using its built-in defaults. Add, import, or seed below to customise."
+          : undefined,
+      }),
+    )
+    .join("");
+
+  const body = `
+<h1>Bot Status</h1>
+<p class="subtitle">The "Watching …" presence messages the bot rotates through, picked by how many users are in voice. Edit, import, or export each pool below — changes take effect without a redeploy. Empty pools fall back to the built-in defaults.</p>
+${renderFlash(props.flash)}
+${editors}
+`;
+  return renderAdminPage({
+    title: "Bot Status",
+    active: "/admin/bot-status",
     body,
     csrfToken: props.csrfToken,
     remainingMs: props.remainingMs,

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -27,6 +27,13 @@ import { ReactionRoleService } from "../services/reaction-role-service.js";
 import { ReactionRoleConfig } from "../models/reaction-role-config.js";
 import Notice from "../models/notice.js";
 import { NOTICE_CATEGORIES } from "../content/notice-categories.js";
+import { BotStatusMessage } from "../models/bot-status-message.js";
+import {
+  BOT_STATUS_POOLS,
+  BOT_STATUS_POOL_META,
+  STATUS_POOL_DEFAULTS,
+  STATUS_TEXT_MAX,
+} from "../content/statuses.js";
 import { VoiceChannelTruncationService } from "../services/voice-channel-truncation.js";
 import {
   VoiceChannelManager,
@@ -49,6 +56,7 @@ import {
 import {
   renderAnnouncementsPage,
   renderBootstrapPage,
+  renderBotStatusPage,
   renderCommandAuditPage,
   renderDashboardPage,
   renderDatabasePage,
@@ -695,6 +703,52 @@ export function createReadOnlyRouter(
           total: notices.length,
           groups,
           categoryOptions,
+          flash: readFlash(req),
+        }),
+      );
+    }),
+  );
+
+  // ---------- Bot Status (issue #557) ----------
+  router.get(
+    "/bot-status",
+    asyncHandler(async (req, res) => {
+      const common = await commonFromReq(req);
+      const rows = await BotStatusMessage.find({ guildId: common.guildId })
+        .sort({ pool: 1, order: 1 })
+        .lean();
+
+      const pools = BOT_STATUS_POOLS.map((pool) => {
+        const meta = BOT_STATUS_POOL_META[pool];
+        const items = rows
+          .filter((r) => r.pool === pool)
+          .map((r) => ({
+            id: String(r._id),
+            order: r.order,
+            text: r.text,
+          }));
+        const usingDefaults = items.length === 0;
+        // The export textarea shows the effective list: stored entries when
+        // present, otherwise the built-in defaults the bot is actually using.
+        const effective = usingDefaults
+          ? [...STATUS_POOL_DEFAULTS[pool]]
+          : items.map((i) => i.text);
+        return {
+          pool,
+          label: meta.label,
+          description: meta.description,
+          requiresCount: meta.requiresCount,
+          items,
+          usingDefaults,
+          exportText: effective.join("\n"),
+        };
+      });
+
+      res.type("text/html").send(
+        renderBotStatusPage({
+          ...common,
+          maxLength: STATUS_TEXT_MAX,
+          pools,
           flash: readFlash(req),
         }),
       );

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -3003,12 +3003,19 @@ export function createWriteRouter(
   };
 
   // Resolve and guild-check a stored entry; flashes + returns null on miss.
+  // A malformed (non-ObjectId) `:id` makes Mongoose throw a CastError — catch
+  // it and treat it as a clean "not found" rather than a 500.
   const findOwnedEntry = async (
     res: Response,
     guildId: string,
     id: string,
   ): Promise<HydratedDocument<IBotStatusMessage> | null> => {
-    const entry = await BotStatusMessage.findById(id);
+    let entry: HydratedDocument<IBotStatusMessage> | null = null;
+    try {
+      entry = await BotStatusMessage.findById(id);
+    } catch {
+      entry = null;
+    }
     if (!entry || entry.guildId !== guildId) {
       flashRedirect(res, "/admin/bot-status", {
         type: "err",
@@ -3146,20 +3153,35 @@ export function createWriteRouter(
       }
       const entry = await findOwnedEntry(res, session.guildId, id);
       if (!entry) return;
-      const previous = entry.order;
-      entry.order = order;
-      await entry.save();
-      await reloadBotStatusPools();
-      await recordAudit(session, {
-        action: "bot-status.reorder",
-        targetId: id,
-        details: { pool: entry.pool, from: previous, to: order },
-        result: "success",
-      });
-      flashRedirect(res, "/admin/bot-status", {
-        type: "ok",
-        text: `Reordered status entry ${id}: ${previous} → ${order}.`,
-      });
+      try {
+        const previous = entry.order;
+        entry.order = order;
+        await entry.save();
+        await reloadBotStatusPools();
+        await recordAudit(session, {
+          action: "bot-status.reorder",
+          targetId: id,
+          details: { pool: entry.pool, from: previous, to: order },
+          result: "success",
+        });
+        flashRedirect(res, "/admin/bot-status", {
+          type: "ok",
+          text: `Reordered status entry ${id}: ${previous} → ${order}.`,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Reorder bot status failed", err);
+        await recordAudit(session, {
+          action: "bot-status.reorder",
+          targetId: id,
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/bot-status", {
+          type: "err",
+          text: `Failed to reorder status: ${text}`,
+        });
+      }
     }),
   );
 
@@ -3171,18 +3193,33 @@ export function createWriteRouter(
       const entry = await findOwnedEntry(res, session.guildId, id);
       if (!entry) return;
       const pool = entry.pool;
-      await BotStatusMessage.findByIdAndDelete(id);
-      await reloadBotStatusPools();
-      await recordAudit(session, {
-        action: "bot-status.delete",
-        targetId: id,
-        details: { pool, text: entry.text },
-        result: "success",
-      });
-      flashRedirect(res, "/admin/bot-status", {
-        type: "ok",
-        text: `Deleted status entry ${id} from the ${pool} pool.`,
-      });
+      try {
+        await BotStatusMessage.findByIdAndDelete(id);
+        await reloadBotStatusPools();
+        await recordAudit(session, {
+          action: "bot-status.delete",
+          targetId: id,
+          details: { pool, text: entry.text },
+          result: "success",
+        });
+        flashRedirect(res, "/admin/bot-status", {
+          type: "ok",
+          text: `Deleted status entry ${id} from the ${pool} pool.`,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Delete bot status failed", err);
+        await recordAudit(session, {
+          action: "bot-status.delete",
+          targetId: id,
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/bot-status", {
+          type: "err",
+          text: `Failed to delete status: ${text}`,
+        });
+      }
     }),
   );
 
@@ -3282,37 +3319,52 @@ export function createWriteRouter(
         });
         return;
       }
-      const existing = await BotStatusMessage.countDocuments({
-        guildId: session.guildId,
-        pool,
-      });
-      if (existing > 0) {
-        flashRedirect(res, "/admin/bot-status", {
-          type: "warn",
-          text: `The ${pool} pool already has entries — nothing seeded.`,
-        });
-        return;
-      }
-      const defaults = STATUS_POOL_DEFAULTS[pool];
-      await BotStatusMessage.insertMany(
-        defaults.map((text, i) => ({
+      try {
+        const existing = await BotStatusMessage.countDocuments({
           guildId: session.guildId,
           pool,
-          text,
-          order: i,
-          createdBy: session.discordUserId,
-        })),
-      );
-      await reloadBotStatusPools();
-      await recordAudit(session, {
-        action: "bot-status.seed",
-        details: { pool, count: defaults.length },
-        result: "success",
-      });
-      flashRedirect(res, "/admin/bot-status", {
-        type: "ok",
-        text: `Seeded ${defaults.length} default ${pool} entries into the store.`,
-      });
+        });
+        if (existing > 0) {
+          flashRedirect(res, "/admin/bot-status", {
+            type: "warn",
+            text: `The ${pool} pool already has entries — nothing seeded.`,
+          });
+          return;
+        }
+        const defaults = STATUS_POOL_DEFAULTS[pool];
+        await BotStatusMessage.insertMany(
+          defaults.map((text, i) => ({
+            guildId: session.guildId,
+            pool,
+            text,
+            order: i,
+            createdBy: session.discordUserId,
+          })),
+        );
+        await reloadBotStatusPools();
+        await recordAudit(session, {
+          action: "bot-status.seed",
+          details: { pool, count: defaults.length },
+          result: "success",
+        });
+        flashRedirect(res, "/admin/bot-status", {
+          type: "ok",
+          text: `Seeded ${defaults.length} default ${pool} entries into the store.`,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Seed bot status failed", err);
+        await recordAudit(session, {
+          action: "bot-status.seed",
+          details: { pool },
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/bot-status", {
+          type: "err",
+          text: `Failed to seed defaults: ${text}`,
+        });
+      }
     }),
   );
 

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -35,6 +35,17 @@ import type { IPollSchedule } from "../models/poll-schedule.js";
 import type { IPollItem } from "../models/poll-item.js";
 import Notice from "../models/notice.js";
 import { NOTICE_CATEGORIES } from "../content/notice-categories.js";
+import type { HydratedDocument } from "mongoose";
+import {
+  BotStatusMessage,
+  type IBotStatusMessage,
+} from "../models/bot-status-message.js";
+import {
+  isBotStatusPool,
+  validateStatusEntry,
+  STATUS_POOL_DEFAULTS,
+  type BotStatusPool,
+} from "../content/statuses.js";
 import { requireCsrf } from "./csrf.js";
 import { PROTECTED_KEYS } from "./bootstrap-vars.js";
 import {
@@ -163,6 +174,34 @@ function parseHexColor(input: string): number | null {
   const match = input.match(/^#?([0-9A-Fa-f]{6})$/);
   if (!match) return null;
   return parseInt(match[1], 16);
+}
+
+/**
+ * Parse a pasted string-array import (issue #557). Accepts either a JSON
+ * array of strings or a plain newline-separated list. Entries are trimmed
+ * and blank lines dropped. Exported so the parsing is unit-testable apart
+ * from Express.
+ */
+export function parseStringListImport(raw: string): string[] {
+  const trimmed = raw.trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed
+          .filter((v): v is string => typeof v === "string")
+          .map((v) => v.trim())
+          .filter((v) => v.length > 0);
+      }
+    } catch {
+      // Fall through to newline parsing on malformed JSON.
+    }
+  }
+  return trimmed
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
 }
 
 function requireSessionContext(
@@ -2952,6 +2991,328 @@ export function createWriteRouter(
           text: `Force cleanup failed: ${text}`,
         });
       }
+    }),
+  );
+
+  // ============================================================
+  // Bot Status message pools (issue #557)
+  // ============================================================
+
+  const reloadBotStatusPools = async (): Promise<void> => {
+    await BotStatusService.getInstance(client).refreshStatusPools();
+  };
+
+  // Resolve and guild-check a stored entry; flashes + returns null on miss.
+  const findOwnedEntry = async (
+    res: Response,
+    guildId: string,
+    id: string,
+  ): Promise<HydratedDocument<IBotStatusMessage> | null> => {
+    const entry = await BotStatusMessage.findById(id);
+    if (!entry || entry.guildId !== guildId) {
+      flashRedirect(res, "/admin/bot-status", {
+        type: "err",
+        text: `Status entry ${id} not found.`,
+      });
+      return null;
+    }
+    return entry;
+  };
+
+  router.post(
+    "/bot-status/pool/:pool/add",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const pool = String(req.params.pool);
+      if (!isBotStatusPool(pool)) {
+        flashRedirect(res, "/admin/bot-status", {
+          type: "err",
+          text: `Unknown pool: ${pool}.`,
+        });
+        return;
+      }
+      const text = getString(req, "text");
+      const orderRaw = getString(req, "order");
+      const invalid = validateStatusEntry(pool, text);
+      if (invalid) {
+        flashRedirect(res, "/admin/bot-status", { type: "err", text: invalid });
+        return;
+      }
+      const order = parseIntInRange(orderRaw || "0", -1000, 10000);
+      if (order === null) {
+        flashRedirect(res, "/admin/bot-status", {
+          type: "err",
+          text: "Order must be an integer between -1000 and 10000.",
+        });
+        return;
+      }
+      try {
+        const entry = await new BotStatusMessage({
+          guildId: session.guildId,
+          pool,
+          text: text.trim(),
+          order,
+          createdBy: session.discordUserId,
+        }).save();
+        await reloadBotStatusPools();
+        await recordAudit(session, {
+          action: "bot-status.add",
+          targetId: String(entry._id),
+          details: { pool, order },
+          result: "success",
+        });
+        flashRedirect(res, "/admin/bot-status", {
+          type: "ok",
+          text: `Added status to the ${pool} pool.`,
+        });
+      } catch (err) {
+        const text2 = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Add bot status failed", err);
+        await recordAudit(session, {
+          action: "bot-status.add",
+          details: { pool },
+          result: "failure",
+          errorMessage: text2,
+        });
+        flashRedirect(res, "/admin/bot-status", {
+          type: "err",
+          text: `Failed to add status: ${text2}`,
+        });
+      }
+    }),
+  );
+
+  router.post(
+    "/bot-status/entry/:id/update",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const id = String(req.params.id);
+      const text = getString(req, "text");
+      const entry = await findOwnedEntry(res, session.guildId, id);
+      if (!entry) return;
+      const pool: BotStatusPool = entry.pool;
+      const invalid = validateStatusEntry(pool, text);
+      if (invalid) {
+        flashRedirect(res, "/admin/bot-status", { type: "err", text: invalid });
+        return;
+      }
+      try {
+        entry.text = text.trim();
+        await entry.save();
+        await reloadBotStatusPools();
+        await recordAudit(session, {
+          action: "bot-status.update",
+          targetId: id,
+          details: { pool },
+          result: "success",
+        });
+        flashRedirect(res, "/admin/bot-status", {
+          type: "ok",
+          text: `Updated status entry ${id}.`,
+        });
+      } catch (err) {
+        const text2 = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Update bot status failed", err);
+        await recordAudit(session, {
+          action: "bot-status.update",
+          targetId: id,
+          result: "failure",
+          errorMessage: text2,
+        });
+        flashRedirect(res, "/admin/bot-status", {
+          type: "err",
+          text: `Failed to update status: ${text2}`,
+        });
+      }
+    }),
+  );
+
+  router.post(
+    "/bot-status/entry/:id/order",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const id = String(req.params.id);
+      const order = parseIntInRange(
+        getString(req, "order") || "0",
+        -1000,
+        10000,
+      );
+      if (order === null) {
+        flashRedirect(res, "/admin/bot-status", {
+          type: "err",
+          text: "Order must be an integer between -1000 and 10000.",
+        });
+        return;
+      }
+      const entry = await findOwnedEntry(res, session.guildId, id);
+      if (!entry) return;
+      const previous = entry.order;
+      entry.order = order;
+      await entry.save();
+      await reloadBotStatusPools();
+      await recordAudit(session, {
+        action: "bot-status.reorder",
+        targetId: id,
+        details: { pool: entry.pool, from: previous, to: order },
+        result: "success",
+      });
+      flashRedirect(res, "/admin/bot-status", {
+        type: "ok",
+        text: `Reordered status entry ${id}: ${previous} → ${order}.`,
+      });
+    }),
+  );
+
+  router.post(
+    "/bot-status/entry/:id/delete",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const id = String(req.params.id);
+      const entry = await findOwnedEntry(res, session.guildId, id);
+      if (!entry) return;
+      const pool = entry.pool;
+      await BotStatusMessage.findByIdAndDelete(id);
+      await reloadBotStatusPools();
+      await recordAudit(session, {
+        action: "bot-status.delete",
+        targetId: id,
+        details: { pool, text: entry.text },
+        result: "success",
+      });
+      flashRedirect(res, "/admin/bot-status", {
+        type: "ok",
+        text: `Deleted status entry ${id} from the ${pool} pool.`,
+      });
+    }),
+  );
+
+  router.post(
+    "/bot-status/pool/:pool/import",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const pool = String(req.params.pool);
+      if (!isBotStatusPool(pool)) {
+        flashRedirect(res, "/admin/bot-status", {
+          type: "err",
+          text: `Unknown pool: ${pool}.`,
+        });
+        return;
+      }
+      const mode = getString(req, "mode") === "append" ? "append" : "replace";
+      const entries = parseStringListImport(getString(req, "items"));
+      if (entries.length === 0) {
+        flashRedirect(res, "/admin/bot-status", {
+          type: "err",
+          text: "Nothing to import — paste one entry per line or a JSON array.",
+        });
+        return;
+      }
+      // Validate every entry up front so the pool is never left half-written.
+      for (let i = 0; i < entries.length; i++) {
+        const invalid = validateStatusEntry(pool, entries[i]);
+        if (invalid) {
+          flashRedirect(res, "/admin/bot-status", {
+            type: "err",
+            text: `Import rejected at entry ${i + 1} ("${entries[i].slice(0, 40)}"): ${invalid}`,
+          });
+          return;
+        }
+      }
+      try {
+        let baseOrder = 0;
+        if (mode === "replace") {
+          await BotStatusMessage.deleteMany({
+            guildId: session.guildId,
+            pool,
+          });
+        } else {
+          const last = await BotStatusMessage.findOne({
+            guildId: session.guildId,
+            pool,
+          })
+            .sort({ order: -1 })
+            .lean();
+          baseOrder = last ? last.order + 1 : 0;
+        }
+        await BotStatusMessage.insertMany(
+          entries.map((text, i) => ({
+            guildId: session.guildId,
+            pool,
+            text: text.trim(),
+            order: baseOrder + i,
+            createdBy: session.discordUserId,
+          })),
+        );
+        await reloadBotStatusPools();
+        await recordAudit(session, {
+          action: "bot-status.import",
+          details: { pool, mode, count: entries.length },
+          result: "success",
+        });
+        flashRedirect(res, "/admin/bot-status", {
+          type: "ok",
+          text: `Imported ${entries.length} ${entries.length === 1 ? "entry" : "entries"} into the ${pool} pool (${mode}).`,
+        });
+      } catch (err) {
+        const text2 = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Import bot status failed", err);
+        await recordAudit(session, {
+          action: "bot-status.import",
+          details: { pool, mode },
+          result: "failure",
+          errorMessage: text2,
+        });
+        flashRedirect(res, "/admin/bot-status", {
+          type: "err",
+          text: `Failed to import: ${text2}`,
+        });
+      }
+    }),
+  );
+
+  router.post(
+    "/bot-status/pool/:pool/seed",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const pool = String(req.params.pool);
+      if (!isBotStatusPool(pool)) {
+        flashRedirect(res, "/admin/bot-status", {
+          type: "err",
+          text: `Unknown pool: ${pool}.`,
+        });
+        return;
+      }
+      const existing = await BotStatusMessage.countDocuments({
+        guildId: session.guildId,
+        pool,
+      });
+      if (existing > 0) {
+        flashRedirect(res, "/admin/bot-status", {
+          type: "warn",
+          text: `The ${pool} pool already has entries — nothing seeded.`,
+        });
+        return;
+      }
+      const defaults = STATUS_POOL_DEFAULTS[pool];
+      await BotStatusMessage.insertMany(
+        defaults.map((text, i) => ({
+          guildId: session.guildId,
+          pool,
+          text,
+          order: i,
+          createdBy: session.discordUserId,
+        })),
+      );
+      await reloadBotStatusPools();
+      await recordAudit(session, {
+        action: "bot-status.seed",
+        details: { pool, count: defaults.length },
+        result: "success",
+      });
+      flashRedirect(res, "/admin/bot-status", {
+        type: "ok",
+        text: `Seeded ${defaults.length} default ${pool} entries into the store.`,
+      });
     }),
   );
 


### PR DESCRIPTION
Closes #557.

## What & why

The bot's "Watching …" presence messages were hardcoded in `src/content/statuses.ts` as three frozen arrays. Editing them meant changing TypeScript and redeploying. This moves the pools into a per-guild MongoDB collection editable from the WebUI, while keeping the hardcoded arrays as the seed/default fallback so behaviour is unchanged out of the box.

## Changes

- **Model** — new `BotStatusMessage` collection (`{ guildId, pool, text, order }`), pools = `lonely` / `single` / `multiple`.
- **Service** — `BotStatusService` now picks from an in-memory cache seeded with the built-in defaults (so the synchronous presence path always has data). The cache is refreshed at startup, on `/config reload` (reload-callback pattern), and after every WebUI edit, so changes take effect **without a redeploy**. A pool with no stored rows falls back to its `src/content/statuses.ts` defaults.
- **WebUI** — new `/admin/bot-status` page: add / edit / remove / reorder each pool, plus paste-a-list import/export (newline- or JSON-encoded, replace or append) and a **Seed defaults into store** action. Built on a new **reusable `renderStringArrayEditor` partial** so accolades / notice-categories / etc. can adopt the same "array of data" editor later.
- **Validation** — `{count}`-pool entries must contain the `{count}` placeholder; saves/imports that omit it are rejected with a clear message, preserving the invariant the `satisfies` template-literal type guaranteed.
- **Write routes** — add / update / order / delete / import / seed are CSRF-protected, audited (one `WebAuditLog` row per write), and guild-scoped, matching the existing admin write surface.
- **Nav** — "Bot Status" entry added (always shown, like Database/Bootstrap).
- **Docs** — WEBUI.md admin-panel table + a short Bot Status section.

## Acceptance criteria

- [x] Status pools editable from the WebUI (add/edit/remove/reorder), effective without a redeploy.
- [x] Defaults seed an empty store; behaviour unchanged on first run.
- [x] Saving a `{count}`-pool entry without `{count}` is rejected with a clear message.
- [x] List editor implemented as a reusable component.
- [x] Import/export of a pool works (paste newline/JSON list).
- [x] Tests cover `{count}` validation, empty-store fallback to defaults, import parsing, and the CRUD/read round-trip.

## Testing

`npm run check` (build + lint + format) passes; full `npm run test:ci` green (1078 passing). New tests:
- `__tests__/content/statuses.test.ts` — pool validation / `{count}` invariant.
- `__tests__/services/bot-status-pools.test.ts` — refresh, empty-store fallback, stored overrides, `{count}` substitution.
- `__tests__/web/write-routes.test.ts` — `parseStringListImport` (newline + JSON + malformed fallback).

https://claude.ai/code/session_01TfFyotqCPsvizFn2B9q4Ts

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfFyotqCPsvizFn2B9q4Ts)_