### PR TITLE
fix(webui): darken pre-auth pages to match admin theme

### DIFF
--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -7,6 +7,7 @@
 
 import type { ConfigSchema } from "../services/config-schema.js";
 import { getInactivityWindowMs } from "./session.js";
+import { THEME } from "./theme.js";
 
 // Re-exported from session.ts so the renderer and the cookie middleware
 // share a single source of truth for the inactivity sliding window.
@@ -143,8 +144,9 @@ export interface AdminPageOptions {
 
 const STYLE = [
   "*,*::before,*::after{box-sizing:border-box}",
-  "body{margin:0;font-family:system-ui,-apple-system,Segoe UI,sans-serif;background:#0f1115;color:#e4e6eb}",
-  "a{color:#6ea8fe;text-decoration:none}",
+  // Core palette is shared with the pre-auth pages via THEME (issue #569).
+  `body{margin:0;font-family:system-ui,-apple-system,Segoe UI,sans-serif;background:${THEME.bg};color:${THEME.text}}`,
+  `a{color:${THEME.link};text-decoration:none}`,
   "a:hover{text-decoration:underline}",
   ".banner{background:#1f2937;border-bottom:1px solid #2d3748;padding:.5rem 1rem;display:flex;justify-content:space-between;align-items:center;font-size:.85rem}",
   ".banner .left{display:flex;gap:.75rem;align-items:center}",

--- a/src/web/theme.ts
+++ b/src/web/theme.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared dark-theme colour tokens for the WebUI.
+ *
+ * Both the authenticated admin layout (`admin-layout.ts`) and the small
+ * pre-auth pages (`views.ts`) draw their core palette from here so the
+ * sign-in / sign-out / invalid-link pages stay visually consistent with
+ * the rest of the dark admin UI instead of drifting toward a stray light
+ * theme (issue #569).
+ */
+export const THEME = {
+  /** Page background. */
+  bg: "#0f1115",
+  /** Primary body text. */
+  text: "#e4e6eb",
+  /** Links. */
+  link: "#6ea8fe",
+  /** Raised surfaces (cards, side nav, code). */
+  surface: "#161a22",
+  /** Table-header / hover surface. */
+  surfaceAlt: "#1a1f2a",
+  /** Hairline borders / dividers. */
+  border: "#2d3748",
+  /** Primary action button. */
+  primary: "#2563eb",
+  /** Primary action button (hover). */
+  primaryHover: "#1d4ed8",
+  /** Text on the primary button. */
+  onPrimary: "#fff",
+} as const;

--- a/src/web/views.ts
+++ b/src/web/views.ts
@@ -27,7 +27,8 @@ function pageShell(title: string, body: string): string {
     // pre-auth sign-in / sign-out / invalid-link pages don't flash light mode.
     `body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;max-width:48rem;margin:0 auto;padding:2rem;background:${THEME.bg};color:${THEME.text};}`,
     "h1{margin-top:0;}",
-    `a{color:${THEME.link};}`,
+    `a{color:${THEME.link};text-decoration:none;}`,
+    "a:hover{text-decoration:underline;}",
     "table{border-collapse:collapse;width:100%;}",
     `th,td{text-align:left;padding:.4rem .6rem;border-bottom:1px solid ${THEME.border};font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.9rem;}`,
     `th{background:${THEME.surfaceAlt};}`,

--- a/src/web/views.ts
+++ b/src/web/views.ts
@@ -4,6 +4,8 @@
  * later sub-issues.
  */
 
+import { THEME } from "./theme.js";
+
 function escapeHtml(value: string): string {
   return value
     .replace(/&/g, "&amp;")
@@ -21,14 +23,19 @@ function pageShell(title: string, body: string): string {
     `<title>${escapeHtml(title)} — Koolbot Admin</title>`,
     '<meta name="viewport" content="width=device-width,initial-scale=1">',
     "<style>",
-    "body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;max-width:48rem;margin:0 auto;padding:2rem;color:#1f2937;}",
+    // Dark palette shared with the authenticated admin UI (issue #569) so the
+    // pre-auth sign-in / sign-out / invalid-link pages don't flash light mode.
+    `body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;max-width:48rem;margin:0 auto;padding:2rem;background:${THEME.bg};color:${THEME.text};}`,
     "h1{margin-top:0;}",
+    `a{color:${THEME.link};}`,
     "table{border-collapse:collapse;width:100%;}",
-    "th,td{text-align:left;padding:.4rem .6rem;border-bottom:1px solid #e5e7eb;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.9rem;}",
-    "th{background:#f3f4f6;}",
-    "code{background:#f3f4f6;padding:.1rem .3rem;border-radius:.25rem;}",
+    `th,td{text-align:left;padding:.4rem .6rem;border-bottom:1px solid ${THEME.border};font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.9rem;}`,
+    `th{background:${THEME.surfaceAlt};}`,
+    `code{background:${THEME.surface};padding:.1rem .3rem;border-radius:.25rem;}`,
     "nav a{margin-right:.75rem;}",
     "form{margin-top:1rem;}",
+    `button{background:${THEME.primary};color:${THEME.onPrimary};border:0;padding:.45rem .9rem;border-radius:4px;cursor:pointer;font:inherit;font-weight:600;}`,
+    `button:hover{background:${THEME.primaryHover};}`,
     "</style></head><body>",
     body,
     "</body></html>",


### PR DESCRIPTION
## Summary

The magic-link sign-in/consent page (`GET /s/:token`) — and the sibling **Signed out** and **Invalid link** pages — were rendered by `pageShell()` in `src/web/views.ts` with its own **light** inline stylesheet (dark text on no background → white), flashing light mode right before landing in the dark admin UI. Fixes #569.

## Changes

- **New `src/web/theme.ts`** — a single source for the core dark colour tokens (background, text, link, surfaces, borders, primary button), so the pre-auth shell and the authenticated admin layout can't drift apart.
- **`src/web/views.ts`** — `pageShell()` now draws from `THEME`: dark `body` background (`#0f1115`) + light text (`#e4e6eb`), themed links, table borders, `th`/`code` surfaces, and a primary-styled **Continue** button (no more default-white browser button on a dark page).
- **`src/web/admin-layout.ts`** — the core `body`/`a` palette now references the same `THEME` tokens instead of hand-copied hex.

## Acceptance criteria

- [x] `/s/:token` consent page renders dark with no white flash.
- [x] "Signed out" and "Invalid link" pages are likewise dark and consistent with the admin UI.
- [x] The "Continue" button and links/tables/code match the dark theme.
- [x] No readability regression (palette matches the existing admin contrast).

## Testing

- `npm run build` ✅
- `npm run lint` ✅ · `npm run format:check` ✅
- `__tests__/web/admin-layout.test.ts` + `__tests__/web/admin-views.test.ts` ✅ (99 passed)

Closes #569

https://claude.ai/code/session_01BKJzAzuqzZHKdGgdpVwkrY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKJzAzuqzZHKdGgdpVwkrY)_