### PR TITLE
fix(voice): persist and restore dynamic channel ownership across restarts

### DIFF
--- a/__tests__/services/voice-channel-manager-ownership-persistence.test.ts
+++ b/__tests__/services/voice-channel-manager-ownership-persistence.test.ts
@@ -229,7 +229,10 @@ describe("VoiceChannelManager - ownership persistence (issue #615)", () => {
 
     expect(mockOwnershipModel.findOneAndUpdate).toHaveBeenCalledWith(
       { channelId: "new-channel-id" },
-      expect.objectContaining({ ownerId: "lonix-id" }),
+      expect.objectContaining({
+        $set: { ownerId: "lonix-id" },
+        $setOnInsert: { guildId: "guild-id", channelId: "new-channel-id" },
+      }),
       expect.objectContaining({ upsert: true }),
     );
   });

--- a/__tests__/services/voice-channel-manager-ownership-persistence.test.ts
+++ b/__tests__/services/voice-channel-manager-ownership-persistence.test.ts
@@ -1,0 +1,254 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import {
+  ChannelType,
+  Collection,
+  type Client,
+  type Guild,
+  type VoiceChannel,
+} from "discord.js";
+
+// Mock dependencies before importing
+jest.mock("../../src/utils/logger.js");
+jest.mock("../../src/services/voice-channel-tracker.js");
+jest.mock("../../src/services/config-service.js");
+jest.mock("../../src/models/voice-channel-ownership.js");
+
+// Import after mocks
+import { VoiceChannelManager } from "../../src/services/voice-channel-manager.js";
+import { ConfigService } from "../../src/services/config-service.js";
+import { VoiceChannelOwnership } from "../../src/models/voice-channel-ownership.js";
+
+const mockConfigService =
+  ConfigService.getInstance() as jest.Mocked<ConfigService>;
+const mockOwnershipModel = VoiceChannelOwnership as unknown as {
+  find: jest.Mock;
+  findOneAndUpdate: jest.Mock;
+  updateOne: jest.Mock;
+  deleteOne: jest.Mock;
+};
+
+/**
+ * Regression coverage for issue #615: ownership was tracked only in memory, so
+ * a restart orphaned every dynamic channel the bot created beforehand. The
+ * manager now persists ownership and rebuilds it on `initialize()`.
+ */
+describe("VoiceChannelManager - ownership persistence (issue #615)", () => {
+  let manager: VoiceChannelManager;
+  let mockClient: Partial<Client>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (VoiceChannelManager as any).instance = undefined;
+
+    mockOwnershipModel.find = jest.fn<any>().mockResolvedValue([]);
+    mockOwnershipModel.findOneAndUpdate = jest
+      .fn<any>()
+      .mockResolvedValue(undefined);
+    mockOwnershipModel.updateOne = jest.fn<any>().mockResolvedValue(undefined);
+    mockOwnershipModel.deleteOne = jest.fn<any>().mockResolvedValue(undefined);
+
+    mockConfigService.getBoolean = jest
+      .fn()
+      .mockImplementation((key: string, defaultValue?: boolean) => {
+        if (key === "voicechannels.enabled") return Promise.resolve(true);
+        return Promise.resolve(defaultValue ?? false);
+      });
+    mockConfigService.getString = jest
+      .fn()
+      .mockImplementation((key: string, defaultValue?: string) => {
+        switch (key) {
+          case "GUILD_ID":
+            return Promise.resolve("guild-id");
+          case "voicechannels.lobby.name":
+            return Promise.resolve("Lobby");
+          case "voicechannels.lobby.offlinename":
+            return Promise.resolve("Lobby (Offline)");
+          case "voicechannels.category_id":
+            return Promise.resolve("category-id");
+          case "voicechannels.channel.prefix":
+            return Promise.resolve("🎮");
+          default:
+            return Promise.resolve(defaultValue ?? "");
+        }
+      });
+
+    mockClient = {
+      guilds: { fetch: jest.fn() } as any,
+      channels: { fetch: jest.fn() } as any,
+    } as any;
+
+    manager = VoiceChannelManager.getInstance(mockClient as Client);
+    // Pretend Mongo is connected so the persistence helpers run against the
+    // mocked model rather than short-circuiting.
+    jest.spyOn(manager as any, "isDbReady").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    (VoiceChannelManager as any).instance = undefined;
+    jest.restoreAllMocks();
+  });
+
+  function buildGuild(channels: Collection<string, VoiceChannel>): Guild {
+    return {
+      id: "guild-id",
+      channels: { cache: channels },
+    } as unknown as Guild;
+  }
+
+  it("restores managed state for channels that still exist after a restart", async () => {
+    const existingChannel = {
+      id: "channel-id",
+      name: "lonix's Channel",
+      type: ChannelType.GuildVoice,
+      members: new Collection([["lonix-id", {} as any]]),
+    } as unknown as VoiceChannel;
+
+    const guild = buildGuild(new Collection([["channel-id", existingChannel]]));
+
+    mockOwnershipModel.find.mockResolvedValue([
+      {
+        guildId: "guild-id",
+        channelId: "channel-id",
+        ownerId: "lonix-id",
+        customName: "My Cool Room",
+      },
+    ]);
+
+    await (manager as any).restoreOwnership(guild);
+
+    // Ownership and custom name are rebuilt in memory.
+    expect(manager.getUserChannel("lonix-id")).toBe(existingChannel);
+    expect(manager.hasCustomName("channel-id")).toBe(true);
+    // Nothing was pruned for a channel that still exists.
+    expect(mockOwnershipModel.deleteOne).not.toHaveBeenCalled();
+  });
+
+  it("prunes ownership rows for channels deleted while the bot was down", async () => {
+    // Guild no longer contains the persisted channel.
+    const guild = buildGuild(new Collection());
+
+    mockOwnershipModel.find.mockResolvedValue([
+      { guildId: "guild-id", channelId: "gone-channel", ownerId: "lonix-id" },
+    ]);
+
+    await (manager as any).restoreOwnership(guild);
+
+    expect(manager.getUserChannel("lonix-id")).toBeUndefined();
+    expect(mockOwnershipModel.deleteOne).toHaveBeenCalledWith({
+      channelId: "gone-channel",
+    });
+  });
+
+  it("keeps a restored, occupied channel safe from the unmanaged cleanup", async () => {
+    // A channel the bot created before the restart, still occupied, restored
+    // from persistence. The periodic cleanup must treat it as managed.
+    const restoredChannel = {
+      id: "restored-id",
+      name: "lonix's Channel",
+      type: ChannelType.GuildVoice,
+      members: new Collection([["lonix-id", {} as any]]),
+      delete: jest.fn<any>().mockResolvedValue(undefined),
+    } as unknown as VoiceChannel;
+    const foreignChannel = {
+      id: "foreign-id",
+      name: "Some Random Channel",
+      type: ChannelType.GuildVoice,
+      members: new Collection(),
+      delete: jest.fn<any>().mockResolvedValue(undefined),
+    } as unknown as VoiceChannel;
+
+    const channels = new Collection<string, VoiceChannel>([
+      ["restored-id", restoredChannel],
+      ["foreign-id", foreignChannel],
+    ]);
+    const category = {
+      id: "category-id",
+      type: ChannelType.GuildCategory,
+      children: { cache: channels },
+    };
+    // The guild cache exposes every channel (incl. the category), mirroring
+    // discord.js — restoreOwnership resolves channels via guild.channels.cache.
+    const guild = {
+      id: "guild-id",
+      channels: {
+        cache: new Collection<string, any>([
+          ["category-id", category],
+          ["restored-id", restoredChannel],
+          ["foreign-id", foreignChannel],
+        ]),
+      },
+    } as unknown as Guild;
+    (mockClient.guilds as any).fetch = jest.fn<any>().mockResolvedValue(guild);
+
+    mockOwnershipModel.find.mockResolvedValue([
+      { guildId: "guild-id", channelId: "restored-id", ownerId: "lonix-id" },
+    ]);
+
+    // Rebuild ownership from persistence, then run the periodic cleanup.
+    await (manager as any).restoreOwnership(guild);
+    await manager.cleanupEmptyChannels();
+
+    expect(restoredChannel.delete as jest.Mock).not.toHaveBeenCalled();
+    // The genuinely foreign channel is still cleaned up.
+    expect(foreignChannel.delete as jest.Mock).toHaveBeenCalled();
+  });
+
+  it("persists ownership when a dynamic channel is created", async () => {
+    const createdChannel = {
+      id: "new-channel-id",
+      name: "🎮 lonix's Room",
+      type: ChannelType.GuildVoice,
+    } as unknown as VoiceChannel;
+    const guild = {
+      id: "guild-id",
+      channels: {
+        cache: new Collection([
+          [
+            "category-id",
+            { id: "category-id", type: ChannelType.GuildCategory },
+          ],
+        ]),
+        create: jest.fn<any>().mockResolvedValue(createdChannel),
+      },
+      members: {
+        fetch: jest
+          .fn<any>()
+          .mockResolvedValue({ id: "lonix-id", displayName: "lonix" }),
+      },
+      roles: { everyone: { id: "everyone-id" } },
+    } as unknown as Guild;
+
+    await manager.createDynamicChannel(guild, "lonix-id");
+
+    expect(mockOwnershipModel.findOneAndUpdate).toHaveBeenCalledWith(
+      { channelId: "new-channel-id" },
+      expect.objectContaining({ ownerId: "lonix-id" }),
+      expect.objectContaining({ upsert: true }),
+    );
+  });
+
+  it("removes the persisted row when an owned channel is cleaned up", async () => {
+    const emptyChannel = {
+      id: "empty-id",
+      name: "lonix's Channel",
+      type: ChannelType.GuildVoice,
+      members: new Collection(),
+      delete: jest.fn<any>().mockResolvedValue(undefined),
+    } as unknown as VoiceChannel;
+
+    (manager as any).userChannels.set("lonix-id", emptyChannel);
+
+    await (manager as any).cleanupUserChannel("lonix-id");
+
+    expect(mockOwnershipModel.deleteOne).toHaveBeenCalledWith({
+      channelId: "empty-id",
+    });
+  });
+});

--- a/src/models/voice-channel-ownership.ts
+++ b/src/models/voice-channel-ownership.ts
@@ -1,0 +1,41 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+/**
+ * Persisted ownership of a bot-created dynamic voice channel.
+ *
+ * VoiceChannelManager tracks ownership in memory (`userChannels`), which is
+ * lost on restart — orphaning every channel the bot created beforehand so they
+ * are reclassified as "unmanaged" (no owner controls / rename / lifecycle, and
+ * the periodic cleanup treats them as foreign). Persisting one row per managed
+ * channel lets the manager rebuild that state on boot and reconcile against the
+ * channels that still exist in the guild. (issue #615)
+ *
+ * One row per channel: `channelId` is unique. `ownerId` is updated in place
+ * when ownership transfers, and `customName` mirrors a tracked custom rename so
+ * the managed-channel classification survives a restart too.
+ */
+export interface IVoiceChannelOwnership extends Document {
+  guildId: string;
+  channelId: string;
+  ownerId: string;
+  customName?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const VoiceChannelOwnershipSchema = new Schema(
+  {
+    guildId: { type: String, required: true, index: true },
+    channelId: { type: String, required: true, unique: true },
+    ownerId: { type: String, required: true, index: true },
+    customName: { type: String },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+export const VoiceChannelOwnership = mongoose.model<IVoiceChannelOwnership>(
+  "VoiceChannelOwnership",
+  VoiceChannelOwnershipSchema,
+);

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -146,9 +146,13 @@ export class VoiceChannelManager {
   ): Promise<void> {
     if (!this.isDbReady() || !guildId) return;
     try {
+      // Use explicit operators rather than a replacement document: a plain
+      // (operator-less) update would overwrite the whole row and silently drop
+      // a previously-persisted customName when ownership transfers. $set only
+      // touches ownerId; guildId/channelId are fixed for the life of the row.
       await VoiceChannelOwnership.findOneAndUpdate(
         { channelId },
-        { guildId, channelId, ownerId },
+        { $set: { ownerId }, $setOnInsert: { guildId, channelId } },
         { upsert: true },
       );
     } catch (error) {

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -15,9 +15,11 @@ import {
   PermissionFlagsBits,
   Message,
 } from "discord.js";
+import mongoose from "mongoose";
 import logger from "../utils/logger.js";
 import { VoiceChannelTracker } from "../services/voice-channel-tracker.js";
 import { ConfigService } from "./config-service.js";
+import { VoiceChannelOwnership } from "../models/voice-channel-ownership.js";
 
 const configService = ConfigService.getInstance();
 
@@ -124,10 +126,122 @@ export class VoiceChannelManager {
   }
 
   /**
+   * Whether the Mongo connection is ready for ownership persistence. When it
+   * isn't (e.g. unit tests, or a transient disconnect) the persistence helpers
+   * become no-ops so in-memory behaviour is unaffected.
+   */
+  private isDbReady(): boolean {
+    return mongoose.connection?.readyState === 1;
+  }
+
+  /**
+   * Upsert the persisted ownership row for a managed channel. Called whenever a
+   * dynamic channel is created or its ownership transfers, so the in-memory
+   * `userChannels` registry can be rebuilt after a restart (issue #615).
+   */
+  private async persistOwnership(
+    guildId: string | undefined,
+    channelId: string,
+    ownerId: string,
+  ): Promise<void> {
+    if (!this.isDbReady() || !guildId) return;
+    try {
+      await VoiceChannelOwnership.findOneAndUpdate(
+        { channelId },
+        { guildId, channelId, ownerId },
+        { upsert: true },
+      );
+    } catch (error) {
+      logger.error("Error persisting voice channel ownership:", error);
+    }
+  }
+
+  /**
+   * Mirror a tracked custom rename into the persisted ownership row so the
+   * managed-channel classification survives a restart (issue #615).
+   */
+  private async persistCustomName(
+    channelId: string,
+    name: string,
+  ): Promise<void> {
+    if (!this.isDbReady()) return;
+    try {
+      await VoiceChannelOwnership.updateOne(
+        { channelId },
+        { $set: { customName: name } },
+      );
+    } catch (error) {
+      logger.error("Error persisting voice channel custom name:", error);
+    }
+  }
+
+  /**
+   * Drop the persisted ownership row for a channel that has been deleted, so a
+   * future restart doesn't try to re-adopt a channel that no longer exists.
+   */
+  private async removeOwnershipRecord(channelId: string): Promise<void> {
+    if (!this.isDbReady()) return;
+    try {
+      await VoiceChannelOwnership.deleteOne({ channelId });
+    } catch (error) {
+      logger.error("Error removing voice channel ownership record:", error);
+    }
+  }
+
+  /**
+   * Re-establish managed ownership state from the persisted store on startup.
+   *
+   * Ownership otherwise lives only in memory, so a restart orphans every
+   * dynamic channel the bot created beforehand. We reload the persisted rows,
+   * reconcile against the channels that still exist in the guild (pruning rows
+   * for channels deleted while the bot was down), and repopulate `userChannels`
+   * / `customChannelNames` so owner controls, renaming, lifecycle handling and
+   * the periodic cleanup all recognise pre-restart channels as managed again.
+   * (issue #615)
+   */
+  private async restoreOwnership(guild: Guild): Promise<void> {
+    if (!this.isDbReady()) {
+      logger.warn(
+        "Database not ready; skipping voice channel ownership restore",
+      );
+      return;
+    }
+
+    try {
+      const records = await VoiceChannelOwnership.find({ guildId: guild.id });
+      let restored = 0;
+      let pruned = 0;
+
+      for (const record of records) {
+        const channel = guild.channels.cache.get(record.channelId);
+        if (!channel || channel.type !== ChannelType.GuildVoice) {
+          // Channel was deleted while the bot was down — drop the stale row.
+          await this.removeOwnershipRecord(record.channelId);
+          pruned++;
+          continue;
+        }
+
+        this.userChannels.set(record.ownerId, channel as VoiceChannel);
+        if (record.customName) {
+          this.customChannelNames.set(record.channelId, record.customName);
+        }
+        restored++;
+      }
+
+      logger.info(
+        `Restored ${restored} managed voice channel(s) from persistence; pruned ${pruned} stale record(s)`,
+      );
+    } catch (error) {
+      logger.error("Error restoring voice channel ownership:", error);
+    }
+  }
+
+  /**
    * Mark a channel as having a custom name
    */
   public setCustomChannelName(channelId: string, name: string): void {
     this.customChannelNames.set(channelId, name);
+    void this.persistCustomName(channelId, name);
   }
 
   /**
@@ -434,6 +548,11 @@ export class VoiceChannelManager {
         }
       }
 
+      // Rebuild managed ownership from persistence. Run after the empty-channel
+      // sweep above so only channels that survive (i.e. still have members) are
+      // re-adopted, and rows for channels deleted during downtime are pruned.
+      await this.restoreOwnership(guild);
+
       logger.info("Voice channel manager initialization completed");
     } catch (error) {
       logger.error("Error during voice channel manager initialization:", error);
@@ -675,6 +794,7 @@ export class VoiceChannelManager {
       // Update ownership tracking
       this.userChannels.delete(currentOwnerId);
       this.userChannels.set(newOwnerId, channel);
+      await this.persistOwnership(channel.guild?.id, channel.id, newOwnerId);
       logger.info(`[Manual Transfer] Updated ownership tracking map`);
 
       // Clear the ownership queue for this channel
@@ -980,6 +1100,7 @@ export class VoiceChannelManager {
       }
 
       this.userChannels.set(member.id, channel);
+      await this.persistOwnership(member.guild?.id, channel.id, member.id);
       logger.info(
         `Created voice channel ${channelName} for ${member.displayName}`,
       );
@@ -1177,6 +1298,8 @@ export class VoiceChannelManager {
     // Cancel any pending ownership-transfer timer so it doesn't fire on the
     // now-deleted channel (issue #540).
     this.cancelOwnershipTransfer(channelId);
+    // Drop the persisted ownership row so a restart doesn't re-adopt it (#615).
+    await this.removeOwnershipRecord(channelId);
   }
 
   /**
@@ -1247,6 +1370,9 @@ export class VoiceChannelManager {
       // now-deleted channel (issue #540).
       this.cancelOwnershipTransfer(channel.id);
 
+      // Drop the persisted ownership row so a restart doesn't re-adopt it (#615).
+      await this.removeOwnershipRecord(channel.id);
+
       // Clean up waiting room (fire-and-forget after channel deleted to avoid race conditions)
       const waitingRoomId = this.waitingRooms.get(channel.id);
       if (waitingRoomId) {
@@ -1295,6 +1421,8 @@ export class VoiceChannelManager {
     this.liveChannels.delete(channelId);
     // Cancel and drop any pending ownership-transfer timer for this channel
     this.cancelOwnershipTransfer(channelId);
+    // Drop the persisted ownership row so a restart doesn't re-adopt it (#615).
+    await this.removeOwnershipRecord(channelId);
 
     // Remove the associated waiting room, if any
     const waitingRoomId = this.waitingRooms.get(channelId);
@@ -1411,6 +1539,7 @@ export class VoiceChannelManager {
 
       // Store ownership
       this.userChannels.set(userId, newChannel);
+      await this.persistOwnership(guild.id, newChannel.id, userId);
 
       // Auto-apply the user's default preset (if presets are enabled)
       const presetsEnabled = await configService.getBoolean(
@@ -2044,6 +2173,7 @@ export class VoiceChannelManager {
         this.userChannels.delete(currentOwnerId);
       }
       this.userChannels.set(newOwner.id, channel);
+      await this.persistOwnership(channel.guild?.id, channel.id, newOwner.id);
       logger.info(`[Ownership Transfer] Updated ownership tracking map`);
 
       // Update control panel message with new owner


### PR DESCRIPTION
## Summary

Fixes #615. Ownership of bot-created dynamic voice channels was tracked only in an in-memory `Map` (`VoiceChannelManager.userChannels`) and never rebuilt on startup. After a restart, every pre-restart dynamic channel was orphaned — reclassified as "unmanaged", losing owner controls / auto-rename / ownership transfer, and the periodic cleanup treated it as foreign.

This implements the issue's recommended approach (option 1): **explicit persisted ownership with reconciliation on boot.**

## Changes

- **New model** `src/models/voice-channel-ownership.ts` — one row per managed channel (`{ guildId, channelId, ownerId, customName? }`, unique on `channelId`, `timestamps: true`).
- **Persistence wired into `VoiceChannelManager`:**
  - Written on creation (`createUserChannel`, `createDynamicChannel`).
  - `ownerId` updated in place on transfer (`transferOwnership`, `updateChannelOwnership`).
  - `customName` mirrored when a channel is custom-renamed (`setCustomChannelName`).
  - Row removed on deletion (`cleanupUserChannel`, `cleanupEmptyChannel`, `reconcileDeletedChannelState`).
- **`restoreOwnership(guild)` on `initialize()`** — reloads persisted rows, reconciles against channels that still exist in the guild (pruning stale rows for channels deleted while the bot was down), and repopulates `userChannels` / `customChannelNames`. Runs after the startup empty-channel sweep, so only channels that survive (i.e. still have members) are re-adopted.
- All DB access is guarded by a Mongo readiness check, so behaviour is unchanged when persistence is unavailable.

## Why no blanket "skip non-empty channel" guard in cleanup

The unmanaged-channel cleanup intentionally deletes foreign channels regardless of occupancy (there is an existing test asserting this for genuinely foreign channels). The acceptance criterion "never deletes a channel that still has members" is satisfied by restoration: pre-restart channels are reclassified as **managed**, so the cleanup skips them — verified by a new test.

## Acceptance criteria

- [x] After a restart, channels the bot created beforehand are recognised as managed again.
- [x] The periodic cleanup classifies pre-restart channels as managed and doesn't delete an occupied restored channel.
- [x] Ownership state is reconciled on boot (channels deleted during downtime are pruned).
- [x] Tests cover: managed state restored on `restoreOwnership` for pre-existing channels; restored occupied channel not deleted by cleanup; stale ownership rows pruned; ownership persisted on create and removed on cleanup.

## Testing

- New suite `__tests__/services/voice-channel-manager-ownership-persistence.test.ts` (5 tests).
- `npm run build`, `npm run lint`, `npm run format:check` all clean.
- Full suite green: `Test Suites: 104 passed`, `1169 passed, 1 skipped`.

https://claude.ai/code/session_01LKSY2R7NwRho7hUBivMqtR

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKSY2R7NwRho7hUBivMqtR)_