### PR TITLE
fix(polls): rebuild import URL from allowlisted host to close SSRF alert

### DIFF
--- a/__tests__/services/poll-service.test.ts
+++ b/__tests__/services/poll-service.test.ts
@@ -191,6 +191,23 @@ describe("PollService", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it("rejects subdomains of an allowed host (exact match only)", async () => {
+    const service = PollService.getInstance({} as never);
+
+    const result = await service.importFromUrl(
+      "https://cdn.example.com/polls.yaml",
+      "guild-1",
+      "user-1",
+    );
+
+    expect(result).toEqual({
+      imported: 0,
+      skipped: 0,
+      errors: ["URL host is not allowed for imports"],
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("allows GitHub raw hosts by default when no allowlist is configured", async () => {
     delete process.env.POLL_IMPORT_ALLOWED_HOSTS;
     mockFetch.mockResolvedValue(

--- a/src/services/poll-service.ts
+++ b/src/services/poll-service.ts
@@ -130,17 +130,22 @@ function getAllowedImportHosts(): string[] {
 }
 
 /**
- * Returns true when the hostname exactly matches an allowed host or is a
- * subdomain of one. The leading-dot check prevents a look-alike host such as
- * "raw.githubusercontent.com.evil.com" from slipping through a naive
- * `endsWith` comparison.
+ * Resolves the allowlist entry that matches the given hostname, or undefined
+ * when the host is not allowed. Matching is intentionally exact: the import
+ * path rebuilds the outgoing request URL from the returned value, so a
+ * look-alike host such as "raw.githubusercontent.com.evil.com" never matches
+ * and the request origin is always one the operator configured.
+ *
+ * Returning the allowlist entry (rather than a boolean) is deliberate — it is
+ * a server-controlled value sourced from code/env, never from the admin-
+ * supplied URL, which lets the caller anchor the request to a non-attacker-
+ * controlled host. See `importFromUrl` for why that matters (SSRF /
+ * CodeQL js/request-forgery).
  */
-function isAllowedImportHost(hostname: string): boolean {
+function resolveAllowedImportHost(hostname: string): string | undefined {
   const normalizedHostname = hostname.toLowerCase();
-  return getAllowedImportHosts().some(
-    (allowed) =>
-      normalizedHostname === allowed ||
-      normalizedHostname.endsWith(`.${allowed}`),
+  return getAllowedImportHosts().find(
+    (allowed) => allowed === normalizedHostname,
   );
 }
 
@@ -573,13 +578,29 @@ export class PollService {
       return results;
     }
 
-    // Enforce the server-controlled host allowlist before making any request.
-    // This is the primary SSRF mitigation: it confines outbound traffic to
-    // trusted destinations regardless of what URL the admin supplies.
-    if (!isAllowedImportHost(parsedUrl.hostname)) {
+    // Enforce the server-controlled host allowlist before making any request
+    // and resolve the matching entry. This is the primary SSRF mitigation: it
+    // confines outbound traffic to trusted destinations regardless of what URL
+    // the admin supplies.
+    const allowedHost = resolveAllowedImportHost(parsedUrl.hostname);
+    if (!allowedHost) {
       results.errors.push("URL host is not allowed for imports");
       return results;
     }
+
+    // Rebuild the request URL from allowlisted components rather than reusing
+    // the admin-supplied string verbatim. The origin (scheme + host) is taken
+    // entirely from server-controlled values — a fixed scheme literal and the
+    // resolved allowlist host — and only the path and query are carried over.
+    // Anchoring the origin to a value the caller cannot influence is what
+    // actually confines the request, and it gives CodeQL's js/request-forgery
+    // taint tracker a barrier it recognizes: the host no longer flows from
+    // request input. (The earlier protocol check guarantees http/https here.)
+    const scheme = parsedUrl.protocol === "https:" ? "https" : "http";
+    const safeUrl = new globalThis.URL(
+      `${parsedUrl.pathname}${parsedUrl.search}`,
+      `${scheme}://${allowedHost}`,
+    );
 
     // Reject the request if it has not completed within IMPORT_TIMEOUT_MS so a
     // slow or unresponsive server cannot hang the import indefinitely. The same
@@ -590,7 +611,7 @@ export class PollService {
     try {
       // Fetch the content. The body is read as raw text so we can inspect the
       // Content-Type and parse it ourselves rather than trusting the server.
-      const response = await fetch(parsedUrl.toString(), {
+      const response = await fetch(safeUrl.toString(), {
         signal: controller.signal,
         // Do not follow redirects: an allowed host could otherwise 3xx-redirect
         // the request to an internal or cloud-metadata endpoint, bypassing the


### PR DESCRIPTION
## Summary

Resolves the critical CodeQL **Server-side request forgery** alert (#56) at the poll-library URL-import `fetch` (`src/services/poll-service.ts`). As triaged in #576, the existing guards (protocol allowlist, private/local-IP block, server-controlled host allowlist, `redirect: "error"`, request timeout) already make the call safe — but CodeQL's `js/request-forgery` query can't model the runtime `isAllowedImportHost` allowlist as a sanitizer, so it traces the admin-supplied URL straight to the sink and keeps re-failing the CodeQL check on PRs.

Rather than suppress the alert (inline `// codeql[...]` comments are **not** honored by GitHub code scanning, and a config query-filter would disable SSRF detection repo-wide), this gives the taint tracker a barrier it recognizes — the approach the issue itself suggested.

## Change

- Resolve the matching allowlist entry (`resolveAllowedImportHost`) instead of a boolean check.
- **Rebuild the request URL from server-controlled components** right before `fetch`: a fixed scheme literal (`http`/`https`, already guaranteed by the earlier protocol check) plus the resolved allowlist host as the origin, carrying over only the path and query from the parsed URL. The request host now originates from code/env, never from request input — which both genuinely hardens the request and breaks the taint flow CodeQL was reporting.

This keeps the `js/request-forgery` query active everywhere else (no loss of coverage) and needs no manual alert dismissal.

## Behavior note

Allowlist matching is now **exact** — a host must equal an allowlist entry, rather than also matching subdomains via `endsWith`. This matches the documented behavior of `POLL_IMPORT_ALLOWED_HOSTS` and the defaults (`raw.githubusercontent.com`, `gist.githubusercontent.com`), and look-alike hosts (`raw.githubusercontent.com.evil.com`) remain rejected. No tests or docs relied on subdomain acceptance.

## Testing

- `npm run build` ✅
- `npx eslint` (changed files) ✅
- `npx prettier --check` (changed files) ✅
- `jest __tests__/services/poll-service.test.ts` — 28 passed (added a case asserting subdomains of an allowed host are now rejected; existing case already asserts the rebuilt fetch URL is unchanged for exact-host imports).

Closes #576

https://claude.ai/code/session_01ARB7HzhGriWf98sJ43womq

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARB7HzhGriWf98sJ43womq)_