### PR TITLE
feat(rewind): replace Top channels with a Top voice companions card

### DIFF
--- a/WEBUI.md
+++ b/WEBUI.md
@@ -758,11 +758,11 @@ No dashboard JSON ships with the bot — wire these up to taste:
 
 ### User self-service (`/me/*`, both admin and user roles)
 
-| Page                                    | What it's for                                                                                                                          |
-| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| **Overview** (`/me/`)                   | Index for your own settings — links to the available per-user pages.                                                                   |
-| **Notifications** (`/me/notifications`) | Opt in or out of DM nudges from Koolbot (achievements, weekly digest, Rewind nudge). Each toggle records a `WebAuditLog` row.          |
-| **Rewind** (`/me/rewind`)               | Personal year-in-review: voice time, top channels, peak day, streak, badges, annual rank, weekly-rank journey, and text activity.      |
+| Page                                    | What it's for                                                                                                                                           |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Overview** (`/me/`)                   | Index for your own settings — links to the available per-user pages.                                                                                    |
+| **Notifications** (`/me/notifications`) | Opt in or out of DM nudges from Koolbot (achievements, weekly digest, Rewind nudge). Each toggle records a `WebAuditLog` row.                           |
+| **Rewind** (`/me/rewind`)               | Personal year-in-review: voice time, top voice companions, top channels, peak day, streak, badges, annual rank, weekly-rank journey, and text activity. |
 
 Notification preferences are scoped per `(userId, guildId)`. The page
 lists every notification type with the current state and a checkbox;

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -758,11 +758,11 @@ No dashboard JSON ships with the bot — wire these up to taste:
 
 ### User self-service (`/me/*`, both admin and user roles)
 
-| Page                                    | What it's for                                                                                                                                           |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Overview** (`/me/`)                   | Index for your own settings — links to the available per-user pages.                                                                                    |
-| **Notifications** (`/me/notifications`) | Opt in or out of DM nudges from Koolbot (achievements, weekly digest, Rewind nudge). Each toggle records a `WebAuditLog` row.                           |
-| **Rewind** (`/me/rewind`)               | Personal year-in-review: voice time, top voice companions, top channels, peak day, streak, badges, annual rank, weekly-rank journey, and text activity. |
+| Page                                    | What it's for                                                                                                                             |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **Overview** (`/me/`)                   | Index for your own settings — links to the available per-user pages.                                                                      |
+| **Notifications** (`/me/notifications`) | Opt in or out of DM nudges from Koolbot (achievements, weekly digest, Rewind nudge). Each toggle records a `WebAuditLog` row.             |
+| **Rewind** (`/me/rewind`)               | Personal year-in-review: voice time, top voice companions, peak day, streak, badges, annual rank, weekly-rank journey, and text activity. |
 
 Notification preferences are scoped per `(userId, guildId)`. The page
 lists every notification type with the current state and a checkbox;

--- a/__tests__/services/rewind-service.test.ts
+++ b/__tests__/services/rewind-service.test.ts
@@ -57,6 +57,8 @@ const {
   computeLongestStreak,
   computePeakDay,
   computeTopChannels,
+  computeTopCompanions,
+  isManagedChannelName,
   computePeakMessageDay,
   computeTopTextChannels,
   messagesInWindow,
@@ -177,6 +179,94 @@ describe("RewindService pure helpers", () => {
         { startTime: new Date(), duration: 4, channelId: "d" },
       ];
       expect(computeTopChannels(sessions, 2)).toHaveLength(2);
+    });
+  });
+
+  describe("computeTopCompanions", () => {
+    it("returns an empty array for no sessions", () => {
+      expect(computeTopCompanions([], 5)).toEqual([]);
+    });
+
+    it("returns an empty array when no session has otherUsers", () => {
+      const sessions = [
+        {
+          startTime: new Date("2026-01-01T10:00:00Z"),
+          duration: 600,
+          channelId: "a",
+          channelName: "alpha",
+        },
+        {
+          startTime: new Date("2026-01-02T10:00:00Z"),
+          duration: 600,
+          channelId: "a",
+          channelName: "alpha",
+          otherUsers: [],
+        },
+      ];
+      expect(computeTopCompanions(sessions, 5)).toEqual([]);
+    });
+
+    it("sums co-present seconds per companion and ranks by total", () => {
+      const sessions = [
+        {
+          startTime: new Date("2026-01-01T10:00:00Z"),
+          duration: 600,
+          channelId: "a",
+          channelName: "alpha",
+          otherUsers: ["bob", "carol"],
+        },
+        {
+          startTime: new Date("2026-01-02T10:00:00Z"),
+          duration: 1200,
+          channelId: "a",
+          channelName: "alpha",
+          otherUsers: ["bob"],
+        },
+        // Zero-duration sessions are ignored.
+        {
+          startTime: new Date("2026-01-03T10:00:00Z"),
+          duration: 0,
+          channelId: "a",
+          channelName: "alpha",
+          otherUsers: ["carol"],
+        },
+      ];
+      const top = computeTopCompanions(sessions, 5);
+      expect(top).toEqual([
+        { userId: "bob", totalSeconds: 1800 },
+        { userId: "carol", totalSeconds: 600 },
+      ]);
+    });
+
+    it("honours the limit", () => {
+      const sessions = [
+        {
+          startTime: new Date("2026-01-01T10:00:00Z"),
+          duration: 600,
+          channelId: "a",
+          otherUsers: ["b", "c", "d", "e"],
+        },
+      ];
+      expect(computeTopCompanions(sessions, 2)).toHaveLength(2);
+    });
+  });
+
+  describe("isManagedChannelName", () => {
+    it("matches the configured prefix", () => {
+      expect(isManagedChannelName("🎮 Alice's Room", "🎮", "")).toBe(true);
+    });
+
+    it("matches the configured suffix", () => {
+      expect(isManagedChannelName("Alice's Room", "", "'s Room")).toBe(true);
+    });
+
+    it("does not match a standing channel", () => {
+      expect(isManagedChannelName("general-vc", "🎮", "'s Room")).toBe(false);
+    });
+
+    it("ignores empty prefix/suffix and missing names", () => {
+      expect(isManagedChannelName("anything", "", "")).toBe(false);
+      expect(isManagedChannelName(undefined, "🎮", "'s Room")).toBe(false);
     });
   });
 
@@ -441,6 +531,67 @@ describe("RewindService.getSummary", () => {
     expect(summary!.weeklyJourney.last?.isoWeek).toBe(5);
     expect(summary!.weeklyJourney.best?.isoWeek).toBe(4);
     expect(summary!.availableYears).toEqual([2026, 2025]);
+  });
+
+  it("aggregates and resolves top voice companions (#567)", async () => {
+    const year = 2026;
+    const sessions = [
+      {
+        startTime: new Date(`${year}-02-01T10:00:00Z`),
+        duration: 3600,
+        channelId: "general",
+        channelName: "general-vc",
+        otherUsers: ["bob", "carol"],
+      },
+      {
+        startTime: new Date(`${year}-02-02T10:00:00Z`),
+        duration: 1800,
+        channelId: "general",
+        channelName: "general-vc",
+        otherUsers: ["bob"],
+      },
+    ];
+    mockFindOneVc.mockReturnValueOnce(lean({ sessions }));
+    mockFindOneAch.mockReturnValueOnce(lean(null));
+    mockAggregateVc
+      .mockResolvedValueOnce([{ _id: 2026 }])
+      .mockResolvedValueOnce([{ _id: "u1", totalTime: 5400 }])
+      .mockResolvedValueOnce([]);
+
+    // Client cache resolves bob (guild nickname) and carol (global
+    // username); a left member would simply miss both caches.
+    const client = {
+      guilds: {
+        cache: {
+          get: (id: string) =>
+            id === "g1"
+              ? {
+                  members: {
+                    cache: {
+                      get: (uid: string) =>
+                        uid === "bob" ? { displayName: "Bob the Builder" } : undefined,
+                    },
+                  },
+                }
+              : undefined,
+        },
+      },
+      users: {
+        cache: {
+          get: (uid: string) =>
+            uid === "carol" ? { username: "carol123" } : undefined,
+        },
+      },
+    };
+
+    const svc = RewindService.getInstance(
+      client as Parameters<typeof RewindService.getInstance>[0],
+    );
+    const summary = await svc.getSummary("u1", "g1", year);
+    expect(summary!.topCompanions).toEqual([
+      { userId: "bob", displayName: "Bob the Builder", totalSeconds: 5400 },
+      { userId: "carol", displayName: "carol123", totalSeconds: 3600 },
+    ]);
   });
 
   it("filters achievements and accolades by year and ignores unknown types", async () => {

--- a/__tests__/services/rewind-service.test.ts
+++ b/__tests__/services/rewind-service.test.ts
@@ -56,9 +56,7 @@ const {
   RewindService,
   computeLongestStreak,
   computePeakDay,
-  computeTopChannels,
   computeTopCompanions,
-  isManagedChannelName,
   computePeakMessageDay,
   computeTopTextChannels,
   messagesInWindow,
@@ -121,64 +119,6 @@ describe("RewindService pure helpers", () => {
           channelId: "c",
         }),
       ).toBe(0);
-    });
-  });
-
-  describe("computeTopChannels", () => {
-    it("sums duration per channel and ranks by total", () => {
-      const sessions = [
-        {
-          startTime: new Date("2026-01-01T10:00:00Z"),
-          duration: 600,
-          channelId: "a",
-          channelName: "alpha",
-        },
-        {
-          startTime: new Date("2026-01-02T10:00:00Z"),
-          duration: 1200,
-          channelId: "b",
-          channelName: "beta",
-        },
-        {
-          startTime: new Date("2026-01-03T10:00:00Z"),
-          duration: 300,
-          channelId: "a",
-          channelName: "alpha",
-        },
-      ];
-      const top = computeTopChannels(sessions, 3);
-      expect(top).toHaveLength(2);
-      expect(top[0]).toMatchObject({ channelId: "b", totalSeconds: 1200 });
-      expect(top[1]).toMatchObject({ channelId: "a", totalSeconds: 900 });
-    });
-
-    it("uses the most recent non-empty channel name for renames", () => {
-      const sessions = [
-        {
-          startTime: new Date("2026-01-01T10:00:00Z"),
-          duration: 600,
-          channelId: "a",
-          channelName: "old-name",
-        },
-        {
-          startTime: new Date("2026-01-02T10:00:00Z"),
-          duration: 600,
-          channelId: "a",
-          channelName: "new-name",
-        },
-      ];
-      const [first] = computeTopChannels(sessions, 3);
-      expect(first.channelName).toBe("new-name");
-    });
-
-    it("honours the limit", () => {
-      const sessions = [
-        { startTime: new Date(), duration: 1, channelId: "a" },
-        { startTime: new Date(), duration: 2, channelId: "b" },
-        { startTime: new Date(), duration: 3, channelId: "c" },
-        { startTime: new Date(), duration: 4, channelId: "d" },
-      ];
-      expect(computeTopChannels(sessions, 2)).toHaveLength(2);
     });
   });
 
@@ -248,25 +188,6 @@ describe("RewindService pure helpers", () => {
         },
       ];
       expect(computeTopCompanions(sessions, 2)).toHaveLength(2);
-    });
-  });
-
-  describe("isManagedChannelName", () => {
-    it("matches the configured prefix", () => {
-      expect(isManagedChannelName("🎮 Alice's Room", "🎮", "")).toBe(true);
-    });
-
-    it("matches the configured suffix", () => {
-      expect(isManagedChannelName("Alice's Room", "", "'s Room")).toBe(true);
-    });
-
-    it("does not match a standing channel", () => {
-      expect(isManagedChannelName("general-vc", "🎮", "'s Room")).toBe(false);
-    });
-
-    it("ignores empty prefix/suffix and missing names", () => {
-      expect(isManagedChannelName("anything", "", "")).toBe(false);
-      expect(isManagedChannelName(undefined, "🎮", "'s Room")).toBe(false);
     });
   });
 
@@ -443,7 +364,7 @@ describe("RewindService.getSummary", () => {
     expect(summary!.hasData).toBe(false);
     expect(summary!.totalSeconds).toBe(0);
     expect(summary!.annualRank).toBeNull();
-    expect(summary!.topChannels).toEqual([]);
+    expect(summary!.topCompanions).toEqual([]);
   });
 
   it("aggregates a full summary when the user has voice data", async () => {
@@ -515,10 +436,6 @@ describe("RewindService.getSummary", () => {
     expect(summary!.totalSeconds).toBe(7200); // 3600 + 1800 + 1800
     expect(summary!.sessionCount).toBe(3);
     expect(summary!.daysActive).toBe(2);
-    expect(summary!.topChannels.map((c) => c.channelId)).toEqual([
-      "general",
-      "gaming",
-    ]);
     expect(summary!.peakDay).toEqual({
       date: "2026-01-15",
       totalSeconds: 5400,

--- a/__tests__/services/rewind-service.test.ts
+++ b/__tests__/services/rewind-service.test.ts
@@ -617,7 +617,7 @@ describe("RewindService snapshots (#574)", () => {
       expect(norm.guildId).toBe("g");
       expect(norm.year).toBe(2021);
       expect(norm.totalSeconds).toBe(5);
-      expect(norm.topChannels).toEqual([]);
+      expect(norm.topCompanions).toEqual([]);
       expect(norm.weeklyJourney).toEqual({
         first: null,
         last: null,

--- a/__tests__/web/user-routes.test.ts
+++ b/__tests__/web/user-routes.test.ts
@@ -663,6 +663,9 @@ describe("/me/rewind", () => {
         { channelId: "c2", channelName: "gaming", totalSeconds: 3600 * 4 },
         { channelId: "c3", channelName: "afk", totalSeconds: 3600 * 2 },
       ],
+      topCompanions: [
+        { userId: "u2", displayName: "Companion One", totalSeconds: 3600 * 5 },
+      ],
       peakDay: { date: "2026-03-15", totalSeconds: 3600 * 3 },
       messagesSent: 0,
       topTextChannels: [],
@@ -691,6 +694,8 @@ describe("/me/rewind", () => {
     expect(out.body).toContain("12 hr"); // formatHoursMinutes(3600 * 12)
     expect(out.body).toContain("#7"); // annual rank
     expect(out.body).toContain("+30%"); // median delta
+    expect(out.body).toContain("Top voice companions"); // #567 card
+    expect(out.body).toContain("Companion One");
   });
 
   it("renders a specific past year when the route param is present", async () => {

--- a/__tests__/web/user-routes.test.ts
+++ b/__tests__/web/user-routes.test.ts
@@ -658,11 +658,6 @@ describe("/me/rewind", () => {
       totalSeconds: 3600 * 12,
       sessionCount: 8,
       daysActive: 5,
-      topChannels: [
-        { channelId: "c1", channelName: "general-vc", totalSeconds: 3600 * 6 },
-        { channelId: "c2", channelName: "gaming", totalSeconds: 3600 * 4 },
-        { channelId: "c3", channelName: "afk", totalSeconds: 3600 * 2 },
-      ],
       topCompanions: [
         { userId: "u2", displayName: "Companion One", totalSeconds: 3600 * 5 },
       ],
@@ -690,12 +685,12 @@ describe("/me/rewind", () => {
     });
     expect(out.statusCode).toBe(200);
     expect(out.body).toContain("Rewind");
-    expect(out.body).toContain("general-vc");
     expect(out.body).toContain("12 hr"); // formatHoursMinutes(3600 * 12)
     expect(out.body).toContain("#7"); // annual rank
     expect(out.body).toContain("+30%"); // median delta
     expect(out.body).toContain("Top voice companions"); // #567 card
     expect(out.body).toContain("Companion One");
+    expect(out.body).not.toContain("Top channels"); // removed from Rewind
   });
 
   it("renders a specific past year when the route param is present", async () => {
@@ -743,7 +738,7 @@ describe("/me/rewind", () => {
         totalSeconds: 0,
         sessionCount: 0,
         daysActive: 0,
-        topChannels: [],
+        topCompanions: [],
         peakDay: null,
         longestStreakDays: 0,
         longestStreakRange: null,

--- a/src/services/rewind-service.ts
+++ b/src/services/rewind-service.ts
@@ -381,7 +381,9 @@ export function normalizeSnapshotSummary(
     totalSeconds: s.totalSeconds ?? 0,
     sessionCount: s.sessionCount ?? 0,
     daysActive: s.daysActive ?? 0,
-    topChannels: s.topChannels ?? [],
+    // Older snapshots predate companions (#567) and any that recorded the
+    // since-removed topChannels are simply dropped here.
+    topCompanions: s.topCompanions ?? [],
     peakDay: s.peakDay ?? null,
     messagesSent: s.messagesSent ?? 0,
     topTextChannels: s.topTextChannels ?? [],

--- a/src/services/rewind-service.ts
+++ b/src/services/rewind-service.ts
@@ -489,24 +489,30 @@ export class RewindService {
       // Top channels: on a guild using dynamic VCs the ephemeral
       // per-session rooms dominate and tell the user nothing, so filter
       // them out and let companions lead (#567). The filter follows the
-      // configured prefix / suffix rather than a hardcoded name.
-      const dynamicVcEnabled = await this.configService.getBoolean(
-        "voicechannels.enabled",
-        false,
-      );
+      // configured prefix / suffix rather than a hardcoded name. Mirror
+      // the feature gate used by ChannelInitializer / VoiceChannelManager,
+      // including the legacy keys, so deployments on older config still
+      // get the filter.
+      const dynamicVcEnabled =
+        (await this.configService.getBoolean("voicechannels.enabled", false)) ||
+        (await this.configService.getBoolean("voice_channel.enabled", false)) ||
+        (await this.configService.getBoolean("ENABLE_VC_MANAGEMENT", false));
       let channelSessions = sessions;
       if (dynamicVcEnabled) {
         const prefix = await this.configService.getString(
           "voicechannels.channel.prefix",
           "🎮",
         );
-        // Mirror VoiceChannelManager's fallback so an unset suffix still
-        // matches the default "'s Room" rooms.
+        // Mirror VoiceChannelManager's suffix resolution (current key,
+        // legacy key, then the default "'s Room") so an unset suffix still
+        // matches the default dynamic rooms.
         const suffix =
           (await this.configService.getString(
             "voicechannels.channel.suffix",
             "",
-          )) || "'s Room";
+          )) ||
+          (await this.configService.getString("voice_channel.suffix", "")) ||
+          "'s Room";
         channelSessions = sessions.filter(
           (s) => !isManagedChannelName(s.channelName, prefix, suffix),
         );

--- a/src/services/rewind-service.ts
+++ b/src/services/rewind-service.ts
@@ -832,9 +832,10 @@ export class RewindService {
   /**
    * Resolve a companion's user id to a display name (#567), preferring the
    * guild nickname, then the global username, both read from the client
-   * cache like `resolveChannelName`. Users who have since left the guild
-   * simply miss the cache and fall back to a neutral placeholder rather
-   * than breaking the page.
+   * cache like `resolveChannelName`. A cache miss can mean the user left
+   * the guild, but also simply that partial member caching (gateway
+   * intents / cache limits) never populated them — so we fall back to a
+   * neutral placeholder rather than asserting they've gone.
    */
   private resolveUserName(guildId: string, userId: string): string {
     const member = this.client.guilds?.cache
@@ -843,7 +844,7 @@ export class RewindService {
     if (member?.displayName) return member.displayName;
     const user = this.client.users?.cache?.get(userId);
     if (user?.username) return user.username;
-    return "Former member";
+    return "Unknown user";
   }
 
   /**

--- a/src/services/rewind-service.ts
+++ b/src/services/rewind-service.ts
@@ -32,6 +32,18 @@ export interface RewindChannel {
 }
 
 /**
+ * A voice "companion" for the Rewind summary (#567) — another user the
+ * requesting user shared a voice channel with, ranked by co-present
+ * seconds. With this server's dynamic VCs the meaningful unit is *who*
+ * you spent time with rather than *which* ephemeral room you sat in.
+ */
+export interface RewindCompanion {
+  userId: string;
+  displayName: string;
+  totalSeconds: number;
+}
+
+/**
  * Top text channel for the Rewind summary (#496). Mirrors `RewindChannel`
  * but ranked by message count rather than seconds, since text activity is
  * counted per message.
@@ -65,6 +77,8 @@ export interface RewindSummary {
   sessionCount: number;
   daysActive: number;
   topChannels: RewindChannel[];
+  // People the user spent the most voice time with this year (#567).
+  topCompanions: RewindCompanion[];
   peakDay: { date: string; totalSeconds: number } | null; // ISO date (YYYY-MM-DD)
   // Text-message activity (#496). Mirrors the voice aggregates above and
   // reads as zero / empty when message tracking is disabled or absent.
@@ -95,6 +109,8 @@ interface RawSession {
   duration?: number;
   channelId: string;
   channelName?: string;
+  // Union of other user ids encountered during the session (#567).
+  otherUsers?: string[];
 }
 
 interface RawTextMessage {
@@ -173,6 +189,62 @@ export function computeTopChannels(
   return [...totals.values()]
     .sort((a, b) => b.totalSeconds - a.totalSeconds)
     .slice(0, limit);
+}
+
+/**
+ * Aggregate co-present voice seconds per other user (#567) and return the
+ * top `limit` ranked desc. For each session, every id in `otherUsers[]` is
+ * credited the *whole* session's duration.
+ *
+ * Caveat: `otherUsers[]` is the union of everyone encountered during the
+ * session, not a per-moment overlap, so a companion who only dropped in
+ * for a minute is still credited the full session. That over-counts, but
+ * it's an acceptable approximation for a fun year-in-review stat; precise
+ * overlap would need interval tracking (out of scope here).
+ *
+ * Returns ids + seconds; the service resolves ids → display names, mirroring
+ * how `computeTopTextChannels` defers name resolution.
+ */
+export function computeTopCompanions(
+  sessions: RawSession[],
+  limit = 5,
+): Array<{ userId: string; totalSeconds: number }> {
+  const totals = new Map<string, number>();
+  for (const s of sessions) {
+    const seconds = sessionSeconds(s);
+    if (seconds <= 0) continue;
+    for (const userId of s.otherUsers ?? []) {
+      if (!userId) continue;
+      totals.set(userId, (totals.get(userId) ?? 0) + seconds);
+    }
+  }
+  return [...totals.entries()]
+    .map(([userId, totalSeconds]) => ({ userId, totalSeconds }))
+    .sort((a, b) => b.totalSeconds - a.totalSeconds)
+    .slice(0, limit);
+}
+
+/**
+ * Whether a stored session `channelName` looks like a bot-managed,
+ * ephemeral dynamic VC (#567) rather than a standing channel.
+ * `VoiceChannelManager` creates dynamic rooms as
+ * `${prefix} ${displayName}${suffix}` (e.g. "🎮 Alice's Room"), so a name
+ * carrying the configured prefix or suffix is treated as managed. Matching
+ * follows config rather than a hardcoded name, so renaming the prefix /
+ * suffix keeps the filter accurate. Empty prefix / suffix are ignored so we
+ * never accidentally match every channel.
+ */
+export function isManagedChannelName(
+  channelName: string | undefined,
+  prefix: string,
+  suffix: string,
+): boolean {
+  if (!channelName) return false;
+  const trimmedPrefix = prefix.trim();
+  const trimmedSuffix = suffix.trim();
+  if (trimmedPrefix && channelName.startsWith(trimmedPrefix)) return true;
+  if (trimmedSuffix && channelName.endsWith(trimmedSuffix)) return true;
+  return false;
 }
 
 export function computePeakDay(
@@ -414,7 +486,41 @@ export class RewindService {
           .map((s) => dayKey(s.startTime, dayZone)),
       ).size;
 
-      const topChannels = computeTopChannels(sessions, 3);
+      // Top channels: on a guild using dynamic VCs the ephemeral
+      // per-session rooms dominate and tell the user nothing, so filter
+      // them out and let companions lead (#567). The filter follows the
+      // configured prefix / suffix rather than a hardcoded name.
+      const dynamicVcEnabled = await this.configService.getBoolean(
+        "voicechannels.enabled",
+        false,
+      );
+      let channelSessions = sessions;
+      if (dynamicVcEnabled) {
+        const prefix = await this.configService.getString(
+          "voicechannels.channel.prefix",
+          "🎮",
+        );
+        // Mirror VoiceChannelManager's fallback so an unset suffix still
+        // matches the default "'s Room" rooms.
+        const suffix =
+          (await this.configService.getString(
+            "voicechannels.channel.suffix",
+            "",
+          )) || "'s Room";
+        channelSessions = sessions.filter(
+          (s) => !isManagedChannelName(s.channelName, prefix, suffix),
+        );
+      }
+
+      const topChannels = computeTopChannels(channelSessions, 3);
+      const topCompanions: RewindCompanion[] = computeTopCompanions(
+        sessions,
+        5,
+      ).map((c) => ({
+        userId: c.userId,
+        displayName: this.resolveUserName(guildId, c.userId),
+        totalSeconds: c.totalSeconds,
+      }));
       const peakDay = computePeakDay(sessions, dayZone);
       const streak = computeLongestStreak(sessions, dayZone);
 
@@ -466,6 +572,7 @@ export class RewindService {
         sessionCount: sessions.filter((s) => sessionSeconds(s) > 0).length,
         daysActive,
         topChannels,
+        topCompanions,
         peakDay,
         messagesSent: text.messagesSent,
         topTextChannels: text.topTextChannels,
@@ -613,6 +720,23 @@ export class RewindService {
       return channel.name;
     }
     return "Unknown channel";
+  }
+
+  /**
+   * Resolve a companion's user id to a display name (#567), preferring the
+   * guild nickname, then the global username, both read from the client
+   * cache like `resolveChannelName`. Users who have since left the guild
+   * simply miss the cache and fall back to a neutral placeholder rather
+   * than breaking the page.
+   */
+  private resolveUserName(guildId: string, userId: string): string {
+    const member = this.client.guilds?.cache
+      ?.get(guildId)
+      ?.members?.cache?.get(userId);
+    if (member?.displayName) return member.displayName;
+    const user = this.client.users?.cache?.get(userId);
+    if (user?.username) return user.username;
+    return "Former member";
   }
 
   /**

--- a/src/services/rewind-service.ts
+++ b/src/services/rewind-service.ts
@@ -25,12 +25,6 @@ const SECONDS_PER_MINUTE = 60;
 const SECONDS_PER_HOUR = 60 * 60;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
-export interface RewindChannel {
-  channelId: string;
-  channelName: string;
-  totalSeconds: number;
-}
-
 /**
  * A voice "companion" for the Rewind summary (#567) — another user the
  * requesting user shared a voice channel with, ranked by co-present
@@ -44,9 +38,8 @@ export interface RewindCompanion {
 }
 
 /**
- * Top text channel for the Rewind summary (#496). Mirrors `RewindChannel`
- * but ranked by message count rather than seconds, since text activity is
- * counted per message.
+ * Top text channel for the Rewind summary (#496). Ranked by message count
+ * rather than seconds, since text activity is counted per message.
  */
 export interface RewindTextChannel {
   channelId: string;
@@ -76,8 +69,9 @@ export interface RewindSummary {
   totalSeconds: number;
   sessionCount: number;
   daysActive: number;
-  topChannels: RewindChannel[];
   // People the user spent the most voice time with this year (#567).
+  // (Top channels was removed from Rewind — with dynamic VCs the ephemeral
+  // per-session room names are noise; companions replace it.)
   topCompanions: RewindCompanion[];
   peakDay: { date: string; totalSeconds: number } | null; // ISO date (YYYY-MM-DD)
   // Text-message activity (#496). Mirrors the voice aggregates above and
@@ -161,36 +155,6 @@ export function sessionSeconds(session: RawSession): number {
   return 0;
 }
 
-export function computeTopChannels(
-  sessions: RawSession[],
-  limit = 3,
-): RewindChannel[] {
-  const totals = new Map<
-    string,
-    { channelId: string; channelName: string; totalSeconds: number }
-  >();
-  for (const s of sessions) {
-    const key = s.channelId;
-    const seconds = sessionSeconds(s);
-    if (seconds <= 0) continue;
-    const existing = totals.get(key);
-    if (existing) {
-      existing.totalSeconds += seconds;
-      // Prefer the most recent non-empty name (handles renames).
-      if (s.channelName) existing.channelName = s.channelName;
-    } else {
-      totals.set(key, {
-        channelId: key,
-        channelName: s.channelName ?? "Unknown channel",
-        totalSeconds: seconds,
-      });
-    }
-  }
-  return [...totals.values()]
-    .sort((a, b) => b.totalSeconds - a.totalSeconds)
-    .slice(0, limit);
-}
-
 /**
  * Aggregate co-present voice seconds per other user (#567) and return the
  * top `limit` ranked desc. For each session, every id in `otherUsers[]` is
@@ -222,29 +186,6 @@ export function computeTopCompanions(
     .map(([userId, totalSeconds]) => ({ userId, totalSeconds }))
     .sort((a, b) => b.totalSeconds - a.totalSeconds)
     .slice(0, limit);
-}
-
-/**
- * Whether a stored session `channelName` looks like a bot-managed,
- * ephemeral dynamic VC (#567) rather than a standing channel.
- * `VoiceChannelManager` creates dynamic rooms as
- * `${prefix} ${displayName}${suffix}` (e.g. "🎮 Alice's Room"), so a name
- * carrying the configured prefix or suffix is treated as managed. Matching
- * follows config rather than a hardcoded name, so renaming the prefix /
- * suffix keeps the filter accurate. Empty prefix / suffix are ignored so we
- * never accidentally match every channel.
- */
-export function isManagedChannelName(
-  channelName: string | undefined,
-  prefix: string,
-  suffix: string,
-): boolean {
-  if (!channelName) return false;
-  const trimmedPrefix = prefix.trim();
-  const trimmedSuffix = suffix.trim();
-  if (trimmedPrefix && channelName.startsWith(trimmedPrefix)) return true;
-  if (trimmedSuffix && channelName.endsWith(trimmedSuffix)) return true;
-  return false;
 }
 
 export function computePeakDay(
@@ -486,39 +427,9 @@ export class RewindService {
           .map((s) => dayKey(s.startTime, dayZone)),
       ).size;
 
-      // Top channels: on a guild using dynamic VCs the ephemeral
-      // per-session rooms dominate and tell the user nothing, so filter
-      // them out and let companions lead (#567). The filter follows the
-      // configured prefix / suffix rather than a hardcoded name. Mirror
-      // the feature gate used by ChannelInitializer / VoiceChannelManager,
-      // including the legacy keys, so deployments on older config still
-      // get the filter.
-      const dynamicVcEnabled =
-        (await this.configService.getBoolean("voicechannels.enabled", false)) ||
-        (await this.configService.getBoolean("voice_channel.enabled", false)) ||
-        (await this.configService.getBoolean("ENABLE_VC_MANAGEMENT", false));
-      let channelSessions = sessions;
-      if (dynamicVcEnabled) {
-        const prefix = await this.configService.getString(
-          "voicechannels.channel.prefix",
-          "🎮",
-        );
-        // Mirror VoiceChannelManager's suffix resolution (current key,
-        // legacy key, then the default "'s Room") so an unset suffix still
-        // matches the default dynamic rooms.
-        const suffix =
-          (await this.configService.getString(
-            "voicechannels.channel.suffix",
-            "",
-          )) ||
-          (await this.configService.getString("voice_channel.suffix", "")) ||
-          "'s Room";
-        channelSessions = sessions.filter(
-          (s) => !isManagedChannelName(s.channelName, prefix, suffix),
-        );
-      }
-
-      const topChannels = computeTopChannels(channelSessions, 3);
+      // Top voice companions (#567) replace the old "Top channels" card:
+      // with dynamic VCs the ephemeral per-session room names are noise, so
+      // we surface *who* the user spent time with instead.
       const topCompanions: RewindCompanion[] = computeTopCompanions(
         sessions,
         5,
@@ -577,7 +488,6 @@ export class RewindService {
         totalSeconds,
         sessionCount: sessions.filter((s) => sessionSeconds(s) > 0).length,
         daysActive,
-        topChannels,
         topCompanions,
         peakDay,
         messagesSent: text.messagesSent,

--- a/src/web/user-layout.ts
+++ b/src/web/user-layout.ts
@@ -252,7 +252,7 @@ export function renderUserIndexBody(opts: {
     '<li><span class="feature-name"><a href="/me/timezone">Timezone</a></span>' +
       '<span class="feature-desc">Choose the timezone Koolbot uses when it shows you times in digests, Rewind, and voicestats.</span></li>',
     '<li><span class="feature-name"><a href="/me/rewind">Rewind</a></span>' +
-      '<span class="feature-desc">Your personal year-in-review of voice activity, top channels, peak day, and badges earned.</span></li>',
+      '<span class="feature-desc">Your personal year-in-review of voice activity, top voice companions, peak day, and badges earned.</span></li>',
     "</ul>",
     "</div>",
     '<div class="card">',
@@ -286,6 +286,12 @@ export interface RewindTextChannelView {
   count: number;
 }
 
+export interface RewindCompanionView {
+  userId: string;
+  displayName: string;
+  duration: string; // pre-formatted
+}
+
 export interface RewindBodyOptions {
   year: number;
   availableYears: number[]; // includes `year` for the current selection
@@ -295,6 +301,8 @@ export interface RewindBodyOptions {
   sessionCount: number;
   daysActive: number;
   topChannels: RewindChannelView[];
+  // People the user shared voice channels with most this year (#567).
+  topCompanions: RewindCompanionView[];
   peakDay: { date: string; duration: string } | null;
   longestStreakDays: number;
   longestStreakRange: { startDate: string; endDate: string } | null;
@@ -488,6 +496,23 @@ export function renderUserRewindBody(opts: RewindBodyOptions): string {
           .join("") +
         "</ul>";
 
+  // Top voice companions (#567) — ranked ahead of channels because with
+  // dynamic VCs *who* you sat with matters more than the throwaway room.
+  const companions =
+    opts.topCompanions.length === 0
+      ? '<div class="empty">No voice companions yet — hop in a channel with someone!</div>'
+      : '<ul class="rw-channels">' +
+        opts.topCompanions
+          .map(
+            (c) =>
+              "<li>" +
+              `<span class="name">${escapeHtml(c.displayName)}</span>` +
+              `<span class="dur">${escapeHtml(c.duration)}</span>` +
+              "</li>",
+          )
+          .join("") +
+        "</ul>";
+
   return [
     `<h1>Rewind ${opts.year}</h1>`,
     '<p class="subtitle">Your personal year-in-review.</p>',
@@ -505,6 +530,7 @@ export function renderUserRewindBody(opts: RewindBodyOptions): string {
       medianStat +
       "</div>",
     "</div>",
+    '<div class="card"><h2>Top voice companions</h2>' + companions + "</div>",
     '<div class="card"><h2>Top channels</h2>' + channels + "</div>",
     renderTextActivity(opts),
     '<div class="card"><h2>Rank journey</h2>' +

--- a/src/web/user-layout.ts
+++ b/src/web/user-layout.ts
@@ -274,12 +274,6 @@ export interface RewindBadgeView {
   earnedAt: string; // ISO date already formatted by the route
 }
 
-export interface RewindChannelView {
-  channelId: string;
-  channelName: string;
-  duration: string; // pre-formatted
-}
-
 export interface RewindTextChannelView {
   channelId: string;
   channelName: string;
@@ -300,8 +294,8 @@ export interface RewindBodyOptions {
   funComparison: string | null;
   sessionCount: number;
   daysActive: number;
-  topChannels: RewindChannelView[];
   // People the user shared voice channels with most this year (#567).
+  // Replaces the old Top channels card, which was noise under dynamic VCs.
   topCompanions: RewindCompanionView[];
   peakDay: { date: string; duration: string } | null;
   longestStreakDays: number;
@@ -481,23 +475,8 @@ export function renderUserRewindBody(opts: RewindBodyOptions): string {
         : `<div class="value">${opts.percentAboveMedian}%</div><div class="detail">vs. the guild median</div>`
       : '<div class="value">—</div>';
 
-  const channels =
-    opts.topChannels.length === 0
-      ? '<div class="empty">No tracked channels this year.</div>'
-      : '<ul class="rw-channels">' +
-        opts.topChannels
-          .map(
-            (c) =>
-              "<li>" +
-              `<span class="name">${escapeHtml(c.channelName)}</span>` +
-              `<span class="dur">${escapeHtml(c.duration)}</span>` +
-              "</li>",
-          )
-          .join("") +
-        "</ul>";
-
-  // Top voice companions (#567) — ranked ahead of channels because with
-  // dynamic VCs *who* you sat with matters more than the throwaway room.
+  // Top voice companions (#567) — with dynamic VCs *who* you sat with
+  // matters more than the throwaway room, so this replaces Top channels.
   const companions =
     opts.topCompanions.length === 0
       ? '<div class="empty">No voice companions yet — hop in a channel with someone!</div>'
@@ -531,7 +510,6 @@ export function renderUserRewindBody(opts: RewindBodyOptions): string {
       "</div>",
     "</div>",
     '<div class="card"><h2>Top voice companions</h2>' + companions + "</div>",
-    '<div class="card"><h2>Top channels</h2>' + channels + "</div>",
     renderTextActivity(opts),
     '<div class="card"><h2>Rank journey</h2>' +
       renderJourney(opts.weeklyJourney) +

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -526,6 +526,11 @@ export function createUserRouter(
             channelName: c.channelName,
             duration: formatHoursMinutes(c.totalSeconds),
           })),
+          topCompanions: (summary.topCompanions ?? []).map((c) => ({
+            userId: c.userId,
+            displayName: c.displayName,
+            duration: formatHoursMinutes(c.totalSeconds),
+          })),
           peakDay: summary.peakDay
             ? {
                 date: summary.peakDay.date,

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -521,11 +521,6 @@ export function createUserRouter(
           funComparison: formatFunComparison(summary.totalSeconds),
           sessionCount: summary.sessionCount,
           daysActive: summary.daysActive,
-          topChannels: summary.topChannels.map((c) => ({
-            channelId: c.channelId,
-            channelName: c.channelName,
-            duration: formatHoursMinutes(c.totalSeconds),
-          })),
           topCompanions: (summary.topCompanions ?? []).map((c) => ({
             userId: c.userId,
             displayName: c.displayName,


### PR DESCRIPTION
## Summary

Closes #567.

Rewind's **Top channels** card is low-signal on servers built around **dynamic voice channels**: each session captures an ephemeral, auto-generated room name (e.g. "🎮 Alice's Room"), so the card just ranks throwaway names. The far more valuable angle is *who* you spent time with — data we already track in each session's `otherUsers[]` co-presence array but never surfaced in Rewind.

This PR adds a **Top voice companions** card and **removes Top channels from Rewind entirely**.

> **Decision (updated per PR feedback):** #567 floated three options — hide, demote, or filter Top channels. The PR initially demoted it below companions and filtered out managed/ephemeral dynamic VCs (`isManagedChannelName`). The repo owner then asked for Top channels to be removed from the Rewind page completely, so the filter approach and the `isManagedChannelName` helper were dropped — companions fully replace it. The acceptance-criteria item about Top channels not dominating the page is satisfied by removal.

## Changes

- **`computeTopCompanions(sessions, limit)`** — new pure helper in `rewind-service.ts`. Walks sessions, crediting each session's duration to every id in `otherUsers[]`, sorts desc, slices. Returns ids + seconds; the service resolves ids → display names (mirrors `computeTopTextChannels`). Over-counting caveat documented in a comment (`otherUsers[]` is a session-wide union, not per-moment overlap — acceptable for a fun stat).
- **`RewindSummary.topCompanions`** + a `RewindCompanionView` card in `src/web/user-layout.ts`, reusing the existing `.rw-channels` styling.
- **Top channels removed** — the `topChannels` field, route mapping, rendered card, and the `computeTopChannels` / `isManagedChannelName` helpers are all gone. `normalizeSnapshotSummary` (from #574/#580, picked up in the merge) now carries `topCompanions`; older snapshots default to `[]`.
- Companion ids resolve to guild nickname → global username via the client cache, falling back to a neutral **"Unknown user"** when the cache misses (left guild, or partial member caching).
- Self-scope preserved — only the requesting user's own co-presence is ever shown (page is already `assertSelfScope`-gated).
- Docs: `WEBUI.md` + the `/me` index description updated.

## Acceptance criteria

- [x] Rewind shows a "Top voice companions" card ranked by co-present seconds.
- [x] On a dynamic-VC guild, Top channels no longer dominates the page — it's removed entirely (decision recorded above).
- [x] Companion resolution handles members who have left the guild (and partial-cache misses) without breaking the page.
- [x] Only the requesting user's own data is shown.
- [x] Unit tests cover `computeTopCompanions`: empty sessions, sessions with no `otherUsers`, correct per-companion summation and ordering.

## Testing

- `npm run build` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npx markdownlint WEBUI.md` ✅
- `npm test` ✅ — 100 suites, 1122 passed (after merging main)

https://claude.ai/code/session_01JrT1dgTGynbEEr4LhNNqXU