### PR TITLE
feat(tracking): capture reactions, poll votes, and voice companion overlap when enabled

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -33,6 +33,7 @@ Complete configuration reference for all KoolBot settings.
 - [Voice Activity Tracking](#-voice-activity-tracking)
 - [Voice Channel Cleanup](#-voice-channel-cleanup)
 - [Message Tracking](#-message-tracking)
+- [Reaction Tracking](#-reaction-tracking)
 - [Announcements](#-announcements)
 - [Achievements System](#-achievements-system)
 - [Weekly Digest](#-weekly-digest)
@@ -256,6 +257,7 @@ on the Web UI's **Polls** page; the settings below are global defaults.
 | `polls.enabled` | `false` | Enable/disable the poll system |
 | `polls.default_duration_hours` | `24` | Default poll duration (1-768, max 32 days) |
 | `polls.cooldown_days` | `7` | Minimum days before reusing the same poll question |
+| `polls.participation.enabled` | `false` | Capture per-user "votes cast" (lifetime + per-year) when users vote on any guild poll. Data-capture foundation for a future Rewind stat (#570) |
 
 **Features:**
 
@@ -339,6 +341,7 @@ Track user voice channel activity and generate statistics.
 | `voicetracking.stats.top.enabled` | `false` | Enable `/voicestats top` subcommand |
 | `voicetracking.stats.user.enabled` | `false` | Enable `/voicestats user` subcommand |
 | `voicetracking.seen.enabled` | `false` | Enable `/seen` command for last-seen tracking |
+| `voicetracking.companions.enabled` | `false` | Persist precise per-companion co-presence seconds and join-order metadata (was-first, who you joined) on each voice session. Data-capture foundation for future Rewind companion stats (#570) |
 | `voicetracking.excluded_channels` | `""` | Channel IDs to exclude from tracking (comma-separated) |
 | `voicetracking.admin_roles` | `""` | Role names with tracking admin powers (comma-separated) |
 
@@ -678,6 +681,33 @@ The cleanup job only trims the per-message detail (`recentMessages`)
 beyond the retention window. The all-time per-channel totals and
 `totalCount` are **never** pruned — they're cheap to keep and feed
 all-time leaderboards.
+
+---
+
+## 😀 Reaction Tracking
+
+Track how many reactions each user **gives** (adds to other people's
+messages) and **receives** (others add to theirs) via a
+`messageReactionAdd` listener. Like message tracking, this is the
+**data-capture foundation only** — nothing is surfaced on Rewind or the
+Web UI yet (that lives in a follow-up). No slash command is introduced.
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `reactiontracking.enabled` | `false` | Master switch — turning this off stops the listener entirely |
+| `reactiontracking.excluded_channels` | `""` | Channel IDs to skip (comma-separated; mirrors `messagetracking.excluded_channels`) |
+
+**What's tracked:**
+
+- Reactions from bots and on DM messages are ignored; only guild
+  reactions count. Reactions in excluded channels are skipped.
+- The reactor's `totalGiven` counter is bumped; the message author's
+  `totalReceived` counter is bumped (skipped when the author is a bot or
+  the reactor themselves, to avoid self-inflation).
+- Counts are stored as a lifetime total plus per-year buckets keyed by
+  `"YYYY"`, so a future Rewind can read a single year's count in one
+  lookup. **No per-reaction detail is retained**, so reactions stay cheap
+  even at high volume and **no cleanup job is needed**.
 
 ---
 

--- a/__tests__/services/config-schema.test.ts
+++ b/__tests__/services/config-schema.test.ts
@@ -167,15 +167,18 @@ describe('Config Schema', () => {
       'polls.enabled': false,
       'leaderboard_roles.enabled': false,
       'messagetracking.enabled': false,
+      'reactiontracking.enabled': false,
 
       // ─── Sub-features that default off (auxiliary opt-ins) ──────────
       'voicechannels.presets.enabled': false,
       'voicetracking.stats.top.enabled': false,
       'voicetracking.stats.user.enabled': false,
       'voicetracking.seen.enabled': false,
+      'voicetracking.companions.enabled': false,
       'voicetracking.announcements.enabled': false,
       'voicetracking.cleanup.enabled': false,
       'messagetracking.cleanup.enabled': false,
+      'polls.participation.enabled': false,
 
       // ─── Sub-features that default on (rule 2: parent-gated) ────────
       'voicechannels.controlpanel.enabled': true,

--- a/__tests__/services/poll-participation-tracker.test.ts
+++ b/__tests__/services/poll-participation-tracker.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import type { Client, PollAnswer, User } from "discord.js";
+
+jest.mock("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+  isDebugMode: jest.fn(() => false),
+}));
+
+import { PollParticipationTracker } from "../../src/services/poll-participation-tracker.js";
+import { PollParticipationTracking } from "../../src/models/poll-participation-tracking.js";
+
+(
+  PollParticipationTracking as unknown as { updateOne: jest.Mock }
+).updateOne = jest.fn();
+
+function createTracker(voter: { username: string; bot: boolean } | null) {
+  const usersFetch = jest
+    .fn<(id: string) => Promise<User>>()
+    .mockResolvedValue(
+      (voter
+        ? { id: "voter1", username: voter.username, bot: voter.bot }
+        : { id: "voter1", username: "Voter", bot: false }) as User,
+    );
+  const mockClient = { users: { fetch: usersFetch } } as unknown as Client;
+  const tracker = PollParticipationTracker.getInstance(mockClient);
+
+  const mockConfigService = {
+    getString: jest.fn().mockResolvedValue("mongodb://localhost/test"),
+    getBoolean: jest.fn().mockResolvedValue(true),
+    get: jest.fn().mockResolvedValue(null),
+    getNumber: jest.fn().mockResolvedValue(0),
+  };
+  (tracker as never)["configService"] = mockConfigService;
+  (tracker as never)["isConnected"] = true;
+  (tracker as never)["client"] = mockClient;
+
+  return { tracker, mockConfigService, usersFetch };
+}
+
+function makePollAnswer(guildId: string | null = "guild1"): PollAnswer {
+  return {
+    poll: {
+      message: {
+        guild: guildId ? { id: guildId } : null,
+        guildId: guildId ?? null,
+      },
+    },
+  } as unknown as PollAnswer;
+}
+
+describe("PollParticipationTracker", () => {
+  let updateOne: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    updateOne = (
+      PollParticipationTracking as unknown as { updateOne: jest.Mock }
+    ).updateOne;
+    updateOne.mockResolvedValue({ matchedCount: 1 });
+    (
+      PollParticipationTracker as unknown as { instance: unknown }
+    ).instance = undefined;
+  });
+
+  describe("singleton pattern", () => {
+    it("returns the same instance", () => {
+      const a = PollParticipationTracker.getInstance({} as Client);
+      const b = PollParticipationTracker.getInstance({} as Client);
+      expect(a).toBe(b);
+    });
+  });
+
+  describe("gating", () => {
+    it("does not write when tracking is disabled", async () => {
+      const { tracker, mockConfigService } = createTracker({
+        username: "Voter",
+        bot: false,
+      });
+      mockConfigService.getBoolean.mockResolvedValue(false);
+
+      await tracker.handlePollVoteAdd(makePollAnswer(), "voter1");
+      expect(updateOne).not.toHaveBeenCalled();
+    });
+
+    it("ignores DM polls (no guild)", async () => {
+      const { tracker } = createTracker({ username: "Voter", bot: false });
+      await tracker.handlePollVoteAdd(makePollAnswer(null), "voter1");
+      expect(updateOne).not.toHaveBeenCalled();
+    });
+
+    it("ignores votes cast by bots", async () => {
+      const { tracker } = createTracker({ username: "Botty", bot: true });
+      await tracker.handlePollVoteAdd(makePollAnswer(), "voter1");
+      expect(updateOne).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("recording", () => {
+    it("records a vote with a per-year bucket", async () => {
+      const { tracker } = createTracker({ username: "Voter", bot: false });
+      await tracker.handlePollVoteAdd(makePollAnswer(), "voter1");
+
+      expect(updateOne).toHaveBeenCalledTimes(1);
+      const [filter, update] = updateOne.mock.calls[0];
+      expect(filter).toEqual({ userId: "voter1", guildId: "guild1" });
+      expect(update.$inc.totalVotes).toBe(1);
+      const year = String(new Date().getFullYear());
+      expect(update.$inc[`yearlyVotes.${year}`]).toBe(1);
+      expect(update.$set.username).toBe("Voter");
+    });
+  });
+
+  describe("error handling", () => {
+    it("swallows DB errors", async () => {
+      const { tracker } = createTracker({ username: "Voter", bot: false });
+      updateOne.mockRejectedValue(new Error("DB error"));
+
+      await expect(
+        tracker.handlePollVoteAdd(makePollAnswer(), "voter1"),
+      ).resolves.not.toThrow();
+    });
+  });
+});

--- a/__tests__/services/poll-participation-tracker.test.ts
+++ b/__tests__/services/poll-participation-tracker.test.ts
@@ -26,7 +26,9 @@ function createTracker(voter: { username: string; bot: boolean } | null) {
         ? { id: "voter1", username: voter.username, bot: voter.bot }
         : { id: "voter1", username: "Voter", bot: false }) as User,
     );
-  const mockClient = { users: { fetch: usersFetch } } as unknown as Client;
+  const mockClient = {
+    users: { fetch: usersFetch, cache: new Map<string, User>() },
+  } as unknown as Client;
   const tracker = PollParticipationTracker.getInstance(mockClient);
 
   const mockConfigService = {

--- a/__tests__/services/reaction-activity-tracker.test.ts
+++ b/__tests__/services/reaction-activity-tracker.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import type { Client, MessageReaction, User } from "discord.js";
+
+jest.mock("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+  isDebugMode: jest.fn(() => false),
+}));
+
+import { ReactionActivityTracker } from "../../src/services/reaction-activity-tracker.js";
+import { ReactionActivityTracking } from "../../src/models/reaction-activity-tracking.js";
+
+// The global mongoose mock does not provide updateOne; attach it to the
+// shared model object so the tracker can call it.
+(
+  ReactionActivityTracking as unknown as { updateOne: jest.Mock }
+).updateOne = jest.fn();
+
+function createTracker() {
+  const mockClient = {} as Client;
+  const tracker = ReactionActivityTracker.getInstance(mockClient);
+
+  const mockConfigService = {
+    getString: jest.fn().mockResolvedValue("mongodb://localhost/test"),
+    getBoolean: jest.fn().mockResolvedValue(true),
+    get: jest.fn().mockResolvedValue(null),
+    getNumber: jest.fn().mockResolvedValue(0),
+  };
+  (tracker as never)["configService"] = mockConfigService;
+  (tracker as never)["isConnected"] = true;
+
+  return { tracker, mockConfigService };
+}
+
+function makeReaction(
+  overrides: Partial<{
+    guildId: string | null;
+    channelId: string;
+    authorId: string | null;
+    authorBot: boolean;
+    authorUsername: string;
+  }> = {},
+): MessageReaction {
+  const {
+    guildId = "guild1",
+    channelId = "chan1",
+    authorId = "author1",
+    authorBot = false,
+    authorUsername = "Author",
+  } = overrides;
+  return {
+    partial: false,
+    message: {
+      guild: guildId ? { id: guildId } : null,
+      channelId,
+      author: authorId
+        ? { id: authorId, username: authorUsername, bot: authorBot }
+        : null,
+    },
+  } as unknown as MessageReaction;
+}
+
+function makeUser(
+  overrides: Partial<{ id: string; username: string; bot: boolean }> = {},
+): User {
+  const { id = "reactor1", username = "Reactor", bot = false } = overrides;
+  return { partial: false, id, username, bot } as unknown as User;
+}
+
+describe("ReactionActivityTracker", () => {
+  let updateOne: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    updateOne = (
+      ReactionActivityTracking as unknown as { updateOne: jest.Mock }
+    ).updateOne;
+    updateOne.mockResolvedValue({ matchedCount: 1 });
+    (
+      ReactionActivityTracker as unknown as { instance: unknown }
+    ).instance = undefined;
+  });
+
+  describe("singleton pattern", () => {
+    it("returns the same instance", () => {
+      const a = ReactionActivityTracker.getInstance({} as Client);
+      const b = ReactionActivityTracker.getInstance({} as Client);
+      expect(a).toBe(b);
+    });
+  });
+
+  describe("gating", () => {
+    it("does not write when tracking is disabled", async () => {
+      const { tracker, mockConfigService } = createTracker();
+      mockConfigService.getBoolean.mockResolvedValue(false);
+
+      await tracker.handleReactionAdd(makeReaction(), makeUser());
+      expect(updateOne).not.toHaveBeenCalled();
+    });
+
+    it("ignores reactions from bots", async () => {
+      const { tracker } = createTracker();
+      await tracker.handleReactionAdd(makeReaction(), makeUser({ bot: true }));
+      expect(updateOne).not.toHaveBeenCalled();
+    });
+
+    it("ignores DM reactions (no guild)", async () => {
+      const { tracker } = createTracker();
+      await tracker.handleReactionAdd(
+        makeReaction({ guildId: null }),
+        makeUser(),
+      );
+      expect(updateOne).not.toHaveBeenCalled();
+    });
+
+    it("skips excluded channels", async () => {
+      const { tracker, mockConfigService } = createTracker();
+      mockConfigService.get.mockResolvedValue("chan1,chan2");
+
+      await tracker.handleReactionAdd(
+        makeReaction({ channelId: "chan1" }),
+        makeUser(),
+      );
+      expect(updateOne).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("recording", () => {
+    it("records both given (reactor) and received (author)", async () => {
+      const { tracker } = createTracker();
+      await tracker.handleReactionAdd(makeReaction(), makeUser());
+
+      expect(updateOne).toHaveBeenCalledTimes(2);
+
+      const [givenFilter, givenUpdate] = updateOne.mock.calls[0];
+      expect(givenFilter).toEqual({ userId: "reactor1", guildId: "guild1" });
+      expect(givenUpdate.$inc.totalGiven).toBe(1);
+      const year = String(new Date().getFullYear());
+      expect(givenUpdate.$inc[`yearlyGiven.${year}`]).toBe(1);
+
+      const [recvFilter, recvUpdate] = updateOne.mock.calls[1];
+      expect(recvFilter).toEqual({ userId: "author1", guildId: "guild1" });
+      expect(recvUpdate.$inc.totalReceived).toBe(1);
+      expect(recvUpdate.$inc[`yearlyReceived.${year}`]).toBe(1);
+    });
+
+    it("does not record received when reacting to a bot's message", async () => {
+      const { tracker } = createTracker();
+      await tracker.handleReactionAdd(
+        makeReaction({ authorBot: true }),
+        makeUser(),
+      );
+      // Only the reactor's "given" write happens.
+      expect(updateOne).toHaveBeenCalledTimes(1);
+      expect(updateOne.mock.calls[0][1].$inc.totalGiven).toBe(1);
+    });
+
+    it("does not double-count a self-reaction", async () => {
+      const { tracker } = createTracker();
+      await tracker.handleReactionAdd(
+        makeReaction({ authorId: "same" }),
+        makeUser({ id: "same" }),
+      );
+      // Reactor === author: only "given" is recorded.
+      expect(updateOne).toHaveBeenCalledTimes(1);
+      expect(updateOne.mock.calls[0][1].$inc.totalReceived).toBeUndefined();
+    });
+  });
+
+  describe("partials", () => {
+    it("fetches a partial reaction and user before recording", async () => {
+      const { tracker } = createTracker();
+      const fetched = makeReaction();
+      const partialReaction = {
+        partial: true,
+        fetch: jest.fn<() => Promise<MessageReaction>>().mockResolvedValue(
+          fetched,
+        ),
+      } as unknown as MessageReaction;
+      const fetchedUser = makeUser();
+      const partialUser = {
+        partial: true,
+        fetch: jest.fn<() => Promise<User>>().mockResolvedValue(fetchedUser),
+      } as unknown as User;
+
+      await tracker.handleReactionAdd(partialReaction, partialUser);
+
+      expect(
+        (partialReaction as unknown as { fetch: jest.Mock }).fetch,
+      ).toHaveBeenCalled();
+      expect(
+        (partialUser as unknown as { fetch: jest.Mock }).fetch,
+      ).toHaveBeenCalled();
+      expect(updateOne).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("error handling", () => {
+    it("swallows DB errors", async () => {
+      const { tracker } = createTracker();
+      updateOne.mockRejectedValue(new Error("DB error"));
+
+      await expect(
+        tracker.handleReactionAdd(makeReaction(), makeUser()),
+      ).resolves.not.toThrow();
+    });
+  });
+});

--- a/__tests__/services/settings-metadata.test.ts
+++ b/__tests__/services/settings-metadata.test.ts
@@ -54,6 +54,7 @@ describe("settingsMetadata", () => {
       "polls",
       "leaderboard_roles",
       "messagetracking",
+      "reactiontracking",
     ]);
     const violations: string[] = [];
     for (const [key, meta] of Object.entries(settingsMetadata)) {

--- a/__tests__/services/voice-channel-tracker.test.ts
+++ b/__tests__/services/voice-channel-tracker.test.ts
@@ -185,6 +185,120 @@ describe('VoiceChannelTracker', () => {
     });
   });
 
+  describe('companion overlap & voice firsts (#570)', () => {
+    // Builds a member whose guild channel cache returns a channel populated
+    // with `presentIds` so startTracking can snapshot co-present users.
+    function memberInChannel(
+      id: string,
+      channelId: string,
+      channelName: string,
+      presentIds: string[],
+    ): GuildMember {
+      const members = new Map(presentIds.map((p) => [p, { id: p }]));
+      const channel = { id: channelId, name: channelName, members };
+      return {
+        id,
+        displayName: id,
+        guild: { channels: { cache: { get: jest.fn().mockReturnValue(channel) } } },
+      } as unknown as GuildMember;
+    }
+
+    function gate(companionsEnabled: boolean) {
+      return (key: string) =>
+        Promise.resolve(
+          key === 'voicetracking.enabled' ||
+            (companionsEnabled && key === 'voicetracking.companions.enabled'),
+        );
+    }
+
+    async function joinThenLeave(
+      tracker: VoiceChannelTracker,
+      member: GuildMember,
+      channelId: string,
+      channelName: string,
+    ) {
+      const channelState = { id: channelId, name: channelName } as unknown as VoiceChannel;
+      // The global findOneAndUpdate mock accumulates calls across tests; clear
+      // it so the assertion can read this scenario's session as calls[0].
+      (VoiceChannelTracking.findOneAndUpdate as jest.Mock).mockClear();
+      await tracker.handleVoiceStateUpdate(
+        { member, channel: null } as unknown as VoiceState,
+        { member, channel: channelState } as unknown as VoiceState,
+      );
+      await tracker.handleVoiceStateUpdate(
+        { member, channel: channelState } as unknown as VoiceState,
+        { member, channel: null } as unknown as VoiceState,
+      );
+    }
+
+    it('omits companion/firsts fields when the feature is disabled', async () => {
+      const { tracker, mockConfigService } = createTracker(mockClient);
+      mockConfigService.getBoolean.mockImplementation(gate(false));
+      (mockClient.users as any).fetch = jest
+        .fn()
+        .mockResolvedValue({ username: 'u1', id: 'u1' });
+
+      await joinThenLeave(
+        tracker,
+        memberInChannel('u1', 'c1', 'C1', ['other1']),
+        'c1',
+        'C1',
+      );
+
+      const pushed = (VoiceChannelTracking.findOneAndUpdate as jest.Mock).mock
+        .calls[0][1].$push.sessions;
+      expect(pushed.companions).toBeUndefined();
+      expect(pushed.wasFirst).toBeUndefined();
+      expect(pushed.joinedExisting).toBeUndefined();
+      // The legacy union set is still captured.
+      expect(pushed.otherUsers).toEqual(['other1']);
+    });
+
+    it('captures companions, joinedExisting, and wasFirst=false when present at join', async () => {
+      const { tracker, mockConfigService } = createTracker(mockClient);
+      mockConfigService.getBoolean.mockImplementation(gate(true));
+      (mockClient.users as any).fetch = jest
+        .fn()
+        .mockResolvedValue({ username: 'u1', id: 'u1' });
+
+      await joinThenLeave(
+        tracker,
+        memberInChannel('u1', 'c1', 'C1', ['other1']),
+        'c1',
+        'C1',
+      );
+
+      const pushed = (VoiceChannelTracking.findOneAndUpdate as jest.Mock).mock
+        .calls[0][1].$push.sessions;
+      expect(pushed.wasFirst).toBe(false);
+      expect(pushed.joinedExisting).toEqual(['other1']);
+      expect(pushed.companions).toEqual([
+        { userId: 'other1', seconds: expect.any(Number) },
+      ]);
+    });
+
+    it('marks wasFirst=true when the channel was empty at join', async () => {
+      const { tracker, mockConfigService } = createTracker(mockClient);
+      mockConfigService.getBoolean.mockImplementation(gate(true));
+      (mockClient.users as any).fetch = jest
+        .fn()
+        .mockResolvedValue({ username: 'u1', id: 'u1' });
+
+      await joinThenLeave(
+        tracker,
+        memberInChannel('u1', 'c1', 'C1', []),
+        'c1',
+        'C1',
+      );
+
+      const pushed = (VoiceChannelTracking.findOneAndUpdate as jest.Mock).mock
+        .calls[0][1].$push.sessions;
+      expect(pushed.wasFirst).toBe(true);
+      expect(pushed.joinedExisting).toEqual([]);
+      expect(pushed.companions).toEqual([]);
+    });
+  });
+
   describe('getUserStats', () => {
     it('should return null when user not found', async () => {
       const { tracker } = createTracker(mockClient);

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ import { VoiceChannelAnnouncer } from "./services/voice-channel-announcer.js";
 import { VoiceChannelTruncationService } from "./services/voice-channel-truncation.js";
 import { MessageActivityTracker } from "./services/message-activity-tracker.js";
 import { MessageActivityCleanupService } from "./services/message-activity-cleanup.js";
+import { ReactionActivityTracker } from "./services/reaction-activity-tracker.js";
+import { PollParticipationTracker } from "./services/poll-participation-tracker.js";
 import { CommandAuditCleanupService } from "./services/command-audit-cleanup.js";
 import { ScheduledAnnouncementService } from "./services/scheduled-announcement-service.js";
 import { ChannelInitializer } from "./services/channel-initializer.js";
@@ -103,6 +105,9 @@ const client = new Client({
     GatewayIntentBits.GuildVoiceStates,
     GatewayIntentBits.MessageContent,
     GatewayIntentBits.GuildMessageReactions,
+    // Required to receive messagePollVoteAdd events for poll-participation
+    // tracking (#570). The events still only fire for guild polls.
+    GatewayIntentBits.GuildMessagePolls,
   ],
   partials: [Partials.Message, Partials.Reaction],
 });
@@ -539,6 +544,8 @@ let voiceChannelAnnouncer: VoiceChannelAnnouncer;
 let voiceChannelTruncation: VoiceChannelTruncationService;
 let messageActivityTracker: MessageActivityTracker;
 let messageActivityCleanup: MessageActivityCleanupService;
+let reactionActivityTracker: ReactionActivityTracker;
+let pollParticipationTracker: PollParticipationTracker;
 let scheduledAnnouncementService: ScheduledAnnouncementService;
 let channelInitializer: ChannelInitializer;
 let startupMigrator: StartupMigrator;
@@ -562,6 +569,8 @@ try {
   voiceChannelTruncation = VoiceChannelTruncationService.getInstance(client);
   messageActivityTracker = MessageActivityTracker.getInstance(client);
   messageActivityCleanup = MessageActivityCleanupService.getInstance(client);
+  reactionActivityTracker = ReactionActivityTracker.getInstance(client);
+  pollParticipationTracker = PollParticipationTracker.getInstance(client);
   scheduledAnnouncementService =
     ScheduledAnnouncementService.getInstance(client);
   channelInitializer = ChannelInitializer.getInstance(client);
@@ -649,6 +658,8 @@ async function initializeServices(): Promise<void> {
     await voiceChannelTruncation.initialize();
     await messageActivityTracker.initialize();
     await messageActivityCleanup.initialize();
+    await reactionActivityTracker.initialize();
+    await pollParticipationTracker.initialize();
     await voiceChannelAnnouncer.start();
     await scheduledAnnouncementService.start();
     await channelInitializer.initializeChannels(
@@ -896,6 +907,28 @@ client.on(Events.MessageCreate, async (message) => {
     await messageActivityTracker.handleMessageCreate(message);
   } catch (error) {
     logger.error("Error handling messageCreate:", error);
+  }
+});
+
+// Handle reactions for per-user given/received activity tracking (#570).
+// Gating (enabled, bot/DM, excluded channels) lives in the tracker.
+client.on(Events.MessageReactionAdd, async (reaction, user) => {
+  recordDiscordEvent("messageReactionAdd");
+  try {
+    await reactionActivityTracker.handleReactionAdd(reaction, user);
+  } catch (error) {
+    logger.error("Error handling messageReactionAdd:", error);
+  }
+});
+
+// Handle native-poll votes for per-user participation tracking (#570).
+// Gating (enabled, DM/bot) lives in the tracker.
+client.on(Events.MessagePollVoteAdd, async (pollAnswer, userId) => {
+  recordDiscordEvent("messagePollVoteAdd");
+  try {
+    await pollParticipationTracker.handlePollVoteAdd(pollAnswer, userId);
+  } catch (error) {
+    logger.error("Error handling messagePollVoteAdd:", error);
   }
 });
 

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -44,6 +44,7 @@ const ConfigSchema = new Schema<IConfig>(
         "quotes",
         "ratelimit",
         "reactionroles",
+        "reactiontracking",
         "rewind",
         "voicechannels",
         "voicetracking",

--- a/src/models/poll-participation-tracking.ts
+++ b/src/models/poll-participation-tracking.ts
@@ -1,0 +1,47 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+/**
+ * Per-user, per-guild poll-participation tracking.
+ *
+ * Discord's native polls do not persist per-user votes anywhere we can query
+ * after the fact, so a vote that isn't captured the moment it is cast can
+ * never be backfilled. This collection records one cheap counter per user:
+ * how many poll votes they have cast. As with reaction tracking we keep only
+ * a lifetime total plus per-year buckets keyed by "YYYY", so a future Rewind
+ * can read a single year's "votes cast" count without retaining per-vote
+ * detail or needing a cleanup pass.
+ *
+ * Data-capture foundation only — nothing is surfaced on Rewind or the WebUI
+ * yet. Gated behind `polls.participation.enabled`; nothing is written while
+ * that key is false.
+ */
+export interface IPollParticipationTracking extends Document {
+  userId: string;
+  guildId: string;
+  username: string;
+  totalVotes: number;
+  // Per-year vote counters keyed by "YYYY" (host-timezone year at capture).
+  yearlyVotes: Map<string, number>;
+  lastVoteAt: Date | null;
+}
+
+const PollParticipationTrackingSchema = new Schema({
+  userId: { type: String, required: true },
+  guildId: { type: String, required: true },
+  username: { type: String, required: true },
+  totalVotes: { type: Number, default: 0 },
+  yearlyVotes: { type: Map, of: Number, default: {} },
+  lastVoteAt: { type: Date, default: null },
+});
+
+// One tracking document per user per guild.
+PollParticipationTrackingSchema.index(
+  { userId: 1, guildId: 1 },
+  { unique: true },
+);
+
+export const PollParticipationTracking =
+  mongoose.model<IPollParticipationTracking>(
+    "PollParticipationTracking",
+    PollParticipationTrackingSchema,
+  );

--- a/src/models/reaction-activity-tracking.ts
+++ b/src/models/reaction-activity-tracking.ts
@@ -1,0 +1,51 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+/**
+ * Per-user, per-guild reaction activity tracking.
+ *
+ * Captures two cheap, append-only counters per user: how many reactions they
+ * have *given* (added to other people's messages) and *received* (added by
+ * others to their messages). Reaction events are high-volume, so rather than
+ * retaining per-reaction detail (which would need a cleanup pass and grow
+ * without bound) we keep only lifetime totals plus per-year buckets keyed by
+ * "YYYY". A future Rewind can read a single year's count in one lookup, and
+ * the storage cost is one tiny map entry per user per year.
+ *
+ * This is a data-capture foundation only — like message tracking (#495), it
+ * does not surface anything on Rewind or the WebUI yet. Gated behind
+ * `reactiontracking.enabled`; nothing is written while that key is false.
+ */
+export interface IReactionActivityTracking extends Document {
+  userId: string;
+  guildId: string;
+  username: string;
+  totalGiven: number;
+  totalReceived: number;
+  // Per-year counters keyed by "YYYY" (host-timezone year at capture time).
+  yearlyGiven: Map<string, number>;
+  yearlyReceived: Map<string, number>;
+  lastReactionAt: Date | null;
+}
+
+const ReactionActivityTrackingSchema = new Schema({
+  userId: { type: String, required: true },
+  guildId: { type: String, required: true },
+  username: { type: String, required: true },
+  totalGiven: { type: Number, default: 0 },
+  totalReceived: { type: Number, default: 0 },
+  yearlyGiven: { type: Map, of: Number, default: {} },
+  yearlyReceived: { type: Map, of: Number, default: {} },
+  lastReactionAt: { type: Date, default: null },
+});
+
+// One tracking document per user per guild.
+ReactionActivityTrackingSchema.index(
+  { userId: 1, guildId: 1 },
+  { unique: true },
+);
+
+export const ReactionActivityTracking =
+  mongoose.model<IReactionActivityTracking>(
+    "ReactionActivityTracking",
+    ReactionActivityTrackingSchema,
+  );

--- a/src/models/voice-channel-tracking.ts
+++ b/src/models/voice-channel-tracking.ts
@@ -12,6 +12,17 @@ export interface IVoiceChannelTracking extends Document {
     channelId: string;
     channelName: string;
     otherUsers?: string[]; // Array of other user IDs who were in the channel during this session
+    // Precise per-companion co-presence in seconds — the overlapping interval
+    // between this user and each other user, not the session-level union that
+    // `otherUsers` records. Captured only when `voicetracking.companions.enabled`
+    // is true; omitted otherwise so existing documents are unaffected. (#570)
+    companions?: Array<{ userId: string; seconds: number }>;
+    // Voice "firsts": whether the channel was empty when this user joined
+    // (they were the first occupant), and the set of users already present at
+    // their join (enables "who you most often joined right after"). Captured
+    // only when `voicetracking.companions.enabled` is true. (#570)
+    wasFirst?: boolean;
+    joinedExisting?: string[];
   }>;
   excludedChannels: string[]; // Array of voice channel IDs to exclude from tracking
   // Cleanup-related fields for future use
@@ -45,6 +56,14 @@ const VoiceChannelTrackingSchema = new Schema({
       channelId: { type: String, required: true },
       channelName: { type: String, required: true },
       otherUsers: { type: [String], default: [] },
+      // Optional companion/firsts capture (#570). `default: undefined` keeps
+      // the fields off existing and companion-disabled sessions entirely.
+      companions: {
+        type: [{ userId: String, seconds: Number }],
+        default: undefined,
+      },
+      wasFirst: { type: Boolean },
+      joinedExisting: { type: [String], default: undefined },
     },
   ],
   excludedChannels: { type: [String], default: [] },

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -16,6 +16,7 @@ export interface ConfigSchema {
   "voicetracking.stats.user.enabled": boolean; // Enable /voicestats user subcommand
   "voicetracking.stats.leaderboard_max_results": number; // Server-side cap on /voicestats top rows
   "voicetracking.seen.enabled": boolean;
+  "voicetracking.companions.enabled": boolean; // Capture precise per-companion overlap + voice "firsts" (#570)
   "voicetracking.excluded_channels": string; // Comma-separated channel IDs
   "voicetracking.announcements.enabled": boolean;
   "voicetracking.announcements.schedule": string; // Cron schedule
@@ -34,6 +35,10 @@ export interface ConfigSchema {
   "messagetracking.cleanup.enabled": boolean; // Master switch for the cleanup job
   "messagetracking.cleanup.schedule": string; // Cron schedule for the cleanup job
   "messagetracking.cleanup.retention.detailed_days": number; // Drop recentMessages older than N days
+
+  // Reaction Activity Tracking (#570)
+  "reactiontracking.enabled": boolean; // Master switch — turning this off stops the listener entirely
+  "reactiontracking.excluded_channels": string; // Comma-separated channel IDs to skip
 
   // Individual Features
   "ping.enabled": boolean;
@@ -89,6 +94,7 @@ export interface ConfigSchema {
   "polls.enabled": boolean;
   "polls.default_duration_hours": number; // Default poll duration in hours (1-768)
   "polls.cooldown_days": number; // Minimum days between reusing same poll
+  "polls.participation.enabled": boolean; // Capture per-user votes cast for a future Rewind (#570)
 
   // Leaderboard Role Rewards
   "leaderboard_roles.enabled": boolean;
@@ -150,6 +156,11 @@ export const defaultConfig: ConfigSchema = {
   "voicetracking.stats.user.enabled": false,
   "voicetracking.stats.leaderboard_max_results": 50,
   "voicetracking.seen.enabled": false,
+  // Companion overlap + voice "firsts" capture (#570). Off by default
+  // (rule 1): turning it on makes voice sessions persist precise
+  // per-companion co-presence seconds and join-order metadata. The base
+  // session shape is unchanged while this is off.
+  "voicetracking.companions.enabled": false,
   "voicetracking.excluded_channels": "",
   "voicetracking.announcements.enabled": false,
   "voicetracking.announcements.schedule": "0 16 * * 5", // Every Friday at 16:00
@@ -171,6 +182,13 @@ export const defaultConfig: ConfigSchema = {
   "messagetracking.cleanup.enabled": false,
   "messagetracking.cleanup.schedule": "0 3 * * *", // Daily at 03:00 host timezone
   "messagetracking.cleanup.retention.detailed_days": 400, // Full Rewind year + buffer
+
+  // Reaction Activity Tracking defaults (#570). Master gate off, follows
+  // rule 1 — the messageReactionAdd listener does nothing until an operator
+  // opts in. Data-capture foundation only; only lifetime + per-year counts
+  // are stored, so no cleanup job is needed.
+  "reactiontracking.enabled": false,
+  "reactiontracking.excluded_channels": "",
 
   // Individual Features
   "ping.enabled": false,
@@ -231,6 +249,10 @@ export const defaultConfig: ConfigSchema = {
   "polls.enabled": false,
   "polls.default_duration_hours": 24, // Default 24 hours
   "polls.cooldown_days": 7, // Minimum 7 days between reusing same poll
+  // Poll-participation capture (#570). Off by default (rule 1): when on, a
+  // messagePollVoteAdd listener records per-user "votes cast" for a future
+  // Rewind. Independent of whether the bot created the poll.
+  "polls.participation.enabled": false,
 
   // Leaderboard Role Rewards defaults
   "leaderboard_roles.enabled": false,
@@ -329,6 +351,11 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
     title: "Message Tracking",
     description:
       "Per-user, per-channel text-message activity tracking with a retention-trimmed detail log. Data-capture foundation for text stats; surfacing lives in the Rewind follow-up.",
+  },
+  reactiontracking: {
+    title: "Reaction Tracking",
+    description:
+      "Per-user counts of reactions given and received, stored as lifetime + per-year totals. Data-capture foundation for a future Rewind stat; surfacing lives in a follow-up.",
   },
   ping: {
     title: "Ping",
@@ -490,6 +517,13 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
     category: "voicetracking",
     type: "boolean",
   },
+  "voicetracking.companions.enabled": {
+    label: "Companion overlap & voice firsts capture",
+    description:
+      "Persist precise per-companion co-presence seconds and join-order metadata (was-first, who you joined) on each voice session. Data-capture foundation for future Rewind companion stats; off by default. Requires voice tracking to be enabled.",
+    category: "voicetracking",
+    type: "boolean",
+  },
   "voicetracking.excluded_channels": {
     label: "Excluded channel IDs",
     description:
@@ -584,6 +618,22 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
       "Days to keep per-message detail (recentMessages) before it is pruned. All-time per-channel totals are never pruned.",
     category: "messagetracking",
     type: "number",
+  },
+
+  // Reaction Activity Tracking (#570)
+  "reactiontracking.enabled": {
+    label: "Reaction Tracking enabled",
+    description:
+      "Enable per-user reaction tracking (given + received counts). Turning this off stops the messageReactionAdd listener entirely.",
+    category: "reactiontracking",
+    type: "boolean",
+  },
+  "reactiontracking.excluded_channels": {
+    label: "Excluded channel IDs",
+    description:
+      "Comma-separated channel IDs to exclude from reaction tracking (mirrors messagetracking.excluded_channels).",
+    category: "reactiontracking",
+    type: "channel_list",
   },
 
   // Individual Features
@@ -826,6 +876,13 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
       "Minimum days before a question from the library can be reused.",
     category: "polls",
     type: "number",
+  },
+  "polls.participation.enabled": {
+    label: "Poll participation tracking enabled",
+    description:
+      "Record per-user 'votes cast' (lifetime + per-year) whenever a user votes on any guild poll. Data-capture foundation for a future Rewind stat; off by default.",
+    category: "polls",
+    type: "boolean",
   },
 
   // Leaderboard Role Rewards

--- a/src/services/poll-participation-tracker.ts
+++ b/src/services/poll-participation-tracker.ts
@@ -1,0 +1,156 @@
+import { Client, PollAnswer, PartialPollAnswer, Snowflake } from "discord.js";
+import logger, { isDebugMode } from "../utils/logger.js";
+import { PollParticipationTracking } from "../models/poll-participation-tracking.js";
+import mongoose from "mongoose";
+import { ConfigService } from "./config-service.js";
+
+/**
+ * Tracks poll participation: a `messagePollVoteAdd` listener bumps a
+ * per-user "votes cast" counter (plus per-year buckets) in the
+ * `PollParticipationTracking` collection. Discord does not let us query a
+ * poll's per-user votes after the fact, so this capture is the only chance to
+ * record participation for a future Rewind.
+ *
+ * Data-capture foundation only (see #570); nothing is surfaced on Rewind or
+ * the WebUI yet. Writes are gated on `polls.participation.enabled`. A vote on
+ * any guild poll counts — the tracking is independent of whether the bot's
+ * own poll feature created the poll.
+ */
+export class PollParticipationTracker {
+  private static instance: PollParticipationTracker;
+  private client: Client;
+  private isConnected: boolean = false;
+  private configService: ConfigService;
+
+  private constructor(client: Client) {
+    this.client = client;
+    this.configService = ConfigService.getInstance();
+    this.setupMongoConnectionHandlers();
+  }
+
+  private setupMongoConnectionHandlers(): void {
+    mongoose.connection.on("connected", () => {
+      this.isConnected = true;
+      logger.info(
+        "MongoDB connection established for poll participation tracker",
+      );
+    });
+
+    mongoose.connection.on("disconnected", () => {
+      this.isConnected = false;
+      logger.warn("MongoDB connection lost for poll participation tracker");
+    });
+
+    mongoose.connection.on("error", (error: Error) => {
+      this.isConnected = false;
+      logger.error(
+        "MongoDB connection error in poll participation tracker:",
+        error,
+      );
+    });
+  }
+
+  private async ensureConnection(): Promise<void> {
+    if (!this.isConnected) {
+      try {
+        await mongoose.connect(
+          await this.configService.getString(
+            "MONGODB_URI",
+            "mongodb://mongodb:27017/koolbot",
+          ),
+        );
+        logger.info("Reconnected to MongoDB for poll participation tracker");
+      } catch (error: unknown) {
+        logger.error("Error reconnecting to MongoDB:", error);
+        throw error;
+      }
+    }
+  }
+
+  public static getInstance(client: Client): PollParticipationTracker {
+    if (!PollParticipationTracker.instance) {
+      PollParticipationTracker.instance = new PollParticipationTracker(client);
+    }
+    return PollParticipationTracker.instance;
+  }
+
+  /**
+   * Handle a `messagePollVoteAdd` event. Writes are gated on
+   * `polls.participation.enabled = true`; DM polls and bot voters are
+   * skipped. Each selected answer fires its own event, so a multi-select
+   * vote counts once per chosen answer (i.e. "votes cast").
+   */
+  public async handlePollVoteAdd(
+    pollAnswer: PollAnswer | PartialPollAnswer,
+    userId: Snowflake,
+  ): Promise<void> {
+    try {
+      const isEnabled = await this.configService.getBoolean(
+        "polls.participation.enabled",
+        false,
+      );
+      if (!isEnabled) {
+        return;
+      }
+
+      const message = pollAnswer.poll.message;
+
+      // Guild-scoped only — ignore DM polls.
+      const guildId = message.guild?.id ?? message.guildId;
+      if (!guildId) {
+        return;
+      }
+
+      // Resolve the voter so we can store a friendly username and skip bots.
+      const user = await this.client.users.fetch(userId);
+      if (user.bot) {
+        return;
+      }
+
+      const year = String(new Date().getFullYear());
+      await this.recordVote(userId, guildId, user.username, year);
+
+      if (isDebugMode()) {
+        logger.info(
+          `[DEBUG] Recorded poll vote by ${user.username} (${userId}) in guild ${guildId}`,
+        );
+      }
+    } catch (error: unknown) {
+      logger.error("Error handling messagePollVoteAdd in tracker:", error);
+    }
+  }
+
+  /**
+   * Atomically upsert one user's vote counters. A Mongo `Map` field lets us
+   * `$inc` the per-year bucket on a dotted path, so a new user, a new year,
+   * and the steady state are all a single write.
+   */
+  private async recordVote(
+    userId: string,
+    guildId: string,
+    username: string,
+    year: string,
+  ): Promise<void> {
+    await this.ensureConnection();
+
+    await PollParticipationTracking.updateOne(
+      { userId, guildId },
+      {
+        $setOnInsert: { userId, guildId },
+        $set: { username, lastVoteAt: new Date() },
+        $inc: { totalVotes: 1, [`yearlyVotes.${year}`]: 1 },
+      },
+      { upsert: true },
+    );
+  }
+
+  public async initialize(): Promise<void> {
+    try {
+      await this.ensureConnection();
+      logger.info("PollParticipationTracker initialized");
+    } catch (error) {
+      logger.error("Error initializing PollParticipationTracker:", error);
+      throw error;
+    }
+  }
+}

--- a/src/services/poll-participation-tracker.ts
+++ b/src/services/poll-participation-tracker.ts
@@ -102,7 +102,11 @@ export class PollParticipationTracker {
       }
 
       // Resolve the voter so we can store a friendly username and skip bots.
-      const user = await this.client.users.fetch(userId);
+      // Prefer the in-memory cache to avoid an API round-trip on every vote;
+      // only hit the REST API when the user isn't cached.
+      const user =
+        this.client.users.cache.get(userId) ??
+        (await this.client.users.fetch(userId));
       if (user.bot) {
         return;
       }

--- a/src/services/reaction-activity-tracker.ts
+++ b/src/services/reaction-activity-tracker.ts
@@ -1,0 +1,237 @@
+import {
+  Client,
+  MessageReaction,
+  PartialMessageReaction,
+  User,
+  PartialUser,
+} from "discord.js";
+import logger, { isDebugMode } from "../utils/logger.js";
+import { ReactionActivityTracking } from "../models/reaction-activity-tracking.js";
+import mongoose from "mongoose";
+import { ConfigService } from "./config-service.js";
+
+/**
+ * Tracks reaction activity the same way `MessageActivityTracker` tracks
+ * text messages: a `messageReactionAdd` listener bumps per-user "given" and
+ * "received" counters (plus per-year buckets) in the
+ * `ReactionActivityTracking` collection.
+ *
+ * Reactions are high-volume, so each event is at most two single-document
+ * upserts (one for the reactor, one for the message author) and we keep no
+ * per-reaction detail — only lifetime totals and per-year counts. This is
+ * the data-capture foundation only (see #570 / #495); nothing is surfaced on
+ * Rewind or the WebUI yet. Writes are gated on `reactiontracking.enabled`.
+ */
+export class ReactionActivityTracker {
+  private static instance: ReactionActivityTracker;
+  private client: Client;
+  private isConnected: boolean = false;
+  private configService: ConfigService;
+
+  private constructor(client: Client) {
+    this.client = client;
+    this.configService = ConfigService.getInstance();
+    this.setupMongoConnectionHandlers();
+  }
+
+  private setupMongoConnectionHandlers(): void {
+    mongoose.connection.on("connected", () => {
+      this.isConnected = true;
+      logger.info(
+        "MongoDB connection established for reaction activity tracker",
+      );
+    });
+
+    mongoose.connection.on("disconnected", () => {
+      this.isConnected = false;
+      logger.warn("MongoDB connection lost for reaction activity tracker");
+    });
+
+    mongoose.connection.on("error", (error: Error) => {
+      this.isConnected = false;
+      logger.error(
+        "MongoDB connection error in reaction activity tracker:",
+        error,
+      );
+    });
+  }
+
+  private async ensureConnection(): Promise<void> {
+    if (!this.isConnected) {
+      try {
+        await mongoose.connect(
+          await this.configService.getString(
+            "MONGODB_URI",
+            "mongodb://mongodb:27017/koolbot",
+          ),
+        );
+        logger.info("Reconnected to MongoDB for reaction activity tracker");
+      } catch (error: unknown) {
+        logger.error("Error reconnecting to MongoDB:", error);
+        throw error;
+      }
+    }
+  }
+
+  public static getInstance(client: Client): ReactionActivityTracker {
+    if (!ReactionActivityTracker.instance) {
+      ReactionActivityTracker.instance = new ReactionActivityTracker(client);
+    }
+    return ReactionActivityTracker.instance;
+  }
+
+  /**
+   * Returns true when the given channel ID is listed in
+   * `reactiontracking.excluded_channels`. Mirrors the comma-separated-ID
+   * convention used by `messagetracking.excluded_channels`.
+   */
+  private async isChannelExcluded(channelId: string): Promise<boolean> {
+    try {
+      const excludedChannels = await this.configService.get(
+        "reactiontracking.excluded_channels",
+      );
+
+      if (!excludedChannels) return false;
+
+      if (typeof excludedChannels === "string") {
+        return excludedChannels
+          .split(",")
+          .map((id) => id.trim())
+          .includes(channelId);
+      }
+
+      if (Array.isArray(excludedChannels)) {
+        return excludedChannels.includes(channelId);
+      }
+
+      return false;
+    } catch (error: unknown) {
+      logger.error("Error checking excluded reaction channels:", error);
+      return false;
+    }
+  }
+
+  /**
+   * Handle a `messageReactionAdd` event. Writes are gated on
+   * `reactiontracking.enabled = true`; bot reactors, DMs (non-guild
+   * messages), and excluded channels are skipped. The reactor's "given"
+   * counter and the message author's "received" counter are bumped.
+   */
+  public async handleReactionAdd(
+    reaction: MessageReaction | PartialMessageReaction,
+    user: User | PartialUser,
+  ): Promise<void> {
+    try {
+      const isEnabled = await this.configService.getBoolean(
+        "reactiontracking.enabled",
+        false,
+      );
+      if (!isEnabled) {
+        return;
+      }
+
+      // Resolve partial reactions/users so message author + channel are known.
+      // Reactions on uncached (old) messages arrive partial.
+      if (reaction.partial) {
+        reaction = await reaction.fetch();
+      }
+      if (user.partial) {
+        user = await user.fetch();
+      }
+
+      // Ignore reactions added by bots (including ourselves).
+      if (user.bot) {
+        return;
+      }
+
+      const message = reaction.message;
+
+      // Guild-scoped only — ignore DM reactions.
+      if (!message.guild) {
+        return;
+      }
+
+      const channelId = message.channelId;
+      if (await this.isChannelExcluded(channelId)) {
+        if (isDebugMode()) {
+          logger.info(
+            `[DEBUG] Channel ${channelId} is excluded from reaction tracking`,
+          );
+        }
+        return;
+      }
+
+      const guildId = message.guild.id;
+      const year = String(new Date().getFullYear());
+
+      // The reactor "gives" a reaction.
+      await this.recordReaction(
+        user.id,
+        guildId,
+        user.username ?? "unknown",
+        "given",
+        year,
+      );
+
+      // The message author "receives" a reaction. Skip when the author is a
+      // bot, missing, or the reactor themselves (don't inflate own totals).
+      const author = message.author;
+      if (author && !author.bot && author.id !== user.id) {
+        await this.recordReaction(
+          author.id,
+          guildId,
+          author.username ?? "unknown",
+          "received",
+          year,
+        );
+      }
+
+      if (isDebugMode()) {
+        logger.info(
+          `[DEBUG] Recorded reaction given by ${user.username} (${user.id}) in channel ${channelId}`,
+        );
+      }
+    } catch (error: unknown) {
+      logger.error("Error handling messageReactionAdd in tracker:", error);
+    }
+  }
+
+  /**
+   * Atomically upsert one user's reaction counters. A Mongo `Map` field lets
+   * us `$inc` the per-year bucket on a dotted path in a single operation, so
+   * a brand-new user, a new year, and the steady state are all one write —
+   * no seed-then-increment slow path is needed.
+   */
+  private async recordReaction(
+    userId: string,
+    guildId: string,
+    username: string,
+    kind: "given" | "received",
+    year: string,
+  ): Promise<void> {
+    await this.ensureConnection();
+
+    const totalField = kind === "given" ? "totalGiven" : "totalReceived";
+    const yearField = kind === "given" ? "yearlyGiven" : "yearlyReceived";
+
+    await ReactionActivityTracking.updateOne(
+      { userId, guildId },
+      {
+        $setOnInsert: { userId, guildId },
+        $set: { username, lastReactionAt: new Date() },
+        $inc: { [totalField]: 1, [`${yearField}.${year}`]: 1 },
+      },
+      { upsert: true },
+    );
+  }
+
+  public async initialize(): Promise<void> {
+    try {
+      await this.ensureConnection();
+      logger.info("ReactionActivityTracker initialized");
+    } catch (error) {
+      logger.error("Error initializing ReactionActivityTracker:", error);
+      throw error;
+    }
+  }
+}

--- a/src/services/voice-channel-tracker.ts
+++ b/src/services/voice-channel-tracker.ts
@@ -45,6 +45,19 @@ export class VoiceChannelTracker {
   private activeSessions: Map<string, VoiceSession> = new Map();
   private userChannels: Map<string, VoiceChannel> = new Map();
   private encounteredUsers: Map<string, Set<string>> = new Map(); // Track all users encountered during each session
+  // Precise per-companion co-presence accounting (#570). For each tracked
+  // session: `companionSince` holds the epoch-ms start of the *current* open
+  // overlap interval with each presently-co-located user, and
+  // `companionSeconds` accumulates closed intervals. A companion's interval
+  // opens when both are in the channel and closes when either leaves (or the
+  // session ends). `sessionFirsts` records the channel's emptiness and the
+  // users already present at the tracked user's join.
+  private companionSince: Map<string, Map<string, number>> = new Map();
+  private companionSeconds: Map<string, Map<string, number>> = new Map();
+  private sessionFirsts: Map<
+    string,
+    { wasFirst: boolean; joinedExisting: string[] }
+  > = new Map();
   private client: Client;
   private isConnected: boolean = false;
   private configService: ConfigService;
@@ -179,13 +192,17 @@ export class VoiceChannelTracker {
       if (oldChannel && !newChannel) {
         // User left a channel - record interaction for all active sessions in that channel
         this.recordUserInteraction(oldChannel.id, member.id);
+        this.companionLeft(oldChannel.id, member.id);
       } else if (!oldChannel && newChannel) {
         // User joined a channel - record interaction for all active sessions in that channel
         this.recordUserInteraction(newChannel.id, member.id);
+        this.companionJoined(newChannel.id, member.id);
       } else if (oldChannel && newChannel && oldChannel.id !== newChannel.id) {
         // User switched channels - record for both
         this.recordUserInteraction(oldChannel.id, member.id);
         this.recordUserInteraction(newChannel.id, member.id);
+        this.companionLeft(oldChannel.id, member.id);
+        this.companionJoined(newChannel.id, member.id);
       }
     } catch (error) {
       logger.error("Error handling voice state update in tracker:", error);
@@ -206,6 +223,57 @@ export class VoiceChannelTracker {
         }
       }
     }
+  }
+
+  /**
+   * Opens a co-presence interval between `companionId` and every tracked
+   * session currently in `channelId`. Called when a user joins a channel.
+   * In-memory only — persistence is gated separately in `endTracking`.
+   */
+  private companionJoined(channelId: string, companionId: string): void {
+    const now = Date.now();
+    for (const [sessionUserId, session] of this.activeSessions.entries()) {
+      if (session.channelId !== channelId || sessionUserId === companionId) {
+        continue;
+      }
+      const since = this.companionSince.get(sessionUserId);
+      if (since && !since.has(companionId)) {
+        since.set(companionId, now);
+      }
+    }
+  }
+
+  /**
+   * Closes the open co-presence interval between `companionId` and every
+   * tracked session in `channelId`, accumulating the elapsed seconds. Called
+   * when a user leaves a channel.
+   */
+  private companionLeft(channelId: string, companionId: string): void {
+    for (const [sessionUserId, session] of this.activeSessions.entries()) {
+      if (session.channelId !== channelId || sessionUserId === companionId) {
+        continue;
+      }
+      this.accumulateCompanion(sessionUserId, companionId);
+    }
+  }
+
+  /**
+   * Folds the currently-open interval for `(sessionUserId, companionId)` into
+   * the accumulated total and clears it. Safe to call when no interval is
+   * open (no-op).
+   */
+  private accumulateCompanion(
+    sessionUserId: string,
+    companionId: string,
+  ): void {
+    const since = this.companionSince.get(sessionUserId);
+    const seconds = this.companionSeconds.get(sessionUserId);
+    if (!since || !seconds) return;
+    const start = since.get(companionId);
+    if (start === undefined) return;
+    const elapsed = Math.max(0, Math.floor((Date.now() - start) / 1000));
+    seconds.set(companionId, (seconds.get(companionId) ?? 0) + elapsed);
+    since.delete(companionId);
   }
 
   private async isChannelExcluded(channelId: string): Promise<boolean> {
@@ -268,6 +336,12 @@ export class VoiceChannelTracker {
 
       // Initialize encountered users Set with current channel members
       const encounteredSet = new Set<string>();
+      // Companion overlap (#570): open an interval for every user already in
+      // the channel at the moment this user joins, and snapshot that set for
+      // the "firsts" capture.
+      const now = Date.now();
+      const since = new Map<string, number>();
+      const presentAtJoin: string[] = [];
       const guild = member.guild;
       if (guild) {
         const channel = guild.channels.cache.get(channelId) as VoiceChannel;
@@ -278,12 +352,20 @@ export class VoiceChannelTracker {
             channel.members.forEach((m) => {
               if (m.id !== member.id) {
                 encounteredSet.add(m.id);
+                since.set(m.id, now);
+                presentAtJoin.push(m.id);
               }
             });
           }
         }
       }
       this.encounteredUsers.set(member.id, encounteredSet);
+      this.companionSince.set(member.id, since);
+      this.companionSeconds.set(member.id, new Map());
+      this.sessionFirsts.set(member.id, {
+        wasFirst: presentAtJoin.length === 0,
+        joinedExisting: presentAtJoin,
+      });
 
       if (debugModeEnabled) {
         logger.info(
@@ -334,6 +416,44 @@ export class VoiceChannelTracker {
         ? Array.from(encounteredSet)
         : [];
 
+      // Close any still-open companion intervals so the final session reflects
+      // everyone who was co-present right up to the disconnect.
+      const stillOpen = this.companionSince.get(userId);
+      if (stillOpen) {
+        for (const companionId of Array.from(stillOpen.keys())) {
+          this.accumulateCompanion(userId, companionId);
+        }
+      }
+
+      // Build the optional companion/firsts payload only when the feature is
+      // enabled, so disabled deployments persist exactly the legacy shape.
+      const companionsEnabled = await this.configService.getBoolean(
+        "voicetracking.companions.enabled",
+        false,
+      );
+      const sessionDoc: Record<string, unknown> = {
+        startTime: session.startTime,
+        endTime,
+        duration,
+        channelId: session.channelId,
+        channelName: session.channelName,
+        otherUsers,
+      };
+      if (companionsEnabled) {
+        const seconds = this.companionSeconds.get(userId);
+        sessionDoc.companions = seconds
+          ? Array.from(seconds.entries()).map(([id, secs]) => ({
+              userId: id,
+              seconds: secs,
+            }))
+          : [];
+        const firsts = this.sessionFirsts.get(userId);
+        sessionDoc.wasFirst = firsts
+          ? firsts.wasFirst
+          : otherUsers.length === 0;
+        sessionDoc.joinedExisting = firsts ? firsts.joinedExisting : [];
+      }
+
       // Update or create user tracking record
       await VoiceChannelTracking.findOneAndUpdate(
         { userId },
@@ -344,14 +464,7 @@ export class VoiceChannelTracker {
           },
           $inc: { totalTime: duration },
           $push: {
-            sessions: {
-              startTime: session.startTime,
-              endTime,
-              duration,
-              channelId: session.channelId,
-              channelName: session.channelName,
-              otherUsers,
-            },
+            sessions: sessionDoc,
           },
         },
         { upsert: true, new: true },
@@ -360,6 +473,9 @@ export class VoiceChannelTracker {
       this.activeSessions.delete(userId);
       this.userChannels.delete(userId);
       this.encounteredUsers.delete(userId);
+      this.companionSince.delete(userId);
+      this.companionSeconds.delete(userId);
+      this.sessionFirsts.delete(userId);
 
       if (debugModeEnabled) {
         logger.info(

--- a/src/services/voice-channel-tracker.ts
+++ b/src/services/voice-channel-tracker.ts
@@ -188,21 +188,29 @@ export class VoiceChannelTracker {
       }
 
       // Track users joining/leaving channels where we have active sessions
-      // This ensures we capture all interactions even if users leave before the session ends
+      // This ensures we capture all interactions even if users leave before the session ends.
+      // Companion overlap accounting is extra per-update work, so only run it when
+      // the feature is enabled (read the gate once for this update).
+      const companionsEnabled = await this.configService.getBoolean(
+        "voicetracking.companions.enabled",
+        false,
+      );
       if (oldChannel && !newChannel) {
         // User left a channel - record interaction for all active sessions in that channel
         this.recordUserInteraction(oldChannel.id, member.id);
-        this.companionLeft(oldChannel.id, member.id);
+        if (companionsEnabled) this.companionLeft(oldChannel.id, member.id);
       } else if (!oldChannel && newChannel) {
         // User joined a channel - record interaction for all active sessions in that channel
         this.recordUserInteraction(newChannel.id, member.id);
-        this.companionJoined(newChannel.id, member.id);
+        if (companionsEnabled) this.companionJoined(newChannel.id, member.id);
       } else if (oldChannel && newChannel && oldChannel.id !== newChannel.id) {
         // User switched channels - record for both
         this.recordUserInteraction(oldChannel.id, member.id);
         this.recordUserInteraction(newChannel.id, member.id);
-        this.companionLeft(oldChannel.id, member.id);
-        this.companionJoined(newChannel.id, member.id);
+        if (companionsEnabled) {
+          this.companionLeft(oldChannel.id, member.id);
+          this.companionJoined(newChannel.id, member.id);
+        }
       }
     } catch (error) {
       logger.error("Error handling voice state update in tracker:", error);
@@ -416,17 +424,9 @@ export class VoiceChannelTracker {
         ? Array.from(encounteredSet)
         : [];
 
-      // Close any still-open companion intervals so the final session reflects
-      // everyone who was co-present right up to the disconnect.
-      const stillOpen = this.companionSince.get(userId);
-      if (stillOpen) {
-        for (const companionId of Array.from(stillOpen.keys())) {
-          this.accumulateCompanion(userId, companionId);
-        }
-      }
-
       // Build the optional companion/firsts payload only when the feature is
-      // enabled, so disabled deployments persist exactly the legacy shape.
+      // enabled, so disabled deployments persist exactly the legacy shape and
+      // skip the interval-closing / map churn entirely.
       const companionsEnabled = await this.configService.getBoolean(
         "voicetracking.companions.enabled",
         false,
@@ -440,6 +440,14 @@ export class VoiceChannelTracker {
         otherUsers,
       };
       if (companionsEnabled) {
+        // Close any still-open companion intervals so the final session reflects
+        // everyone who was co-present right up to the disconnect.
+        const stillOpen = this.companionSince.get(userId);
+        if (stillOpen) {
+          for (const companionId of Array.from(stillOpen.keys())) {
+            this.accumulateCompanion(userId, companionId);
+          }
+        }
         const seconds = this.companionSeconds.get(userId);
         sessionDoc.companions = seconds
           ? Array.from(seconds.entries()).map(([id, secs]) => ({


### PR DESCRIPTION
## Summary

Lands the **"must-start-now" capture** from the Rewind umbrella issue #570: the
stats that *cannot be backfilled*, so a year we don't track today is a year we
can never show in a future Rewind. Each new capture is **gated behind its own
`*.enabled` config key, off by default**, and stores only what a future Rewind
needs. As with message tracking (#495), this is the **data-capture foundation
only** — nothing is surfaced on Rewind or the Web UI yet (that lives in
follow-ups), and no new slash commands are introduced.

Per the issue's audit, **quotes added/quoted are already fully tracked**
(`addedById`/`authorId` + timestamps), so no work was needed there.

## What's added

### 1. Reactions given / received — `reactiontracking.enabled`
- New `ReactionActivityTracking` model + `ReactionActivityTracker` service and a
  `messageReactionAdd` listener.
- Bumps the reactor's `totalGiven` and the message author's `totalReceived`.
  Bots, DMs, excluded channels (`reactiontracking.excluded_channels`), and
  self-reactions are skipped.
- Stores **lifetime totals + per-year buckets** keyed by `"YYYY"` (Mongo `Map`,
  single-write upsert). **No per-reaction detail** is retained, so it stays
  cheap even at high volume and **needs no cleanup job** — directly addressing
  the issue's "reactions are high-volume" concern.

### 2. Poll participation — `polls.participation.enabled`
- New `PollParticipationTracking` model + `PollParticipationTracker` service and
  a `messagePollVoteAdd` listener (adds the `GuildMessagePolls` gateway intent).
- Records per-user **"votes cast"** as lifetime + per-year counts. Discord
  exposes no way to query a poll's per-user votes after the fact, so this
  capture is the only chance to record participation.

### 3. Voice companions & "firsts" — `voicetracking.companions.enabled`
- `VoiceChannelTracker` now accumulates **precise per-companion co-presence
  seconds** (pairwise overlap intervals — opens when both are in-channel, closes
  when either leaves or the session ends) instead of only the session-level
  `otherUsers` union, plus voice **"firsts"** (`wasFirst`, `joinedExisting`) as
  optional session fields.
- When the gate is off, sessions persist **exactly the legacy shape** (new
  fields use `default: undefined`).

## Also updated
- `config-schema.ts` (keys, defaults, metadata, new `reactiontracking`
  category) and the Mongo `Config` model category enum.
- `SETTINGS.md` (new rows + a Reaction Tracking section + ToC entries).
- Unit tests for all three trackers (gating, recording, partials, error
  handling) and the companion-overlap/firsts paths.

## Open questions from #570 deferred to surfacing follow-ups
- **Privacy/opt-out** for companion-based stats — relevant when surfaced, not at
  capture time.
- **Retention** — reactions/polls store only bounded per-year counters (no
  cleanup needed); companion data rides on existing voice-session retention.

## Test plan
- `npm run check:all` — build + lint + format:check + test all green
  (102 suites, 1120 passing).
- New per-tracker unit tests cover the disabled-gate no-write path, the
  recording path, partial reaction/user fetches, and DB-error swallowing.

Closes the capture portion of #570.

https://claude.ai/code/session_015zBAyth26MMqpojFe4sDxh

---
_Generated by [Claude Code](https://claude.ai/code/session_015zBAyth26MMqpojFe4sDxh)_