### PR TITLE
feat(rewind): cover a full year by default and warn on low retention

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -620,7 +620,7 @@ Automatic cleanup of old tracking data with data aggregation.
 | --- | --- | --- |
 | `voicetracking.cleanup.enabled` | `false` | Enable automatic data cleanup |
 | `voicetracking.cleanup.schedule` | `"0 0 * * *"` | Cron schedule (default: daily at midnight) |
-| `voicetracking.cleanup.retention.detailed_sessions_days` | `30` | Days to keep detailed session data |
+| `voicetracking.cleanup.retention.detailed_sessions_days` | `400` | Days to keep detailed session data (full Rewind year + buffer) |
 | `voicetracking.cleanup.retention.monthly_summaries_months` | `6` | Months to keep monthly summaries |
 | `voicetracking.cleanup.retention.yearly_summaries_years` | `1` | Years to keep yearly summaries |
 
@@ -632,15 +632,25 @@ Automatic cleanup of old tracking data with data aggregation.
 4. Manual cleanup runs from the Web UI's **Database** page (replaces
    the old `/dbtrunk run`)
 
+⚠️ **Important for Rewind (year-in-review):**
+
+Rewind is built live from the **detailed** voice sessions that this job
+prunes. To render a full year-in-review, keep
+`detailed_sessions_days` at or above a full year — **366 days** (the
+default of `400` leaves a buffer). Below that threshold, recaps that
+reach further back than the retention window are incomplete. The WebUI
+shows a soft, non-blocking warning when this (or
+`messagetracking.cleanup.retention.detailed_days`) is set below 366
+days. Lower it only if you don't need a full year-in-review.
+
 ⚠️ **Important for consecutive-days accolades:**
 
 The cleanup job deletes session history older than
 `detailed_sessions_days`. This affects consecutive-day streak
 calculations:
 
-- **Default retention (30 days):** supports streaks up to ~25 days
-- **For 30-day "No-Lifer" accolade:** raise retention to at least **60
-  days**
+- **Default retention (400 days):** comfortably supports the streaks and
+  the full Rewind year
 - **Formula:** retention ≥ longest streak × 2
 
 ---
@@ -915,7 +925,7 @@ above).
 
 - `voicetracking.cleanup.enabled` (bool, default: false)
 - `voicetracking.cleanup.schedule` (string, default: `"0 0 * * *"`)
-- `voicetracking.cleanup.retention.detailed_sessions_days` (number, default: 30)
+- `voicetracking.cleanup.retention.detailed_sessions_days` (number, default: 400)
 - `voicetracking.cleanup.retention.monthly_summaries_months` (number, default: 6)
 - `voicetracking.cleanup.retention.yearly_summaries_years` (number, default: 1)
 

--- a/__tests__/services/config-schema.test.ts
+++ b/__tests__/services/config-schema.test.ts
@@ -3,6 +3,7 @@ import {
   defaultConfig,
   settingsMetadata,
   categoryMetadata,
+  REWIND_RETENTION_MIN_DAYS,
 } from '../../src/services/config-schema.js';
 
 describe('Config Schema', () => {
@@ -24,6 +25,17 @@ describe('Config Schema', () => {
       expect(defaultConfig['voicetracking.cleanup.retention.detailed_sessions_days']).toBeGreaterThan(0);
       expect(defaultConfig['voicetracking.cleanup.retention.monthly_summaries_months']).toBeGreaterThan(0);
       expect(defaultConfig['voicetracking.cleanup.retention.yearly_summaries_years']).toBeGreaterThan(0);
+    });
+
+    it('keeps Rewind-relevant retention defaults at or above a full year (#575)', () => {
+      // Rewind is built live from detailed voice sessions and per-message
+      // detail; out-of-the-box defaults must cover a full year-in-review.
+      expect(
+        defaultConfig['voicetracking.cleanup.retention.detailed_sessions_days'],
+      ).toBeGreaterThanOrEqual(REWIND_RETENTION_MIN_DAYS);
+      expect(
+        defaultConfig['messagetracking.cleanup.retention.detailed_days'],
+      ).toBeGreaterThanOrEqual(REWIND_RETENTION_MIN_DAYS);
     });
 
     it('should have reasonable default values for quote system', () => {
@@ -113,6 +125,20 @@ describe('Config Schema', () => {
           mismatches.push(key);
       }
       expect(mismatches).toEqual([]);
+    });
+
+    it('attaches a warnBelow hint at the Rewind threshold to both detailed-retention keys (#575)', () => {
+      const voice =
+        settingsMetadata[
+          'voicetracking.cleanup.retention.detailed_sessions_days'
+        ];
+      const message =
+        settingsMetadata['messagetracking.cleanup.retention.detailed_days'];
+      for (const meta of [voice, message]) {
+        expect(meta.warnBelow).toBeDefined();
+        expect(meta.warnBelow?.value).toBe(REWIND_RETENTION_MIN_DAYS);
+        expect(meta.warnBelow?.message.trim()).not.toBe('');
+      }
     });
 
     it('does not have stale entries for keys that no longer exist in defaultConfig', () => {

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -299,6 +299,34 @@ describe("renderSettingsPage", () => {
     expect(html).not.toContain("Rewind needs 366 days of detailed data.");
   });
 
+  it("does not warn on an unset (empty/null) value despite a warnBelow hint (#575)", () => {
+    for (const current of ["", null, undefined] as const) {
+      const html = renderSettingsPage({
+        ...COMMON,
+        groups: [
+          {
+            category: "voicetracking",
+            rows: [
+              {
+                key: "voicetracking.cleanup.retention.detailed_sessions_days",
+                current,
+                defaultValue: 400,
+                type: "number",
+                description: "",
+                category: "voicetracking",
+                warnBelow: {
+                  value: 366,
+                  message: "Rewind needs 366 days of detailed data.",
+                },
+              },
+            ],
+          },
+        ],
+      });
+      expect(html).not.toContain('class="settings-warn"');
+    }
+  });
+
   it("renders the action bar and import textarea", () => {
     const html = renderSettingsPage({ ...COMMON, groups: [] });
     expect(html).toContain('action="/admin/settings/reload"');

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -245,6 +245,60 @@ describe("renderSettingsPage", () => {
     expect(html).not.toContain('<td style="white-space:nowrap">');
   });
 
+  it("shows the warnBelow warning when a value is below the threshold (#575)", () => {
+    const html = renderSettingsPage({
+      ...COMMON,
+      groups: [
+        {
+          category: "voicetracking",
+          rows: [
+            {
+              key: "voicetracking.cleanup.retention.detailed_sessions_days",
+              current: 30,
+              defaultValue: 400,
+              type: "number",
+              description: "",
+              category: "voicetracking",
+              warnBelow: {
+                value: 366,
+                message: "Rewind needs 366 days of detailed data.",
+              },
+            },
+          ],
+        },
+      ],
+    });
+    expect(html).toContain('class="settings-warn"');
+    expect(html).toContain("Rewind needs 366 days of detailed data.");
+  });
+
+  it("hides the warnBelow warning at or above the threshold (#575)", () => {
+    const html = renderSettingsPage({
+      ...COMMON,
+      groups: [
+        {
+          category: "voicetracking",
+          rows: [
+            {
+              key: "voicetracking.cleanup.retention.detailed_sessions_days",
+              current: 400,
+              defaultValue: 400,
+              type: "number",
+              description: "",
+              category: "voicetracking",
+              warnBelow: {
+                value: 366,
+                message: "Rewind needs 366 days of detailed data.",
+              },
+            },
+          ],
+        },
+      ],
+    });
+    expect(html).not.toContain('class="settings-warn"');
+    expect(html).not.toContain("Rewind needs 366 days of detailed data.");
+  });
+
   it("renders the action bar and import textarea", () => {
     const html = renderSettingsPage({ ...COMMON, groups: [] });
     expect(html).toContain('action="/admin/settings/reload"');

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -158,7 +158,7 @@ export const defaultConfig: ConfigSchema = {
   // Voice Channel Cleanup
   "voicetracking.cleanup.enabled": false,
   "voicetracking.cleanup.schedule": "0 0 * * *", // Every day at midnight
-  "voicetracking.cleanup.retention.detailed_sessions_days": 30,
+  "voicetracking.cleanup.retention.detailed_sessions_days": 400, // Full Rewind year + buffer (mirrors messagetracking.cleanup.retention.detailed_days)
   "voicetracking.cleanup.retention.monthly_summaries_months": 6,
   "voicetracking.cleanup.retention.yearly_summaries_years": 1,
 
@@ -289,6 +289,28 @@ export interface SettingOption {
   label: string;
 }
 
+/**
+ * Minimum days of *detailed* data a full Rewind / year-in-review needs to
+ * render a complete recap. The in-progress year is built live from detailed
+ * voice sessions and per-message detail, so any retention shorter than this
+ * silently degrades Rewind. Defined once here and referenced by the retention
+ * defaults' `warnBelow` hints, the WebUI warning, and the docs so the
+ * threshold can't drift. 366 covers a full leap year.
+ */
+export const REWIND_RETENTION_MIN_DAYS = 366;
+
+/**
+ * Soft "minimum recommended value" hint for a numeric setting. When the
+ * current value is below `value`, the WebUI surfaces `message` as a
+ * non-blocking inline warning — both on save and on first load — so operators
+ * notice a degraded feature without having to edit anything. Purely advisory:
+ * it never blocks the save (operators may legitimately want a lower value).
+ */
+export interface SettingWarnBelow {
+  value: number;
+  message: string;
+}
+
 export interface SettingMetadata {
   label: string;
   description: string;
@@ -302,7 +324,24 @@ export interface SettingMetadata {
    * valid values (e.g. `leaderboard_roles.period`).
    */
   options?: SettingOption[];
+  /**
+   * Optional "minimum recommended value" hint for `number`-typed keys. The
+   * WebUI shows the warning when the current value drops below the threshold.
+   * Reusable across settings; today it guards the Rewind-relevant retention
+   * keys (see `REWIND_RETENTION_MIN_DAYS`).
+   */
+  warnBelow?: SettingWarnBelow;
 }
+
+/**
+ * Shared warning shown when a Rewind-relevant retention is below the year
+ * threshold. Built from `REWIND_RETENTION_MIN_DAYS` so the number stays in
+ * one place.
+ */
+const rewindRetentionWarning: SettingWarnBelow = {
+  value: REWIND_RETENTION_MIN_DAYS,
+  message: `⚠️ Rewind / year-in-review needs ≥ ${REWIND_RETENTION_MIN_DAYS} days of detailed data. At this value, recaps that reach further back will be incomplete. Lower it only if you don't need a full year-in-review.`,
+};
 
 /**
  * Per-category metadata for the WebUI Settings page section headers and
@@ -533,9 +572,10 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
   "voicetracking.cleanup.retention.detailed_sessions_days": {
     label: "Detailed-session retention (days)",
     description:
-      "Days to keep detailed session rows before they are summarised away.",
+      "Days to keep detailed session rows before they are summarised away. Rewind reads these detailed sessions, so keep this at or above a full year.",
     category: "voicetracking",
     type: "number",
+    warnBelow: rewindRetentionWarning,
   },
   "voicetracking.cleanup.retention.monthly_summaries_months": {
     label: "Monthly-summary retention (months)",
@@ -581,9 +621,10 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
   "messagetracking.cleanup.retention.detailed_days": {
     label: "Message-detail retention (days)",
     description:
-      "Days to keep per-message detail (recentMessages) before it is pruned. All-time per-channel totals are never pruned.",
+      "Days to keep per-message detail (recentMessages) before it is pruned. All-time per-channel totals are never pruned. Rewind reads this detail, so keep it at or above a full year.",
     category: "messagetracking",
     type: "number",
+    warnBelow: rewindRetentionWarning,
   },
 
   // Individual Features

--- a/src/services/voice-channel-truncation.ts
+++ b/src/services/voice-channel-truncation.ts
@@ -414,7 +414,7 @@ export class VoiceChannelTruncationService {
     try {
       const detailedSessionsDays = await this.configService.getNumber(
         "voicetracking.cleanup.retention.detailed_sessions_days",
-        30,
+        400,
       );
       const monthlySummariesMonths = await this.configService.getNumber(
         "voicetracking.cleanup.retention.monthly_summaries_months",
@@ -433,7 +433,7 @@ export class VoiceChannelTruncationService {
     } catch (error) {
       logger.warn("Failed to load retention config, using defaults:", error);
       return {
-        detailedSessionsDays: 30,
+        detailedSessionsDays: 400,
         monthlySummariesMonths: 6,
         yearlySummariesYears: 1,
       };

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -556,9 +556,17 @@ function renderResetButton(key: string): string {
  */
 export function renderWarnBelow(r: SettingRow): string {
   if (!r.warnBelow) return "";
+  // Only warn on a value that's genuinely a number below the threshold.
+  // An unset key (null/undefined/empty string) renders as a blank input via
+  // coerceToDisplayValue, so coercing it to 0 here would flash a misleading
+  // warning — guard those out rather than letting Number("") become 0.
+  if (r.current === null || r.current === undefined || r.current === "")
+    return "";
   const value = typeof r.current === "number" ? r.current : Number(r.current);
   if (!Number.isFinite(value) || value >= r.warnBelow.value) return "";
-  return `<div class="settings-warn" role="alert" style="margin-top:.4rem;color:#b45309;font-size:.85em">${escapeHtml(r.warnBelow.message)}</div>`;
+  // role="status" (implicit aria-live=polite) keeps this persistent advisory
+  // from being announced assertively on every page load like role="alert".
+  return `<div class="settings-warn" role="status" style="margin-top:.4rem;color:#b45309;font-size:.85em">${escapeHtml(r.warnBelow.message)}</div>`;
 }
 
 export function renderSettingsPage(props: SettingsProps): string {

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -188,6 +188,12 @@ export interface SettingRow {
    * `SettingMetadata.options`.
    */
   options?: SettingOption[];
+  /**
+   * Soft "minimum recommended value" hint. When `current` is a number below
+   * `warnBelow.value`, the settings page renders `warnBelow.message` as a
+   * non-blocking inline warning. Sourced from `SettingMetadata.warnBelow`.
+   */
+  warnBelow?: { value: number; message: string };
 }
 
 export interface SettingsProps extends CommonProps {
@@ -541,6 +547,20 @@ function renderResetButton(key: string): string {
   );
 }
 
+/**
+ * Render the soft "minimum recommended value" warning when a numeric setting
+ * is below its `warnBelow` threshold. Returns an empty string when there's no
+ * hint or the value clears the threshold, so it adds nothing to rows that
+ * don't need it. Shown unconditionally (not gated on a feature toggle) so the
+ * degraded state is visible without editing — and it re-renders after a save.
+ */
+export function renderWarnBelow(r: SettingRow): string {
+  if (!r.warnBelow) return "";
+  const value = typeof r.current === "number" ? r.current : Number(r.current);
+  if (!Number.isFinite(value) || value >= r.warnBelow.value) return "";
+  return `<div class="settings-warn" role="alert" style="margin-top:.4rem;color:#b45309;font-size:.85em">${escapeHtml(r.warnBelow.message)}</div>`;
+}
+
 export function renderSettingsPage(props: SettingsProps): string {
   const csrf = escapeHtml(props.csrfToken);
 
@@ -581,7 +601,7 @@ export function renderSettingsPage(props: SettingsProps): string {
   <code class="mono muted" style="font-size:.85em">${escapeHtml(r.key)}</code>
   <input type="hidden" name="keys" value="${escapeHtml(r.key)}">
 </td>
-<td class="settings-value">${renderSettingControl(r, pickers, r.key === cascadeMasterKey)}${renderResetButton(r.key)}</td>
+<td class="settings-value">${renderSettingControl(r, pickers, r.key === cascadeMasterKey)}${renderResetButton(r.key)}${renderWarnBelow(r)}</td>
 <td><span class="tag tag-info">${escapeHtml(r.type)}</span></td>
 <td class="settings-default">${formatValue(r.defaultValue)}</td>
 <td class="muted">${escapeHtml(r.description)}</td>

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -774,7 +774,7 @@ export function createReadOnlyRouter(
           truncation.getSchedule(),
           config.getNumber(
             "voicetracking.cleanup.retention.detailed_sessions_days",
-            30,
+            400,
           ),
           config.getNumber(
             "voicetracking.cleanup.retention.monthly_summaries_months",

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -384,6 +384,7 @@ export function createReadOnlyRouter(
             category:
               dbEntry?.category ?? meta?.category ?? deriveCategory(key),
             options: meta?.options,
+            warnBelow: meta?.warnBelow,
           };
         },
       );


### PR DESCRIPTION
Closes #575.

## Problem

Rewind / year-in-review is built **live** from detailed voice sessions and per-message detail, but the retention/cleanup jobs prune exactly that data — and the **default** voice retention (`voicetracking.cleanup.retention.detailed_sessions_days = 30`) was far shorter than a Rewind year. So out of the box, voice Rewind stats only reflected the last ~30 days, and the WebUI gave no warning when an admin lowered (or left the default on) a Rewind-relevant retention.

## Changes

**Fix the defaults**
- Raise `voicetracking.cleanup.retention.detailed_sessions_days` default `30 → 400` (full Rewind year + buffer, mirroring the message side's existing `400`).
- Update the hardcoded fallback constants in `voice-channel-truncation.ts` (`getNumber` default and the catch-block fallback) to `400` to match.

**Warn in the WebUI**
- Add a reusable, optional `warnBelow` ("minimum recommended value") hint to `SettingMetadata`, plus a shared `REWIND_RETENTION_MIN_DAYS = 366` constant defined once and referenced by the warning and the docs.
- Attach `warnBelow` to both Rewind-relevant keys (`voicetracking…detailed_sessions_days`, `messagetracking…detailed_days`).
- The settings page renders a **soft, non-blocking** inline warning whenever a value is below its threshold. Because it's rendered unconditionally on the row, it's visible **without editing** (incl. the default) and re-appears **on save** — covering both acceptance criteria with one reusable mechanism. Operators who don't want a full year-in-review can still set a lower value; the save is never blocked.

**Docs & tests**
- `SETTINGS.md`: updated the changed default, added a Rewind-dependency note and the 366-day threshold.
- Tests: new defaults are ≥ the threshold; `warnBelow` attached to both keys at `366`; warning shown below the threshold and hidden at/above it.

## Verification
- `npm run build` ✅ · `npm run lint` ✅ · `npm run format:check` ✅
- `npm run test:ci` ✅ (100 suites, 1105 passing; coverage thresholds hold)
- `markdownlint SETTINGS.md` ✅

## Notes
- Storage cost: detailed sessions are heavier than message detail, but `400` matches the intent already accepted for the message side; `30` was clearly too low for a year-in-review feature.
- Complementary to the "snapshot completed years at rollover" issue: the raised default ensures the first snapshot captures a full year, and the warning still matters for the in-progress (live-built) year.

https://claude.ai/code/session_013sNbq1WGEdeVJdvF19vbtX

---
_Generated by [Claude Code](https://claude.ai/code/session_013sNbq1WGEdeVJdvF19vbtX)_