### PR TITLE
fix(rewind): resolve voice companions to stored username, skip nameless ids

### DIFF
--- a/__tests__/services/rewind-service.test.ts
+++ b/__tests__/services/rewind-service.test.ts
@@ -909,6 +909,23 @@ describe("RewindService snapshots (#574)", () => {
       });
     });
 
+    it("drops baked-in 'Unknown user' companion rows from legacy snapshots (#606)", () => {
+      const norm = normalizeSnapshotSummary(
+        {
+          topCompanions: [
+            { userId: "a", displayName: "Alice", totalSeconds: 100 },
+            { userId: "b", displayName: "Unknown user", totalSeconds: 50 },
+            { userId: "c", displayName: "Carol", totalSeconds: 25 },
+          ],
+        },
+        { userId: "u", guildId: "g", year: 2021 },
+      );
+      expect(norm.topCompanions).toEqual([
+        { userId: "a", displayName: "Alice", totalSeconds: 100 },
+        { userId: "c", displayName: "Carol", totalSeconds: 25 },
+      ]);
+    });
+
     it("tolerates a null stored payload (empty state)", () => {
       const empty = normalizeSnapshotSummary(null, {
         userId: "u",

--- a/__tests__/services/rewind-service.test.ts
+++ b/__tests__/services/rewind-service.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 // once mocks are in place.
 
 const mockFindOneVc = jest.fn();
+const mockFindVc = jest.fn();
 const mockAggregateVc = jest.fn();
 const mockFindOneAch = jest.fn();
 const mockSnapFindOne = jest.fn();
@@ -16,6 +17,7 @@ const mockSnapCreate = jest.fn();
 jest.unstable_mockModule("../../src/models/voice-channel-tracking.js", () => ({
   VoiceChannelTracking: {
     findOne: mockFindOneVc,
+    find: mockFindVc,
     aggregate: mockAggregateVc,
   },
 }));
@@ -468,12 +470,21 @@ describe("RewindService.getSummary", () => {
     return { lean: jest.fn(async () => value) };
   }
 
+  // The companion-username fallback query chains `.find().select().lean()`.
+  function selectLean<T>(value: T): {
+    select: () => { lean: () => Promise<T> };
+  } {
+    return { select: jest.fn(() => lean(value)) };
+  }
+
   beforeEach(() => {
     jest.clearAllMocks();
     resetSingleton();
     // Default chainable returns so tests that don't override the
     // `findOne` calls still chain through `.lean()` without crashing.
     mockFindOneVc.mockReturnValue(lean({ sessions: [] }));
+    // Stored-username fallback (#606): no tracking docs by default.
+    mockFindVc.mockReturnValue(selectLean([]));
     mockFindOneAch.mockReturnValue(lean(null));
     mockAggregateVc.mockResolvedValue([]);
     // By default no snapshots exist, so getSummary takes the live path.
@@ -651,6 +662,74 @@ describe("RewindService.getSummary", () => {
       { userId: "bob", displayName: "Bob the Builder", totalSeconds: 5400 },
       { userId: "carol", displayName: "carol123", totalSeconds: 3600 },
     ]);
+  });
+
+  it("falls back to the stored tracking username when a companion is not cached (#606)", async () => {
+    const year = 2026;
+    const sessions = [
+      {
+        startTime: new Date(`${year}-02-01T10:00:00Z`),
+        duration: 3600,
+        channelId: "general",
+        channelName: "general-vc",
+        // "left" is in neither the guild member nor the user cache.
+        otherUsers: ["left"],
+      },
+    ];
+    mockFindOneVc.mockReturnValueOnce(lean({ sessions }));
+    mockFindOneAch.mockReturnValueOnce(lean(null));
+    // The companion query returns the last-known username we persisted.
+    mockFindVc.mockReturnValueOnce(
+      selectLean([{ userId: "left", username: "DeparturedDan" }]),
+    );
+    mockAggregateVc
+      .mockResolvedValueOnce([{ _id: 2026 }])
+      .mockResolvedValueOnce([{ _id: "u1", totalTime: 3600 }])
+      .mockResolvedValueOnce([]);
+
+    // Empty client caches — nothing resolves live.
+    const svc = RewindService.getInstance(
+      makeClient() as Parameters<typeof RewindService.getInstance>[0],
+    );
+    const summary = await svc.getSummary("u1", "g1", year);
+    expect(summary!.topCompanions).toEqual([
+      { userId: "left", displayName: "DeparturedDan", totalSeconds: 3600 },
+    ]);
+  });
+
+  it("skips companions with no name anywhere instead of showing 'Unknown user' (#606)", async () => {
+    const year = 2026;
+    const sessions = [
+      {
+        startTime: new Date(`${year}-02-01T10:00:00Z`),
+        duration: 3600,
+        channelId: "general",
+        channelName: "general-vc",
+        otherUsers: ["ghost", "carol"],
+      },
+    ];
+    mockFindOneVc.mockReturnValueOnce(lean({ sessions }));
+    mockFindOneAch.mockReturnValueOnce(lean(null));
+    // Only carol has a stored username; "ghost" is nameless everywhere.
+    mockFindVc.mockReturnValueOnce(
+      selectLean([{ userId: "carol", username: "carol123" }]),
+    );
+    mockAggregateVc
+      .mockResolvedValueOnce([{ _id: 2026 }])
+      .mockResolvedValueOnce([{ _id: "u1", totalTime: 3600 }])
+      .mockResolvedValueOnce([]);
+
+    const svc = RewindService.getInstance(
+      makeClient() as Parameters<typeof RewindService.getInstance>[0],
+    );
+    const summary = await svc.getSummary("u1", "g1", year);
+    // "ghost" is dropped entirely; only the named companion survives.
+    expect(summary!.topCompanions).toEqual([
+      { userId: "carol", displayName: "carol123", totalSeconds: 3600 },
+    ]);
+    expect(
+      summary!.topCompanions.some((c) => c.displayName === "Unknown user"),
+    ).toBe(false);
   });
 
   it("filters achievements and accolades by year and ignores unknown types", async () => {

--- a/src/services/rewind-service.ts
+++ b/src/services/rewind-service.ts
@@ -121,6 +121,17 @@ export interface RewindSummary {
  */
 export const SNAPSHOT_SCHEMA_VERSION = 1;
 
+/** How many voice companions the Rewind card renders (#567). */
+export const TOP_COMPANIONS_SHOWN = 5;
+
+/**
+ * Pull this many times `TOP_COMPANIONS_SHOWN` candidates before resolving
+ * names, so companions whose id can't be named anywhere (#606) can be
+ * dropped and backfilled from the next-ranked companion instead of leaving
+ * a gap in the card.
+ */
+const COMPANION_CANDIDATE_MULTIPLIER = 4;
+
 interface RawSession {
   startTime: Date;
   endTime?: Date;
@@ -549,15 +560,14 @@ export class RewindService {
 
       // Top voice companions (#567) replace the old "Top channels" card:
       // with dynamic VCs the ephemeral per-session room names are noise, so
-      // we surface *who* the user spent time with instead.
-      const topCompanions: RewindCompanion[] = computeTopCompanions(
+      // we surface *who* the user spent time with instead. We pull a few
+      // extra candidates beyond the 5 shown so that any id we can't name at
+      // all gets skipped (#606) and backfilled from the next-ranked
+      // companion, rather than leaving a "Unknown user" hole in the card.
+      const companionCandidates = computeTopCompanions(
         sessions,
-        5,
-      ).map((c) => ({
-        userId: c.userId,
-        displayName: this.resolveUserName(guildId, c.userId),
-        totalSeconds: c.totalSeconds,
-      }));
+        TOP_COMPANIONS_SHOWN * COMPANION_CANDIDATE_MULTIPLIER,
+      );
       const peakDay = computePeakDay(sessions, dayZone);
       const longestSession = computeLongestSession(sessions, dayZone);
       const streak = computeLongestStreak(sessions, dayZone);
@@ -585,12 +595,33 @@ export class RewindService {
         weeklyJourney,
         text,
         snapshotYears,
+        storedCompanionNames,
       ] = await Promise.all([
         this.computeAnnualRank(userId, start, end, totalSeconds),
         this.computeWeeklyJourney(userId, start, end),
         this.computeTextActivity(userId, guildId, start, end, dayZone),
         this.collectSnapshotYears(userId, guildId),
+        this.fetchStoredUsernames(companionCandidates.map((c) => c.userId)),
       ]);
+
+      // Resolve companion ids → names now that the stored-username fallback
+      // is loaded. Skip any id we still can't name and take the first
+      // TOP_COMPANIONS_SHOWN that resolve (#606).
+      const topCompanions: RewindCompanion[] = [];
+      for (const c of companionCandidates) {
+        if (topCompanions.length >= TOP_COMPANIONS_SHOWN) break;
+        const displayName = this.resolveUserName(
+          guildId,
+          c.userId,
+          storedCompanionNames,
+        );
+        if (!displayName) continue;
+        topCompanions.push({
+          userId: c.userId,
+          displayName,
+          totalSeconds: c.totalSeconds,
+        });
+      }
 
       // The picker should offer any year the user has either kind of data,
       // plus any snapshotted year — those must stay navigable even after
@@ -980,21 +1011,62 @@ export class RewindService {
   }
 
   /**
-   * Resolve a companion's user id to a display name (#567), preferring the
-   * guild nickname, then the global username, both read from the client
-   * cache like `resolveChannelName`. A cache miss can mean the user left
-   * the guild, but also simply that partial member caching (gateway
-   * intents / cache limits) never populated them — so we fall back to a
-   * neutral placeholder rather than asserting they've gone.
+   * Resolve a companion's user id to a display name (#567, #606), trying in
+   * order: live guild nickname → cached global username → the username we
+   * already persist on the companion's `VoiceChannelTracking` doc. The
+   * stored-username fallback (passed in via `storedUsernames`) is what
+   * rescues the common cases the client caches miss — a companion who has
+   * left the guild, or one partial member caching (gateway intents / cache
+   * limits) never populated.
+   *
+   * Returns `null` when no name can be found anywhere; the caller drops
+   * those ids rather than rendering a useless "Unknown user" row (#606).
    */
-  private resolveUserName(guildId: string, userId: string): string {
+  private resolveUserName(
+    guildId: string,
+    userId: string,
+    storedUsernames?: Map<string, string>,
+  ): string | null {
     const member = this.client.guilds?.cache
       ?.get(guildId)
       ?.members?.cache?.get(userId);
     if (member?.displayName) return member.displayName;
     const user = this.client.users?.cache?.get(userId);
     if (user?.username) return user.username;
-    return "Unknown user";
+    const stored = storedUsernames?.get(userId);
+    if (stored) return stored;
+    return null;
+  }
+
+  /**
+   * Look up the last-known stored username for each id from its
+   * `VoiceChannelTracking` doc (#606). Used as the companion-name fallback
+   * when the client caches don't have the user. Only the two needed fields
+   * are projected so we don't drag each companion's full session history
+   * into memory. A query failure degrades to an empty map (companions then
+   * fall through to "skip") rather than failing the whole recap.
+   */
+  private async fetchStoredUsernames(
+    userIds: string[],
+  ): Promise<Map<string, string>> {
+    const names = new Map<string, string>();
+    if (userIds.length === 0) return names;
+    try {
+      const docs = await VoiceChannelTracking.find({
+        userId: { $in: userIds },
+      })
+        .select("userId username")
+        .lean<Array<{ userId: string; username?: string }>>();
+      for (const doc of docs) {
+        if (doc.username) names.set(doc.userId, doc.username);
+      }
+    } catch (error) {
+      logger.warn(
+        "RewindService.fetchStoredUsernames failed; companions without a cached name will be skipped:",
+        error,
+      );
+    }
+    return names;
   }
 
   /**

--- a/src/services/rewind-service.ts
+++ b/src/services/rewind-service.ts
@@ -446,8 +446,14 @@ export function normalizeSnapshotSummary(
     sessionCount: s.sessionCount ?? 0,
     daysActive: s.daysActive ?? 0,
     // Older snapshots predate companions (#567) and any that recorded the
-    // since-removed topChannels are simply dropped here.
-    topCompanions: s.topCompanions ?? [],
+    // since-removed topChannels are simply dropped here. Snapshots frozen
+    // before #606 may carry baked-in "Unknown user" rows; drop them so the
+    // "skip rather than show Unknown user" guarantee also holds for the
+    // snapshot path (we can't re-resolve names here — this is a pure
+    // function with no client/DB access).
+    topCompanions: (s.topCompanions ?? []).filter(
+      (c) => c.displayName !== "Unknown user",
+    ),
     peakDay: s.peakDay ?? null,
     // Older snapshots predate the longest-session card (#568).
     longestSession: s.longestSession ?? null,


### PR DESCRIPTION
## Summary

Fixes #606. The shipped "Top voice companions" card (#567) showed a lot of **"Unknown user"** rows because companion ids were resolved only from the in-memory client caches (guild member cache → user cache). A companion fell through to "Unknown user" whenever they'd **left the guild** or simply **weren't cached** (gateway intents / cache limits) — common, hence the near-useless card.

Meanwhile each user's `VoiceChannelTracking` document already persists a `username`, and the session data the card is built from comes from those very docs — so a usable name was on hand and thrown away.

## Changes

- `resolveUserName` now resolves in order: live guild `displayName` → cached `user.username` → **stored tracking `username`** → `null`. It no longer returns the `"Unknown user"` placeholder.
- New `fetchStoredUsernames(ids)` helper loads the last-known username for the companion ids in a single projected query (`userId`, `username` only), folded into the existing concurrent reads in `getSummary`. A query failure degrades to an empty map rather than failing the whole recap.
- Per the issue's follow-up comment ("if all else fails, skip unknown user"), companions that still can't be named anywhere are **dropped** rather than shown as "Unknown user". We pull a few extra candidates (`TOP_COMPANIONS_SHOWN * 4`) so a dropped id is backfilled from the next-ranked companion and the card stays full.
- Snapshots are produced from `getSummary`, so newly frozen recaps inherit the clean names automatically.

The single name-resolution site is in `rewind-service`; the web view just passes the cleaned `topCompanions` through.

## Acceptance criteria

- [x] Companions who left the guild / aren't cached resolve to their last-known stored username.
- [x] "Unknown user" no longer appears — nameless ids are skipped instead.
- [x] No regression for present members (live `displayName` still preferred).
- [x] Unit tests: cache-miss companion present in tracking docs resolves to the stored username; an id absent everywhere is skipped.

## Testing

- `npm run build` ✅
- `npm run lint` / `npm run format:check` ✅
- `npm test` — 1166 passing (added 2 tests for #606) ✅

https://claude.ai/code/session_01KQvjreoriPAKwrxSErT2bB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQvjreoriPAKwrxSErT2bB)_