### PR TITLE
ci(docker): pull fresh base image so rebuilds absorb patched OpenSSL

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -122,6 +122,14 @@ jobs:
         with:
           context: .
           push: true
+          # Always pull the latest node:22-alpine base layers instead of
+          # reusing a cached digest. The Node team rebuilds the Alpine base
+          # whenever Alpine ships security updates, so pulling fresh is how the
+          # image absorbs patched system OpenSSL (libssl3/libcrypto3) — e.g. the
+          # High PKCS7_verify use-after-free (#57/#72). Without this, the gha
+          # build cache reuses the stale base + `apk upgrade` layers and a
+          # rebuild on main never clears the CVE.
+          pull: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

Fixes #588 (Trivy High — OpenSSL Heap Use-After-Free in `PKCS7_verify()`, alerts #57/#72).

The Dockerfile already carries the recommended stopgap from #593:

```dockerfile
RUN apk --no-cache upgrade libssl3 libcrypto3
```

`libcrypto3` is exactly where `PKCS7_verify` lives, so this line *should* clear #57/#72. The reason it hasn't is in the **build workflow, not the Dockerfile**:

`docker.yml` builds with `cache-from: type=gha` / `cache-to: type=gha,mode=max` but never pulls a fresh base image. So a "no-op rebuild on `main`" — the exact remediation step the issue calls for — reuses the cached `FROM node:22-alpine` layer **and** the cached `apk upgrade` layer, shipping stale `libssl3`/`libcrypto3`. The CVE never clears.

## Change

Add `pull: true` to the `docker/build-push-action` step so every build pulls the latest `node:22-alpine`. The Node team rebuilds the Alpine base whenever Alpine ships a security update; pulling fresh changes the base digest, which invalidates the downstream `apk upgrade` layer and forces a genuine rebuild that absorbs the patched OpenSSL packages. The gha cache still accelerates unchanged layers.

This is a one-line, proportionate change that makes the issue's recommended remediation actually take effect.

## Verification

- YAML parses cleanly.
- After merge, the next `docker.yml` run on `main` will pull the patched base and re-run the OpenSSL upgrade; Trivy (already wired into the workflow) should clear #57/#72 against the new digest. Dismiss the alerts if they linger against the old digest.

Closes #588

https://claude.ai/code/session_01VqcGHxy2B7v1kdpB4isi53

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqcGHxy2B7v1kdpB4isi53)_