### PR TITLE
feat(rewind): default bare /me/rewind to the most recent year with data

### DIFF
--- a/WEBUI.md
+++ b/WEBUI.md
@@ -784,11 +784,16 @@ lists every notification type with the current state and a checkbox;
 toggling one row is a single POST that records the diff in the audit
 log and PRG-redirects back to the page.
 
-The **Rewind** page defaults to the current calendar year (UTC);
-`/me/rewind/:year` lets you browse past years. A small year picker at
-the top of the page only offers years for which you have data (voice
-sessions, text-message activity, or badges), plus any year that has been
-snapshotted (see below). Years with no data render a friendly empty state.
+The bare **Rewind** page (`/me/rewind`) lands on the most recent year you
+actually have data for, so visiting right after the year rolls over shows
+a finished recap rather than the empty new year (`#573`); a brand-new user
+with no activity anywhere still sees the current year's empty state.
+`/me/rewind/:year` is an exact deep link — it always renders the requested
+year, including the empty state for a year with no data. A small year
+picker at the top of the page only offers years for which you have data
+(voice sessions, text-message activity, or badges), plus any year that has
+been snapshotted (see below), and highlights the year actually shown.
+Years with no data render a friendly empty state.
 Aggregation is on-demand and not cached in v1 — see [`SETTINGS.md`](SETTINGS.md#-rewind-year-in-review)
 for the `rewind.*` keys that control the end-of-year DM nudge.
 

--- a/__tests__/services/rewind-service.test.ts
+++ b/__tests__/services/rewind-service.test.ts
@@ -582,6 +582,18 @@ describe("RewindService.getDefaultRewindYear (#573)", () => {
     const year = await makeSvc().getDefaultRewindYear("u1", "g1");
     expect(year).toBe(currentYear);
   });
+
+  it("ignores non-finite years from corrupt data instead of returning NaN", async () => {
+    // A snapshot row whose `year` is NaN passes a `typeof === number`
+    // check; it must be filtered out before Math.max so the route fallback
+    // never sees NaN.
+    mockSnapFind.mockReturnValueOnce(lean([{ year: Number.NaN }]));
+    mockAggregateVc.mockResolvedValueOnce([{ _id: currentYear - 1 }]);
+
+    const year = await makeSvc().getDefaultRewindYear("u1", "g1");
+    expect(Number.isFinite(year)).toBe(true);
+    expect(year).toBe(currentYear - 1);
+  });
 });
 
 describe("RewindService snapshots (#574)", () => {

--- a/__tests__/services/rewind-service.test.ts
+++ b/__tests__/services/rewind-service.test.ts
@@ -516,6 +516,74 @@ describe("RewindService.getSummary", () => {
   });
 });
 
+describe("RewindService.getDefaultRewindYear (#573)", () => {
+  function lean<T>(value: T): { lean: () => Promise<T> } {
+    return { lean: jest.fn(async () => value) };
+  }
+
+  function makeSvc() {
+    return RewindService.getInstance(
+      makeClient() as Parameters<typeof RewindService.getInstance>[0],
+    );
+  }
+
+  const currentYear = new Date().getUTCFullYear();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetSingleton();
+    // `clearAllMocks` does NOT drain queued `mockResolvedValueOnce`
+    // implementations left over from earlier describe blocks, so reset the
+    // shared aggregate mock outright before installing the default.
+    mockAggregateVc.mockReset();
+    mockFindOneAch.mockReturnValue(lean(null));
+    mockAggregateVc.mockResolvedValue([]);
+    mockSnapFind.mockReturnValue(lean([]));
+  });
+
+  it("lands on the prior year when the current year has no data", async () => {
+    // collectAvailableYears aggregate — only the prior year has sessions.
+    mockAggregateVc.mockResolvedValueOnce([{ _id: currentYear - 1 }]);
+
+    const year = await makeSvc().getDefaultRewindYear("u1", "g1");
+    expect(year).toBe(currentYear - 1);
+  });
+
+  it("lands on the current year when it already has data", async () => {
+    mockAggregateVc.mockResolvedValueOnce([
+      { _id: currentYear },
+      { _id: currentYear - 1 },
+    ]);
+
+    const year = await makeSvc().getDefaultRewindYear("u1", "g1");
+    expect(year).toBe(currentYear);
+  });
+
+  it("falls back to the current year when the user has no data anywhere", async () => {
+    const year = await makeSvc().getDefaultRewindYear("u1", "g1");
+    expect(year).toBe(currentYear);
+  });
+
+  it("considers snapshotted years that have outlived their raw data", async () => {
+    // No live sessions/achievements, but a frozen snapshot remains.
+    mockSnapFind.mockReturnValueOnce(lean([{ year: currentYear - 2 }]));
+
+    const year = await makeSvc().getDefaultRewindYear("u1", "g1");
+    expect(year).toBe(currentYear - 2);
+  });
+
+  it("degrades to the current year if a lookup throws", async () => {
+    mockFindOneAch.mockReturnValueOnce({
+      lean: jest.fn(async () => {
+        throw new Error("mongo exploded");
+      }),
+    });
+
+    const year = await makeSvc().getDefaultRewindYear("u1", "g1");
+    expect(year).toBe(currentYear);
+  });
+});
+
 describe("RewindService snapshots (#574)", () => {
   function lean<T>(value: T): { lean: () => Promise<T> } {
     return { lean: jest.fn(async () => value) };

--- a/__tests__/web/user-routes.test.ts
+++ b/__tests__/web/user-routes.test.ts
@@ -579,7 +579,13 @@ describe("/me/rewind", () => {
   async function dispatchRewind(opts: {
     pathSuffix: string; // "" for "/rewind", "/2024" for "/rewind/2024"
     summary: unknown; // What RewindService.getInstance(...).getSummary should resolve to
-  }): Promise<{ statusCode: number; body: string }> {
+    defaultYear?: number; // What getDefaultRewindYear resolves to (bare route only)
+  }): Promise<{
+    statusCode: number;
+    body: string;
+    getSummary: jest.Mock;
+    getDefaultRewindYear: jest.Mock;
+  }> {
     const now = Date.now();
     const payload: CookiePayload = {
       sid: "session-id",
@@ -616,8 +622,14 @@ describe("/me/rewind", () => {
     const { RewindService } =
       await import("../../src/services/rewind-service.js");
     const getSummary = jest.fn().mockResolvedValue(opts.summary as never);
+    const getDefaultRewindYear = jest
+      .fn()
+      .mockResolvedValue(
+        (opts.defaultYear ?? new Date().getUTCFullYear()) as never,
+      );
     jest.spyOn(RewindService, "getInstance").mockReturnValue({
       getSummary,
+      getDefaultRewindYear,
     } as never);
 
     const mockClient = {} as never;
@@ -644,7 +656,12 @@ describe("/me/rewind", () => {
       setTimeout(resolve, 0);
     });
     await new Promise((r) => setTimeout(r, 10));
-    return { statusCode: res.statusCode, body: res.body };
+    return {
+      statusCode: res.statusCode,
+      body: res.body,
+      getSummary,
+      getDefaultRewindYear,
+    };
   }
 
   function makeSummary(
@@ -700,6 +717,42 @@ describe("/me/rewind", () => {
     });
     expect(out.statusCode).toBe(200);
     expect(out.body).toContain("Rewind 2024");
+  });
+
+  it("defaults the bare route to the most recent year with data (#573)", async () => {
+    const out = await dispatchRewind({
+      pathSuffix: "",
+      defaultYear: 2025,
+      summary: makeSummary({ year: 2025 }),
+    });
+    expect(out.statusCode).toBe(200);
+    expect(out.body).toContain("Rewind 2025");
+    // The resolved default year drives the summary build, not the
+    // (possibly empty) current year.
+    expect(out.getDefaultRewindYear).toHaveBeenCalledWith("user-1", "guild-1");
+    expect(out.getSummary).toHaveBeenCalledWith(
+      "user-1",
+      "guild-1",
+      2025,
+      null,
+    );
+  });
+
+  it("does not resolve a default year for the explicit :year route (#573)", async () => {
+    const out = await dispatchRewind({
+      pathSuffix: "/2024",
+      summary: makeSummary({ year: 2024 }),
+    });
+    expect(out.statusCode).toBe(200);
+    // The deep-link honours the requested year directly — the default
+    // resolver is never consulted.
+    expect(out.getDefaultRewindYear).not.toHaveBeenCalled();
+    expect(out.getSummary).toHaveBeenCalledWith(
+      "user-1",
+      "guild-1",
+      2024,
+      null,
+    );
   });
 
   it("renders the text-activity card when text data exists (#496)", async () => {

--- a/src/services/rewind-service.ts
+++ b/src/services/rewind-service.ts
@@ -561,6 +561,55 @@ export class RewindService {
   }
 
   /**
+   * Resolve the year the bare `/me/rewind` route should land on (#573): the
+   * most recent year the user actually has data for, falling back to the
+   * current UTC year for brand-new users with nothing to recap (so they
+   * still see today's empty state).
+   *
+   * Reuses the same lightweight year-collection queries that back
+   * `availableYears` so we never pay for a full summary build just to pick
+   * the landing year. The explicit `/rewind/:year` route bypasses this and
+   * honours the requested year, empty or not.
+   */
+  public async getDefaultRewindYear(
+    userId: string,
+    guildId: string,
+  ): Promise<number> {
+    const currentYear = new Date().getUTCFullYear();
+    try {
+      const achievementsDoc = await UserAchievements.findOne({
+        userId,
+      }).lean<{
+        accolades?: Array<{ earnedAt: Date }>;
+        achievements?: Array<{ earnedAt: Date }>;
+      }>();
+
+      const [sessionAndAchievementYears, textYears, snapshotYears] =
+        await Promise.all([
+          this.collectAvailableYears(userId, achievementsDoc),
+          this.collectTextActivityYears(userId, guildId),
+          this.collectSnapshotYears(userId, guildId),
+        ]);
+
+      const years = [
+        ...sessionAndAchievementYears,
+        ...textYears,
+        ...snapshotYears,
+      ];
+      // No data anywhere → land on the (empty) current year, preserving
+      // the brand-new-user experience. Otherwise pick the newest year with
+      // data, which is the current year when it already has activity.
+      return years.length === 0 ? currentYear : Math.max(...years);
+    } catch (error) {
+      logger.warn(
+        `RewindService.getDefaultRewindYear failed for ${userId}, defaulting to current year:`,
+        error,
+      );
+      return currentYear;
+    }
+  }
+
+  /**
    * Freeze a user's completed-year recap into an immutable `RewindSnapshot`
    * (#574). Called by the end-of-year cron once the year has wrapped up.
    *
@@ -675,6 +724,39 @@ export class RewindService {
     } catch (error) {
       logger.warn(
         `RewindService.collectSnapshotYears failed for ${userId}:`,
+        error,
+      );
+      return [];
+    }
+  }
+
+  /**
+   * Distinct years present in the user's retained message detail (#573). A
+   * lighter cousin of `computeTextActivity` used purely for landing-year
+   * resolution — it skips channel resolution and the in-window aggregation,
+   * and respects the same `messagetracking.enabled` gate. A failure (or a
+   * disabled feature) degrades to an empty list.
+   */
+  private async collectTextActivityYears(
+    userId: string,
+    guildId: string,
+  ): Promise<number[]> {
+    try {
+      const enabled = await this.configService.getBoolean(
+        "messagetracking.enabled",
+        false,
+      );
+      if (!enabled) return [];
+
+      const doc = await MessageActivityTracking.findOne(
+        { userId, guildId },
+        { recentMessages: 1 },
+      ).lean<{ recentMessages?: RawTextMessage[] }>();
+      const all = doc?.recentMessages ?? [];
+      return [...new Set(all.map((m) => m.sentAt.getUTCFullYear()))];
+    } catch (error) {
+      logger.warn(
+        `RewindService.collectTextActivityYears failed for ${userId}:`,
         error,
       );
       return [];

--- a/src/services/rewind-service.ts
+++ b/src/services/rewind-service.ts
@@ -591,11 +591,16 @@ export class RewindService {
           this.collectSnapshotYears(userId, guildId),
         ]);
 
+      // Guard against a non-finite year slipping through any collector
+      // (e.g. a corrupt `sentAt`/`earnedAt` yielding `NaN` — which passes a
+      // `typeof === "number"` check). An unfiltered `NaN` would make
+      // `Math.max` return `NaN` and, for the bare route, flow straight
+      // through `parseYearParam` into `getSummary` as "Rewind NaN".
       const years = [
         ...sessionAndAchievementYears,
         ...textYears,
         ...snapshotYears,
-      ];
+      ].filter((y) => Number.isFinite(y));
       // No data anywhere → land on the (empty) current year, preserving
       // the brand-new-user experience. Otherwise pick the newest year with
       // data, which is the current year when it already has activity.
@@ -753,7 +758,13 @@ export class RewindService {
         { recentMessages: 1 },
       ).lean<{ recentMessages?: RawTextMessage[] }>();
       const all = doc?.recentMessages ?? [];
-      return [...new Set(all.map((m) => m.sentAt.getUTCFullYear()))];
+      return [
+        ...new Set(
+          all
+            .map((m) => m.sentAt.getUTCFullYear())
+            .filter((y) => Number.isFinite(y)),
+        ),
+      ];
     } catch (error) {
       logger.warn(
         `RewindService.collectTextActivityYears failed for ${userId}:`,

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -476,7 +476,19 @@ export function createUserRouter(
       guildId: session.guildId,
     });
     const currentYear = new Date().getUTCFullYear();
-    const year = parseYearParam(req.params.year, currentYear);
+    // The explicit `/rewind/:year` deep-link must always honour the
+    // requested year (even an empty one), so it falls back to the current
+    // year only when the param is junk. The bare `/rewind` route instead
+    // lands on the most recent year the user actually has data for, so a
+    // visit right after the year rolls over shows a finished recap rather
+    // than the empty new year (#573).
+    const fallbackYear = req.params.year
+      ? currentYear
+      : await RewindService.getInstance(client).getDefaultRewindYear(
+          userId,
+          guildId,
+        );
+    const year = parseYearParam(req.params.year, fallbackYear);
 
     const timezone =
       await UserNotificationPrefsService.getInstance().getTimezone(


### PR DESCRIPTION
## Summary

Closes #573.

The bare `/me/rewind` route computed `new Date().getUTCFullYear()` and always rendered the current UTC year. Right after the year rolls over — exactly when the end-of-year nudge DM (`RewindNudgeService`) drives users to the page — the current year is brand new and empty, so the default render showed the "Nothing to recap yet" empty state and users had to manually pick last year to see their actual recap.

This changes the **bare** route to land on the **most recent year the user actually has data for**, falling back to the current (empty) year only when there's no data anywhere (preserving the brand-new-user experience). The explicit `/me/rewind/:year` deep link is unchanged — it always honours the requested year, including the empty state.

## Implementation

Follows **approach (b)** from the issue:

- Adds `RewindService.getDefaultRewindYear(userId, guildId)` — a lightweight resolver that reuses the same cheap year-collection queries backing `availableYears` (voice sessions, achievements, retained text-message detail, and snapshots), then returns `max(years)` or the current year when empty. No double summary build, no redirect.
- Adds a small `collectTextActivityYears` helper (a lighter cousin of `computeTextActivity` that skips channel resolution / in-window aggregation and respects the `messagetracking.enabled` gate).
- `rewindHandler` now resolves the fallback year via `getDefaultRewindYear` only when `req.params.year` is absent; the `:year` route still falls back to the current year only for a junk param.

The picker already highlights `summary.year`, so it tracks the resolved year automatically.

## Acceptance criteria

- [x] `/me/rewind` with no current-year activity lands on the most recent year that has data.
- [x] A brand-new user with no data anywhere still gets the current-year empty state.
- [x] `/me/rewind/:year` renders exactly that year, including the empty state.
- [x] The year picker highlights the year actually shown.
- [x] Tests cover: current-year empty + prior year has data (→ prior), current year has data (→ current), no data at all (→ current empty), snapshot-only years, error fallback, and the route-level behaviour (bare route resolves default; explicit `:year` does not).

## Testing

- `npm run build` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm test -- __tests__/services/rewind-service.test.ts __tests__/web/user-routes.test.ts` ✅ (78 passed)
- `npx markdownlint WEBUI.md` ✅

Docs: updated the Rewind section of `WEBUI.md`.

https://claude.ai/code/session_01Thu9XCahVp3Jbq5KhvLjX8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Thu9XCahVp3Jbq5KhvLjX8)_