### PR TITLE
fix(web): surface real error detail on settings save failures

### DIFF
--- a/__tests__/web/http-flash.test.ts
+++ b/__tests__/web/http-flash.test.ts
@@ -244,6 +244,27 @@ describe("wantsJson / truncateFlash (re-homed in http-flash, issue #612)", () =>
     expect(wantsJson(makeReq({}))).toBe(false);
   });
 
+  it("falls back to the `header` alias when `get` is absent", () => {
+    // Some Express-like stubs (and our own /me route test mocks) expose only
+    // `.header`, not `.get`. wantsJson must still negotiate correctly.
+    const headerOnly = {
+      header: (name: string) =>
+        name.toLowerCase() === "x-requested-with" ? "fetch" : undefined,
+    };
+    expect(wantsJson(headerOnly)).toBe(true);
+
+    const headerOnlyAccept = {
+      header: (name: string) =>
+        name.toLowerCase() === "accept" ? "application/json" : undefined,
+    };
+    expect(wantsJson(headerOnlyAccept)).toBe(true);
+
+    const headerOnlyPlain = {
+      header: (): string | undefined => undefined,
+    };
+    expect(wantsJson(headerOnlyPlain)).toBe(false);
+  });
+
   it("truncates only when over the cap", () => {
     expect(truncateFlash("short")).toBe("short");
     expect(truncateFlash("y".repeat(600)).length).toBe(500);

--- a/__tests__/web/http-flash.test.ts
+++ b/__tests__/web/http-flash.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Unit tests for the shared WebUI flash/error helpers (issue #612) and the
+ * middleware that now uses them to speak JSON on error paths, so the Settings
+ * per-section save surfaces a real message instead of a flat toast.
+ */
+
+import { describe, it, expect, jest } from "@jest/globals";
+import type { Request, Response } from "express";
+import {
+  respondFlashError,
+  truncateFlash,
+  wantsJson,
+} from "../../src/web/http-flash.js";
+import { requireCsrf, CSRF_COOKIE } from "../../src/web/csrf.js";
+import { createRateLimiter } from "../../src/web/rate-limit.js";
+import { webErrorStatus, webErrorText } from "../../src/web/index.js";
+
+interface MockResponse {
+  statusCode: number;
+  body: unknown;
+  contentType: string | null;
+  status: jest.Mock;
+  json: jest.Mock;
+  type: jest.Mock;
+  send: jest.Mock;
+  setHeader: jest.Mock;
+  headers: Record<string, unknown>;
+}
+
+function makeRes(): MockResponse {
+  const res = {
+    statusCode: 200,
+    body: undefined as unknown,
+    contentType: null as string | null,
+    headers: {} as Record<string, unknown>,
+    status: jest.fn(),
+    json: jest.fn(),
+    type: jest.fn(),
+    send: jest.fn(),
+    setHeader: jest.fn(),
+  } as MockResponse;
+  res.status.mockImplementation((code: number) => {
+    res.statusCode = code;
+    return res;
+  });
+  res.json.mockImplementation((data: unknown) => {
+    res.body = data;
+    return res;
+  });
+  res.type.mockImplementation((t: string) => {
+    res.contentType = t;
+    return res;
+  });
+  res.send.mockImplementation((data: unknown) => {
+    res.body = data;
+    return res;
+  });
+  res.setHeader.mockImplementation((name: string, value: unknown) => {
+    res.headers[name.toLowerCase()] = value;
+    return res;
+  });
+  return res;
+}
+
+/** Minimal request stub exposing the bits the helpers/middleware read. */
+function makeReq(opts: {
+  headers?: Record<string, string>;
+  method?: string;
+  cookie?: string;
+  body?: Record<string, unknown>;
+}): Request {
+  const headers: Record<string, string> = {};
+  for (const [k, v] of Object.entries(opts.headers ?? {})) {
+    headers[k.toLowerCase()] = v;
+  }
+  if (opts.cookie) headers["cookie"] = opts.cookie;
+  return {
+    method: opts.method ?? "POST",
+    body: opts.body ?? {},
+    headers,
+    ip: "203.0.113.1",
+    socket: { remoteAddress: "203.0.113.1" },
+    get(name: string): string | undefined {
+      return headers[name.toLowerCase()];
+    },
+    header(name: string): string | undefined {
+      return headers[name.toLowerCase()];
+    },
+  } as unknown as Request;
+}
+
+describe("respondFlashError (issue #612)", () => {
+  it("returns JSON {type:'err',text} with the real status for AJAX callers", () => {
+    const res = makeRes();
+    respondFlashError(
+      makeReq({ headers: { "X-Requested-With": "fetch" } }),
+      res as unknown as Response,
+      500,
+      "boom",
+    );
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ type: "err", text: "boom" });
+    expect(res.json).toHaveBeenCalledTimes(1);
+    expect(res.send).not.toHaveBeenCalled();
+  });
+
+  it("falls back to plain text for non-JSON callers", () => {
+    const res = makeRes();
+    respondFlashError(makeReq({}), res as unknown as Response, 403, "nope");
+    expect(res.statusCode).toBe(403);
+    expect(res.contentType).toBe("text/plain");
+    expect(res.body).toBe("nope");
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it("caps the surfaced text via truncateFlash", () => {
+    const res = makeRes();
+    respondFlashError(
+      makeReq({ headers: { Accept: "application/json" } }),
+      res as unknown as Response,
+      413,
+      "x".repeat(800),
+    );
+    const text = (res.body as { text: string }).text;
+    expect(text.length).toBe(500);
+    expect(text.endsWith("…")).toBe(true);
+  });
+});
+
+describe("requireCsrf JSON error responses (issue #612)", () => {
+  it("returns a JSON error when the token is missing for an AJAX request", () => {
+    const res = makeRes();
+    const next = jest.fn();
+    requireCsrf(
+      makeReq({ headers: { "X-Requested-With": "fetch" } }),
+      res as unknown as Response,
+      next,
+    );
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toMatchObject({ type: "err" });
+    expect((res.body as { text: string }).text).toContain("CSRF");
+  });
+
+  it("returns a JSON error on token mismatch for an AJAX request", () => {
+    const res = makeRes();
+    const next = jest.fn();
+    requireCsrf(
+      makeReq({
+        headers: { "X-Requested-With": "fetch", "x-csrf-token": "bbbb" },
+        cookie: `${CSRF_COOKIE}=aaaa`,
+      }),
+      res as unknown as Response,
+      next,
+    );
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toMatchObject({ type: "err" });
+    expect((res.body as { text: string }).text).toContain("mismatch");
+  });
+
+  it("still returns plain text for a no-JS form POST", () => {
+    const res = makeRes();
+    const next = jest.fn();
+    requireCsrf(makeReq({}), res as unknown as Response, next);
+    expect(res.statusCode).toBe(403);
+    expect(res.contentType).toBe("text/plain");
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it("passes through a valid matching token", () => {
+    const res = makeRes();
+    const next = jest.fn();
+    requireCsrf(
+      makeReq({
+        headers: { "x-csrf-token": "match" },
+        cookie: `${CSRF_COOKIE}=match`,
+      }),
+      res as unknown as Response,
+      next,
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});
+
+describe("createRateLimiter JSON error responses (issue #612)", () => {
+  it("returns a JSON 429 (with Retry-After) for AJAX callers over the limit", () => {
+    const limiter = createRateLimiter({
+      windowMs: 60_000,
+      max: 1,
+      keyName: "test",
+    });
+    const next = jest.fn();
+    // First hit passes.
+    limiter(
+      makeReq({ headers: { "X-Requested-With": "fetch" } }),
+      makeRes() as unknown as Response,
+      next,
+    );
+    // Second hit is over the limit.
+    const res = makeRes();
+    limiter(
+      makeReq({ headers: { "X-Requested-With": "fetch" } }),
+      res as unknown as Response,
+      next,
+    );
+    expect(res.statusCode).toBe(429);
+    expect(res.body).toMatchObject({ type: "err" });
+    expect(res.headers["retry-after"]).toBeDefined();
+  });
+});
+
+describe("webErrorStatus / webErrorText (router error handler, issue #612)", () => {
+  it("uses a body-parser error's status (e.g. payload-too-large 413)", () => {
+    expect(webErrorStatus({ status: 413, type: "entity.too.large" })).toBe(413);
+    expect(webErrorStatus({ statusCode: 400 })).toBe(400);
+  });
+
+  it("falls back to 500 for an unhandled error", () => {
+    expect(webErrorStatus(new Error("db exploded"))).toBe(500);
+    expect(webErrorStatus(null)).toBe(500);
+    expect(webErrorStatus({ status: 200 })).toBe(500);
+  });
+
+  it("returns a sanitized, status-specific message without leaking internals", () => {
+    expect(webErrorText(413)).toMatch(/too large/i);
+    expect(webErrorText(400)).toMatch(/malformed/i);
+    expect(webErrorText(403)).toContain("(403)");
+    const five = webErrorText(500);
+    expect(five).toMatch(/unexpected server error/i);
+    expect(five).not.toMatch(/db exploded|stack|Error:/i);
+  });
+});
+
+describe("wantsJson / truncateFlash (re-homed in http-flash, issue #612)", () => {
+  it("detects the fetch sentinel and Accept header", () => {
+    expect(
+      wantsJson(makeReq({ headers: { "X-Requested-With": "fetch" } })),
+    ).toBe(true);
+    expect(
+      wantsJson(makeReq({ headers: { Accept: "application/json" } })),
+    ).toBe(true);
+    expect(wantsJson(makeReq({}))).toBe(false);
+  });
+
+  it("truncates only when over the cap", () => {
+    expect(truncateFlash("short")).toBe("short");
+    expect(truncateFlash("y".repeat(600)).length).toBe(500);
+  });
+});

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -411,10 +411,22 @@ const SETTINGS_SAVE_SCRIPT =
   "headers:{'Accept':'application/json','X-Requested-With':'fetch'}," +
   "body:new FormData(form)})" +
   ".then(function(res){if(res.status===401){window.location.href='/admin/';return null}" +
-  "return res.json().catch(function(){return null})})" +
-  ".then(function(d){if(save)save.disabled=false;" +
-  "if(!d){show(form,'err','Save failed — unexpected server response.');return}" +
-  "show(form,d.type||'ok',d.text||'Saved.')})" +
+  // Read the body once as text and try to parse it as JSON. The server's
+  // happy path and its error paths (CSRF/rate-limit/payload/unhandled) all
+  // speak JSON now (issue #612); if something still returns non-JSON we keep
+  // the HTTP status and the readable body so the toast says what went wrong
+  // instead of a flat 'unexpected server response'.
+  "var status=res.status;" +
+  "return res.text().then(function(t){var d=null;try{d=JSON.parse(t)}catch(e){}" +
+  "return{status:status,json:d,text:t}})})" +
+  ".then(function(r){if(save)save.disabled=false;" +
+  "if(!r)return;" +
+  "if(r.json&&typeof r.json==='object'){show(form,r.json.type||'ok',r.json.text||'Saved.');return}" +
+  // No JSON body: surface the status plus any readable (tag-stripped) text.
+  "var detail=(r.text||'').replace(/<[^>]*>/g,' ').replace(/\\s+/g,' ').trim();" +
+  "var msg='Save failed ('+r.status+').';" +
+  "if(detail)msg+=' '+(detail.length>200?detail.slice(0,199)+'…':detail);" +
+  "show(form,'err',msg)})" +
   ".catch(function(){if(save)save.disabled=false;" +
   "show(form,'err','Save failed — network error. Your changes were not saved.')})}" +
   "function wire(form){var last=null;" +

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -421,8 +421,15 @@ const SETTINGS_SAVE_SCRIPT =
   "return{status:status,json:d,text:t}})})" +
   ".then(function(r){if(save)save.disabled=false;" +
   "if(!r)return;" +
-  "if(r.json&&typeof r.json==='object'){show(form,r.json.type||'ok',r.json.text||'Saved.');return}" +
-  // No JSON body: surface the status plus any readable (tag-stripped) text.
+  // A structured flash (server's happy path AND its error paths) carries a
+  // non-empty `text`; show it, letting the HTTP status decide ok/err when the
+  // server omits an explicit `type`. JSON without usable text (e.g. a proxy's
+  // own envelope) must NOT be mistaken for a successful save, so fall through.
+  "var jt=r.json&&typeof r.json==='object'?r.json.text:null;" +
+  "var okStatus=r.status>=200&&r.status<300;" +
+  "if(typeof jt==='string'&&jt){show(form,(r.json.type)||(okStatus?'ok':'err'),jt);return}" +
+  "if(okStatus){show(form,'ok','Saved.');return}" +
+  // Non-2xx with no usable JSON: surface the status plus any readable text.
   "var detail=(r.text||'').replace(/<[^>]*>/g,' ').replace(/\\s+/g,' ').trim();" +
   "var msg='Save failed ('+r.status+').';" +
   "if(detail)msg+=' '+(detail.length>200?detail.slice(0,199)+'…':detail);" +

--- a/src/web/csrf.ts
+++ b/src/web/csrf.ts
@@ -2,6 +2,7 @@ import crypto from "crypto";
 import { Buffer } from "buffer";
 import { Request, Response, NextFunction } from "express";
 import { parseCookies, setCookie } from "./cookies.js";
+import { respondFlashError } from "./http-flash.js";
 import { env } from "../config/env.js";
 
 export const CSRF_COOKIE = "koolbot_csrf";
@@ -59,14 +60,27 @@ export function requireCsrf(
   const cookies = parseCookies(req);
   const cookieToken = cookies.get(CSRF_COOKIE);
   const headerToken = req.header(CSRF_HEADER) || (req.body && req.body._csrf);
+  // AJAX callers (e.g. the Settings per-section save) get a JSON error so the
+  // client can surface a real message instead of a generic toast (issue #612);
+  // plain form POSTs still get the text/plain body via `respondFlashError`.
   if (!cookieToken || !headerToken) {
-    res.status(403).type("text/plain").send("CSRF token missing");
+    respondFlashError(
+      req,
+      res,
+      403,
+      "Security check failed (CSRF token missing). Reload the page and try again.",
+    );
     return;
   }
   const a = Buffer.from(String(cookieToken));
   const b = Buffer.from(String(headerToken));
   if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
-    res.status(403).type("text/plain").send("CSRF token mismatch");
+    respondFlashError(
+      req,
+      res,
+      403,
+      "Security check failed (CSRF token mismatch). Reload the page and try again.",
+    );
     return;
   }
   next();

--- a/src/web/http-flash.ts
+++ b/src/web/http-flash.ts
@@ -1,0 +1,75 @@
+import type { Response } from "express";
+
+/**
+ * Shared flash/error helpers for the WebUI's state-changing routes.
+ *
+ * Lives in its own module (rather than `write-routes.ts`) so the CSRF and
+ * rate-limit middleware and the router-level error handler can reuse
+ * `wantsJson` / `respondFlashError` without importing the heavyweight write
+ * router (which itself imports the CSRF middleware — a cycle we avoid here).
+ */
+
+/** Max length for inline flash/toast text, shared by redirect + JSON paths. */
+export const FLASH_MAX = 500;
+
+export function truncateFlash(text: string): string {
+  return text.length > FLASH_MAX ? `${text.slice(0, FLASH_MAX - 1)}…` : text;
+}
+
+/**
+ * Whether the client wants a JSON reply instead of the usual 303 flash
+ * redirect. The Settings page's per-section Save is progressively enhanced to
+ * submit via `fetch()` (issue #555) so the page no longer reloads and jumps to
+ * the top; that request advertises itself with `X-Requested-With: fetch` (and
+ * `Accept: application/json`). A plain form POST — the no-JS fallback — sends
+ * neither and keeps the redirect path.
+ */
+/** A request we can read headers off — either `get` or its `header` alias. */
+type HeaderReadable = {
+  get?(name: string): string | string[] | undefined;
+  header?(name: string): string | string[] | undefined;
+};
+
+export function wantsJson(req: HeaderReadable): boolean {
+  // Express exposes header lookup as both `.get` and its `.header` alias; use
+  // whichever is present so callers (and test stubs) can supply either.
+  const lookup =
+    typeof req.get === "function"
+      ? req.get.bind(req)
+      : typeof req.header === "function"
+        ? req.header.bind(req)
+        : undefined;
+  // Header values are compared case-insensitively: media types (RFC 9110)
+  // and our `fetch` sentinel are both case-insensitive, so a client sending
+  // `Accept: Application/JSON` must still get the JSON reply.
+  const header = (name: string): string => {
+    const raw = lookup?.(name);
+    return (Array.isArray(raw) ? raw.join(",") : (raw ?? "")).toLowerCase();
+  };
+  if (header("X-Requested-With") === "fetch") {
+    return true;
+  }
+  return header("Accept").includes("application/json");
+}
+
+/**
+ * Reply to a failed state-changing request with a structured error. AJAX
+ * callers (`wantsJson`) get `{ type: 'err', text }` carrying the real HTTP
+ * status so the client can surface the actual reason instead of a flat
+ * "unexpected server response" (issue #612); the no-JS fallback gets the same
+ * text as plain text. Text is capped so a noisy failure can't blow past
+ * header/body limits.
+ */
+export function respondFlashError(
+  req: HeaderReadable,
+  res: Response,
+  status: number,
+  text: string,
+): void {
+  const body = truncateFlash(text);
+  if (wantsJson(req)) {
+    res.status(status).json({ type: "err", text: body });
+    return;
+  }
+  res.status(status).type("text/plain").send(body);
+}

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -4,6 +4,7 @@ import logger from "../utils/logger.js";
 import { env, getEnv } from "../config/env.js";
 import { WebSessionService } from "../services/web-session-service.js";
 import { ensureCsrfCookie, requireCsrf } from "./csrf.js";
+import { respondFlashError } from "./http-flash.js";
 import { createRateLimiter } from "./rate-limit.js";
 import {
   AuthenticatedRequest,
@@ -140,17 +141,49 @@ export function createWebRouter(client: Client): Router {
   router.use(createReadOnlyRouter(client, requireSession));
 
   router.use(
-    (err: unknown, _req: Request, res: Response, next: NextFunction): void => {
+    (err: unknown, req: Request, res: Response, next: NextFunction): void => {
       logger.error("WebUI router error", err);
       if (res.headersSent) {
         next(err);
         return;
       }
-      res.status(500).type("text/plain").send("Internal Server Error");
+      // Surface a sanitized, status-aware error so AJAX callers (e.g. the
+      // Settings per-section save) get a JSON `{type:'err',text}` instead of
+      // an HTML 500 the client can't parse (issue #612). We deliberately do
+      // not echo `err.message` — only a friendly reason keyed off the HTTP
+      // status — so DB/validation/internal details never leak to the admin.
+      const status = webErrorStatus(err);
+      respondFlashError(req, res, status, webErrorText(status));
     },
   );
 
   return router;
+}
+
+/**
+ * Best-effort HTTP status for a thrown WebUI error. Body-parser failures
+ * (e.g. payload-too-large) carry `status`/`statusCode`; anything else is an
+ * unhandled server error → 500.
+ */
+export function webErrorStatus(err: unknown): number {
+  const e = err as { status?: unknown; statusCode?: unknown } | null;
+  const raw = e?.statusCode ?? e?.status;
+  if (typeof raw === "number" && raw >= 400 && raw <= 599) return raw;
+  return 500;
+}
+
+/** Sanitized, user-facing reason keyed off the HTTP status (no internals). */
+export function webErrorText(status: number): string {
+  if (status === 413) {
+    return "Save failed — the submitted data was too large.";
+  }
+  if (status === 400) {
+    return "Save failed — the request was malformed.";
+  }
+  if (status >= 400 && status < 500) {
+    return `Save failed — request rejected (${status}).`;
+  }
+  return "Save failed — an unexpected server error occurred. Please try again.";
 }
 
 /**

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -172,18 +172,23 @@ export function webErrorStatus(err: unknown): number {
   return 500;
 }
 
-/** Sanitized, user-facing reason keyed off the HTTP status (no internals). */
+/**
+ * Sanitized, user-facing reason keyed off the HTTP status (no internals).
+ * The text is intentionally generic ("request"/"action") rather than
+ * save-specific: this handler covers every WebUI route — GET pages and POST
+ * actions alike — not just the Settings save.
+ */
 export function webErrorText(status: number): string {
   if (status === 413) {
-    return "Save failed — the submitted data was too large.";
+    return "The submitted data was too large.";
   }
   if (status === 400) {
-    return "Save failed — the request was malformed.";
+    return "The request was malformed.";
   }
   if (status >= 400 && status < 500) {
-    return `Save failed — request rejected (${status}).`;
+    return `Request rejected (${status}).`;
   }
-  return "Save failed — an unexpected server error occurred. Please try again.";
+  return "An unexpected server error occurred. Please try again.";
 }
 
 /**

--- a/src/web/rate-limit.ts
+++ b/src/web/rate-limit.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from "express";
+import { respondFlashError } from "./http-flash.js";
 
 interface Bucket {
   hits: number;
@@ -67,7 +68,14 @@ export function createRateLimiter(opts: {
     if (bucket.hits > opts.max) {
       const retryAfter = Math.max(1, Math.ceil((bucket.resetAt - now) / 1000));
       res.setHeader("Retry-After", retryAfter);
-      res.status(429).type("text/plain").send("Too Many Requests");
+      // AJAX callers get a JSON error so the client can show a real message
+      // (issue #612); plain requests still get the text/plain body.
+      respondFlashError(
+        req,
+        res,
+        429,
+        `Too many requests — slow down and retry in ${retryAfter}s.`,
+      );
       return;
     }
     next();

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -47,6 +47,10 @@ import {
   type BotStatusPool,
 } from "../content/statuses.js";
 import { requireCsrf } from "./csrf.js";
+import { FLASH_MAX, truncateFlash, wantsJson } from "./http-flash.js";
+// Re-exported so existing callers/tests can keep importing these from the
+// write router; the canonical home is `./http-flash.js` (issue #612).
+export { truncateFlash, wantsJson };
 import { PROTECTED_KEYS } from "./bootstrap-vars.js";
 import {
   requireAdminRoleMiddleware,
@@ -71,8 +75,6 @@ import {
 } from "./admin-views.js";
 
 type Flash = { type: "ok" | "warn" | "err"; text: string };
-
-const FLASH_MAX = 500;
 
 /**
  * Maximum lengths for user-supplied free text (issue #508). Each cap is
@@ -120,10 +122,6 @@ export function firstLengthError(
   return null;
 }
 
-export function truncateFlash(text: string): string {
-  return text.length > FLASH_MAX ? `${text.slice(0, FLASH_MAX - 1)}…` : text;
-}
-
 function flashRedirect(res: Response, path: string, flash: Flash): void {
   // Mirror the renderer's 500-char cap on the way out so the redirect
   // URL itself can't balloon to header/URI limits on a noisy failure.
@@ -132,30 +130,6 @@ function flashRedirect(res: Response, path: string, flash: Flash): void {
     msg: truncateFlash(flash.text),
   }).toString();
   res.redirect(303, `${path}?${qs}`);
-}
-
-/**
- * Whether the client wants a JSON reply instead of the usual 303 flash
- * redirect. The Settings page's per-section Save is progressively enhanced to
- * submit via `fetch()` (issue #555) so the page no longer reloads and jumps to
- * the top; that request advertises itself with `X-Requested-With: fetch` (and
- * `Accept: application/json`). A plain form POST — the no-JS fallback — sends
- * neither and keeps the redirect path.
- */
-export function wantsJson(req: {
-  get(name: string): string | string[] | undefined;
-}): boolean {
-  // Header values are compared case-insensitively: media types (RFC 9110)
-  // and our `fetch` sentinel are both case-insensitive, so a client sending
-  // `Accept: Application/JSON` must still get the JSON reply.
-  const header = (name: string): string => {
-    const raw = req.get(name);
-    return (Array.isArray(raw) ? raw.join(",") : (raw ?? "")).toLowerCase();
-  };
-  if (header("X-Requested-With") === "fetch") {
-    return true;
-  }
-  return header("Accept").includes("application/json");
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #612. The admin Settings per-section save collapsed every non-JSON response into a flat **"Save failed — unexpected server response."** toast, discarding the HTTP status, any error body the server sent, and unhandled exceptions that returned Express's default **HTML** error page (which `res.json()` can't parse). So precisely when something unexpected went wrong — CSRF failure, rate-limit, payload-too-large, or a thrown error mid-save — the UI said the least.

## What changed

**Client (`src/web/admin-layout.ts`)** — the AJAX save handler now:
- keeps the 401 redirect,
- reads the response body **once as text** and tries `JSON.parse`,
- shows structured `{type,text}` replies verbatim (happy path *and* error paths),
- when no JSON exists, builds a toast that includes the **HTTP status** and any readable, tag-stripped body text (capped) — e.g. `Save failed (500). ...` — instead of the bare generic string.

**Server — make error paths speak JSON for `wantsJson` requests** so detail actually exists to show, without leaking internals:
- **CSRF** rejection (token missing / mismatch) → JSON `403` with a clear, actionable reason (`src/web/csrf.ts`).
- **Rate-limit** → JSON `429` with a retry hint; `Retry-After` header preserved (`src/web/rate-limit.ts`).
- **Router error handler** (`src/web/index.ts`) → sanitized, **status-aware** JSON: payload-too-large `413`, malformed `400`, generic `500`. `err.message` is never echoed, so DB / validation / internal details don't leak.

**Refactor** — `wantsJson` / `truncateFlash` plus a new `respondFlashError` helper move into a dependency-free `src/web/http-flash.ts`, so the CSRF/rate-limit middleware and the error handler can reuse them without importing the heavyweight write router (which itself imports the CSRF middleware — a cycle we avoid). The old names are re-exported from `write-routes.ts` for compatibility. `wantsJson` also tolerates either `req.get` or its `req.header` alias.

## Acceptance criteria

- [x] A failed save shows the server's actual error message when one is provided.
- [x] When no structured body exists, the toast includes the HTTP status (and any readable body text) rather than the bare "unexpected server response".
- [x] CSRF / rate-limit / payload-size / unhandled-exception failures return a meaningful JSON message for AJAX callers.
- [x] No sensitive internals leaked in the surfaced text (status-keyed messages only; `err.message` never echoed).
- [x] Tests cover JSON-vs-plain-text negotiation, CSRF/rate-limit JSON errors, and the status→message mapping.

## Testing

- `npm run build` ✓
- `npm run lint` ✓ · `npm run format:check` ✓
- `npm run test:ci` ✓ — 1177 passing, coverage thresholds hold. New suite: `__tests__/web/http-flash.test.ts`.

https://claude.ai/code/session_01BbAjLh5kc2YHBeiE9LxAVW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbAjLh5kc2YHBeiE9LxAVW)_