### PR TITLE
ci: exclude js/log-injection from CodeQL and drop dead suppressions

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,21 @@
+name: "KoolBot CodeQL config"
+
+# Query selection still comes from the workflow's `queries:` input
+# (security-extended,security-and-quality); this file only filters that set.
+
+query-filters:
+  # Exclude js/log-injection.
+  #
+  # Every user-controlled value interpolated into a log line is passed through
+  # src/utils/log-sanitize.ts:sanitizeForLog, which strips CR/LF and other
+  # control characters at the call site (44 sites across the codebase). CodeQL's
+  # js/log-injection query does not credit this helper as a sanitizer across the
+  # function boundary, so it reports only false positives here. GitHub code
+  # scanning also ignores inline `// codeql[js/log-injection]` suppression
+  # comments, so the query cannot be quieted per-line either.
+  #
+  # The underlying risk (log forging via newline injection) is mitigated in code
+  # via sanitizeForLog; excluding the query removes the false-positive churn.
+  # Revisit if the logging/sanitization convention changes.
+  - exclude:
+      id: js/log-injection

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4.36.0

--- a/__tests__/utils/log-sanitize.test.ts
+++ b/__tests__/utils/log-sanitize.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "@jest/globals";
+import { sanitizeForLog } from "../../src/utils/log-sanitize.js";
+
+// This suite pins the central log-injection mitigation. CodeQL's
+// js/log-injection query is excluded (see .github/codeql/codeql-config.yml)
+// on the basis that every user-controlled value interpolated into a log line
+// passes through sanitizeForLog. These tests guarantee that helper keeps
+// neutralising newline/control-character injection so that assumption holds.
+describe("sanitizeForLog", () => {
+  it("strips CR and LF so an attacker cannot forge extra log lines", () => {
+    expect(sanitizeForLog("alice\nADMIN logged in")).toBe(
+      "alice ADMIN logged in",
+    );
+    expect(sanitizeForLog("a\rb")).toBe("a b");
+    // Each CR/LF is replaced individually, so CRLF becomes two spaces.
+    expect(sanitizeForLog("a\r\nb")).toBe("a  b");
+  });
+
+  it("never returns a string containing CR or LF, whatever the input", () => {
+    const hostile = "line1\nline2\r\nline3\rline4";
+    const out = sanitizeForLog(hostile);
+    expect(out).not.toMatch(/[\r\n]/);
+  });
+
+  it("strips other control characters", () => {
+    expect(sanitizeForLog("a\x00b\x1fc\x7fd")).toBe("a b c d");
+    expect(sanitizeForLog("tab\there")).toBe("tab here");
+  });
+
+  it("returns an empty string for null or undefined", () => {
+    expect(sanitizeForLog(null)).toBe("");
+    expect(sanitizeForLog(undefined)).toBe("");
+  });
+
+  it("coerces non-string values to a string", () => {
+    expect(sanitizeForLog(42)).toBe("42");
+    expect(sanitizeForLog(true)).toBe("true");
+  });
+
+  it("truncates overly long values with an ellipsis", () => {
+    const long = "x".repeat(200);
+    const out = sanitizeForLog(long);
+    expect(out).toHaveLength(129); // 128 chars + the ellipsis
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("respects a custom maxLength", () => {
+    expect(sanitizeForLog("abcdef", 3)).toBe("abc…");
+  });
+
+  it("leaves a clean value within the limit untouched", () => {
+    expect(sanitizeForLog("clean-value_123")).toBe("clean-value_123");
+  });
+});

--- a/src/services/config-service.ts
+++ b/src/services/config-service.ts
@@ -325,7 +325,7 @@ export class ConfigService {
         const oldConfig = await Config.findOne({ key: oldKey });
         if (oldConfig) {
           logger.info(
-            `⚠️  Found old gamification config key: ${sanitizeForLog(oldKey)}, migrating to ${sanitizeForLog(key)}`, // codeql[js/log-injection]
+            `⚠️  Found old gamification config key: ${sanitizeForLog(oldKey)}, migrating to ${sanitizeForLog(key)}`,
           );
           // Migrate the old key to new key
           await this.set(
@@ -362,7 +362,7 @@ export class ConfigService {
       return null;
     } catch (error) {
       logger.error(
-        `Error getting configuration for key ${sanitizeForLog(key)}:`, // codeql[js/log-injection]
+        `Error getting configuration for key ${sanitizeForLog(key)}:`,
         error,
       );
       return null;
@@ -439,13 +439,13 @@ export class ConfigService {
 
       this.cache.set(key, value);
       logger.info(
-        `Configuration updated: ${sanitizeForLog(key)} = ${sanitizeForLog(value)}`, // codeql[js/log-injection]
+        `Configuration updated: ${sanitizeForLog(key)} = ${sanitizeForLog(value)}`,
       );
 
       // No automatic reloads - users must manually trigger via /config reload
     } catch (error) {
       logger.error(
-        `Error updating configuration ${sanitizeForLog(key)}:`, // codeql[js/log-injection]
+        `Error updating configuration ${sanitizeForLog(key)}:`,
         error,
       );
       throw error;

--- a/src/services/permissions-service.ts
+++ b/src/services/permissions-service.ts
@@ -164,7 +164,7 @@ export class PermissionsService {
       this.permissionsCache.set(cacheKey, roleIds);
 
       logger.info(
-        `Set permissions for command ${sanitizeForLog(commandName)}: ${roleIds.length} role(s)`, // codeql[js/log-injection]
+        `Set permissions for command ${sanitizeForLog(commandName)}: ${roleIds.length} role(s)`,
       );
     } catch (error) {
       logger.error("Error setting command permissions:", error);
@@ -276,7 +276,7 @@ export class PermissionsService {
       await CommandPermission.deleteOne({ guildId, commandName });
       this.permissionsCache.delete(`${guildId}:${commandName}`);
       logger.info(
-        `Cleared all permissions for command ${sanitizeForLog(commandName)}`, // codeql[js/log-injection]
+        `Cleared all permissions for command ${sanitizeForLog(commandName)}`,
       );
     } catch (error) {
       logger.error("Error clearing command permissions:", error);

--- a/src/services/poll-service.ts
+++ b/src/services/poll-service.ts
@@ -285,7 +285,7 @@ export class PollService {
       return true;
     } catch (error) {
       logger.error(
-        `Invalid cron expression: ${sanitizeForLog(expression)}`, // codeql[js/log-injection]
+        `Invalid cron expression: ${sanitizeForLog(expression)}`,
         error,
       );
       return false;
@@ -397,7 +397,7 @@ export class PollService {
       const channel = await guild.channels.fetch(schedule.channelId);
       if (!channel || !(channel instanceof TextChannel)) {
         logger.error(
-          `Channel not found or not a text channel: ${sanitizeForLog(schedule.channelId)} for schedule ${sanitizeForLog(schedule._id)}`, // codeql[js/log-injection]
+          `Channel not found or not a text channel: ${sanitizeForLog(schedule.channelId)} for schedule ${sanitizeForLog(schedule._id)}`,
         );
         return;
       }
@@ -444,7 +444,7 @@ export class PollService {
       await schedule.save();
 
       logger.info(
-        `Posted poll "${sanitizeForLog(pollItem.question)}" to channel ${sanitizeForLog(schedule.channelId)} (schedule ${sanitizeForLog(schedule._id)})`, // codeql[js/log-injection]
+        `Posted poll "${sanitizeForLog(pollItem.question)}" to channel ${sanitizeForLog(schedule.channelId)} (schedule ${sanitizeForLog(schedule._id)})`,
       );
     } catch (error) {
       logger.error(
@@ -457,7 +457,7 @@ export class PollService {
   private schedulePoll(schedule: IPollSchedule): CronJob | null {
     if (!this.validateCronExpression(schedule.cronSchedule)) {
       logger.error(
-        `Invalid cron schedule for poll ${sanitizeForLog(schedule._id)}: ${sanitizeForLog(schedule.cronSchedule)}`, // codeql[js/log-injection]
+        `Invalid cron schedule for poll ${sanitizeForLog(schedule._id)}: ${sanitizeForLog(schedule.cronSchedule)}`,
       );
       return null;
     }
@@ -476,7 +476,7 @@ export class PollService {
 
       job.start();
       logger.info(
-        `Scheduled poll ${sanitizeForLog(schedule._id)} with cron: ${sanitizeForLog(schedule.cronSchedule)}`, // codeql[js/log-injection]
+        `Scheduled poll ${sanitizeForLog(schedule._id)} with cron: ${sanitizeForLog(schedule.cronSchedule)}`,
       );
 
       const nextRun = job.nextDate();
@@ -999,7 +999,7 @@ export class PollService {
 
     if (guildId && schedule.guildId !== guildId) {
       logger.warn(
-        `Attempted to delete schedule ${sanitizeForLog(scheduleId)} from wrong guild`, // codeql[js/log-injection]
+        `Attempted to delete schedule ${sanitizeForLog(scheduleId)} from wrong guild`,
       );
       return false;
     }
@@ -1012,7 +1012,7 @@ export class PollService {
     }
 
     await PollSchedule.findByIdAndDelete(scheduleId);
-    logger.info(`Deleted poll schedule: ${sanitizeForLog(scheduleId)}`); // codeql[js/log-injection]
+    logger.info(`Deleted poll schedule: ${sanitizeForLog(scheduleId)}`);
     return true;
   }
 
@@ -1105,13 +1105,13 @@ export class PollService {
 
     if (guildId && item.guildId !== guildId) {
       logger.warn(
-        `Attempted to delete poll item ${sanitizeForLog(itemId)} from wrong guild`, // codeql[js/log-injection]
+        `Attempted to delete poll item ${sanitizeForLog(itemId)} from wrong guild`,
       );
       return false;
     }
 
     await PollItem.findByIdAndDelete(itemId);
-    logger.info(`Deleted poll item: ${sanitizeForLog(itemId)}`); // codeql[js/log-injection]
+    logger.info(`Deleted poll item: ${sanitizeForLog(itemId)}`);
     return true;
   }
 

--- a/src/services/reaction-role-service.ts
+++ b/src/services/reaction-role-service.ts
@@ -431,7 +431,7 @@ export class ReactionRoleService {
         throw new Error("Failed to save configuration to database.");
       }
 
-      logger.info(`Saved reaction role config for ${sanitizeForLog(roleName)}`); // codeql[js/log-injection]
+      logger.info(`Saved reaction role config for ${sanitizeForLog(roleName)}`);
 
       return {
         success: true,
@@ -527,7 +527,7 @@ export class ReactionRoleService {
           if (message) {
             await message.delete();
             logger.info(
-              `Deleted reaction message ${config.messageId} for archived role ${sanitizeForLog(roleName)}`, // codeql[js/log-injection]
+              `Deleted reaction message ${config.messageId} for archived role ${sanitizeForLog(roleName)}`,
             );
           }
         }
@@ -535,7 +535,7 @@ export class ReactionRoleService {
         logger.error("Error deleting reaction message:", error);
       }
 
-      logger.info(`Archived reaction role: ${sanitizeForLog(roleName)}`); // codeql[js/log-injection]
+      logger.info(`Archived reaction role: ${sanitizeForLog(roleName)}`);
 
       return {
         success: true,
@@ -636,7 +636,7 @@ export class ReactionRoleService {
       }
 
       logger.info(
-        `Created new reaction role message ${message.id} for unarchived role ${sanitizeForLog(roleName)}`, // codeql[js/log-injection]
+        `Created new reaction role message ${message.id} for unarchived role ${sanitizeForLog(roleName)}`,
       );
 
       // Update database with error handling
@@ -662,7 +662,7 @@ export class ReactionRoleService {
         };
       }
 
-      logger.info(`Unarchived reaction role: ${sanitizeForLog(roleName)}`); // codeql[js/log-injection]
+      logger.info(`Unarchived reaction role: ${sanitizeForLog(roleName)}`);
 
       return {
         success: true,
@@ -753,7 +753,7 @@ export class ReactionRoleService {
       // Delete from database
       await ReactionRoleConfig.deleteOne({ _id: config._id });
 
-      logger.info(`Fully deleted reaction role: ${sanitizeForLog(roleName)}`); // codeql[js/log-injection]
+      logger.info(`Fully deleted reaction role: ${sanitizeForLog(roleName)}`);
 
       return {
         success: true,

--- a/src/services/scheduled-announcement-service.ts
+++ b/src/services/scheduled-announcement-service.ts
@@ -82,7 +82,7 @@ export class ScheduledAnnouncementService {
       return true;
     } catch (error) {
       logger.error(
-        `Invalid cron expression: ${sanitizeForLog(expression)}`, // codeql[js/log-injection]
+        `Invalid cron expression: ${sanitizeForLog(expression)}`,
         error,
       );
       return false;
@@ -458,7 +458,7 @@ export class ScheduledAnnouncementService {
     // If guildId is provided, verify it matches
     if (guildId && announcement.guildId !== guildId) {
       logger.warn(
-        `Attempted to delete announcement ${sanitizeForLog(announcementId)} from wrong guild. Expected: ${sanitizeForLog(announcement.guildId)}, Got: ${sanitizeForLog(guildId)}`, // codeql[js/log-injection]
+        `Attempted to delete announcement ${sanitizeForLog(announcementId)} from wrong guild. Expected: ${sanitizeForLog(announcement.guildId)}, Got: ${sanitizeForLog(guildId)}`,
       );
       return false;
     }
@@ -472,7 +472,7 @@ export class ScheduledAnnouncementService {
 
     // Delete from database
     await ScheduledAnnouncement.findByIdAndDelete(announcementId);
-    logger.info(`Deleted announcement: ${sanitizeForLog(announcementId)}`); // codeql[js/log-injection]
+    logger.info(`Deleted announcement: ${sanitizeForLog(announcementId)}`);
     return true;
   }
 

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -432,7 +432,7 @@ export function createUserRouter(
         result = "failure";
         errorMessage = err instanceof Error ? err.message : String(err);
         logger.error(
-          `Failed to save user timezone: ${sanitizeForLog(errorMessage)}`, // codeql[js/log-injection]
+          `Failed to save user timezone: ${sanitizeForLog(errorMessage)}`,
         );
       }
 


### PR DESCRIPTION
## Problem

CodeQL's `js/log-injection` query produces **25 false positives** on log call sites that are already sanitized. Every user-controlled value interpolated into a log line is passed through `src/utils/log-sanitize.ts:sanitizeForLog` (strips CR/LF + control chars), but CodeQL does not credit that helper as a sanitizer across the function boundary, so it keeps flagging the sanitized sinks.

Two previously-attempted fixes don't work:
- **Inline `// codeql[js/log-injection]` comments** — GitHub's managed code-scanning pipeline ignores source-level suppression comments, so all 25 were inert.
- **Dismissing in the UI** — doesn't scale (25 alerts by hand) and isn't preventive: every new sanitized log call site becomes a fresh false positive.

## Fix

- Add `.github/codeql/codeql-config.yml` that excludes `js/log-injection`, with an inline rationale documenting that the risk is mitigated in code via `sanitizeForLog`.
- Wire it into the workflow via `config-file:` on the `init` step.
- Remove the 25 dead `// codeql[js/log-injection]` comments across 6 files.
- Add `__tests__/utils/log-sanitize.test.ts` — a regression suite that pins the mitigation (strips CR/LF + control chars, truncates) so the assumption behind the exclusion cannot silently regress.

The underlying newline-injection risk stays mitigated in code — `sanitizeForLog` is still applied at every call site; this change only stops the false-positive churn.

## Note on coverage

Excluding the query means CodeQL will no longer flag a *future* unsanitized log interpolation. A naive ESLint "always sanitize" rule was considered but rejected: ~148 of 157 logger interpolations are safe values (counts, ids, enum strings), so such a rule would be ~148 false positives — trading CodeQL noise for ESLint noise (matching CodeQL's precision needs taint analysis, which ESLint can't do). Instead, coverage is preserved two ways: the centralized `sanitizeForLog` convention enforced in review, and the new regression test guaranteeing the helper keeps neutralising injection.

## Verification

`npm run check` passes (build + lint + format); the new suite passes (8 tests).

https://claude.ai/code/session_017nnT1cEGBJymqs6qjMFHNf