### PR TITLE
fix(webui): excluded-voice picker lists voice channels, not text

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -342,14 +342,15 @@ Track user voice channel activity and generate statistics.
 | `voicetracking.stats.user.enabled` | `false` | Enable `/voicestats user` subcommand |
 | `voicetracking.seen.enabled` | `false` | Enable `/seen` command for last-seen tracking |
 | `voicetracking.companions.enabled` | `false` | Persist precise per-companion co-presence seconds and join-order metadata (was-first, who you joined) on each voice session. Data-capture foundation for future Rewind companion stats (#570) |
-| `voicetracking.excluded_channels` | `""` | Channel IDs to exclude from tracking (comma-separated) |
+| `voicetracking.excluded_channels` | `""` | Voice channel IDs to exclude from tracking (comma-separated; the Web UI picker lists voice + stage channels) |
 | `voicetracking.admin_roles` | `""` | Role names with tracking admin powers (comma-separated) |
 
 ### Managing excluded channels
 
-Right-click each channel in Discord and **Copy ID** (with Developer Mode
-enabled), then set `voicetracking.excluded_channels` on the Web UI's
-Settings page as a comma-separated list:
+Right-click each **voice** channel in Discord and **Copy ID** (with Developer
+Mode enabled), then set `voicetracking.excluded_channels` on the Web UI's
+Settings page — the picker lists voice and stage channels — as a
+comma-separated list:
 
 ```text
 123456789012345678,987654321098765432

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -485,13 +485,50 @@ describe("renderSettingsPage", () => {
     expect(html).toContain('<option value="r2">@Member</option>');
   });
 
-  it("renders a channel_list-type setting as a multi-select with CSV pre-selection", () => {
+  it("renders a text channel_list-type setting as a multi-select with CSV pre-selection", () => {
     const html = renderSettingsPage({
       ...COMMON,
       textChannels: [
         { id: "111", name: "general" },
         { id: "222", name: "afk" },
         { id: "333", name: "other" },
+      ],
+      voiceChannels: [],
+      categoryChannels: [],
+      roles: [],
+      groups: [
+        {
+          category: "messagetracking",
+          rows: [
+            {
+              key: "messagetracking.excluded_channels",
+              label: "Excluded channels",
+              current: "111,333",
+              defaultValue: "",
+              type: "channel_list",
+              description: "",
+              category: "messagetracking",
+            },
+          ],
+        },
+      ],
+    });
+    expect(html).toMatch(
+      /<select name="value_messagetracking\.excluded_channels" multiple/,
+    );
+    expect(html).toContain('<option value="111" selected>#general</option>');
+    expect(html).toContain('<option value="222">#afk</option>');
+    expect(html).toContain('<option value="333" selected>#other</option>');
+  });
+
+  it("renders a voice channel_list (channelKind: voice) from voiceChannels, not textChannels (#611)", () => {
+    const html = renderSettingsPage({
+      ...COMMON,
+      textChannels: [{ id: "t1", name: "general-text" }],
+      voiceChannels: [
+        { id: "v1", name: "Lounge" },
+        { id: "v2", name: "Gaming" },
+        { id: "v3", name: "AFK" },
       ],
       categoryChannels: [],
       roles: [],
@@ -502,22 +539,25 @@ describe("renderSettingsPage", () => {
             {
               key: "voicetracking.excluded_channels",
               label: "Excluded channels",
-              current: "111,333",
+              current: "v1,v3",
               defaultValue: "",
               type: "channel_list",
               description: "",
               category: "voicetracking",
+              channelKind: "voice",
             },
           ],
         },
       ],
     });
-    expect(html).toMatch(
-      /<select name="value_voicetracking\.excluded_channels" multiple/,
-    );
-    expect(html).toContain('<option value="111" selected>#general</option>');
-    expect(html).toContain('<option value="222">#afk</option>');
-    expect(html).toContain('<option value="333" selected>#other</option>');
+    // Voice channels are offered…
+    expect(html).toContain('<option value="v1" selected>#Lounge</option>');
+    expect(html).toContain('<option value="v2">#Gaming</option>');
+    expect(html).toContain('<option value="v3" selected>#AFK</option>');
+    // …and the text channel is NOT present in this control.
+    expect(html).not.toContain("general-text");
+    // Selected channels render as a readable, separated summary (no blob).
+    expect(html).toContain("Selected: #Lounge, #AFK");
   });
 
   it("renders a role_list-type setting as a multi-select with CSV pre-selection", () => {

--- a/__tests__/web/read-only-routes.test.ts
+++ b/__tests__/web/read-only-routes.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "@jest/globals";
+import { ChannelType } from "discord.js";
+import { fetchChannelData } from "../../src/web/read-only-routes.js";
+import { createMockCollection } from "../test-utils.js";
+
+/**
+ * Build a minimal mock Client whose single guild exposes the given channels
+ * through the `guild.channels.cache` collection that fetchChannelData iterates.
+ */
+function mockClientWithChannels(
+  channels: Array<{ id: string; name: string; type: number }>,
+): any {
+  const cache = createMockCollection(channels.map((c) => [c.id, c]));
+  const guild = {
+    id: "guild-1",
+    name: "Test Guild",
+    channels: {
+      fetch: async (): Promise<void> => undefined,
+      cache,
+    },
+  };
+  return {
+    guilds: {
+      fetch: async (): Promise<typeof guild> => guild,
+    },
+  };
+}
+
+describe("fetchChannelData (#611)", () => {
+  it("collects voice and stage channels into voiceChannels, not textChannels", async () => {
+    const client = mockClientWithChannels([
+      { id: "t1", name: "general", type: ChannelType.GuildText },
+      { id: "t2", name: "news", type: ChannelType.GuildAnnouncement },
+      { id: "v1", name: "Lounge", type: ChannelType.GuildVoice },
+      { id: "v2", name: "Stage", type: ChannelType.GuildStageVoice },
+      { id: "cat", name: "Voice Channels", type: ChannelType.GuildCategory },
+    ]);
+
+    const data = await fetchChannelData(client, "guild-1");
+
+    // Voice + stage land in voiceChannels.
+    expect(data.voiceChannels.map((c) => c.id).sort()).toEqual(["v1", "v2"]);
+    // Text + announcement stay in textChannels (no voice leakage).
+    expect(data.textChannels.map((c) => c.id).sort()).toEqual(["t1", "t2"]);
+    expect(data.voiceChannels.some((c) => c.id === "t1")).toBe(false);
+    // Categories remain separate.
+    expect(data.categoryChannels.map((c) => c.id)).toEqual(["cat"]);
+    // Every channel contributes to the id→name map.
+    expect(data.names.get("v1")).toBe("Lounge");
+  });
+
+  it("sorts voiceChannels by name", async () => {
+    const client = mockClientWithChannels([
+      { id: "v1", name: "Zeta", type: ChannelType.GuildVoice },
+      { id: "v2", name: "Alpha", type: ChannelType.GuildVoice },
+    ]);
+
+    const data = await fetchChannelData(client, "guild-1");
+
+    expect(data.voiceChannels.map((c) => c.name)).toEqual(["Alpha", "Zeta"]);
+  });
+
+  it("returns empty lists when the guild fetch throws", async () => {
+    const client = {
+      guilds: {
+        fetch: async (): Promise<never> => {
+          throw new Error("no guild");
+        },
+      },
+    } as any;
+
+    const data = await fetchChannelData(client, "guild-1");
+
+    expect(data.voiceChannels).toEqual([]);
+    expect(data.textChannels).toEqual([]);
+    expect(data.categoryChannels).toEqual([]);
+  });
+});

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -353,6 +353,16 @@ export interface SettingMetadata {
    * keys (see `REWIND_RETENTION_MIN_DAYS`).
    */
   warnBelow?: SettingWarnBelow;
+  /**
+   * Which kind of Discord channel a `channel` / `channel_list` picker offers.
+   * `"text"` (the default when omitted) lists text/announcement channels;
+   * `"voice"` lists voice + stage channels. Set `"voice"` on keys that
+   * exclude or target voice channels — e.g. `voicetracking.excluded_channels`,
+   * which excludes voice channels a session could be tracked in — so the
+   * picker doesn't offer text channels that can't host a voice session.
+   * Ignored for non-channel types.
+   */
+  channelKind?: "text" | "voice";
 }
 
 /**
@@ -569,6 +579,7 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
       "Comma-separated channel IDs to exclude from voice activity tracking.",
     category: "voicetracking",
     type: "channel_list",
+    channelKind: "voice",
   },
   "voicetracking.announcements.enabled": {
     label: "Scheduled voice-stats announcements enabled",

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -487,9 +487,10 @@ function channelOptionsFor(
  * multi-select. A `<select multiple>` buries its picks among unselected rows,
  * and a long voice-exclusion list otherwise reads as an unseparated blob
  * (issue #611); this surfaces them as a clean, comma-separated `#name` /
- * `@name` list. Ids no longer in the live option set render as `(missing)
- * <id>` so a stale selection is visible rather than silently dropped. Returns
- * an empty string when nothing is selected.
+ * `@name` list. Ids no longer in the live option set render as a `(missing)`
+ * entry followed by the raw id, so a stale selection is visible rather than
+ * silently dropped (mirroring the `(missing)` option label `buildOptionsHtml`
+ * emits). Returns an empty string when nothing is selected.
  */
 function renderSelectionSummary(
   options: ChannelOption[] | RoleOption[],

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -194,11 +194,18 @@ export interface SettingRow {
    * non-blocking inline warning. Sourced from `SettingMetadata.warnBelow`.
    */
   warnBelow?: { value: number; message: string };
+  /**
+   * Which channel picker a `channel` / `channel_list` control draws from:
+   * `"voice"` uses the voice (+ stage) list, anything else (the default) uses
+   * the text-channel list. Sourced from `SettingMetadata.channelKind`.
+   */
+  channelKind?: "text" | "voice";
 }
 
 export interface SettingsProps extends CommonProps {
   groups: Array<{ category: string; rows: SettingRow[] }>;
   textChannels: ChannelOption[];
+  voiceChannels: ChannelOption[];
   categoryChannels: ChannelOption[];
   roles: RoleOption[];
   /** Guild id of the session, used as the reset-confirmation fallback. */
@@ -459,10 +466,54 @@ function renderOptionsSelect(
   return `<select name="${valueName}">${opts}${placeholder}</select>`;
 }
 
+/**
+ * Pick the channel option list backing a `channel` / `channel_list` control.
+ * Voice-oriented keys (`channelKind: "voice"`, e.g.
+ * `voicetracking.excluded_channels`) draw from the voice + stage list; every
+ * other channel field keeps the text-channel list. Centralised so both the
+ * single- and multi-select branches stay in sync (issue #611).
+ */
+function channelOptionsFor(
+  r: SettingRow,
+  pickers: { textChannels: ChannelOption[]; voiceChannels: ChannelOption[] },
+): ChannelOption[] {
+  return r.channelKind === "voice"
+    ? pickers.voiceChannels
+    : pickers.textChannels;
+}
+
+/**
+ * Render a compact, readable summary of the currently-selected entries below a
+ * multi-select. A `<select multiple>` buries its picks among unselected rows,
+ * and a long voice-exclusion list otherwise reads as an unseparated blob
+ * (issue #611); this surfaces them as a clean, comma-separated `#name` /
+ * `@name` list. Ids no longer in the live option set render as `(missing)
+ * <id>` so a stale selection is visible rather than silently dropped. Returns
+ * an empty string when nothing is selected.
+ */
+function renderSelectionSummary(
+  options: ChannelOption[] | RoleOption[],
+  selected: Set<string>,
+  prefix: string,
+): string {
+  if (selected.size === 0) return "";
+  const byId = new Map(options.map((o) => [o.id, o.name]));
+  const tokens = Array.from(selected).map((id) => {
+    const name = byId.get(id);
+    return name ? `${prefix}${name}` : `(missing) ${id}`;
+  });
+  return (
+    `<div class="settings-selected muted" style="margin-top:.4rem;font-size:.85em">` +
+    `Selected: ${escapeHtml(tokens.join(", "))}` +
+    `</div>`
+  );
+}
+
 function renderSettingControl(
   r: SettingRow,
   pickers: {
     textChannels: ChannelOption[];
+    voiceChannels: ChannelOption[];
     categoryChannels: ChannelOption[];
     roles: RoleOption[];
   },
@@ -494,7 +545,7 @@ function renderSettingControl(
   if (r.type === "channel" || r.type === "category" || r.type === "role") {
     const options =
       r.type === "channel"
-        ? pickers.textChannels
+        ? channelOptionsFor(r, pickers)
         : r.type === "category"
           ? pickers.categoryChannels
           : pickers.roles;
@@ -508,7 +559,7 @@ function renderSettingControl(
   }
   if (r.type === "channel_list" || r.type === "role_list") {
     const options =
-      r.type === "channel_list" ? pickers.textChannels : pickers.roles;
+      r.type === "channel_list" ? channelOptionsFor(r, pickers) : pickers.roles;
     const prefix = r.type === "role_list" ? "@" : "#";
     const selected = new Set(
       currentStr
@@ -519,7 +570,8 @@ function renderSettingControl(
     return (
       `<select name="${valueName}" multiple size="${Math.min(8, Math.max(3, options.length))}">` +
       buildOptionsHtml(options, selected, prefix, false) +
-      `</select>`
+      `</select>` +
+      renderSelectionSummary(options, selected, prefix)
     );
   }
   if (r.type === "cron") {
@@ -585,6 +637,7 @@ export function renderSettingsPage(props: SettingsProps): string {
 
   const pickers = {
     textChannels: props.textChannels,
+    voiceChannels: props.voiceChannels,
     categoryChannels: props.categoryChannels,
     roles: props.roles,
   };

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -134,8 +134,9 @@ interface RoleData {
  * normal channel pickers, voice (+ stage) channels for voice-oriented
  * pickers (e.g. `voicetracking.excluded_channels`, which excludes voice
  * channels a session could be tracked in), and category channels for the
- * voicechannels managed-category picker. One Discord API roundtrip per
- * request.
+ * voicechannels managed-category picker. At most two Discord API calls per
+ * request (the guild fetch, then its channel fetch — both no-ops when already
+ * cached).
  */
 export async function fetchChannelData(
   client: Client,

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -119,6 +119,7 @@ async function commonFromReq(req: AuthenticatedRequest): Promise<{
 interface ChannelData {
   names: Map<string, string>;
   textChannels: ChannelOption[];
+  voiceChannels: ChannelOption[];
   categoryChannels: ChannelOption[];
 }
 
@@ -129,16 +130,20 @@ interface RoleData {
 
 /**
  * Fetch the guild's channel cache once and derive the id→name map plus
- * the option lists used to populate picker dropdowns (text channels for
- * normal channel pickers, category channels for the voicechannels
- * managed-category picker). One Discord API roundtrip per request.
+ * the option lists used to populate picker dropdowns: text channels for
+ * normal channel pickers, voice (+ stage) channels for voice-oriented
+ * pickers (e.g. `voicetracking.excluded_channels`, which excludes voice
+ * channels a session could be tracked in), and category channels for the
+ * voicechannels managed-category picker. One Discord API roundtrip per
+ * request.
  */
-async function fetchChannelData(
+export async function fetchChannelData(
   client: Client,
   guildId: string,
 ): Promise<ChannelData> {
   const names = new Map<string, string>();
   const textChannels: ChannelOption[] = [];
+  const voiceChannels: ChannelOption[] = [];
   const categoryChannels: ChannelOption[] = [];
   try {
     const guild = await client.guilds.fetch(guildId);
@@ -152,16 +157,22 @@ async function fetchChannelData(
         ch.type === ChannelType.GuildAnnouncement
       ) {
         textChannels.push({ id: ch.id, name });
+      } else if (
+        ch.type === ChannelType.GuildVoice ||
+        ch.type === ChannelType.GuildStageVoice
+      ) {
+        voiceChannels.push({ id: ch.id, name });
       } else if (ch.type === ChannelType.GuildCategory) {
         categoryChannels.push({ id: ch.id, name });
       }
     }
     textChannels.sort((a, b) => a.name.localeCompare(b.name));
+    voiceChannels.sort((a, b) => a.name.localeCompare(b.name));
     categoryChannels.sort((a, b) => a.name.localeCompare(b.name));
   } catch (err) {
     logger.debug("fetchChannelData failed", err);
   }
-  return { names, textChannels, categoryChannels };
+  return { names, textChannels, voiceChannels, categoryChannels };
 }
 
 /**
@@ -385,6 +396,7 @@ export function createReadOnlyRouter(
               dbEntry?.category ?? meta?.category ?? deriveCategory(key),
             options: meta?.options,
             warnBelow: meta?.warnBelow,
+            channelKind: meta?.channelKind,
           };
         },
       );
@@ -418,15 +430,17 @@ export function createReadOnlyRouter(
         rows: rs,
       }));
 
-      // Guild cache for the new dropdown selectors. One fetch, three lists.
-      const { textChannels, categoryChannels, roles } = await Promise.all([
-        fetchChannelData(client, common.guildId),
-        fetchRoleData(client, common.guildId),
-      ]).then(([chData, roleData]) => ({
-        textChannels: chData.textChannels,
-        categoryChannels: chData.categoryChannels,
-        roles: roleData.roles,
-      }));
+      // Guild cache for the dropdown selectors. One fetch, four lists.
+      const { textChannels, voiceChannels, categoryChannels, roles } =
+        await Promise.all([
+          fetchChannelData(client, common.guildId),
+          fetchRoleData(client, common.guildId),
+        ]).then(([chData, roleData]) => ({
+          textChannels: chData.textChannels,
+          voiceChannels: chData.voiceChannels,
+          categoryChannels: chData.categoryChannels,
+          roles: roleData.roles,
+        }));
 
       // Guild name backs the "type to confirm" step of the danger-zone
       // reset. Best-effort: when the fetch fails the renderer falls back to
@@ -444,6 +458,7 @@ export function createReadOnlyRouter(
           ...common,
           groups,
           textChannels,
+          voiceChannels,
           categoryChannels,
           roles,
           guildId: common.guildId,


### PR DESCRIPTION
## Summary

Fixes #611. The `voicetracking.excluded_channels` admin-settings picker offered **text** channels — so a voice channel could never actually be selected — and rendered the current selection as an unseparated `#admin-channel#announcement#botspam…` blob.

## Changes

- **Collect voice channels.** `fetchChannelData` (`src/web/read-only-routes.ts`) now gathers `GuildVoice` + `GuildStageVoice` into a new `voiceChannels` list, threaded through the settings-page picker data into `pickers`.
- **Let a field choose its channel kind.** Added a `channelKind: "text" | "voice"` hint to `SettingMetadata` (defaults to text). `channel` / `channel_list` controls now draw from the voice picker when `channelKind === "voice"`, via a shared `channelOptionsFor` helper so the single- and multi-select branches stay in sync. Pointed `voicetracking.excluded_channels` at voice.
- **Audit.** Confirmed every other `channel` / `channel_list` key is text-oriented (message destinations / text exclusions — `messagetracking.*`, `reactiontracking.*`, quotes, notices, reaction-role, leaderboard, voice-stats announcement), so only the one key needed the voice hint.
- **Readable selection.** Multi-selects now render a compact, comma-separated `#name` / `@name` summary of the current picks below the control (stale ids show as `(missing) <id>`), replacing the concatenated blob.
- **Docs.** Clarified `SETTINGS.md` that this picker lists voice + stage channels.

## Acceptance criteria

- [x] The `voicetracking.excluded_channels` picker lists **voice** (and stage) channels, not text channels.
- [x] Other voice-oriented `channel_list` fields use the voice picker; text-oriented ones (e.g. `messagetracking.excluded_channels`) keep text.
- [x] Selected channels render as a readable, separated list — no concatenated blob.
- [x] No regression for `role_list` / text `channel_list` controls.
- [x] Tests cover: `fetchChannelData` returns voice channels; a voice field renders voice options.

## Testing

- `npm run build`, `npm run lint`, `npm run format:check` — all green.
- `npm test` web + config suites: 320 passed. New `__tests__/web/read-only-routes.test.ts` covers voice/stage collection and the error path; `admin-views.test.ts` gains a voice-field rendering + selection-summary test.

https://claude.ai/code/session_019MVCKYXuDAehtoJTFR7tCb

---
_Generated by [Claude Code](https://claude.ai/code/session_019MVCKYXuDAehtoJTFR7tCb)_