### PR TITLE
refactor(achievements): extract formatMetadata helper to fix CodeQL alert

### DIFF
--- a/__tests__/commands/achievements.test.ts
+++ b/__tests__/commands/achievements.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest } from '@jest/globals';
-import { data } from '../../src/commands/achievements.js';
+import { data, formatMetadata } from '../../src/commands/achievements.js';
 
 jest.mock('../../src/services/achievements-service.js');
 jest.mock('../../src/utils/logger.js');
@@ -114,53 +114,36 @@ describe('Achievements Command', () => {
 
   describe('metadata formatting', () => {
     it('should use unit field when available', () => {
-      const metadata = {
+      const metadataText = formatMetadata({
         value: 100,
         description: '100 hours milestone',
         unit: 'hrs',
-      };
-
-      const metadataText = metadata.value
-        ? ` - ${metadata.value}${metadata.unit ? ` ${metadata.unit}` : ''}`
-        : '';
+      });
 
       expect(metadataText).toBe(' - 100 hrs');
     });
 
     it('should handle missing unit field gracefully', () => {
-      const metadata = {
+      const metadataText = formatMetadata({
         value: 100,
         description: '100 hours milestone',
-      };
-
-      const metadataUnit = (metadata as any).unit ?? '';
-      const metadataText = metadata.value
-        ? ` - ${metadata.value}${metadataUnit ? ` ${metadataUnit}` : ''}`
-        : '';
+      });
 
       expect(metadataText).toBe(' - 100');
     });
 
     it('should handle user count with users unit', () => {
-      const metadata = {
+      const metadataText = formatMetadata({
         value: 25,
         description: '25+ unique users',
         unit: 'users',
-      };
-
-      const metadataText = metadata.value
-        ? ` - ${metadata.value}${metadata.unit ? ` ${metadata.unit}` : ''}`
-        : '';
+      });
 
       expect(metadataText).toBe(' - 25 users');
     });
 
     it('should handle missing metadata', () => {
-      const metadata = undefined;
-
-      const metadataText = metadata?.value
-        ? ` - ${metadata.value}${metadata.unit ? ` ${metadata.unit}` : ''}`
-        : '';
+      const metadataText = formatMetadata(undefined);
 
       expect(metadataText).toBe('');
     });

--- a/src/commands/achievements.ts
+++ b/src/commands/achievements.ts
@@ -4,20 +4,15 @@ import {
   EmbedBuilder,
 } from "discord.js";
 import { AchievementsService } from "../services/achievements-service.js";
+import type { IAccolade } from "../models/user-achievements.js";
 import logger from "../utils/logger.js";
-
-interface AchievementMetadata {
-  value?: number;
-  description?: string;
-  unit?: string;
-}
 
 /**
  * Format the optional metadata of an accolade/achievement into the
  * trailing " - <value> <unit>" suffix shown next to its name. Returns an
  * empty string when there is no value to display.
  */
-export function formatMetadata(metadata?: AchievementMetadata): string {
+export function formatMetadata(metadata?: IAccolade["metadata"]): string {
   if (!metadata?.value) {
     return "";
   }

--- a/src/commands/achievements.ts
+++ b/src/commands/achievements.ts
@@ -6,6 +6,25 @@ import {
 import { AchievementsService } from "../services/achievements-service.js";
 import logger from "../utils/logger.js";
 
+interface AchievementMetadata {
+  value?: number;
+  description?: string;
+  unit?: string;
+}
+
+/**
+ * Format the optional metadata of an accolade/achievement into the
+ * trailing " - <value> <unit>" suffix shown next to its name. Returns an
+ * empty string when there is no value to display.
+ */
+export function formatMetadata(metadata?: AchievementMetadata): string {
+  if (!metadata?.value) {
+    return "";
+  }
+  const unit = metadata.unit ?? "";
+  return ` - ${metadata.value}${unit ? ` ${unit}` : ""}`;
+}
+
 export const data = new SlashCommandBuilder()
   .setName("achievements")
   .setDescription("View earned badges and achievements")
@@ -58,10 +77,7 @@ export async function execute(
           if (!definition) return null;
 
           const earnedDate = accolade.earnedAt.toLocaleDateString();
-          const metadataUnit = accolade.metadata?.unit ?? "";
-          const metadataText = accolade.metadata?.value
-            ? ` - ${accolade.metadata.value}${metadataUnit ? ` ${metadataUnit}` : ""}`
-            : "";
+          const metadataText = formatMetadata(accolade.metadata);
 
           const accoladeText = `${definition.emoji} **${definition.name}**${metadataText}\n*${definition.description}*\nEarned: ${earnedDate}`;
 
@@ -127,10 +143,7 @@ export async function execute(
 
           const earnedDate = achievement.earnedAt.toLocaleDateString();
           const period = achievement.period || "N/A";
-          const metadataUnit = achievement.metadata?.unit ?? "";
-          const metadataText = achievement.metadata?.value
-            ? ` - ${achievement.metadata.value}${metadataUnit ? ` ${metadataUnit}` : ""}`
-            : "";
+          const metadataText = formatMetadata(achievement.metadata);
 
           return `${definition.emoji} **${definition.name}**${metadataText}\n*${definition.description}* (${period})\nEarned: ${earnedDate}`;
         })


### PR DESCRIPTION
## Summary

Fixes the CodeQL "Property access on null or undefined" Error-level alerts (#3–#5) reported in #592 at `__tests__/commands/achievements.test.ts:162`.

CodeQL flagged `metadata.value` / `metadata.unit` because the test inlined the production formatting expression over a `const metadata = undefined` fixture — a guaranteed-undefined property access that the analyzer sees even though optional chaining short-circuits it at runtime.

This applies **Option 1** (the preferred option from the issue): extract the formatting into a small typed helper and route both production and the test through it. This removes duplicated logic and makes the test exercise real code instead of a copy of it.

## Changes

- **`src/commands/achievements.ts`** — added an exported `formatMetadata(metadata?: AchievementMetadata): string` helper and replaced the two duplicated inline metadata-formatting blocks (accolades + achievements sections) with calls to it.
- **`__tests__/commands/achievements.test.ts`** — the four `metadata formatting` tests now call the real `formatMetadata` helper instead of re-inlining the expression. No more guaranteed-undefined fixture, so the CodeQL alert no longer triggers.

## Verification

- `npm run build` — passes
- `npm run lint` — passes
- `npm run format:check` — passes
- `jest __tests__/commands/achievements.test.ts` — 14/14 passing

Closes #592

https://claude.ai/code/session_01NBGdsEoEh1zLR1mDQFaXgV

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBGdsEoEh1zLR1mDQFaXgV)_