### PR TITLE
ci: keep CodeQL runs on main from being cancelled

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Do not cancel in-progress runs on main: a cancelled analyze uploads no
+  # results, so the default branch never receives the "finding is gone" signal
+  # and fixed alerts stay open. PR/branch runs can still be superseded.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

CodeQL's `concurrency` block used `cancel-in-progress: true` unconditionally. A code-scanning alert is only auto-marked **Fixed** when a *completed* analysis on the same branch (same tool + category) no longer reports it. A **cancelled** `analyze` job uploads **no results**.

So when back-to-back pushes land on `main` (squash-merges, release-please commits), the in-progress CodeQL run for the fix commit gets cancelled before it can upload — `main` never receives the "this finding is gone" signal, and alerts that the code already fixed stay **Open** until the weekly cron eventually reconciles them.

## Fix

Scope `cancel-in-progress` to non-main refs:

```yaml
cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

PR/branch runs can still supersede each other (saving CI time), but runs on `main` always complete and upload their results, so fixed alerts close reliably on merge.

https://claude.ai/code/session_017nnT1cEGBJymqs6qjMFHNf

---
_Generated by [Claude Code](https://claude.ai/code/session_017nnT1cEGBJymqs6qjMFHNf)_