### PR TITLE
fix(docker): upgrade OpenSSL libs in runtime image to clear Trivy CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,12 @@ FROM node:22-alpine
 
 WORKDIR /app
 
+# Stopgap: pull patched OpenSSL libraries ahead of the base image so Trivy's
+# system-package scan stays clean (OpenSSL CVEs in node:22-alpine — High
+# #57/#72, Medium #590, Low #62-#71/#77-#86). Runs as root before dropping to
+# USER node. Remove once node:22-alpine ships the fixed libssl3/libcrypto3.
+RUN apk --no-cache upgrade libssl3 libcrypto3
+
 # Copy only runtime artifacts
 COPY --from=builder --chown=node:node /app/package*.json ./
 COPY --from=builder --chown=node:node /app/dist ./dist


### PR DESCRIPTION
## Summary

Adds a stopgap `apk --no-cache upgrade libssl3 libcrypto3` to the **production stage** of the `Dockerfile` so the shipped image picks up patched OpenSSL packages ahead of the `node:22-alpine` base image. This clears the four medium-severity OpenSSL CVEs Trivy flags against the image (alerts #58–#61 / #73–#76):

| CVE summary | Alerts |
| --- | --- |
| AES-OCB IV Ignored on `EVP_Cipher()` Path | #76, #61 |
| NULL pointer dereference in QUIC server initial packet handling | #75, #60 |
| Unbounded Memory Growth in the QUIC `PATH_CHALLENGE` handler | #74, #59 |
| CMS `AuthEnvelopedData` processing may accept forged messages | #73, #58 |

## Details

- These are system OpenSSL (`libssl3`/`libcrypto3`) vulns in the Alpine base image, not npm deps. KoolBot doesn't use QUIC/CMS/AES-OCB directly, so practical exposure is low.
- The upgrade runs as **root before dropping to `USER node`**, in the final stage that Trivy actually scans (the image pushed by `docker.yml`).
- Comment notes it's a temporary measure to remove once `node:22-alpine` ships the fixed packages itself.
- Same remediation applies to the companion High (#57/#72) and Low (#62–#71/#77–#86) OpenSSL issues from the same base image.

## Verification

After this merges and `docker.yml` rebuilds/repushes, re-run Trivy and confirm #58–#61 / #73–#76 clear; dismiss any that only linger against the old digest.

Closes #590

https://claude.ai/code/session_01Q6ULsxtqzWDtTa5cqAiU1j

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6ULsxtqzWDtTa5cqAiU1j)_