### PR TITLE
feat(rewind): add longest single voice session to year-in-review

### DIFF
--- a/WEBUI.md
+++ b/WEBUI.md
@@ -773,11 +773,11 @@ that omit it.
 
 ### User self-service (`/me/*`, both admin and user roles)
 
-| Page                                    | What it's for                                                                                                                             |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| **Overview** (`/me/`)                   | Index for your own settings — links to the available per-user pages.                                                                      |
-| **Notifications** (`/me/notifications`) | Opt in or out of DM nudges from Koolbot (achievements, weekly digest, Rewind nudge). Each toggle records a `WebAuditLog` row.             |
-| **Rewind** (`/me/rewind`)               | Personal year-in-review: voice time, top voice companions, peak day, streak, badges, annual rank, weekly-rank journey, and text activity. |
+| Page                                    | What it's for                                                                                                                                              |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Overview** (`/me/`)                   | Index for your own settings — links to the available per-user pages.                                                                                       |
+| **Notifications** (`/me/notifications`) | Opt in or out of DM nudges from Koolbot (achievements, weekly digest, Rewind nudge). Each toggle records a `WebAuditLog` row.                              |
+| **Rewind** (`/me/rewind`)               | Personal year-in-review: voice time, top voice companions, peak day, longest session, streak, badges, annual rank, weekly-rank journey, and text activity. |
 
 Notification preferences are scoped per `(userId, guildId)`. The page
 lists every notification type with the current state and a checkbox;

--- a/__tests__/services/rewind-service.test.ts
+++ b/__tests__/services/rewind-service.test.ts
@@ -67,6 +67,7 @@ const {
   RewindService,
   normalizeSnapshotSummary,
   SNAPSHOT_SCHEMA_VERSION,
+  computeLongestSession,
   computeLongestStreak,
   computePeakDay,
   computeTopCompanions,
@@ -251,6 +252,124 @@ describe("RewindService pure helpers", () => {
       });
       // Without a zone, the two sessions land on separate UTC days.
       expect(computePeakDay(sessions)?.totalSeconds).toBe(3600);
+    });
+  });
+
+  describe("computeLongestSession", () => {
+    it("returns null when there are no sessions", () => {
+      expect(computeLongestSession([])).toBeNull();
+    });
+
+    it("returns null when no session has a positive duration", () => {
+      expect(
+        computeLongestSession([
+          {
+            startTime: new Date("2026-03-15T10:00:00Z"),
+            duration: 0,
+            channelId: "a",
+          },
+        ]),
+      ).toBeNull();
+    });
+
+    it("returns the single session's duration, date and channel", () => {
+      expect(
+        computeLongestSession([
+          {
+            startTime: new Date("2026-03-14T08:00:00Z"),
+            duration: 3600 * 6,
+            channelId: "a",
+            channelName: "General",
+          },
+        ]),
+      ).toEqual({
+        totalSeconds: 3600 * 6,
+        date: "2026-03-14",
+        channelId: "a",
+        channelName: "General",
+      });
+    });
+
+    it("picks the longest of several sessions with its own date", () => {
+      const result = computeLongestSession([
+        {
+          startTime: new Date("2026-01-02T10:00:00Z"),
+          duration: 1800,
+          channelId: "a",
+          channelName: "alpha",
+        },
+        {
+          startTime: new Date("2026-03-14T09:00:00Z"),
+          duration: 3600 * 6,
+          channelId: "b",
+          channelName: "beta",
+        },
+        {
+          startTime: new Date("2026-05-20T10:00:00Z"),
+          duration: 3600 * 2,
+          channelId: "c",
+          channelName: "gamma",
+        },
+      ]);
+      expect(result).toEqual({
+        totalSeconds: 3600 * 6,
+        date: "2026-03-14",
+        channelId: "b",
+        channelName: "beta",
+      });
+    });
+
+    it("falls back to endTime - startTime when duration is absent", () => {
+      const result = computeLongestSession([
+        {
+          startTime: new Date("2026-03-14T09:00:00Z"),
+          endTime: new Date("2026-03-14T12:00:00Z"),
+          channelId: "b",
+        },
+        {
+          startTime: new Date("2026-03-15T09:00:00Z"),
+          duration: 1800,
+          channelId: "a",
+        },
+      ]);
+      expect(result).toEqual({
+        totalSeconds: 3600 * 3,
+        date: "2026-03-14",
+        channelId: "b",
+        channelName: null,
+      });
+    });
+
+    it("keeps the earliest session on a duration tie", () => {
+      const result = computeLongestSession([
+        {
+          startTime: new Date("2026-04-02T10:00:00Z"),
+          duration: 3600,
+          channelId: "late",
+        },
+        {
+          startTime: new Date("2026-04-01T10:00:00Z"),
+          duration: 3600,
+          channelId: "early",
+        },
+      ]);
+      expect(result?.channelId).toBe("early");
+      expect(result?.date).toBe("2026-04-01");
+    });
+
+    it("buckets the date in the supplied timezone (#524)", () => {
+      const result = computeLongestSession(
+        [
+          {
+            startTime: new Date("2026-03-16T02:00:00Z"),
+            duration: 3600 * 4,
+            channelId: "a",
+          },
+        ],
+        "America/New_York",
+      );
+      // 02:00 UTC on the 16th is still the 15th in New York.
+      expect(result?.date).toBe("2026-03-15");
     });
   });
 
@@ -456,6 +575,12 @@ describe("RewindService.getSummary", () => {
     expect(summary!.peakDay).toEqual({
       date: "2026-01-15",
       totalSeconds: 5400,
+    });
+    expect(summary!.longestSession).toEqual({
+      totalSeconds: 3600,
+      date: "2026-01-15",
+      channelId: "general",
+      channelName: "general-vc",
     });
     expect(summary!.longestStreakDays).toBe(2);
     expect(summary!.annualRank).toBe(2);

--- a/__tests__/web/user-routes.test.ts
+++ b/__tests__/web/user-routes.test.ts
@@ -679,6 +679,12 @@ describe("/me/rewind", () => {
         { userId: "u2", displayName: "Companion One", totalSeconds: 3600 * 5 },
       ],
       peakDay: { date: "2026-03-15", totalSeconds: 3600 * 3 },
+      longestSession: {
+        totalSeconds: 3600 * 6,
+        date: "2026-03-14",
+        channelId: "c1",
+        channelName: "General",
+      },
       messagesSent: 0,
       topTextChannels: [],
       peakMessageDay: null,
@@ -708,6 +714,8 @@ describe("/me/rewind", () => {
     expect(out.body).toContain("Top voice companions"); // #567 card
     expect(out.body).toContain("Companion One");
     expect(out.body).not.toContain("Top channels"); // removed from Rewind
+    expect(out.body).toContain("Longest session"); // #568 card
+    expect(out.body).toContain("on 2026-03-14 in General"); // date + channel
   });
 
   it("renders a specific past year when the route param is present", async () => {

--- a/src/services/rewind-service.ts
+++ b/src/services/rewind-service.ts
@@ -75,6 +75,17 @@ export interface RewindSummary {
   // per-session room names are noise; companions replace it.)
   topCompanions: RewindCompanion[];
   peakDay: { date: string; totalSeconds: number } | null; // ISO date (YYYY-MM-DD)
+  // Single longest contiguous voice session of the year (#568). `date` is
+  // the ISO day the session started, bucketed in the user's timezone like
+  // `peakDay`. `channelName` is the session's stored room name (often
+  // ephemeral under dynamic VCs), null when unknown. Null when the user had
+  // no qualifying session that year.
+  longestSession: {
+    totalSeconds: number;
+    date: string;
+    channelId: string;
+    channelName: string | null;
+  } | null;
   // Text-message activity (#496). Mirrors the voice aggregates above and
   // reads as zero / empty when message tracking is disabled or absent.
   messagesSent: number;
@@ -222,6 +233,48 @@ export function computePeakDay(
     }
   }
   return bestDate ? { date: bestDate, totalSeconds: bestSeconds } : null;
+}
+
+/**
+ * The single longest contiguous voice session of the set (#568). Returns
+ * its duration, the ISO day it started on (bucketed in UTC by default, or
+ * the supplied IANA `timeZone` like `computePeakDay`), and the session's
+ * channel. Returns null when there is no session with positive duration.
+ *
+ * Tie-break: when two sessions are exactly as long, the earliest by
+ * `startTime` wins, so the surfaced date is deterministic.
+ */
+export function computeLongestSession(
+  sessions: RawSession[],
+  timeZone?: string,
+): {
+  totalSeconds: number;
+  date: string;
+  channelId: string;
+  channelName: string | null;
+} | null {
+  let best: RawSession | null = null;
+  let bestSeconds = 0;
+  for (const s of sessions) {
+    const seconds = sessionSeconds(s);
+    if (seconds <= 0) continue;
+    if (
+      seconds > bestSeconds ||
+      (seconds === bestSeconds &&
+        best !== null &&
+        s.startTime.getTime() < best.startTime.getTime())
+    ) {
+      best = s;
+      bestSeconds = seconds;
+    }
+  }
+  if (!best) return null;
+  return {
+    totalSeconds: bestSeconds,
+    date: dayKey(best.startTime, timeZone),
+    channelId: best.channelId,
+    channelName: best.channelName ?? null,
+  };
 }
 
 /**
@@ -385,6 +438,8 @@ export function normalizeSnapshotSummary(
     // since-removed topChannels are simply dropped here.
     topCompanions: s.topCompanions ?? [],
     peakDay: s.peakDay ?? null,
+    // Older snapshots predate the longest-session card (#568).
+    longestSession: s.longestSession ?? null,
     messagesSent: s.messagesSent ?? 0,
     topTextChannels: s.topTextChannels ?? [],
     peakMessageDay: s.peakMessageDay ?? null,
@@ -504,6 +559,7 @@ export class RewindService {
         totalSeconds: c.totalSeconds,
       }));
       const peakDay = computePeakDay(sessions, dayZone);
+      const longestSession = computeLongestSession(sessions, dayZone);
       const streak = computeLongestStreak(sessions, dayZone);
 
       const accolades = (achievementsDoc?.accolades ?? [])
@@ -559,6 +615,7 @@ export class RewindService {
         daysActive,
         topCompanions,
         peakDay,
+        longestSession,
         messagesSent: text.messagesSent,
         topTextChannels: text.topTextChannels,
         peakMessageDay: text.peakMessageDay,

--- a/src/web/user-layout.ts
+++ b/src/web/user-layout.ts
@@ -298,6 +298,14 @@ export interface RewindBodyOptions {
   // Replaces the old Top channels card, which was noise under dynamic VCs.
   topCompanions: RewindCompanionView[];
   peakDay: { date: string; duration: string } | null;
+  // Longest single voice session of the year (#568): pre-formatted duration,
+  // the ISO date it started, and the (often ephemeral) channel name. Null
+  // when the user had no qualifying session that year.
+  longestSession: {
+    duration: string;
+    date: string;
+    channelName: string | null;
+  } | null;
   longestStreakDays: number;
   longestStreakRange: { startDate: string; endDate: string } | null;
   accolades: RewindBadgeView[];
@@ -456,6 +464,17 @@ export function renderUserRewindBody(opts: RewindBodyOptions): string {
     ? `<div class="value">${escapeHtml(opts.peakDay.date)}</div><div class="detail">${escapeHtml(opts.peakDay.duration)} that day</div>`
     : '<div class="value">—</div>';
 
+  // Longest single session (#568): show its duration, then the date (and
+  // channel when known) as the supporting detail.
+  const longestSession = opts.longestSession
+    ? `<div class="value">${escapeHtml(opts.longestSession.duration)}</div>` +
+      `<div class="detail">on ${escapeHtml(opts.longestSession.date)}` +
+      (opts.longestSession.channelName
+        ? ` in ${escapeHtml(opts.longestSession.channelName)}`
+        : "") +
+      "</div>"
+    : '<div class="value">—</div>';
+
   const streak = opts.longestStreakDays
     ? `<div class="value">${opts.longestStreakDays} day${opts.longestStreakDays === 1 ? "" : "s"}</div>` +
       (opts.longestStreakRange
@@ -499,6 +518,9 @@ export function renderUserRewindBody(opts: RewindBodyOptions): string {
     hero,
     '<div class="rw-grid">',
     '<div class="rw-stat"><div class="label">Peak day</div>' + peak + "</div>",
+    '<div class="rw-stat"><div class="label">Longest session</div>' +
+      longestSession +
+      "</div>",
     '<div class="rw-stat"><div class="label">Longest streak</div>' +
       streak +
       "</div>",

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -544,6 +544,15 @@ export function createUserRouter(
                 duration: formatHoursMinutes(summary.peakDay.totalSeconds),
               }
             : null,
+          longestSession: summary.longestSession
+            ? {
+                duration: formatHoursMinutes(
+                  summary.longestSession.totalSeconds,
+                ),
+                date: summary.longestSession.date,
+                channelName: summary.longestSession.channelName,
+              }
+            : null,
           longestStreakDays: summary.longestStreakDays,
           longestStreakRange: summary.longestStreakRange,
           accolades: summary.accolades.map((a) => ({


### PR DESCRIPTION
## Summary

Adds the **single longest voice session** of the year to the Rewind / year-in-review page (`/me/rewind`), e.g. *"Your longest session was 6 hr 12 min on 14 March."* The per-session `duration` data already existed (we reduce to it for the Marathon accolades) — this just surfaces it on Rewind, sitting alongside the existing peak-day and streak cards. Closes #568.

## Changes

- **`src/services/rewind-service.ts`**
  - New pure helper `computeLongestSession(sessions, timeZone?)` next to the sibling `compute*` helpers. Returns `{ totalSeconds, date, channelId, channelName } | null`, bucketing the date with the same timezone-aware `dayKey` used by `computePeakDay` (#524). Tie-break: when two sessions are exactly as long, the **earliest** by `startTime` wins (documented in a comment). Reuses `sessionSeconds`, so it inherits the `duration` → `endTime - startTime` fallback.
  - Added `longestSession` to `RewindSummary`, wired into `getSummary`, and defaulted in `normalizeSnapshotSummary` so older snapshots (which predate the field) render as `null`.
- **`src/web/user-layout.ts`** — new `longestSession` field on `RewindBodyOptions` and a **"Longest session"** `.rw-stat` card (duration as the value; date, and channel name when known, as the detail). Shows `—` when there's no qualifying session.
- **`src/web/user-routes.ts`** — maps `summary.longestSession` into the view, formatting the duration with the existing `formatHoursMinutes` used by the other cards.
- **`WEBUI.md`** — mention longest session in the Rewind feature row (table re-aligned to satisfy markdownlint).

## Tests

- Unit tests for `computeLongestSession`: no sessions, no positive-duration session, single session, multiple sessions (correct max + its own date/channel), `duration`-absent fallback to `endTime - startTime`, earliest-wins tie-break, and timezone bucketing.
- Extended the full-summary `getSummary` test to assert `longestSession`, and the `/me/rewind` route test to assert the rendered card (`Longest session` + `on 2026-03-14 in General`).

`npm run check:all` passes (build, lint, format:check, 1137 tests).

## Acceptance criteria

- [x] Rewind shows the user's longest single voice session for the selected year, with its date in the user's timezone.
- [x] The card shows an empty state (`—`) when there are no qualifying sessions that year.
- [x] Duration formatting matches the other Rewind cards (`formatHoursMinutes`).
- [x] Unit tests cover no sessions, single session, multiple sessions, and the `duration`-absent fallback.

https://claude.ai/code/session_01HTbMwZkHrDGVgJpPJEmRi1

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTbMwZkHrDGVgJpPJEmRi1)_