### PR TITLE
fix(web): even out Rewind stat card grid wrap

### DIFF
--- a/src/web/user-layout.ts
+++ b/src/web/user-layout.ts
@@ -114,7 +114,7 @@ const STYLE = [
   ".rw-hero .total{font-size:2.5rem;font-weight:700;color:#fff;line-height:1.1}",
   ".rw-hero .compare{margin-top:.4rem;color:#c7d2fe;font-size:1rem}",
   ".rw-hero .sub{margin-top:.6rem;color:#a5b4fc;font-size:.85rem}",
-  ".rw-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:.75rem;margin:0 0 1rem}",
+  ".rw-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:.75rem;margin:0 0 1rem}",
   ".rw-stat{background:#161a22;border:1px solid #2d3748;border-radius:8px;padding:.85rem 1rem}",
   ".rw-stat .label{font-size:.7rem;color:#94a3b8;text-transform:uppercase;letter-spacing:.05em}",
   ".rw-stat .value{font-size:1.2rem;color:#e4e6eb;font-weight:600;margin-top:.2rem}",


### PR DESCRIPTION
## Summary

Fixes #607 — on the Rewind page the five stat cards (Peak day, Longest session, Longest streak, Annual rank, Above median) used an auto-fit grid with `minmax(220px, 1fr)`. At the page's capped desktop width this fit exactly four cards per row, stranding the fifth ("Above median") alone on its own row.

## Change

`src/web/user-layout.ts` — lower the `.rw-grid` auto-fit min track width from `220px` to `180px` (issue's recommended option 1).

The `main` container is capped at `max-width: 64rem` (1024px) with 2rem padding each side ≈ 960px content width:

- **Before (`220px`):** 960 / 220 = 4 columns → 4 + 1 stranded.
- **After (`180px`):** 5 × 180px + 4 × 12px gap = 948px ≤ 960px → all five cards fit on one row.

`.rw-grid` is also shared by the two-card text-activity grid. Keeping `auto-fit` (rather than switching to a fixed column count, which would squish the two-card case) means that grid is unaffected — empty tracks collapse and the two cards still lay out side by side. Cards still stack sensibly on narrow/mobile widths.

## Acceptance criteria

- [x] At desktop widths the stat cards don't leave a single card alone on its own row.
- [x] Cards remain readable and stack on narrow/mobile widths (`auto-fit` retained).
- [x] No regression to the shared two-card text-activity grid or other `.rw-*` grids (only `.rw-grid`'s min track width changed).

Build, lint, and prettier checks pass locally.

https://claude.ai/code/session_011jqwbw9eWmCuX7NFQGpezY

---
_Generated by [Claude Code](https://claude.ai/code/session_011jqwbw9eWmCuX7NFQGpezY)_