### PR TITLE
deps: dedupe picomatch to 4.0.4 to clear dev-only ReDoS/method-injection CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "koolbot",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "koolbot",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "dependencies": {
         "@discordjs/builders": "^1.14.1",
         "cron": "^4.4.0",
@@ -3182,19 +3182,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/arg": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "overrides": {
     "undici": "^7.18.2",
-    "diff": "^8.0.3"
+    "diff": "^8.0.3",
+    "picomatch": "^4.0.4"
   }
 }


### PR DESCRIPTION
## Summary

Fixes #585. Trivy flagged two `picomatch` CVEs:

| Alert | Severity | CVE summary |
| --- | --- | --- |
| #9  | High   | ReDoS via crafted extglob patterns |
| #10 | Medium | Method injection via crafted POSIX bracket expressions |

The tree previously carried **two** picomatch copies:

- `node_modules/picomatch` → `4.0.4` (already patched)
- `node_modules/anymatch/node_modules/picomatch` → `2.3.2` (**the vulnerable copy**)

The lone consumer of the 2.x line is `anymatch@3.1.3` (`picomatch@^2.0.4`), pulled in by `jest-haste-map` — i.e. dev/build-time tooling only.

## Change

Added a single npm override:

```json
"overrides": {
  "picomatch": "^4.0.4"
}
```

This forces `anymatch`'s picomatch up to the patched `4.0.4` line. The lockfile now resolves to a **single** `picomatch@4.0.4` (the nested `2.3.2` entry is removed), clearing alerts #9 and #10.

## Risk / verification

- **Not in production.** picomatch is `dev: true`; the prod image's `node_modules` come from the `npm ci --omit=dev` stage in the `Dockerfile`, so the vulnerable copy never reached the runtime image. This is build-tooling hardening.
- **Compatibility confirmed.** `anymatch@3.1.3` works fine against picomatch 4 — `npm run build`, `npm run lint`, `npm run format:check`, and the full `npm run test:ci` (102 suites, 1156 tests) all pass.
- The lockfile `version` field also synced `1.0.1`→`1.1.0` to match `package.json` (an incidental, correct fixup from `npm install`).

Closes #585

https://claude.ai/code/session_01QLtNNzjmSXQbKzPXwGLwFf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLtNNzjmSXQbKzPXwGLwFf)_