### PR TITLE
fix(deps): bump undici to 7.27.2 to resolve DoS and request smuggling advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "ts-jest": "^29.4.11",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.3",
-        "undici": "^7.18.2"
+        "undici": "^7.27.2"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -8607,9 +8607,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
-      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -56,10 +56,10 @@
     "ts-jest": "^29.4.11",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3",
-    "undici": "^7.18.2"
+    "undici": "^7.27.2"
   },
   "overrides": {
-    "undici": "^7.18.2",
+    "undici": "^7.27.2",
     "diff": "^8.0.3",
     "picomatch": "^4.0.4"
   }


### PR DESCRIPTION
## What

Bumps the production `undici` dependency from **7.18.2 → 7.27.2** (latest 7.x), via both the `devDependencies` entry and the `overrides` block, and refreshes `package-lock.json`.

## Why

Trivy image scanning flagged six advisories against the `undici@7.18.2` copy bundled into the production image at `app/.../undici` (it's pulled transitively by `discord.js` / `@discordjs/rest` and pinned up to 7.x by our `overrides`):

| Alert | Severity | Advisory |
|---|---|---|
| #13 | High | DoS via invalid WebSocket permessage-deflate extension parameter |
| #12 | High | DoS via crafted WebSocket frame with large length |
| #11 | High | DoS via unbounded memory during permessage-deflate decompression |
| #16 | Medium | DoS due to uncontrolled resource consumption |
| #15 | Medium | HTTP header injection / request smuggling |
| #14 | Medium | HTTP Request Smuggling & DoS via duplicate Content-Length headers |

These are genuinely in the shipped image (unlike the `picomatch`/`brace-expansion` alerts, which sit in npm's base-image bundle under `usr/...` and aren't fixable from our lockfile).

## Approach

Staying on the latest **7.x** rather than jumping to 8.x: discord.js natively targets undici 6.x and we're already one major ahead at 7.x, so 7.27.2 gets the security fixes with minimal compatibility risk. A move to 8.x would be a second major bump and is out of scope here.

## Verification

- `npm install` resolves `undici@7.27.2` (production, non-dev).
- `npm run check:all` passes: build + lint + format + 102 test suites (1156 tests).

https://claude.ai/code/session_017nnT1cEGBJymqs6qjMFHNf

---
_Generated by [Claude Code](https://claude.ai/code/session_017nnT1cEGBJymqs6qjMFHNf)_