### PR TITLE
feat(webui): edit existing poll questions and schedules in place

### DIFF
--- a/__tests__/services/poll-service.test.ts
+++ b/__tests__/services/poll-service.test.ts
@@ -677,6 +677,7 @@ describe("PollService", () => {
       const service = PollService.getInstance({} as never);
       // Simulate a running service with an existing job for this schedule.
       const oldStop = jest.fn();
+      const oldJob = { stop: oldStop };
       const internals = service as unknown as {
         isInitialized: boolean;
         jobs: Map<string, { schedule: unknown; job: { stop: () => void } }>;
@@ -684,7 +685,7 @@ describe("PollService", () => {
       internals.isInitialized = true;
       internals.jobs.set("sched-1", {
         schedule,
-        job: { stop: oldStop },
+        job: oldJob,
       });
 
       const result = await service.updateSchedule(
@@ -704,11 +705,11 @@ describe("PollService", () => {
       expect(schedule.cronSchedule).toBe("0 12 * * 1");
       expect(schedule.pollDuration).toBe(6);
       expect(schedule.roleIdToPing).toBe("role-9");
-      // Old job stopped, a fresh job armed in its place.
+      // Old job stopped, a fresh job armed in its place (a different object).
       expect(oldStop).toHaveBeenCalledTimes(1);
       const rearmed = internals.jobs.get("sched-1");
       expect(rearmed).toBeDefined();
-      expect(rearmed?.job).not.toBe(oldStop);
+      expect(rearmed?.job).not.toBe(oldJob);
 
       // Stop the real CronJob so it does not leak a live timer.
       service.destroy();

--- a/__tests__/services/poll-service.test.ts
+++ b/__tests__/services/poll-service.test.ts
@@ -10,6 +10,8 @@ import {
 const mockFetch = jest.fn<typeof fetch>();
 const mockPollItemFindOne = jest.fn();
 const mockPollItemCreate = jest.fn();
+const mockPollItemFindById = jest.fn();
+const mockPollScheduleFindById = jest.fn();
 const mockRegisterReloadCallback = jest.fn();
 const mockConfigGetBoolean = jest.fn();
 const mockConfigGetNumber = jest.fn();
@@ -28,11 +30,14 @@ jest.unstable_mockModule("../../src/models/poll-item.js", () => ({
   PollItem: {
     findOne: mockPollItemFindOne,
     create: mockPollItemCreate,
+    findById: mockPollItemFindById,
   },
 }));
 
 jest.unstable_mockModule("../../src/models/poll-schedule.js", () => ({
-  PollSchedule: {},
+  PollSchedule: {
+    findById: mockPollScheduleFindById,
+  },
 }));
 
 jest.unstable_mockModule("../../src/utils/logger.js", () => ({
@@ -72,6 +77,8 @@ describe("PollService", () => {
     mockConfigGetNumber.mockResolvedValue(7);
     mockPollItemFindOne.mockResolvedValue(null);
     mockPollItemCreate.mockResolvedValue({});
+    mockPollItemFindById.mockResolvedValue(null);
+    mockPollScheduleFindById.mockResolvedValue(null);
     global.fetch = mockFetch as unknown as typeof fetch;
     // The import host allowlist is server-controlled; allow the fixture host
     // used throughout these tests via the configurable env var.
@@ -554,6 +561,181 @@ describe("PollService", () => {
 
       expect(result).toEqual({ imported: 0, skipped: 1, errors: [] });
       expect(mockPollItemCreate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("updatePollItem", () => {
+    it("changes only the editable fields and preserves usage stats/provenance", async () => {
+      const save = jest.fn<() => Promise<void>>().mockResolvedValue();
+      const item = {
+        _id: { toString: () => "item-1" },
+        guildId: "guild-1",
+        question: "Old question?",
+        answers: ["A", "B"],
+        multiSelect: false,
+        tags: ["old"],
+        usageCount: 7,
+        lastUsed: new Date("2026-01-01T00:00:00Z"),
+        createdBy: "creator-1",
+        source: "manual",
+        save,
+      };
+      mockPollItemFindById.mockResolvedValue(item);
+      const service = PollService.getInstance({} as never);
+
+      const result = await service.updatePollItem(
+        "item-1",
+        {
+          question: "New question?",
+          answers: ["Yes", "No", "Maybe"],
+          multiSelect: true,
+          tags: ["new", "fun"],
+        },
+        "guild-1",
+      );
+
+      expect(result).toBe(item);
+      expect(save).toHaveBeenCalledTimes(1);
+      // Editable fields changed.
+      expect(item.question).toBe("New question?");
+      expect(item.answers).toEqual(["Yes", "No", "Maybe"]);
+      expect(item.multiSelect).toBe(true);
+      expect(item.tags).toEqual(["new", "fun"]);
+      // Stats and provenance are untouched.
+      expect(item.usageCount).toBe(7);
+      expect(item.lastUsed).toEqual(new Date("2026-01-01T00:00:00Z"));
+      expect(item.createdBy).toBe("creator-1");
+      expect(item.source).toBe("manual");
+    });
+
+    it("refuses to edit an item belonging to another guild", async () => {
+      const save = jest.fn<() => Promise<void>>().mockResolvedValue();
+      mockPollItemFindById.mockResolvedValue({
+        _id: { toString: () => "item-1" },
+        guildId: "other-guild",
+        save,
+      });
+      const service = PollService.getInstance({} as never);
+
+      const result = await service.updatePollItem(
+        "item-1",
+        { question: "Q?", answers: ["A", "B"], multiSelect: false, tags: [] },
+        "guild-1",
+      );
+
+      expect(result).toBeNull();
+      expect(save).not.toHaveBeenCalled();
+    });
+
+    it("returns null when the item does not exist", async () => {
+      mockPollItemFindById.mockResolvedValue(null);
+      const service = PollService.getInstance({} as never);
+
+      const result = await service.updatePollItem(
+        "missing",
+        { question: "Q?", answers: ["A", "B"], multiSelect: false, tags: [] },
+        "guild-1",
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("updateSchedule", () => {
+    it("rejects an invalid cron expression before touching the database", async () => {
+      const service = PollService.getInstance({} as never);
+
+      await expect(
+        service.updateSchedule(
+          "sched-1",
+          {
+            channelId: "chan-1",
+            cronSchedule: "not a cron",
+            pollDuration: 12,
+            roleIdToPing: null,
+          },
+          "guild-1",
+        ),
+      ).rejects.toThrow("Invalid cron expression");
+      expect(mockPollScheduleFindById).not.toHaveBeenCalled();
+    });
+
+    it("saves the new fields and re-arms the running cron job in place", async () => {
+      const save = jest.fn<() => Promise<void>>().mockResolvedValue();
+      const schedule = {
+        _id: { toString: () => "sched-1" },
+        guildId: "guild-1",
+        channelId: "old-chan",
+        cronSchedule: "0 9 * * *",
+        pollDuration: 24,
+        roleIdToPing: null as string | null,
+        enabled: true,
+        save,
+      };
+      mockPollScheduleFindById.mockResolvedValue(schedule);
+
+      const service = PollService.getInstance({} as never);
+      // Simulate a running service with an existing job for this schedule.
+      const oldStop = jest.fn();
+      const internals = service as unknown as {
+        isInitialized: boolean;
+        jobs: Map<string, { schedule: unknown; job: { stop: () => void } }>;
+      };
+      internals.isInitialized = true;
+      internals.jobs.set("sched-1", {
+        schedule,
+        job: { stop: oldStop },
+      });
+
+      const result = await service.updateSchedule(
+        "sched-1",
+        {
+          channelId: "new-chan",
+          cronSchedule: "0 12 * * 1",
+          pollDuration: 6,
+          roleIdToPing: "role-9",
+        },
+        "guild-1",
+      );
+
+      expect(result).toBe(schedule);
+      expect(save).toHaveBeenCalledTimes(1);
+      expect(schedule.channelId).toBe("new-chan");
+      expect(schedule.cronSchedule).toBe("0 12 * * 1");
+      expect(schedule.pollDuration).toBe(6);
+      expect(schedule.roleIdToPing).toBe("role-9");
+      // Old job stopped, a fresh job armed in its place.
+      expect(oldStop).toHaveBeenCalledTimes(1);
+      const rearmed = internals.jobs.get("sched-1");
+      expect(rearmed).toBeDefined();
+      expect(rearmed?.job).not.toBe(oldStop);
+
+      // Stop the real CronJob so it does not leak a live timer.
+      service.destroy();
+    });
+
+    it("refuses to edit a schedule belonging to another guild", async () => {
+      const save = jest.fn<() => Promise<void>>().mockResolvedValue();
+      mockPollScheduleFindById.mockResolvedValue({
+        _id: { toString: () => "sched-1" },
+        guildId: "other-guild",
+        save,
+      });
+      const service = PollService.getInstance({} as never);
+
+      const result = await service.updateSchedule(
+        "sched-1",
+        {
+          channelId: "chan-1",
+          cronSchedule: "0 12 * * 1",
+          pollDuration: 12,
+          roleIdToPing: null,
+        },
+        "guild-1",
+      );
+
+      expect(result).toBeNull();
+      expect(save).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -883,6 +883,36 @@ describe("renderPollsPage", () => {
     expect(html).toContain('name="multiSelect" value="1" checked');
   });
 
+  it("preserves a deleted channel/role id in the edit form instead of defaulting", () => {
+    const html = renderPollsPage({
+      ...COMMON,
+      enabled: true,
+      defaultDurationHours: 24,
+      cooldownDays: 7,
+      schedules: [
+        {
+          id: "s1",
+          channelId: "gone-chan",
+          channelName: "gone-chan",
+          cron: "0 12 * * 1",
+          durationHours: 12,
+          pingRoleId: "gone-role",
+          pingRoleName: "gone-role",
+          enabled: true,
+          lastRun: "—",
+        },
+      ],
+      items: [],
+      textChannels: [{ id: "c1", name: "polls" }],
+      roles: [{ id: "r1", name: "Members" }],
+    });
+    // The saved-but-missing ids stay selected so a cron-only edit can't
+    // silently reassign the channel or clear the ping role.
+    expect(html).toContain('value="gone-chan" selected');
+    expect(html).toContain('value="gone-role" selected');
+    expect(html).toContain("(unavailable)");
+  });
+
   it("renders write forms for schedules, items and bulk import", () => {
     const html = renderPollsPage({
       ...COMMON,

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -802,9 +802,11 @@ describe("renderPollsPage", () => {
       schedules: [
         {
           id: "s1",
+          channelId: "c1",
           channelName: "polls",
           cron: "0 12 * * 1",
           durationHours: 12,
+          pingRoleId: "r1",
           pingRoleName: "Members",
           enabled: true,
           lastRun: "—",
@@ -816,6 +818,7 @@ describe("renderPollsPage", () => {
           question: "Pineapple on pizza?",
           answers: ["Yes", "No"],
           tags: ["food"],
+          multiSelect: false,
           usageCount: 0,
           lastUsed: "—",
           enabled: true,
@@ -830,6 +833,54 @@ describe("renderPollsPage", () => {
     expect(html).toContain("Yes • No");
     expect(html).toContain("/admin/polls/schedules/s1/test");
     expect(html).toContain("/admin/polls/items/i1/delete");
+  });
+
+  it("renders pre-filled edit forms for each schedule and item row", () => {
+    const html = renderPollsPage({
+      ...COMMON,
+      enabled: true,
+      defaultDurationHours: 24,
+      cooldownDays: 7,
+      schedules: [
+        {
+          id: "s1",
+          channelId: "c1",
+          channelName: "polls",
+          cron: "0 12 * * 1",
+          durationHours: 12,
+          pingRoleId: "r1",
+          pingRoleName: "Members",
+          enabled: true,
+          lastRun: "—",
+        },
+      ],
+      items: [
+        {
+          id: "i1",
+          question: "Pineapple on pizza?",
+          answers: ["Yes", "No"],
+          tags: ["food"],
+          multiSelect: true,
+          usageCount: 3,
+          lastUsed: "—",
+          enabled: true,
+          source: "manual",
+        },
+      ],
+      textChannels: [{ id: "c1", name: "polls" }],
+      roles: [{ id: "r1", name: "Members" }],
+    });
+    // Edit routes are present per row.
+    expect(html).toContain("/admin/polls/schedules/s1/edit");
+    expect(html).toContain("/admin/polls/items/i1/edit");
+    // Edit forms are pre-filled with the row's current values.
+    expect(html).toContain('value="0 12 * * 1"');
+    expect(html).toContain('value="Yes, No"');
+    expect(html).toContain('value="food"');
+    // The selected channel/role and multiSelect state are reflected.
+    expect(html).toContain('value="c1" selected');
+    expect(html).toContain('value="r1" selected');
+    expect(html).toContain('name="multiSelect" value="1" checked');
   });
 
   it("renders write forms for schedules, items and bulk import", () => {

--- a/src/services/poll-service.ts
+++ b/src/services/poll-service.ts
@@ -877,22 +877,24 @@ export class PollService {
     // Re-arm the cron job in place: stop the old job and start a fresh one from
     // the saved row so a changed cron/channel takes effect now, not on the next
     // service restart. Mirrors the stop/restart lockstep in setScheduleEnabled.
-    const existing = this.jobs.get(scheduleId);
+    // Key off the canonical `_id` (not the raw `scheduleId` argument) for both
+    // the lookup and the re-insert so a non-canonical id can't leave the old
+    // job running while a second one is scheduled for the same row.
+    const canonicalId = schedule._id.toString();
+    const existing = this.jobs.get(canonicalId);
     if (existing) {
       existing.job.stop();
-      this.jobs.delete(scheduleId);
+      this.jobs.delete(canonicalId);
     }
 
     if (this.isInitialized && schedule.enabled) {
       const job = this.schedulePoll(schedule);
       if (job) {
-        this.jobs.set(schedule._id.toString(), { schedule, job });
+        this.jobs.set(canonicalId, { schedule, job });
       }
     }
 
-    logger.info(
-      `Updated poll schedule: ${sanitizeForLog(schedule._id.toString())}`,
-    );
+    logger.info(`Updated poll schedule: ${sanitizeForLog(canonicalId)}`);
     return schedule;
   }
 

--- a/src/services/poll-service.ts
+++ b/src/services/poll-service.ts
@@ -836,6 +836,67 @@ export class PollService {
   }
 
   /**
+   * Edit an existing poll schedule's channel, cron, duration, and ping role.
+   * Re-validates the cron expression and re-arms the running `CronJob` in
+   * place — stopping the old job and starting a fresh one from the saved row —
+   * so the live schedule reflects the edit immediately, exactly as
+   * `setScheduleEnabled` does for the toggle path (#556). Other fields
+   * (`enabled`, `createdBy`, `lastRun`) are preserved.
+   */
+  public async updateSchedule(
+    scheduleId: string,
+    data: {
+      channelId: string;
+      cronSchedule: string;
+      pollDuration: number;
+      roleIdToPing: string | null;
+    },
+    guildId?: string,
+  ): Promise<IPollSchedule | null> {
+    if (!this.validateCronExpression(data.cronSchedule)) {
+      throw new Error(`Invalid cron expression: ${data.cronSchedule}`);
+    }
+
+    const schedule = await PollSchedule.findById(scheduleId);
+    if (!schedule) {
+      return null;
+    }
+    if (guildId && schedule.guildId !== guildId) {
+      logger.warn(
+        `Attempted to edit schedule ${sanitizeForLog(schedule._id.toString())} from wrong guild (got ${sanitizeForLog(guildId)})`,
+      );
+      return null;
+    }
+
+    schedule.channelId = data.channelId;
+    schedule.cronSchedule = data.cronSchedule;
+    schedule.pollDuration = data.pollDuration;
+    schedule.roleIdToPing = data.roleIdToPing;
+    await schedule.save();
+
+    // Re-arm the cron job in place: stop the old job and start a fresh one from
+    // the saved row so a changed cron/channel takes effect now, not on the next
+    // service restart. Mirrors the stop/restart lockstep in setScheduleEnabled.
+    const existing = this.jobs.get(scheduleId);
+    if (existing) {
+      existing.job.stop();
+      this.jobs.delete(scheduleId);
+    }
+
+    if (this.isInitialized && schedule.enabled) {
+      const job = this.schedulePoll(schedule);
+      if (job) {
+        this.jobs.set(schedule._id.toString(), { schedule, job });
+      }
+    }
+
+    logger.info(
+      `Updated poll schedule: ${sanitizeForLog(schedule._id.toString())}`,
+    );
+    return schedule;
+  }
+
+  /**
    * Flip a poll schedule's `enabled` flag. Restarts or stops the cron
    * job in lockstep so the toggle reflects in scheduling, not just the
    * database row. Used by the WebUI write surface (#383).
@@ -972,6 +1033,45 @@ export class PollService {
     await pollItem.save();
     logger.info(`Created new poll item: ${pollItem._id}`);
     return pollItem;
+  }
+
+  /**
+   * Edit an existing poll item's question, answers, tags, and multiSelect.
+   * Usage statistics and provenance (`usageCount`, `lastUsed`, `createdBy`,
+   * `source`) are deliberately left untouched so editing a question does not
+   * reset its rotation history (#556). Schema validation on `save()` enforces
+   * the 2–10 answers / 55-char caps as defence-in-depth behind the route-layer
+   * checks.
+   */
+  public async updatePollItem(
+    itemId: string,
+    data: {
+      question: string;
+      answers: string[];
+      multiSelect: boolean;
+      tags: string[];
+    },
+    guildId?: string,
+  ): Promise<IPollItem | null> {
+    const item = await PollItem.findById(itemId);
+    if (!item) {
+      return null;
+    }
+    if (guildId && item.guildId !== guildId) {
+      logger.warn(
+        `Attempted to edit poll item ${sanitizeForLog(item._id.toString())} from wrong guild (got ${sanitizeForLog(guildId)})`,
+      );
+      return null;
+    }
+
+    item.question = data.question;
+    item.answers = data.answers;
+    item.multiSelect = data.multiSelect;
+    item.tags = data.tags;
+    await item.save();
+
+    logger.info(`Updated poll item: ${sanitizeForLog(item._id.toString())}`);
+    return item;
   }
 
   /**

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -1151,25 +1151,44 @@ function channelOptionsHtml(
   options: ChannelOption[],
   selectedId?: string,
 ): string {
-  if (options.length === 0) {
+  const rendered = options.map(
+    (c) =>
+      `<option value="${escapeHtml(c.id)}"${c.id === selectedId ? " selected" : ""}>#${escapeHtml(c.name)}</option>`,
+  );
+  // Preserve a selected channel that's no longer in the list (deleted, or the
+  // bot lost access). Without a matching <option> the browser would default to
+  // the first channel, so editing only the cron/duration would silently
+  // reassign the schedule's channel on submit. Keep the saved id selectable.
+  if (selectedId && !options.some((c) => c.id === selectedId)) {
+    rendered.unshift(
+      `<option value="${escapeHtml(selectedId)}" selected>#${escapeHtml(selectedId)} (unavailable)</option>`,
+    );
+  }
+  if (rendered.length === 0) {
     return `<option value="">(no text channels available)</option>`;
   }
-  return options
-    .map(
-      (c) =>
-        `<option value="${escapeHtml(c.id)}"${c.id === selectedId ? " selected" : ""}>#${escapeHtml(c.name)}</option>`,
-    )
-    .join("");
+  return rendered.join("");
 }
 
 function roleOptionsHtml(options: RoleOption[], selectedId?: string): string {
-  return [
+  const out = [
     `<option value=""${!selectedId ? " selected" : ""}>(none)</option>`,
+  ];
+  // Same guard as channels: if the saved ping role is no longer in the list,
+  // keep it as a selected option so a cron/duration-only edit doesn't silently
+  // clear the role by defaulting the select back to "(none)".
+  if (selectedId && !options.some((r) => r.id === selectedId)) {
+    out.push(
+      `<option value="${escapeHtml(selectedId)}" selected>@${escapeHtml(selectedId)} (unavailable)</option>`,
+    );
+  }
+  out.push(
     ...options.map(
       (r) =>
         `<option value="${escapeHtml(r.id)}"${r.id === selectedId ? " selected" : ""}>@${escapeHtml(r.name)}</option>`,
     ),
-  ].join("");
+  );
+  return out.join("");
 }
 
 const CRON_EXAMPLES_HTML = `

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -1147,24 +1147,27 @@ function renderFlash(flash?: FlashMessage | null): string {
   return `<div class="notice ${cls}">${escapeHtml(flash.text)}</div>`;
 }
 
-function channelOptionsHtml(options: ChannelOption[]): string {
+function channelOptionsHtml(
+  options: ChannelOption[],
+  selectedId?: string,
+): string {
   if (options.length === 0) {
     return `<option value="">(no text channels available)</option>`;
   }
   return options
     .map(
       (c) =>
-        `<option value="${escapeHtml(c.id)}">#${escapeHtml(c.name)}</option>`,
+        `<option value="${escapeHtml(c.id)}"${c.id === selectedId ? " selected" : ""}>#${escapeHtml(c.name)}</option>`,
     )
     .join("");
 }
 
-function roleOptionsHtml(options: RoleOption[]): string {
+function roleOptionsHtml(options: RoleOption[], selectedId?: string): string {
   return [
-    `<option value="">(none)</option>`,
+    `<option value=""${!selectedId ? " selected" : ""}>(none)</option>`,
     ...options.map(
       (r) =>
-        `<option value="${escapeHtml(r.id)}">@${escapeHtml(r.name)}</option>`,
+        `<option value="${escapeHtml(r.id)}"${r.id === selectedId ? " selected" : ""}>@${escapeHtml(r.name)}</option>`,
     ),
   ].join("");
 }
@@ -1291,9 +1294,11 @@ ${renderFlash(props.flash)}
 
 export interface PollScheduleRow {
   id: string;
+  channelId: string;
   channelName: string;
   cron: string;
   durationHours: number;
+  pingRoleId: string | null;
   pingRoleName: string | null;
   enabled: boolean;
   lastRun: string;
@@ -1304,6 +1309,7 @@ export interface PollItemRow {
   question: string;
   answers: string[];
   tags: string[];
+  multiSelect: boolean;
   usageCount: number;
   lastUsed: string;
   enabled: boolean;
@@ -1335,6 +1341,15 @@ export function renderPollsPage(props: PollsProps): string {
 <td>${tagOnOff(s.enabled)}</td>
 <td class="muted">${escapeHtml(s.lastRun)}</td>
 <td class="actions">
+  <details class="helper edit-details"><summary>Edit</summary>
+    <form method="POST" action="/admin/polls/schedules/${escapeHtml(s.id)}/edit" class="stack">${csrfInput}
+      <label>Channel<select name="channelId" required>${channelOptionsHtml(props.textChannels, s.channelId)}</select></label>
+      <label>Cron schedule<input type="text" name="cron" value="${escapeHtml(s.cron)}" required></label>
+      <label>Duration (hours, 1–768)<input type="number" name="durationHours" min="1" max="768" value="${s.durationHours}" required></label>
+      <label>Ping role<select name="pingRoleId">${roleOptionsHtml(props.roles, s.pingRoleId ?? undefined)}</select></label>
+      <button type="submit" class="btn btn-primary">Save changes</button>
+    </form>
+  </details>
   <form method="POST" action="/admin/polls/schedules/${escapeHtml(s.id)}/toggle">${csrfInput}<button type="submit" class="btn">${s.enabled ? "Disable" : "Enable"}</button></form>
   <form method="POST" action="/admin/polls/schedules/${escapeHtml(s.id)}/test">${csrfInput}<button type="submit" class="btn">Test</button></form>
   <form method="POST" action="/admin/polls/schedules/${escapeHtml(s.id)}/delete" onsubmit="return confirm('Delete schedule ${escapeHtml(s.id)}?');">${csrfInput}<button type="submit" class="btn btn-danger">Delete</button></form>
@@ -1353,6 +1368,15 @@ export function renderPollsPage(props: PollsProps): string {
 <td>${tagOnOff(it.enabled)}</td>
 <td class="muted">${escapeHtml(it.source)}</td>
 <td class="actions">
+  <details class="helper edit-details"><summary>Edit</summary>
+    <form method="POST" action="/admin/polls/items/${escapeHtml(it.id)}/edit" class="stack">${csrfInput}
+      <label>Question<input type="text" name="question" maxlength="300" value="${escapeHtml(it.question)}" required></label>
+      <label>Answers (comma-separated, 2–10 options, ≤55 chars each)<input type="text" name="answers" maxlength="600" value="${escapeHtml(it.answers.join(", "))}" required></label>
+      <label>Tags (comma-separated, optional)<input type="text" name="tags" value="${escapeHtml(it.tags.join(", "))}"></label>
+      <label class="checkbox"><input type="checkbox" name="multiSelect" value="1"${it.multiSelect ? " checked" : ""}> Allow multiple answer selections</label>
+      <button type="submit" class="btn btn-primary">Save changes</button>
+    </form>
+  </details>
   <form method="POST" action="/admin/polls/items/${escapeHtml(it.id)}/toggle">${csrfInput}<button type="submit" class="btn">${it.enabled ? "Disable" : "Enable"}</button></form>
   <form method="POST" action="/admin/polls/items/${escapeHtml(it.id)}/delete" onsubmit="return confirm('Delete poll question?');">${csrfInput}<button type="submit" class="btn btn-danger">Delete</button></form>
 </td>

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -555,9 +555,11 @@ export function createReadOnlyRouter(
           flash: readFlash(req),
           schedules: schedules.map((s) => ({
             id: String(s._id),
+            channelId: s.channelId,
             channelName: channelData.names.get(s.channelId) ?? s.channelId,
             cron: s.cronSchedule,
             durationHours: s.pollDuration,
+            pingRoleId: s.roleIdToPing ?? null,
             pingRoleName: s.roleIdToPing
               ? (roleData.names.get(s.roleIdToPing) ?? s.roleIdToPing)
               : null,
@@ -569,6 +571,7 @@ export function createReadOnlyRouter(
             question: it.question,
             answers: it.answers ?? [],
             tags: it.tags ?? [],
+            multiSelect: it.multiSelect,
             usageCount: it.usageCount,
             lastUsed: it.lastUsed ? new Date(it.lastUsed).toISOString() : "—",
             enabled: it.enabled,

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -1995,7 +1995,6 @@ export function createWriteRouter(
         });
       } catch (err) {
         const text = err instanceof Error ? err.message : "Unknown error";
-        logger.error("Edit poll schedule failed", err);
         await recordAudit(session, {
           action: "poll-schedule.edit",
           targetId: id,
@@ -2322,7 +2321,6 @@ export function createWriteRouter(
         });
       } catch (err) {
         const text = err instanceof Error ? err.message : "Unknown error";
-        logger.error("Edit poll item failed", err);
         await recordAudit(session, {
           action: "poll-item.edit",
           targetId: id,

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -1921,6 +1921,97 @@ export function createWriteRouter(
   );
 
   router.post(
+    "/polls/schedules/:id/edit",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const id = String(req.params.id);
+      const channelId = getString(req, "channelId");
+      const cron = normalizeCron(getString(req, "cron"));
+      const durationRaw = getString(req, "durationHours");
+      const pingRoleId = getString(req, "pingRoleId");
+
+      if (!channelId || !cron) {
+        flashRedirect(res, "/admin/polls", {
+          type: "err",
+          text: "Channel and cron are required.",
+        });
+        return;
+      }
+      const duration = Number.parseInt(durationRaw, 10);
+      if (!Number.isFinite(duration) || duration < 1 || duration > 768) {
+        flashRedirect(res, "/admin/polls", {
+          type: "err",
+          text: "Duration must be an integer between 1 and 768 hours.",
+        });
+        return;
+      }
+      if (!validCron(cron)) {
+        flashRedirect(res, "/admin/polls", {
+          type: "err",
+          text: `Invalid cron expression: ${cron}`,
+        });
+        return;
+      }
+
+      const service = PollService.getInstance(client);
+      try {
+        const schedule = await service.updateSchedule(
+          id,
+          {
+            channelId,
+            cronSchedule: cron,
+            pollDuration: duration,
+            roleIdToPing: pingRoleId || null,
+          },
+          session.guildId,
+        );
+        if (!schedule) {
+          await recordAudit(session, {
+            action: "poll-schedule.edit",
+            targetId: id,
+            result: "failure",
+            errorMessage: "not found or wrong guild",
+          });
+          flashRedirect(res, "/admin/polls", {
+            type: "err",
+            text: `Schedule ${id} not found.`,
+          });
+          return;
+        }
+        await recordAudit(session, {
+          action: "poll-schedule.edit",
+          targetId: id,
+          details: {
+            channelId,
+            cron,
+            durationHours: duration,
+            pingRoleId: pingRoleId || null,
+          },
+          result: "success",
+        });
+        flashRedirect(res, "/admin/polls", {
+          type: "ok",
+          text: `Updated poll schedule ${id}.`,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Edit poll schedule failed", err);
+        await recordAudit(session, {
+          action: "poll-schedule.edit",
+          targetId: id,
+          details: { channelId, cron },
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/polls", {
+          type: "err",
+          text: `Failed to update schedule ${id}: ${text}`,
+        });
+      }
+    }),
+  );
+
+  router.post(
     "/polls/schedules/:id/delete",
     asyncHandler(async (req, res) => {
       const session = requireSessionContext(req);
@@ -2140,6 +2231,108 @@ export function createWriteRouter(
         flashRedirect(res, "/admin/polls", {
           type: "err",
           text: `Failed to add question: ${text}`,
+        });
+      }
+    }),
+  );
+
+  router.post(
+    "/polls/items/:id/edit",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const id = String(req.params.id);
+      const question = getString(req, "question");
+      const answersStr = getString(req, "answers");
+      const tagsStr = getString(req, "tags");
+      const multiSelect = getCheckbox(req, "multiSelect");
+
+      if (!question) {
+        flashRedirect(res, "/admin/polls", {
+          type: "err",
+          text: "Question is required.",
+        });
+        return;
+      }
+      if (question.length > TEXT_LIMITS.pollQuestion) {
+        flashRedirect(res, "/admin/polls", {
+          type: "err",
+          text: `Question must be ${TEXT_LIMITS.pollQuestion} characters or fewer.`,
+        });
+        return;
+      }
+      const answers = answersStr
+        .split(",")
+        .map((a) => a.trim())
+        .filter((a) => a.length > 0);
+      if (answers.length < 2 || answers.length > 10) {
+        flashRedirect(res, "/admin/polls", {
+          type: "err",
+          text: "Provide 2–10 comma-separated answers.",
+        });
+        return;
+      }
+      // Same 55-char poll-option cap the create route enforces (#508).
+      if (answers.some((a) => a.length > TEXT_LIMITS.pollAnswer)) {
+        flashRedirect(res, "/admin/polls", {
+          type: "err",
+          text: `Each answer must be ${TEXT_LIMITS.pollAnswer} characters or fewer.`,
+        });
+        return;
+      }
+      const tags = tagsStr
+        ? tagsStr
+            .split(",")
+            .map((t) => t.trim())
+            .filter((t) => t.length > 0)
+        : [];
+
+      const service = PollService.getInstance(client);
+      try {
+        const item = await service.updatePollItem(
+          id,
+          { question, answers, multiSelect, tags },
+          session.guildId,
+        );
+        if (!item) {
+          await recordAudit(session, {
+            action: "poll-item.edit",
+            targetId: id,
+            result: "failure",
+            errorMessage: "not found or wrong guild",
+          });
+          flashRedirect(res, "/admin/polls", {
+            type: "err",
+            text: `Question ${id} not found.`,
+          });
+          return;
+        }
+        await recordAudit(session, {
+          action: "poll-item.edit",
+          targetId: id,
+          details: {
+            answerCount: answers.length,
+            multiSelect,
+            tagCount: tags.length,
+          },
+          result: "success",
+        });
+        flashRedirect(res, "/admin/polls", {
+          type: "ok",
+          text: `Updated poll question ${id}.`,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Edit poll item failed", err);
+        await recordAudit(session, {
+          action: "poll-item.edit",
+          targetId: id,
+          details: { answerCount: answers.length },
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/polls", {
+          type: "err",
+          text: `Failed to update question ${id}: ${text}`,
         });
       }
     }),


### PR DESCRIPTION
## Summary

Closes #556. The `/admin/polls` page could **create**, **delete**, **toggle**, **test** and **import** polls, but had no way to **edit** an existing question or schedule. Fixing a typo, changing answers/tags, or adjusting a schedule's cron/duration/ping-role meant deleting the row and recreating it — losing the item's `usageCount`/`lastUsed` history. This makes it behave like a proper editor.

## What changed

**`src/services/poll-service.ts`**
- `updatePollItem(itemId, data, guildId?)` — edits `question`, `answers`, `multiSelect`, `tags` while **preserving** `usageCount`, `lastUsed`, `createdBy`, `source`. Guild-scoped.
- `updateSchedule(scheduleId, data, guildId?)` — edits `channelId`, `cronSchedule`, `pollDuration`, `roleIdToPing`. Re-validates the cron and **re-arms the running `CronJob` in place** (stops the old job, starts a fresh one from the saved row) the same way `setScheduleEnabled` does, so the live schedule reflects the edit immediately. Guild-scoped.

**`src/web/write-routes.ts`**
- `POST /admin/polls/items/:id/edit` and `POST /admin/polls/schedules/:id/edit`, mirroring the create handlers' validation (2–10 answers ≤55 chars, ≤300-char question, cron validity, 1–768h duration) and recording `poll-item.edit` / `poll-schedule.edit` audit entries. CSRF-protected and guild-scoped via the existing middleware + service guards.

**`src/web/admin-views.ts`** + **`src/web/read-only-routes.ts`**
- Per-row pre-filled `<details>` edit form for each schedule and question (static HTML, no JS framework — consistent with the notices editor). `channelOptionsHtml`/`roleOptionsHtml` now take an optional selected id; `PollScheduleRow`/`PollItemRow` carry the raw `channelId`/`pingRoleId`/`multiSelect` needed to pre-fill the forms.

## Acceptance criteria

- [x] Admin can edit a question's text/answers/tags/multiSelect without deleting it; `usageCount`/`lastUsed` preserved.
- [x] Admin can edit a schedule's channel/cron/duration/ping-role; the running cron job is re-armed immediately.
- [x] Edits use the same validation as create.
- [x] Edits are CSRF-protected, guild-scoped, and audit-logged.
- [x] Tests cover: item edit preserves stats, invalid cron rejected on schedule edit, job re-armed after edit, guild-mismatch refused.

## Testing

- `npm run build` — clean
- `npm run lint` / `npm run format:check` — clean
- `npm test` (web + poll-service suites) — all passing, including new tests for both update methods and the pre-filled edit forms.

https://claude.ai/code/session_01E5FbmUxLRSf72zLj3kHd7e

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5FbmUxLRSf72zLj3kHd7e)_