### PR TITLE
fix: prime VC user count at startup so presence reflects voice occupancy

### DIFF
--- a/__tests__/services/bot-status-service.test.ts
+++ b/__tests__/services/bot-status-service.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import { BotStatusService } from '../../src/services/bot-status-service.js';
+import { lonelyStatuses } from '../../src/content/statuses.js';
 
 // Mock dependencies
 jest.mock('../../src/services/config-service.js');
@@ -78,6 +79,71 @@ describe('BotStatusService', () => {
       service.setShutdownStatus();
       // Method should execute without errors
       expect(true).toBe(true);
+    });
+  });
+
+  describe('VC user count priming (#614)', () => {
+    let service: BotStatusService;
+    let mockClient: any;
+
+    const lastActivityName = (): string => {
+      const calls = mockClient.user.setPresence.mock.calls;
+      return calls[calls.length - 1][0].activities[0].name as string;
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      // Reset the singleton so each test gets a fresh instance bound to its
+      // own mock client (getInstance keeps the first client otherwise).
+      (BotStatusService as any).instance = undefined;
+      mockClient = { user: { setPresence: jest.fn() } };
+      service = BotStatusService.getInstance(mockClient);
+    });
+
+    afterEach(() => {
+      service.stopVcMonitoring();
+    });
+
+    it('reflects users already in voice when primed at startup', async () => {
+      // Simulates a restart with 4 users already sitting in voice: the
+      // provider reports the live count and priming applies it before the
+      // operational status is rendered.
+      service.setVcUserCountProvider(async () => 4);
+      await service.refreshVcUserCount();
+      service.setOperationalStatus();
+
+      expect(service.getStatusInfo().currentVcUserCount).toBe(4);
+      expect(lastActivityName()).toContain('4');
+      expect(lonelyStatuses).not.toContain(lastActivityName());
+    });
+
+    it('still shows the lonely status when no users are in voice', async () => {
+      service.setVcUserCountProvider(async () => 0);
+      await service.refreshVcUserCount();
+      service.setOperationalStatus();
+
+      expect(service.getStatusInfo().currentVcUserCount).toBe(0);
+      expect(lonelyStatuses).toContain(lastActivityName());
+    });
+
+    it('is a no-op when no provider is registered', async () => {
+      service.setVcUserCountProvider(undefined as any);
+      // Should neither throw nor change the count.
+      await expect(service.refreshVcUserCount()).resolves.toBeUndefined();
+    });
+
+    it('swallows provider errors without throwing', async () => {
+      service.setVcUserCountProvider(async () => {
+        throw new Error('cache walk failed');
+      });
+      await expect(service.refreshVcUserCount()).resolves.toBeUndefined();
+    });
+
+    it('starts a self-healing monitor interval', () => {
+      service.startVcMonitoring();
+      expect(service.getStatusInfo().isMonitoring).toBe(true);
+      service.stopVcMonitoring();
+      expect(service.getStatusInfo().isMonitoring).toBe(false);
     });
   });
 });

--- a/__tests__/services/bot-status-service.test.ts
+++ b/__tests__/services/bot-status-service.test.ts
@@ -127,8 +127,9 @@ describe('BotStatusService', () => {
     });
 
     it('is a no-op when no provider is registered', async () => {
-      service.setVcUserCountProvider(undefined as any);
-      // Should neither throw nor change the count.
+      // Explicitly clearing the provider should neither throw nor change
+      // the count (a fresh service also starts with no provider).
+      service.setVcUserCountProvider(null);
       await expect(service.refreshVcUserCount()).resolves.toBeUndefined();
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -704,6 +704,15 @@ async function initializeServices(): Promise<void> {
       logger.error("❌ Error switching lobby to online mode:", error);
     }
 
+    // Prime the VC user count from the live channel cache so the presence
+    // reflects users already sitting in voice at startup, instead of showing
+    // the "lonely" status until the next voiceStateUpdate (#614). Registering
+    // the provider also lets the status monitor self-heal the count later.
+    botStatusService.setVcUserCountProvider(() =>
+      voiceChannelManager.getTotalVcUserCount(),
+    );
+    await botStatusService.refreshVcUserCount();
+
     // Set bot to fully operational status (green) and start VC monitoring
     botStatusService.setOperationalStatus();
     botStatusService.startVcMonitoring();

--- a/src/services/bot-status-service.ts
+++ b/src/services/bot-status-service.ts
@@ -10,6 +10,13 @@ import {
 
 type StatusPools = Record<BotStatusPool, string[]>;
 
+/**
+ * How often the status monitor re-syncs the VC user count from the
+ * provider as a defensive self-heal (in case a `voiceStateUpdate` event
+ * is ever missed). It's a cheap cache walk, no Discord API call.
+ */
+const VC_COUNT_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+
 /** Fresh, mutable copy of the hardcoded defaults for every pool. */
 function defaultStatusPools(): StatusPools {
   return {
@@ -27,6 +34,13 @@ export class BotStatusService {
   private currentVcUserCount = 0;
   // Username tracking removed for simplified status logic (field deleted)
   private statusUpdateInterval: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Pulls the current total VC user count on demand (a cache walk over the
+   * managed category's voice channels). Registered at startup so the count
+   * can be primed once the client is ready and re-synced on the monitor
+   * interval, instead of relying solely on `voiceStateUpdate` events.
+   */
+  private vcUserCountProvider: (() => Promise<number>) | null = null;
   /**
    * In-memory copy of the live status pools, seeded with the hardcoded
    * defaults so `getRandomStatusMessage()` (which is synchronous, called
@@ -233,6 +247,29 @@ export class BotStatusService {
   }
 
   /**
+   * Register a function that reports the live total VC user count. Used to
+   * prime the count at startup and to self-heal it on the monitor interval.
+   */
+  public setVcUserCountProvider(provider: () => Promise<number>): void {
+    this.vcUserCountProvider = provider;
+  }
+
+  /**
+   * Pull the current VC user count from the registered provider and apply
+   * it. No-op (and never throws) when no provider is registered or the
+   * lookup fails, so it's safe to call from startup and interval ticks.
+   */
+  public async refreshVcUserCount(): Promise<void> {
+    if (!this.vcUserCountProvider) return;
+    try {
+      const count = await this.vcUserCountProvider();
+      this.updateVcUserCount(count);
+    } catch (error) {
+      logger.error("Failed to refresh VC user count:", error);
+    }
+  }
+
+  /**
    * Update the VC user count and refresh activity
    */
   public updateVcUserCount(count: number): void {
@@ -253,8 +290,16 @@ export class BotStatusService {
       clearInterval(this.statusUpdateInterval);
     }
 
-    // No periodic updates - only update when user count actually changes
-    this.statusUpdateInterval = null;
+    // Periodically re-sync the count from the provider so the presence
+    // self-heals if a `voiceStateUpdate` event is ever missed (e.g. a
+    // gateway hiccup), not only when voice state changes. The provider is
+    // a cheap cache walk, so this stays inexpensive.
+    this.statusUpdateInterval = setInterval(() => {
+      void this.refreshVcUserCount();
+    }, VC_COUNT_REFRESH_INTERVAL_MS);
+    // Don't let this background self-heal timer keep the process alive on
+    // shutdown (and avoid leaking an open handle in tests).
+    this.statusUpdateInterval.unref?.();
 
     logger.info("Started VC user monitoring for bot status updates");
   }

--- a/src/services/bot-status-service.ts
+++ b/src/services/bot-status-service.ts
@@ -249,9 +249,12 @@ export class BotStatusService {
   /**
    * Register a function that reports the live total VC user count. Used to
    * prime the count at startup and to self-heal it on the monitor interval.
+   * Pass `null`/`undefined` to clear a previously registered provider.
    */
-  public setVcUserCountProvider(provider: () => Promise<number>): void {
-    this.vcUserCountProvider = provider;
+  public setVcUserCountProvider(
+    provider: (() => Promise<number>) | null | undefined,
+  ): void {
+    this.vcUserCountProvider = provider ?? null;
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #614. After a restart, the bot's presence stayed on the "lonely" (*watching nobody*) status even when users were already sitting in voice channels, because `BotStatusService.currentVcUserCount` was only ever updated in response to `voiceStateUpdate` events and was **never primed at startup**. It sat at its initial `0` until someone joined/left/moved.

## Changes

- **Prime the count at startup** (`src/index.ts`): after `voiceChannelManager.initialize()`, register a VC user count provider backed by `VoiceChannelManager.getTotalVcUserCount()` and call `refreshVcUserCount()` before `setOperationalStatus()`. The presence now renders with the real occupancy immediately.
- **Provider + refresh helper** (`src/services/bot-status-service.ts`): `setVcUserCountProvider()` registers a cheap cache-walk callback; `refreshVcUserCount()` pulls the live count and applies it via the existing `updateVcUserCount()` path. It's a no-op when no provider is set and swallows provider errors so it's safe from startup and interval ticks.
- **Defensive self-heal** (`startVcMonitoring`): re-syncs the count from the provider every 5 minutes so the presence recovers even if a `voiceStateUpdate` event is ever missed. The timer is `unref()`'d so it never keeps the process alive on shutdown.

The fix is independent of the sibling "unmanaged channels after restart" bug — `getTotalVcUserCount()` counts all category voice channels regardless of managed state, so priming alone resolves this symptom.

## Acceptance criteria

- [x] After a restart with users already in voice, the presence reflects the real count without waiting for a voice-state change.
- [x] The count stays correct across subsequent joins/leaves (the event path is unchanged).
- [x] Empty-VC case still shows the lonely status.
- [x] Test: starting with N users already present yields a non-lonely status / count N at startup.

## Testing

- New tests in `__tests__/services/bot-status-service.test.ts` cover priming with N users (non-lonely), the empty-VC lonely case, no-provider and error-swallowing behavior, and the monitor interval lifecycle.
- `npm run build`, `npm run lint`, `npm run format:check`, and the full `npm test` suite (105 suites / 1193 tests) all pass.

https://claude.ai/code/session_01HQDTh7tVW7ngWeoZ5V6TVx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQDTh7tVW7ngWeoZ5V6TVx)_