### PR TITLE
feat(rewind): snapshot completed-year recaps at rollover (retention-proof)

### DIFF
--- a/WEBUI.md
+++ b/WEBUI.md
@@ -787,10 +787,21 @@ log and PRG-redirects back to the page.
 The **Rewind** page defaults to the current calendar year (UTC);
 `/me/rewind/:year` lets you browse past years. A small year picker at
 the top of the page only offers years for which you have data (voice
-sessions, text-message activity, or badges). Years with no data render
-a friendly empty state.
+sessions, text-message activity, or badges), plus any year that has been
+snapshotted (see below). Years with no data render a friendly empty state.
 Aggregation is on-demand and not cached in v1 — see [`SETTINGS.md`](SETTINGS.md#-rewind-year-in-review)
 for the `rewind.*` keys that control the end-of-year DM nudge.
+
+The in-progress current year is always computed live from raw activity.
+**Completed years are frozen into an immutable snapshot at year rollover**
+(`#574`): alongside the end-of-year nudge cron, `RewindNudgeService`
+writes one `RewindSnapshot` per qualifying user for the just-completed
+year. Once frozen, that year's recap renders verbatim from the snapshot
+forever — unaffected by the voice-session / message-detail truncation
+that later prunes the source data. Snapshot creation is idempotent
+(re-running the cron never duplicates or mutates an existing record) and
+gated by `rewind.enabled`. A `schemaVersion` is stored so the view can
+render older snapshots even after the summary shape gains new fields.
 
 User-facing commands (`/ping`, `/voicestats`, `/seen`, `/quote`,
 `/achievements`, `/help`) are **not** affected and stay in

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -793,12 +793,15 @@ Aggregation is on-demand and not cached in v1 — see [`SETTINGS.md`](SETTINGS.m
 for the `rewind.*` keys that control the end-of-year DM nudge.
 
 The in-progress current year is always computed live from raw activity.
-**Completed years are frozen into an immutable snapshot at year rollover**
-(`#574`): alongside the end-of-year nudge cron, `RewindNudgeService`
-writes one `RewindSnapshot` per qualifying user for the just-completed
-year. Once frozen, that year's recap renders verbatim from the snapshot
-forever — unaffected by the voice-session / message-detail truncation
-that later prunes the source data. Snapshot creation is idempotent
+**Completed years are served from an immutable snapshot** (`#574`): the
+end-of-year nudge cron (default Dec 30) runs while the current year is
+wrapping up, and alongside the nudge `RewindNudgeService` writes one
+`RewindSnapshot` per qualifying user for that year. The page keeps
+computing the year live until it rolls over; from the next year onward,
+that frozen copy is served verbatim — unaffected by the voice-session /
+message-detail truncation that later prunes the source data. Because the
+snapshot is taken on the cron's December run, activity in the final day
+or two of the year isn't captured. Snapshot creation is idempotent
 (re-running the cron never duplicates or mutates an existing record) and
 gated by `rewind.enabled`. A `schemaVersion` is stored so the view can
 render older snapshots even after the summary shape gains new fields.

--- a/__tests__/services/rewind-nudge-service.test.ts
+++ b/__tests__/services/rewind-nudge-service.test.ts
@@ -7,8 +7,15 @@ const mockConfigGetString = jest.fn();
 const mockConfigGetNumber = jest.fn();
 
 const mockGetPrefs = jest.fn();
+const mockGetTimezone = jest.fn();
 const mockPrefsGetInstance = jest.fn(() => ({
   getPrefs: mockGetPrefs,
+  getTimezone: mockGetTimezone,
+}));
+
+const mockSnapshotYear = jest.fn();
+const mockRewindGetInstance = jest.fn(() => ({
+  snapshotYear: mockSnapshotYear,
 }));
 
 const mockLoggerIsReady = jest.fn(() => false);
@@ -59,6 +66,10 @@ jest.unstable_mockModule("../../src/models/rewind-nudge-state.js", () => ({
     findOne: mockNudgeStateFindOne,
     findOneAndUpdate: mockNudgeStateFindOneAndUpdate,
   },
+}));
+
+jest.unstable_mockModule("../../src/services/rewind-service.js", () => ({
+  RewindService: { getInstance: mockRewindGetInstance },
 }));
 
 jest.unstable_mockModule("../../src/utils/logger.js", () => ({
@@ -113,6 +124,8 @@ describe("RewindNudgeService", () => {
       digest: true,
       rewind: true,
     });
+    mockGetTimezone.mockResolvedValue(null);
+    mockSnapshotYear.mockResolvedValue("created");
     mockUsersFetch.mockImplementation(async (userId: unknown) => ({
       id: userId as string,
       username: `user-${userId as string}`,
@@ -262,6 +275,81 @@ describe("RewindNudgeService", () => {
 
       expect(result!.sent).toBe(0);
       expect(result!.failed).toBe(1);
+    });
+  });
+
+  describe("completed-year snapshots (#574)", () => {
+    it("snapshots each qualifying user for the year and tallies outcomes", async () => {
+      mockTrackingAggregate.mockResolvedValueOnce([
+        { _id: "u1", username: "u1", totalTime: 60 * 60 * 5 },
+        { _id: "u2", username: "u2", totalTime: 60 * 60 * 3 },
+      ]);
+      mockSnapshotYear
+        .mockResolvedValueOnce("created")
+        .mockResolvedValueOnce("exists");
+
+      const svc: ServiceInstance = RewindNudgeService.getInstance(makeClient());
+      const result = await svc.runNow();
+
+      const year = new Date().getUTCFullYear();
+      expect(mockSnapshotYear).toHaveBeenCalledTimes(2);
+      expect(mockSnapshotYear).toHaveBeenCalledWith("u1", "guild-1", year, null);
+      expect(result!.snapshotsCreated).toBe(1);
+      expect(result!.snapshotsExisting).toBe(1);
+    });
+
+    it("snapshots users even when they opted out of the DM", async () => {
+      mockTrackingAggregate.mockResolvedValueOnce([
+        { _id: "u1", username: "u1", totalTime: 60 * 60 * 5 },
+      ]);
+      mockGetPrefs.mockResolvedValue({
+        achievements: true,
+        digest: true,
+        rewind: false,
+      });
+
+      const svc: ServiceInstance = RewindNudgeService.getInstance(makeClient());
+      const result = await svc.runNow();
+
+      expect(result!.skippedOptOut).toBe(1);
+      expect(result!.sent).toBe(0);
+      // The snapshot is independent of DM delivery — the year is still frozen.
+      expect(mockSnapshotYear).toHaveBeenCalledTimes(1);
+      expect(result!.snapshotsCreated).toBe(1);
+    });
+
+    it("passes the user's timezone through to the snapshot", async () => {
+      mockTrackingAggregate.mockResolvedValueOnce([
+        { _id: "u1", username: "u1", totalTime: 60 * 60 * 5 },
+      ]);
+      mockGetTimezone.mockResolvedValue("America/New_York");
+
+      const svc: ServiceInstance = RewindNudgeService.getInstance(makeClient());
+      await svc.runNow();
+
+      const year = new Date().getUTCFullYear();
+      expect(mockSnapshotYear).toHaveBeenCalledWith(
+        "u1",
+        "guild-1",
+        year,
+        "America/New_York",
+      );
+    });
+
+    it("isolates a snapshot failure without aborting the rest", async () => {
+      mockTrackingAggregate.mockResolvedValueOnce([
+        { _id: "u1", username: "u1", totalTime: 60 * 60 * 5 },
+        { _id: "u2", username: "u2", totalTime: 60 * 60 * 3 },
+      ]);
+      mockSnapshotYear
+        .mockRejectedValueOnce(new Error("mongo exploded"))
+        .mockResolvedValueOnce("created");
+
+      const svc: ServiceInstance = RewindNudgeService.getInstance(makeClient());
+      const result = await svc.runNow();
+
+      expect(result!.snapshotsFailed).toBe(1);
+      expect(result!.snapshotsCreated).toBe(1);
     });
   });
 });

--- a/__tests__/services/rewind-service.test.ts
+++ b/__tests__/services/rewind-service.test.ts
@@ -9,11 +9,22 @@ import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 const mockFindOneVc = jest.fn();
 const mockAggregateVc = jest.fn();
 const mockFindOneAch = jest.fn();
+const mockSnapFindOne = jest.fn();
+const mockSnapFind = jest.fn();
+const mockSnapCreate = jest.fn();
 
 jest.unstable_mockModule("../../src/models/voice-channel-tracking.js", () => ({
   VoiceChannelTracking: {
     findOne: mockFindOneVc,
     aggregate: mockAggregateVc,
+  },
+}));
+
+jest.unstable_mockModule("../../src/models/rewind-snapshot.js", () => ({
+  RewindSnapshot: {
+    findOne: mockSnapFindOne,
+    find: mockSnapFind,
+    create: mockSnapCreate,
   },
 }));
 
@@ -54,6 +65,8 @@ jest.unstable_mockModule("../../src/utils/logger.js", () => ({
 
 const {
   RewindService,
+  normalizeSnapshotSummary,
+  SNAPSHOT_SCHEMA_VERSION,
   computeLongestStreak,
   computePeakDay,
   computeTopChannels,
@@ -333,6 +346,10 @@ describe("RewindService.getSummary", () => {
     mockFindOneVc.mockReturnValue(lean({ sessions: [] }));
     mockFindOneAch.mockReturnValue(lean(null));
     mockAggregateVc.mockResolvedValue([]);
+    // By default no snapshots exist, so getSummary takes the live path.
+    mockSnapFindOne.mockReturnValue(lean(null));
+    mockSnapFind.mockReturnValue(lean([]));
+    mockSnapCreate.mockResolvedValue({});
   });
 
   it("returns hasData=false when the user has no sessions or achievements", async () => {
@@ -496,6 +513,175 @@ describe("RewindService.getSummary", () => {
     );
     const summary = await svc.getSummary("u1", "g1", 2026);
     expect(summary).toBeNull();
+  });
+});
+
+describe("RewindService snapshots (#574)", () => {
+  function lean<T>(value: T): { lean: () => Promise<T> } {
+    return { lean: jest.fn(async () => value) };
+  }
+
+  function makeSvc() {
+    return RewindService.getInstance(
+      makeClient() as Parameters<typeof RewindService.getInstance>[0],
+    );
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetSingleton();
+    mockFindOneVc.mockReturnValue(lean({ sessions: [] }));
+    mockFindOneAch.mockReturnValue(lean(null));
+    mockAggregateVc.mockResolvedValue([]);
+    mockSnapFindOne.mockReturnValue(lean(null));
+    mockSnapFind.mockReturnValue(lean([]));
+    mockSnapCreate.mockResolvedValue({});
+  });
+
+  describe("normalizeSnapshotSummary", () => {
+    it("fills defaults and stamps the snapshot source + identity", () => {
+      const norm = normalizeSnapshotSummary(
+        { totalSeconds: 5, hasData: true },
+        { userId: "u", guildId: "g", year: 2021 },
+      );
+      expect(norm.source).toBe("snapshot");
+      expect(norm.userId).toBe("u");
+      expect(norm.guildId).toBe("g");
+      expect(norm.year).toBe(2021);
+      expect(norm.totalSeconds).toBe(5);
+      expect(norm.topChannels).toEqual([]);
+      expect(norm.weeklyJourney).toEqual({
+        first: null,
+        last: null,
+        best: null,
+      });
+    });
+
+    it("tolerates a null stored payload (empty state)", () => {
+      const empty = normalizeSnapshotSummary(null, {
+        userId: "u",
+        guildId: "g",
+        year: 2021,
+      });
+      expect(empty.hasData).toBe(false);
+      expect(empty.availableYears).toEqual([]);
+    });
+  });
+
+  describe("getSummary serving", () => {
+    it("serves a completed year from its snapshot without recomputing live", async () => {
+      mockSnapFindOne.mockReturnValueOnce(
+        lean({
+          summary: {
+            userId: "u1",
+            guildId: "g1",
+            year: 2020,
+            hasData: true,
+            totalSeconds: 12345,
+            availableYears: [2020],
+          },
+        }),
+      );
+      mockSnapFind.mockReturnValueOnce(lean([{ year: 2020 }, { year: 2019 }]));
+
+      const summary = await makeSvc().getSummary("u1", "g1", 2020);
+
+      expect(summary!.source).toBe("snapshot");
+      expect(summary!.totalSeconds).toBe(12345);
+      // Snapshotted years are merged in so they stay navigable.
+      expect(summary!.availableYears).toEqual([2020, 2019]);
+      // No live aggregation happened — the recap came straight from storage.
+      expect(mockFindOneVc).not.toHaveBeenCalled();
+    });
+
+    it("computes the in-progress current year live even if a snapshot exists", async () => {
+      const currentYear = new Date().getUTCFullYear();
+      // Persistent (not `Once`) so an unconsumed queued value can't leak
+      // into the next test — the current year never consults the snapshot.
+      mockSnapFindOne.mockReturnValue(
+        lean({ summary: { hasData: true, totalSeconds: 999 } }),
+      );
+
+      const summary = await makeSvc().getSummary("u1", "g1", currentYear);
+
+      expect(summary!.source).toBe("live");
+      // The snapshot lookup is never consulted for the current year.
+      expect(mockSnapFindOne).not.toHaveBeenCalled();
+    });
+
+    it("computes a past year live when no snapshot exists", async () => {
+      const summary = await makeSvc().getSummary("u1", "g1", 2020);
+      expect(summary!.source).toBe("live");
+      expect(mockFindOneVc).toHaveBeenCalled();
+    });
+
+    it("merges snapshot years into availableYears on the live path", async () => {
+      const currentYear = new Date().getUTCFullYear();
+      mockAggregateVc
+        .mockResolvedValueOnce([{ _id: currentYear }]) // collectAvailableYears
+        .mockResolvedValueOnce([]); // weekly journey
+      mockSnapFind.mockReturnValueOnce(lean([{ year: 2019 }]));
+
+      const summary = await makeSvc().getSummary("u1", "g1", currentYear);
+      expect(summary!.availableYears).toEqual([currentYear, 2019]);
+    });
+  });
+
+  describe("snapshotYear", () => {
+    const session2020 = {
+      startTime: new Date("2020-03-01T10:00:00Z"),
+      duration: 3600,
+      channelId: "a",
+      channelName: "x",
+    };
+
+    it("creates a snapshot when none exists and the user has data", async () => {
+      mockFindOneVc.mockReturnValue(lean({ sessions: [session2020] }));
+
+      const outcome = await makeSvc().snapshotYear("u1", "g1", 2020, null);
+
+      expect(outcome).toBe("created");
+      expect(mockSnapCreate).toHaveBeenCalledTimes(1);
+      const arg = mockSnapCreate.mock.calls[0][0] as {
+        userId: string;
+        guildId: string;
+        year: number;
+        schemaVersion: number;
+        summary: { hasData: boolean };
+      };
+      expect(arg).toMatchObject({
+        userId: "u1",
+        guildId: "g1",
+        year: 2020,
+        schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+      });
+      expect(arg.summary.hasData).toBe(true);
+    });
+
+    it("is idempotent — skips when a snapshot already exists", async () => {
+      mockSnapFindOne.mockReturnValueOnce(lean({ _id: "existing" }));
+
+      const outcome = await makeSvc().snapshotYear("u1", "g1", 2020, null);
+
+      expect(outcome).toBe("exists");
+      expect(mockSnapCreate).not.toHaveBeenCalled();
+    });
+
+    it("skips users with no data worth freezing", async () => {
+      const outcome = await makeSvc().snapshotYear("u1", "g1", 2020, null);
+      expect(outcome).toBe("skipped");
+      expect(mockSnapCreate).not.toHaveBeenCalled();
+    });
+
+    it("treats a duplicate-key race as an existing snapshot", async () => {
+      mockFindOneVc.mockReturnValue(lean({ sessions: [session2020] }));
+      mockSnapCreate.mockRejectedValueOnce(
+        Object.assign(new Error("dup"), { code: 11000 }),
+      );
+
+      const outcome = await makeSvc().snapshotYear("u1", "g1", 2020, null);
+      expect(outcome).toBe("exists");
+    });
   });
 });
 

--- a/src/models/rewind-snapshot.ts
+++ b/src/models/rewind-snapshot.ts
@@ -1,0 +1,56 @@
+import mongoose, { Document, Schema } from "mongoose";
+import type { RewindSummary } from "../services/rewind-service.js";
+
+/**
+ * Immutable per-user per-year Rewind snapshot (#574).
+ *
+ * Rewind is normally computed live from raw voice/text activity, but that
+ * raw data is pruned by retention (`VoiceChannelTruncationService`,
+ * `MessageActivityCleanupService`). So a completed year's recap silently
+ * degrades — open your 2026 Rewind in 2028 and the source sessions/messages
+ * are long gone. To keep a finished year permanent we freeze each
+ * qualifying user's full `RewindSummary` into one row at year rollover.
+ *
+ * One row per `(guildId, userId, year)`, written once by
+ * `RewindNudgeService` alongside the end-of-year nudge cron. Creation is
+ * idempotent via the unique index: a re-run never duplicates or mutates an
+ * existing snapshot — the recap is frozen exactly as it was generated.
+ *
+ * `summary` stores the serialised `RewindSummary` (already a plain,
+ * view-ready shape). `schemaVersion` lets the summary shape evolve: old
+ * snapshots render with their stored version and the view tolerates fields
+ * added after they were frozen.
+ */
+export interface IRewindSnapshot extends Document {
+  guildId: string;
+  userId: string;
+  year: number;
+  summary: RewindSummary;
+  schemaVersion: number;
+  generatedAt: Date;
+}
+
+const RewindSnapshotSchema = new Schema<IRewindSnapshot>(
+  {
+    guildId: { type: String, required: true },
+    userId: { type: String, required: true },
+    year: { type: Number, required: true },
+    // The full view-ready summary, stored verbatim. Mixed because the
+    // shape is owned by `RewindService` and intentionally frozen per
+    // `schemaVersion` rather than re-validated here.
+    summary: { type: Schema.Types.Mixed, required: true },
+    schemaVersion: { type: Number, required: true },
+    generatedAt: { type: Date, required: true },
+  },
+  { timestamps: false, minimize: false },
+);
+
+RewindSnapshotSchema.index(
+  { guildId: 1, userId: 1, year: 1 },
+  { unique: true },
+);
+
+export const RewindSnapshot = mongoose.model<IRewindSnapshot>(
+  "RewindSnapshot",
+  RewindSnapshotSchema,
+);

--- a/src/services/rewind-nudge-service.ts
+++ b/src/services/rewind-nudge-service.ts
@@ -310,10 +310,13 @@ export class RewindNudgeService {
         }
       }
 
-      // Freeze each qualifying user's completed-year recap into an
-      // immutable snapshot (#574). This runs independently of DM delivery
-      // — opted-out / DM-closed users still get their year preserved — and
-      // is idempotent, so a re-run leaves existing snapshots untouched.
+      // Freeze each qualifying user's recap for the wrapping-up year into
+      // an immutable snapshot (#574). The end-of-year cron runs in late
+      // December, so `year` is the current UTC year that's essentially
+      // done; once it rolls over, `getSummary` serves this frozen copy.
+      // This runs independently of DM delivery — opted-out / DM-closed
+      // users still get their year preserved — and is idempotent, so a
+      // re-run leaves existing snapshots untouched.
       await this.snapshotQualifyingUsers(qualifying, guildId, year, summary);
 
       logger.info(
@@ -335,10 +338,13 @@ export class RewindNudgeService {
   }
 
   /**
-   * Persist a frozen `RewindSnapshot` for each qualifying user for the
-   * just-completed `year` (#574). Errors are isolated per user — one bad
-   * snapshot must not abort the rest or crash the cron. Each user's
-   * timezone is applied so the frozen recap matches what they'd see live.
+   * Persist a frozen `RewindSnapshot` for each qualifying user for `year`
+   * (#574). This runs inside the end-of-year cron (default Dec 30), so
+   * `year` is the current UTC year that is wrapping up — `getSummary`
+   * recomputes it live rather than serving an earlier snapshot. Errors are
+   * isolated per user — one bad snapshot must not abort the rest or crash
+   * the cron. Each user's timezone is applied so the frozen recap matches
+   * what they'd see live.
    */
   private async snapshotQualifyingUsers(
     qualifying: Array<{ userId: string; username: string; totalTime: number }>,

--- a/src/services/rewind-nudge-service.ts
+++ b/src/services/rewind-nudge-service.ts
@@ -5,6 +5,7 @@ import { UserNotificationPrefsService } from "./user-notification-prefs-service.
 import { DiscordLogger } from "./discord-logger.js";
 import { VoiceChannelTracking } from "../models/voice-channel-tracking.js";
 import { RewindNudgeState } from "../models/rewind-nudge-state.js";
+import { RewindService } from "./rewind-service.js";
 import logger from "../utils/logger.js";
 
 /**
@@ -33,6 +34,14 @@ export interface RewindNudgeRunSummary {
   /** Already nudged for this year — duplicate-delivery guard. */
   skippedAlreadySent: number;
   failed: number;
+  /** Immutable completed-year snapshots written this run (#574). */
+  snapshotsCreated: number;
+  /** Snapshots that already existed — idempotent re-run, left untouched. */
+  snapshotsExisting: number;
+  /** Qualifying users with no data worth freezing. */
+  snapshotsSkipped: number;
+  /** Snapshots that failed to write. */
+  snapshotsFailed: number;
 }
 
 function sanitizeCronExpression(expression: string): string {
@@ -208,6 +217,10 @@ export class RewindNudgeService {
         skippedDmsClosed: 0,
         skippedAlreadySent: 0,
         failed: 0,
+        snapshotsCreated: 0,
+        snapshotsExisting: 0,
+        snapshotsSkipped: 0,
+        snapshotsFailed: 0,
       };
 
       const prefsService = UserNotificationPrefsService.getInstance();
@@ -297,17 +310,74 @@ export class RewindNudgeService {
         }
       }
 
+      // Freeze each qualifying user's completed-year recap into an
+      // immutable snapshot (#574). This runs independently of DM delivery
+      // — opted-out / DM-closed users still get their year preserved — and
+      // is idempotent, so a re-run leaves existing snapshots untouched.
+      await this.snapshotQualifyingUsers(qualifying, guildId, year, summary);
+
       logger.info(
         `Rewind nudge complete: year=${summary.year} qualifying=${summary.qualifying} ` +
           `sent=${summary.sent} opted_out=${summary.skippedOptOut} ` +
           `already_sent=${summary.skippedAlreadySent} ` +
-          `dms_closed=${summary.skippedDmsClosed} failed=${summary.failed}`,
+          `dms_closed=${summary.skippedDmsClosed} failed=${summary.failed} ` +
+          `snapshots_created=${summary.snapshotsCreated} ` +
+          `snapshots_existing=${summary.snapshotsExisting} ` +
+          `snapshots_skipped=${summary.snapshotsSkipped} ` +
+          `snapshots_failed=${summary.snapshotsFailed}`,
       );
 
       await this.logSummary(summary);
       return summary;
     } finally {
       this.isRunning = false;
+    }
+  }
+
+  /**
+   * Persist a frozen `RewindSnapshot` for each qualifying user for the
+   * just-completed `year` (#574). Errors are isolated per user — one bad
+   * snapshot must not abort the rest or crash the cron. Each user's
+   * timezone is applied so the frozen recap matches what they'd see live.
+   */
+  private async snapshotQualifyingUsers(
+    qualifying: Array<{ userId: string; username: string; totalTime: number }>,
+    guildId: string,
+    year: number,
+    summary: RewindNudgeRunSummary,
+  ): Promise<void> {
+    const rewindService = RewindService.getInstance(this.client);
+    const prefsService = UserNotificationPrefsService.getInstance();
+
+    for (const user of qualifying) {
+      try {
+        const timezone = await prefsService.getTimezone(user.userId, guildId);
+        const outcome = await rewindService.snapshotYear(
+          user.userId,
+          guildId,
+          year,
+          timezone,
+        );
+        switch (outcome) {
+          case "created":
+            summary.snapshotsCreated += 1;
+            break;
+          case "exists":
+            summary.snapshotsExisting += 1;
+            break;
+          case "skipped":
+            summary.snapshotsSkipped += 1;
+            break;
+          default:
+            summary.snapshotsFailed += 1;
+        }
+      } catch (error) {
+        summary.snapshotsFailed += 1;
+        logger.error(
+          `Error snapshotting rewind for user ${user.userId}:`,
+          error,
+        );
+      }
     }
   }
 
@@ -354,7 +424,9 @@ export class RewindNudgeService {
         `Year ${summary.year} · qualifying: ${summary.qualifying} · ` +
         `sent: ${summary.sent} · opted out: ${summary.skippedOptOut} · ` +
         `already sent: ${summary.skippedAlreadySent} · ` +
-        `DMs closed: ${summary.skippedDmsClosed} · failed: ${summary.failed}`;
+        `DMs closed: ${summary.skippedDmsClosed} · failed: ${summary.failed} · ` +
+        `snapshots: ${summary.snapshotsCreated} new / ` +
+        `${summary.snapshotsExisting} kept / ${summary.snapshotsFailed} failed`;
       await discordLogger.logCronSuccess("Rewind Nudge", message);
     } catch (error) {
       logger.error(

--- a/src/services/rewind-service.ts
+++ b/src/services/rewind-service.ts
@@ -2,6 +2,7 @@ import { Client } from "discord.js";
 import { VoiceChannelTracking } from "../models/voice-channel-tracking.js";
 import { UserAchievements } from "../models/user-achievements.js";
 import { MessageActivityTracking } from "../models/message-activity-tracking.js";
+import { RewindSnapshot } from "../models/rewind-snapshot.js";
 import { ConfigService } from "./config-service.js";
 import { ACCOLADE_METADATA } from "../content/accolades.js";
 import { ACHIEVEMENT_METADATA } from "../content/achievements.js";
@@ -87,7 +88,19 @@ export interface RewindSummary {
   // activity, or achievements). Used by the page to render a small year
   // picker.
   availableYears: number[];
+  // How this summary was produced (#574): "live" recomputes from raw
+  // activity, "snapshot" is served verbatim from a frozen completed-year
+  // record. Optional so older serialised summaries (and tests) omit it.
+  source?: "live" | "snapshot";
 }
+
+/**
+ * Schema version stamped on every snapshot we write (#574). Bump when the
+ * `RewindSummary` shape changes in a way worth recording; old snapshots
+ * keep their stored version and are rendered tolerantly by
+ * `normalizeSnapshotSummary`.
+ */
+export const SNAPSHOT_SCHEMA_VERSION = 1;
 
 interface RawSession {
   startTime: Date;
@@ -334,6 +347,45 @@ function lookupAchievement(type: string): {
     : null;
 }
 
+/**
+ * Coerce a stored snapshot summary into a complete `RewindSummary` for
+ * rendering (#574). Snapshots are frozen as-generated, so a snapshot
+ * written under an older schema may be missing fields the current view
+ * expects. We fill every field with a safe default and stamp the identity
+ * from the request so a partial / corrupt stored payload still renders the
+ * empty-state branch rather than throwing in the view layer.
+ */
+export function normalizeSnapshotSummary(
+  stored: Partial<RewindSummary> | null | undefined,
+  identity: { userId: string; guildId: string; year: number },
+): RewindSummary {
+  const s = stored ?? {};
+  return {
+    userId: s.userId ?? identity.userId,
+    guildId: s.guildId ?? identity.guildId,
+    year: s.year ?? identity.year,
+    hasData: s.hasData ?? false,
+    totalSeconds: s.totalSeconds ?? 0,
+    sessionCount: s.sessionCount ?? 0,
+    daysActive: s.daysActive ?? 0,
+    topChannels: s.topChannels ?? [],
+    peakDay: s.peakDay ?? null,
+    messagesSent: s.messagesSent ?? 0,
+    topTextChannels: s.topTextChannels ?? [],
+    peakMessageDay: s.peakMessageDay ?? null,
+    longestStreakDays: s.longestStreakDays ?? 0,
+    longestStreakRange: s.longestStreakRange ?? null,
+    accolades: s.accolades ?? [],
+    achievements: s.achievements ?? [],
+    annualRank: s.annualRank ?? null,
+    annualGuildMembers: s.annualGuildMembers ?? 0,
+    percentAboveMedian: s.percentAboveMedian ?? null,
+    weeklyJourney: s.weeklyJourney ?? { first: null, last: null, best: null },
+    availableYears: s.availableYears ?? [],
+    source: "snapshot",
+  };
+}
+
 // --------------------------------------------------------------------
 // Service
 // --------------------------------------------------------------------
@@ -377,6 +429,17 @@ export class RewindService {
     timeZone?: string | null,
   ): Promise<RewindSummary | null> {
     try {
+      // Completed years are served from their immutable snapshot when one
+      // exists, so the recap is unaffected by later voice-session /
+      // message-detail truncation (#574). The in-progress current year
+      // always recomputes live. A past year predating the snapshot
+      // feature has no record and falls through to the live path below.
+      const currentYear = new Date().getUTCFullYear();
+      if (year < currentYear) {
+        const snapshot = await this.loadSnapshot(userId, guildId, year);
+        if (snapshot) return snapshot;
+      }
+
       const { start, end } = yearBounds(year);
 
       // Only bucket days in a user zone when one is actually set and
@@ -434,22 +497,26 @@ export class RewindService {
         })
         .filter((a): a is RewindAchievement => a !== null);
 
-      // These three reads are independent — run them concurrently so the
+      // These reads are independent — run them concurrently so the
       // on-demand /me/rewind render doesn't pay their latency in series.
       const [
         { annualRank, annualGuildMembers, percentAboveMedian },
         weeklyJourney,
         text,
+        snapshotYears,
       ] = await Promise.all([
         this.computeAnnualRank(userId, start, end, totalSeconds),
         this.computeWeeklyJourney(userId, start, end),
         this.computeTextActivity(userId, guildId, start, end, dayZone),
+        this.collectSnapshotYears(userId, guildId),
       ]);
 
-      // The picker should offer any year the user has either kind of data.
-      const mergedYears = [...new Set([...availableYears, ...text.years])].sort(
-        (a, b) => b - a,
-      );
+      // The picker should offer any year the user has either kind of data,
+      // plus any snapshotted year — those must stay navigable even after
+      // their raw sessions/messages have been truncated away (#574).
+      const mergedYears = [
+        ...new Set([...availableYears, ...text.years, ...snapshotYears]),
+      ].sort((a, b) => b - a);
 
       const hasData =
         totalSeconds > 0 ||
@@ -482,6 +549,7 @@ export class RewindService {
         percentAboveMedian,
         weeklyJourney,
         availableYears: mergedYears,
+        source: "live",
       };
     } catch (error) {
       logger.error(
@@ -489,6 +557,127 @@ export class RewindService {
         error,
       );
       return null;
+    }
+  }
+
+  /**
+   * Freeze a user's completed-year recap into an immutable `RewindSnapshot`
+   * (#574). Called by the end-of-year cron once the year has wrapped up.
+   *
+   * Idempotent: an existing snapshot is never duplicated or mutated, so a
+   * re-run (or a manual replay) is a no-op. We compute the summary live —
+   * at snapshot time the year is the just-completing current year, so
+   * `getSummary` recomputes from raw data rather than short-circuiting.
+   * Users with nothing worth freezing are skipped instead of storing an
+   * empty record.
+   *
+   * Returns the outcome so the caller can roll it into a run summary.
+   */
+  public async snapshotYear(
+    userId: string,
+    guildId: string,
+    year: number,
+    timeZone?: string | null,
+  ): Promise<"created" | "exists" | "skipped" | "failed"> {
+    try {
+      const existing = await RewindSnapshot.findOne({
+        userId,
+        guildId,
+        year,
+      }).lean();
+      if (existing) return "exists";
+
+      const summary = await this.getSummary(userId, guildId, year, timeZone);
+      if (!summary) return "failed";
+      if (!summary.hasData) return "skipped";
+
+      await RewindSnapshot.create({
+        guildId,
+        userId,
+        year,
+        summary,
+        schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+        generatedAt: new Date(),
+      });
+      return "created";
+    } catch (error) {
+      // A concurrent run may have inserted the row between our existence
+      // check and the create — treat the unique-index violation as a
+      // benign "already exists" rather than a failure.
+      if ((error as { code?: number }).code === 11000) return "exists";
+      logger.error(
+        `RewindService.snapshotYear failed for user=${userId} year=${year}:`,
+        error,
+      );
+      return "failed";
+    }
+  }
+
+  /**
+   * Load and normalise the frozen snapshot for a completed year, or return
+   * `null` when none exists (so the caller falls back to live compute).
+   *
+   * The stored summary carries the `availableYears` it had at freeze time;
+   * we union in the full set of snapshotted years so every preserved year
+   * stays reachable from the picker even after the source data is gone.
+   * A lookup failure is swallowed to `null` — better to compute live than
+   * to error the page.
+   */
+  private async loadSnapshot(
+    userId: string,
+    guildId: string,
+    year: number,
+  ): Promise<RewindSummary | null> {
+    try {
+      const doc = await RewindSnapshot.findOne({
+        userId,
+        guildId,
+        year,
+      }).lean<{ summary?: Partial<RewindSummary> }>();
+      if (!doc) return null;
+
+      const summary = normalizeSnapshotSummary(doc.summary, {
+        userId,
+        guildId,
+        year,
+      });
+      const snapshotYears = await this.collectSnapshotYears(userId, guildId);
+      summary.availableYears = [
+        ...new Set([...summary.availableYears, ...snapshotYears]),
+      ].sort((a, b) => b - a);
+      return summary;
+    } catch (error) {
+      logger.warn(
+        `RewindService.loadSnapshot failed for user=${userId} year=${year}:`,
+        error,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Distinct years for which this user has a frozen snapshot. Used to keep
+   * the year picker offering preserved years after their raw data is
+   * truncated (#574). A failure degrades to an empty list.
+   */
+  private async collectSnapshotYears(
+    userId: string,
+    guildId: string,
+  ): Promise<number[]> {
+    try {
+      const rows = await RewindSnapshot.find(
+        { userId, guildId },
+        { year: 1 },
+      ).lean<Array<{ year: number }>>();
+      return rows
+        .map((r) => r.year)
+        .filter((y): y is number => typeof y === "number");
+    } catch (error) {
+      logger.warn(
+        `RewindService.collectSnapshotYears failed for ${userId}:`,
+        error,
+      );
+      return [];
     }
   }
 


### PR DESCRIPTION
## Summary

Closes #574.

Rewind is computed **live** from raw activity on every page view, but that raw data is pruned by retention — detailed voice sessions are truncated beyond `voicetracking.cleanup.retention.detailed_sessions_days` and `recentMessages` beyond `messagetracking.cleanup.retention.detailed_days`. So a completed year's recap silently degrades and eventually empties out (open your 2026 Rewind in 2028 and it's a shadow of what it showed in early 2027).

This **freezes each qualifying user's completed year into an immutable snapshot at rollover**, so a finished year's recap is permanent and no longer depends on the retention-pruned backend data.

## What changed

- **New `models/rewind-snapshot.ts`** — one row per `(guildId, userId, year)`, unique-indexed, storing the serialised `RewindSummary` + `schemaVersion` + `generatedAt`. Mirrors the `rewind-nudge-state` one-shot pattern.
- **`RewindService.snapshotYear()`** — idempotent upsert: never duplicates or mutates an existing snapshot, skips users with no data worth freezing, and treats a duplicate-key race as a benign `exists`.
- **`RewindService.getSummary()`** — completed years (`year < currentYear`) are served from the snapshot when one exists (`source: "snapshot"`); the in-progress current year always computes live. Snapshotted years are merged into `availableYears` so they stay navigable in the year picker **even after** their raw sessions/messages are truncated.
- **`normalizeSnapshotSummary()`** — fills every field with a safe default so older snapshots render tolerantly as the summary shape evolves (`schemaVersion` recorded; bump it when the shape changes meaningfully).
- **`RewindNudgeService`** — alongside the existing end-of-year nudge cron, freezes each qualifying user for the just-completed year. The snapshot pass runs **independently of DM delivery** (opted-out / DM-closed users still get their year preserved) with per-user error isolation. Run summary + Discord log report the snapshot tallies.

Gated by `rewind.enabled`; no new config keys.

## Acceptance criteria

- [x] After year rollover, each qualifying user has an immutable `RewindSnapshot` for the completed year.
- [x] A completed year's recap renders from the snapshot and is unaffected by subsequent voice-session truncation / message-detail pruning.
- [x] The in-progress current year still computes live.
- [x] Snapshot creation is idempotent and gated by `rewind.enabled`.
- [x] `schemaVersion` recorded; the view renders older snapshots without newer fields gracefully.
- [ ] **(Stretch) PDF export** — deferred; see below.
- [x] Tests cover snapshot upsert idempotency, snapshot-preferred-over-live for past years, live-for-current-year, `availableYears` merging, and tolerant normalisation.

## Design notes / decisions

- **Who gets snapshotted:** the same set the nudge already aggregates (`>= rewind.min_minutes` voice), reusing the existing per-user aggregation. Users below the floor still compute live until their data ages out — the documented, acceptable behaviour for pre-feature years.
- **Timing:** snapshots inherit the existing end-of-year cron (default Dec 30), so the year is essentially complete but the source data isn't yet truncated. Activity in the last day or two of the year isn't captured — the tradeoff of reusing the existing cron rather than a January pass.
- **Picker navigability:** the snapshot path doesn't re-query raw data (that's the point), so it merges the full set of snapshotted years into `availableYears`. The top-nav **Rewind** link always points at the live current year, so no page is a dead end.

## Deferred (follow-ups)

- **PDF export** (stretch) — left out of this PR to avoid pulling in a new PDF dependency under the existing CSP/dependency-review constraints. The immutable snapshot is the prerequisite and is now in place, so a `GET /me/rewind/:year.pdf` self-scoped route can land as a focused follow-up.
- **Backfill** of the previous year on first deploy — optional one-shot; not required by the acceptance criteria.

## Testing

`npm run check` (build + lint + format) and the full `npm run test:ci` suite pass (100 suites, coverage thresholds held).

https://claude.ai/code/session_01LoxVAc65kYYvitZM8V5gy9

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoxVAc65kYYvitZM8V5gy9)_