### PR TITLE
feat(rewind): split rewind.enabled into feature and nudge gates

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -482,16 +482,29 @@ Per-user year-in-review page at **`/me/rewind`** (also `/me/rewind/:year`
 for past years). Renders total voice time, top channels, peak day,
 longest streak, badges earned, annual rank, and a first/best/last
 weekly-rank journey. Year picker bottom-anchored to years with data.
-The page is always available; the cron job below only sends a one-shot
-end-of-year DM nudge.
+
+The feature and the end-of-year DM nudge have **separate** switches
+(#608). `rewind.enabled` gates the page itself; `rewind.nudge.enabled`
+gates the December DM independently. Following the repo's opt-in
+convention, both default to `false` — set `rewind.enabled = true` to
+expose the page.
 
 | Setting | Default | Description |
 | --- | --- | --- |
-| `rewind.enabled` | `false` | Master switch for the end-of-year DM nudge (the WebUI page is unaffected) |
+| `rewind.enabled` | `false` | Master switch for the Rewind feature: the `/me/rewind` page, its data aggregation, and the nav link. When off, the page returns a 404 disabled state and is not linked |
+| `rewind.nudge.enabled` | `false` | Send the one-shot end-of-year DM nudge linking eligible users to `/me/rewind`. Independent of `rewind.enabled` |
 | `rewind.cron` | `"0 10 30 12 *"` | Cron schedule for the nudge (default: Dec 30 at 10:00 host timezone) |
 | `rewind.min_minutes` | `60` | Minimum annual voice minutes a user needs to receive the nudge |
 
 **Notes:**
+
+- **Upgrade note (#608):** before this change, the single `rewind.enabled`
+  key only controlled the nudge and the page was always live. The key now
+  gates the *feature*; the nudge moved to `rewind.nudge.enabled`. Installs
+  that had set `rewind.enabled = true` keep both the page and the nudge on
+  (the nudge reads `rewind.nudge.enabled`, falling back to the old
+  `rewind.enabled` value when unset). Installs that never enabled it now
+  have the page off by default, in line with every other feature gate.
 
 - Requires `voicetracking.enabled = true` so the underlying session
   data exists; the page renders an empty state otherwise.
@@ -948,6 +961,7 @@ above).
 #### Rewind (Year-in-Review)
 
 - `rewind.enabled` (bool, default: false)
+- `rewind.nudge.enabled` (bool, default: false)
 - `rewind.cron` (string, default: `"0 10 30 12 *"`)
 - `rewind.min_minutes` (number, default: 60)
 

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -784,6 +784,11 @@ lists every notification type with the current state and a checkbox;
 toggling one row is a single POST that records the diff in the audit
 log and PRG-redirects back to the page.
 
+The whole feature is gated by `rewind.enabled` (`#608`). When it is off
+the route returns a 404 "feature disabled" state and the nav link is
+suppressed on every `/me/*` page; the end-of-year DM nudge is a separate
+toggle (`rewind.nudge.enabled`).
+
 The bare **Rewind** page (`/me/rewind`) lands on the most recent year you
 actually have data for, so visiting right after the year rolls over shows
 a finished recap rather than the empty new year (`#573`); a brand-new user
@@ -795,7 +800,7 @@ picker at the top of the page only offers years for which you have data
 been snapshotted (see below), and highlights the year actually shown.
 Years with no data render a friendly empty state.
 Aggregation is on-demand and not cached in v1 — see [`SETTINGS.md`](SETTINGS.md#-rewind-year-in-review)
-for the `rewind.*` keys that control the end-of-year DM nudge.
+for the `rewind.*` keys that gate the feature and the end-of-year DM nudge.
 
 The in-progress current year is always computed live from raw activity.
 **Completed years are served from an immutable snapshot** (`#574`): the
@@ -808,7 +813,8 @@ message-detail truncation that later prunes the source data. Because the
 snapshot is taken on the cron's December run, activity in the final day
 or two of the year isn't captured. Snapshot creation is idempotent
 (re-running the cron never duplicates or mutates an existing record) and
-gated by `rewind.enabled`. A `schemaVersion` is stored so the view can
+runs as part of the nudge cron, so it follows `rewind.nudge.enabled`
+(with the legacy `rewind.enabled` fallback). A `schemaVersion` is stored so the view can
 render older snapshots even after the summary shape gains new fields.
 
 User-facing commands (`/ping`, `/voicestats`, `/seen`, `/quote`,

--- a/__tests__/services/config-schema.test.ts
+++ b/__tests__/services/config-schema.test.ts
@@ -205,6 +205,9 @@ describe('Config Schema', () => {
       'voicetracking.cleanup.enabled': false,
       'messagetracking.cleanup.enabled': false,
       'polls.participation.enabled': false,
+      // Rewind end-of-year DM nudge — auxiliary opt-in under the rewind
+      // feature gate, independent of `rewind.enabled` (#608).
+      'rewind.nudge.enabled': false,
 
       // ─── Sub-features that default on (rule 2: parent-gated) ────────
       'voicechannels.controlpanel.enabled': true,

--- a/__tests__/services/rewind-nudge-service.test.ts
+++ b/__tests__/services/rewind-nudge-service.test.ts
@@ -101,11 +101,16 @@ describe("RewindNudgeService", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     resetSingleton();
-    mockConfigGetBoolean.mockImplementation(async (key: unknown) => {
-      const k = key as string;
-      if (k === "rewind.enabled") return true;
-      return false;
-    });
+    mockConfigGetBoolean.mockImplementation(
+      async (key: unknown, def: unknown) => {
+        const k = key as string;
+        // Post-#608 the nudge keys off its own toggle; the feature gate
+        // (`rewind.enabled`) is only consulted as a backward-compat default.
+        if (k === "rewind.nudge.enabled") return true;
+        if (k === "rewind.enabled") return true;
+        return (def as boolean) ?? false;
+      },
+    );
     mockConfigGetString.mockImplementation(async (key: unknown) => {
       const k = key as string;
       if (k === "GUILD_ID") return "guild-1";
@@ -160,8 +165,62 @@ describe("RewindNudgeService", () => {
   });
 
   describe("runNow guards", () => {
-    it("returns null when the feature is disabled", async () => {
+    it("returns null when the nudge is disabled", async () => {
       mockConfigGetBoolean.mockResolvedValue(false);
+      const svc: ServiceInstance = RewindNudgeService.getInstance(makeClient());
+      const result = await svc.runNow();
+      expect(result).toBeNull();
+      expect(mockTrackingAggregate).not.toHaveBeenCalled();
+    });
+
+    it("runs off the dedicated rewind.nudge.enabled toggle (#608)", async () => {
+      // Nudge on, feature gate off — the nudge is independent of the page
+      // feature, so it must still run.
+      mockConfigGetBoolean.mockImplementation(
+        async (key: unknown, def: unknown) => {
+          const k = key as string;
+          if (k === "rewind.nudge.enabled") return true;
+          if (k === "rewind.enabled") return false;
+          return (def as boolean) ?? false;
+        },
+      );
+      mockTrackingAggregate.mockResolvedValueOnce([
+        { _id: "u1", username: "u1", totalTime: 60 * 60 * 5 },
+      ]);
+      const svc: ServiceInstance = RewindNudgeService.getInstance(makeClient());
+      const result = await svc.runNow();
+      expect(result).not.toBeNull();
+      expect(result!.sent).toBe(1);
+    });
+
+    it("falls back to the legacy rewind.enabled value when rewind.nudge.enabled is unset (#608)", async () => {
+      // Simulate an install that set the old key before the split: only
+      // `rewind.enabled` exists (true), `rewind.nudge.enabled` is unset so
+      // `getBoolean` returns the passed default (the legacy value).
+      mockConfigGetBoolean.mockImplementation(
+        async (key: unknown, def: unknown) => {
+          const k = key as string;
+          if (k === "rewind.enabled") return true; // legacy nudge opt-in
+          if (k === "rewind.nudge.enabled") return def as boolean; // unset
+          return (def as boolean) ?? false;
+        },
+      );
+      mockTrackingAggregate.mockResolvedValueOnce([
+        { _id: "u1", username: "u1", totalTime: 60 * 60 * 5 },
+      ]);
+      const svc: ServiceInstance = RewindNudgeService.getInstance(makeClient());
+      const result = await svc.runNow();
+      expect(result).not.toBeNull();
+      expect(result!.sent).toBe(1);
+    });
+
+    it("an explicit rewind.nudge.enabled=false wins over a legacy rewind.enabled=true (#608)", async () => {
+      mockConfigGetBoolean.mockImplementation(async (key: unknown) => {
+        const k = key as string;
+        if (k === "rewind.enabled") return true; // legacy value present
+        if (k === "rewind.nudge.enabled") return false; // explicit opt-out
+        return false;
+      });
       const svc: ServiceInstance = RewindNudgeService.getInstance(makeClient());
       const result = await svc.runNow();
       expect(result).toBeNull();

--- a/__tests__/web/user-routes.test.ts
+++ b/__tests__/web/user-routes.test.ts
@@ -9,7 +9,14 @@
  *  - The CSRF-protected `/me/finish` revokes the session and clears the cookie.
  */
 
-import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
 import { Buffer } from "buffer";
 import {
   assertSelfScope,
@@ -576,6 +583,15 @@ describe("/me/rewind", () => {
     (WebSessionService as unknown as { instance: unknown }).instance = null;
   });
 
+  // `dispatchRewind` installs spies (notably on `ConfigService.getInstance`)
+  // that would otherwise persist into later describe blocks — e.g.
+  // `/me/timezone`, which also reads `rewind.enabled` — and make test order
+  // matter. Restore after each test so every override is scoped to its own
+  // dispatch.
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   async function dispatchRewind(opts: {
     pathSuffix: string; // "" for "/rewind", "/2024" for "/rewind/2024"
     summary: unknown; // What RewindService.getInstance(...).getSummary should resolve to
@@ -905,16 +921,14 @@ describe("/me/timezone (#524)", () => {
       expiresAt: new Date(now + 60 * 60 * 1000),
     } as never);
 
-    const { PermissionsService } = await import(
-      "../../src/services/permissions-service.js"
-    );
+    const { PermissionsService } =
+      await import("../../src/services/permissions-service.js");
     jest.spyOn(PermissionsService, "getInstance").mockReturnValue({
       checkCommandPermission: async () => true,
     } as never);
 
-    const { UserNotificationPrefsService } = await import(
-      "../../src/services/user-notification-prefs-service.js"
-    );
+    const { UserNotificationPrefsService } =
+      await import("../../src/services/user-notification-prefs-service.js");
     const getTimezone = jest
       .fn<() => Promise<string | null>>()
       .mockResolvedValue(opts.stored ?? null);
@@ -940,7 +954,8 @@ describe("/me/timezone (#524)", () => {
       .mockResolvedValue({} as never);
 
     const mockClient = {} as never;
-    const { createSessionMiddleware } = await import("../../src/web/session.js");
+    const { createSessionMiddleware } =
+      await import("../../src/web/session.js");
     const requireSession = createSessionMiddleware(mockClient);
     const router = createUserRouter(mockClient, requireSession);
 
@@ -1046,9 +1061,7 @@ describe("/me/timezone (#524)", () => {
   it("clears the timezone when an empty value is submitted", async () => {
     let captured: { tz: string | null } | null = null;
     const setTimezone = jest
-      .fn<
-        (u: string, g: string, tz: string | null) => Promise<string | null>
-      >()
+      .fn<(u: string, g: string, tz: string | null) => Promise<string | null>>()
       .mockImplementation(async (_u, _g, tz) => {
         captured = { tz };
         return tz;
@@ -1067,9 +1080,7 @@ describe("/me/timezone (#524)", () => {
 
   it("surfaces a descriptive error when the service rejects an invalid zone", async () => {
     const setTimezone = jest
-      .fn<
-        (u: string, g: string, tz: string | null) => Promise<string | null>
-      >()
+      .fn<(u: string, g: string, tz: string | null) => Promise<string | null>>()
       .mockRejectedValue(
         new Error('"Mars/Phobos" is not a recognized IANA timezone identifier'),
       );

--- a/__tests__/web/user-routes.test.ts
+++ b/__tests__/web/user-routes.test.ts
@@ -580,6 +580,7 @@ describe("/me/rewind", () => {
     pathSuffix: string; // "" for "/rewind", "/2024" for "/rewind/2024"
     summary: unknown; // What RewindService.getInstance(...).getSummary should resolve to
     defaultYear?: number; // What getDefaultRewindYear resolves to (bare route only)
+    rewindEnabled?: boolean; // Feature gate `rewind.enabled` (#608); defaults to enabled
   }): Promise<{
     statusCode: number;
     body: string;
@@ -617,6 +618,14 @@ describe("/me/rewind", () => {
       await import("../../src/services/user-notification-prefs-service.js");
     jest.spyOn(UserNotificationPrefsService, "getInstance").mockReturnValue({
       getTimezone: async () => null,
+    } as never);
+
+    const { ConfigService } =
+      await import("../../src/services/config-service.js");
+    const rewindEnabled = opts.rewindEnabled ?? true;
+    jest.spyOn(ConfigService, "getInstance").mockReturnValue({
+      getBoolean: async (key: string) =>
+        key === "rewind.enabled" ? rewindEnabled : false,
     } as never);
 
     const { RewindService } =
@@ -828,6 +837,31 @@ describe("/me/rewind", () => {
     });
     expect(out.statusCode).toBe(500);
     expect(out.body).toContain("Could not load your year-in-review");
+  });
+
+  it("returns a 404 disabled state and does not query data when rewind.enabled is off (#608)", async () => {
+    const out = await dispatchRewind({
+      pathSuffix: "",
+      summary: makeSummary(),
+      rewindEnabled: false,
+    });
+    expect(out.statusCode).toBe(404);
+    expect(out.body).toContain("Rewind) feature is currently disabled");
+    // The gate short-circuits before any data work.
+    expect(out.getSummary).not.toHaveBeenCalled();
+    expect(out.getDefaultRewindYear).not.toHaveBeenCalled();
+    // And the disabled feature drops out of the page nav.
+    expect(out.body).not.toContain('href="/me/rewind"');
+  });
+
+  it("gates the explicit :year deep-link too when disabled (#608)", async () => {
+    const out = await dispatchRewind({
+      pathSuffix: "/2024",
+      summary: makeSummary({ year: 2024 }),
+      rewindEnabled: false,
+    });
+    expect(out.statusCode).toBe(404);
+    expect(out.getSummary).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -75,7 +75,8 @@ export interface ConfigSchema {
   "digest.include_achievements": boolean;
 
   // Annual Personal Year-in-Review (Rewind) (#484)
-  "rewind.enabled": boolean;
+  "rewind.enabled": boolean; // Gates the /me/rewind feature (page + nav)
+  "rewind.nudge.enabled": boolean; // Gates the end-of-year DM nudge only (#608)
   "rewind.cron": string; // Cron schedule for the end-of-year DM nudge
   "rewind.min_minutes": number; // Min annual minutes to qualify for the nudge
 
@@ -227,10 +228,12 @@ export const defaultConfig: ConfigSchema = {
   "digest.streak_min_minutes": 30,
   "digest.include_achievements": true,
 
-  // Rewind year-in-review defaults (#484). Master gate off, follows
-  // rule 1. The page works whenever the data exists; this gate only
-  // controls the end-of-year DM nudge.
+  // Rewind year-in-review defaults (#484, #608). Master gate off,
+  // follows rule 1 — the /me/rewind page, its data aggregation, and the
+  // nav link are all gated by `rewind.enabled`. The end-of-year DM nudge
+  // has its own independent toggle (`rewind.nudge.enabled`).
   "rewind.enabled": false,
+  "rewind.nudge.enabled": false,
   "rewind.cron": "0 10 30 12 *", // Dec 30 at 10:00 in the host timezone
   "rewind.min_minutes": 60,
 
@@ -828,11 +831,18 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
     type: "boolean",
   },
 
-  // Rewind year-in-review (#484)
+  // Rewind year-in-review (#484, #608)
   "rewind.enabled": {
+    label: "Rewind enabled",
+    description:
+      "Enable the personal year-in-review feature: the /me/rewind page, its data aggregation, and the nav link. When off, the page returns a disabled state and isn't linked. The end-of-year DM nudge has its own toggle below.",
+    category: "rewind",
+    type: "boolean",
+  },
+  "rewind.nudge.enabled": {
     label: "Rewind end-of-year nudge enabled",
     description:
-      "Send a one-shot end-of-year DM linking eligible users to their personal year-in-review at /me/rewind. The page itself is always available.",
+      "Send a one-shot end-of-year DM linking eligible users to their personal year-in-review at /me/rewind. Independent of the Rewind feature toggle above. Existing installs that set the old `rewind.enabled` key keep their nudge behaviour via a backward-compat fallback.",
     category: "rewind",
     type: "boolean",
   },

--- a/src/services/rewind-nudge-service.ts
+++ b/src/services/rewind-nudge-service.ts
@@ -63,10 +63,7 @@ export class RewindNudgeService {
 
     this.configService.registerReloadCallback(async () => {
       try {
-        const enabled = await this.configService.getBoolean(
-          "rewind.enabled",
-          false,
-        );
+        const enabled = await this.isNudgeEnabled();
         if (!enabled && this.isInitialized) {
           logger.info("Rewind nudge disabled, stopping cron job...");
           this.destroy();
@@ -100,6 +97,24 @@ export class RewindNudgeService {
     RewindNudgeService.instance = undefined as unknown as RewindNudgeService;
   }
 
+  /**
+   * Whether the end-of-year nudge should run. Keys off the dedicated
+   * `rewind.nudge.enabled` toggle (#608), falling back to the legacy
+   * `rewind.enabled` value for installs that opted into the nudge before
+   * the key was split into feature (page) vs nudge. Passing the legacy
+   * value as the default means an explicitly-stored `rewind.nudge.enabled`
+   * always wins, while installs that never set it inherit their old
+   * `rewind.enabled` behaviour — no manual migration required.
+   *
+   * This is deliberately independent of the `rewind.enabled` feature
+   * gate: an admin can keep the page on with no DMs (today's behaviour),
+   * or run the nudge without other coupling.
+   */
+  private async isNudgeEnabled(): Promise<boolean> {
+    const legacy = await this.configService.getBoolean("rewind.enabled", false);
+    return this.configService.getBoolean("rewind.nudge.enabled", legacy);
+  }
+
   private validateCronExpression(expression: string): boolean {
     try {
       new CronTime(expression);
@@ -120,10 +135,7 @@ export class RewindNudgeService {
     }
 
     try {
-      const enabled = await this.configService.getBoolean(
-        "rewind.enabled",
-        false,
-      );
+      const enabled = await this.isNudgeEnabled();
       if (!enabled) {
         logger.info("Rewind nudge is disabled");
         this.isInitialized = true;
@@ -186,12 +198,9 @@ export class RewindNudgeService {
     }
     this.isRunning = true;
     try {
-      const enabled = await this.configService.getBoolean(
-        "rewind.enabled",
-        false,
-      );
+      const enabled = await this.isNudgeEnabled();
       if (!enabled) {
-        logger.info("Rewind nudge aborted: feature disabled");
+        logger.info("Rewind nudge aborted: nudge disabled");
         return null;
       }
 

--- a/src/web/user-layout.ts
+++ b/src/web/user-layout.ts
@@ -16,6 +16,13 @@ export { escapeHtml };
 interface UserNavItem {
   href: string;
   label: string;
+  /**
+   * When set, the item is only advertised in the nav while the named
+   * feature is enabled. Mirrors the admin layout's `featureKey` gate
+   * (#608): a disabled feature drops out of the nav but the URL stays
+   * reachable by direct navigation (the route itself enforces the gate).
+   */
+  feature?: "rewind";
 }
 
 /**
@@ -28,7 +35,7 @@ export const USER_NAV_ITEMS: UserNavItem[] = [
   { href: "/me/", label: "Overview" },
   { href: "/me/notifications", label: "Notifications" },
   { href: "/me/timezone", label: "Timezone" },
-  { href: "/me/rewind", label: "Rewind" },
+  { href: "/me/rewind", label: "Rewind", feature: "rewind" },
 ];
 
 export interface UserFlashMessage {
@@ -55,6 +62,13 @@ export interface UserPageOptions {
    * surface the outcome.
    */
   flash?: UserFlashMessage | null;
+  /**
+   * Enabled-state of the feature-gated Rewind page (#608). When `false`,
+   * the Rewind nav link is suppressed. Omitted/`undefined` keeps the link
+   * visible, so direct callers and tests that don't care about gating work
+   * unchanged.
+   */
+  rewindEnabled?: boolean;
 }
 
 const STYLE = [
@@ -203,20 +217,27 @@ export function renderUserPage(opts: UserPageOptions): string {
     '<button type="submit">Finish</button>',
     "</form></div></div>",
     '<div class="shell">',
-    `<main>${renderPageNav(opts.active)}${renderFlash(opts.flash)}${opts.body}</main></div>`,
+    `<main>${renderPageNav(opts.active, opts.rewindEnabled)}${renderFlash(opts.flash)}${opts.body}</main></div>`,
     `<script>${SCRIPT}</script>`,
     "</body></html>",
   ].join("");
 }
 
-function renderPageNav(active: string): string {
-  const items = USER_NAV_ITEMS.map((item) => {
-    const isActive =
-      item.href === active ||
-      (item.href === "/me/" && (active === "/me" || active === "/me/"));
-    const cls = isActive ? ' class="active"' : "";
-    return `<a href="${escapeHtml(item.href)}"${cls}>${escapeHtml(item.label)}</a>`;
-  }).join("");
+function renderPageNav(active: string, rewindEnabled?: boolean): string {
+  const items = USER_NAV_ITEMS.filter(
+    // A feature-gated item only shows while its feature is enabled.
+    // `undefined` is treated as enabled so non-gating callers are
+    // unaffected (#608).
+    (item) => item.feature !== "rewind" || rewindEnabled !== false,
+  )
+    .map((item) => {
+      const isActive =
+        item.href === active ||
+        (item.href === "/me/" && (active === "/me" || active === "/me/"));
+      const cls = isActive ? ' class="active"' : "";
+      return `<a href="${escapeHtml(item.href)}"${cls}>${escapeHtml(item.label)}</a>`;
+    })
+    .join("");
   return `<nav class="page-nav">${items}</nav>`;
 }
 
@@ -236,10 +257,18 @@ export function renderUserIndexBody(opts: {
   discordUserId: string;
   guildId: string;
   isAdmin: boolean;
+  // Whether the feature-gated Rewind page is enabled (#608). When false,
+  // its card is omitted so the overview never links to a disabled page.
+  rewindEnabled?: boolean;
 }): string {
   const greeting = opts.isAdmin
     ? `<p class="subtitle">Signed in as an administrator viewing your own preferences. Use the <em>Back to admin panel</em> link above to manage the server.</p>`
     : `<p class="subtitle">These pages are scoped to <strong>you</strong> — what you see and change here only affects your own data on this server.</p>`;
+  const rewindCard =
+    opts.rewindEnabled === false
+      ? ""
+      : '<li><span class="feature-name"><a href="/me/rewind">Rewind</a></span>' +
+        '<span class="feature-desc">Your personal year-in-review of voice activity, top voice companions, peak day, and badges earned.</span></li>';
   return [
     "<h1>My preferences</h1>",
     greeting,
@@ -251,8 +280,7 @@ export function renderUserIndexBody(opts: {
       '<span class="feature-desc">Opt in or out of DM nudges from Koolbot.</span></li>',
     '<li><span class="feature-name"><a href="/me/timezone">Timezone</a></span>' +
       '<span class="feature-desc">Choose the timezone Koolbot uses when it shows you times in digests, Rewind, and voicestats.</span></li>',
-    '<li><span class="feature-name"><a href="/me/rewind">Rewind</a></span>' +
-      '<span class="feature-desc">Your personal year-in-review of voice activity, top voice companions, peak day, and badges earned.</span></li>',
+    rewindCard,
     "</ul>",
     "</div>",
     '<div class="card">',

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -24,6 +24,7 @@ import {
   type NotificationPrefKey,
   type NotificationPrefs,
 } from "../services/user-notification-prefs-service.js";
+import { ConfigService } from "../services/config-service.js";
 import { requireCsrf } from "./csrf.js";
 import {
   AuthenticatedRequest,
@@ -183,6 +184,16 @@ export class SelfScopeError extends Error {
   }
 }
 
+/**
+ * Whether the Rewind feature (the `/me/rewind` page + its nav entry) is
+ * enabled (#608). Distinct from the end-of-year DM nudge, which has its
+ * own `rewind.nudge.enabled` toggle handled by `RewindNudgeService`.
+ * Defaults to `false`, following the repo's opt-in feature-gate convention.
+ */
+async function isRewindFeatureEnabled(): Promise<boolean> {
+  return ConfigService.getInstance().getBoolean("rewind.enabled", false);
+}
+
 function parseYearParam(raw: unknown, fallback: number): number {
   if (typeof raw !== "string" || raw.length === 0) return fallback;
   const n = Number.parseInt(raw, 10);
@@ -221,6 +232,7 @@ export function createUserRouter(
         res.status(500).type("text/plain").send("session missing");
         return;
       }
+      const rewindEnabled = await isRewindFeatureEnabled();
       res.type("text/html").send(
         renderUserPage({
           title: "Overview",
@@ -229,10 +241,12 @@ export function createUserRouter(
             discordUserId: session.discordUserId,
             guildId: session.guildId,
             isAdmin: session.role === "admin",
+            rewindEnabled,
           }),
           csrfToken: getCsrfToken(req),
           remainingMs: getDisplayedRemainingMs(session),
           isAdmin: session.role === "admin",
+          rewindEnabled,
         }),
       );
     }),
@@ -268,6 +282,7 @@ export function createUserRouter(
           remainingMs: getDisplayedRemainingMs(session),
           isAdmin: session.role === "admin",
           flash,
+          rewindEnabled: await isRewindFeatureEnabled(),
         }),
       );
     }),
@@ -388,6 +403,7 @@ export function createUserRouter(
           remainingMs: getDisplayedRemainingMs(session),
           isAdmin: session.role === "admin",
           flash,
+          rewindEnabled: await isRewindFeatureEnabled(),
         }),
       );
     }),
@@ -478,6 +494,31 @@ export function createUserRouter(
       userId: session.discordUserId,
       guildId: session.guildId,
     });
+
+    // Feature gate (#608): when Rewind is disabled the page is not served
+    // (and the nav link is already suppressed). Return a friendly disabled
+    // state with 404 so the route can't be used to reach the recap while
+    // off, mirroring how the nav advertisement is hidden.
+    if (!(await isRewindFeatureEnabled())) {
+      res
+        .status(404)
+        .type("text/html")
+        .send(
+          renderUserPage({
+            title: "Rewind",
+            active: "/me/rewind",
+            body:
+              "<h1>Rewind</h1>" +
+              '<div class="notice info">The year-in-review (Rewind) feature is currently disabled on this server.</div>',
+            csrfToken: getCsrfToken(req),
+            remainingMs: getDisplayedRemainingMs(session),
+            isAdmin: session.role === "admin",
+            rewindEnabled: false,
+          }),
+        );
+      return;
+    }
+
     const currentYear = new Date().getUTCFullYear();
     // The explicit `/rewind/:year` deep-link must always honour the
     // requested year (even an empty one), so it falls back to the current
@@ -519,6 +560,7 @@ export function createUserRouter(
             csrfToken: getCsrfToken(req),
             remainingMs: getDisplayedRemainingMs(session),
             isAdmin: session.role === "admin",
+            rewindEnabled: true,
           }),
         );
       return;
@@ -585,6 +627,7 @@ export function createUserRouter(
         csrfToken: getCsrfToken(req),
         remainingMs: getDisplayedRemainingMs(session),
         isAdmin: session.role === "admin",
+        rewindEnabled: true,
       }),
     );
   });


### PR DESCRIPTION
Closes #608.

## Problem

`rewind.enabled` looked like a master switch but only controlled the end-of-year DM nudge. The `/me/rewind` page, its data aggregation, and the nav entry were served unconditionally, so an admin who toggled `rewind.enabled` off (expecting to disable Rewind) found the page still fully live. There was no real on/off switch for the feature.

## Change (Option A from the issue — split the keys)

- **`rewind.enabled`** now gates the **feature**: the `/me/rewind` route and its nav/menu link. When off, the route returns a `404` "feature disabled" state (short-circuiting before any data work) and the link is suppressed on every `/me/*` page via a `featureKey`-style gate mirroring the admin nav.
- **`rewind.nudge.enabled`** (new) gates the **December DM nudge** only. `RewindNudgeService` reads it through a small `isNudgeEnabled()` helper that **falls back to the legacy `rewind.enabled` value when unset**, so installs that already opted into the nudge keep their behaviour with no manual migration. An explicit `rewind.nudge.enabled` always wins.

Both keys default to `false`, following the repo's opt-in feature-gate convention (and the `config-schema` audit test that enforces it).

## Backward compatibility

| Prior stored state | After upgrade |
| --- | --- |
| `rewind.enabled = true` (nudge opt-in) | Page **on**, nudge **on** — fully preserved |
| `rewind.enabled` unset / `false` (default) | Nudge stays **off**; page now off-by-default like every other feature |

The only behaviour change is the page becoming opt-in for installs that never enabled Rewind — which is the point of the issue (a genuine off switch) and is documented as an upgrade note in `SETTINGS.md`.

## Acceptance criteria

- [x] A toggle (`rewind.enabled`) that, when off, disables the feature: `/me/rewind` returns a disabled `404` state and isn't linked.
- [x] The nudge DM is controlled independently via `rewind.nudge.enabled`.
- [x] Settings labels make the distinction unambiguous ("Rewind enabled" vs "Rewind end-of-year nudge enabled").
- [x] Backward compatible: legacy `rewind.enabled` values flow to the nudge via a documented fallback.
- [x] `SETTINGS.md` (and `WEBUI.md`) updated; tests cover route gating on/off and the nudge fallback.

## Tests

- `user-routes`: new tests assert the `404` disabled state for both `/me/rewind` and `/me/rewind/:year`, that the gate short-circuits before querying data, and that the nav link is dropped when disabled.
- `rewind-nudge-service`: new tests cover the dedicated toggle, the legacy `rewind.enabled` fallback when the nudge key is unset, and an explicit nudge opt-out overriding a legacy value.
- `config-schema`: the `*enabled` audit list picks up `rewind.nudge.enabled`.

Full suite (`npm test`): 1193 passing. Lint, Prettier, and markdownlint clean.

https://claude.ai/code/session_011hPFVARAJddnfSf3kaamAj

---
_Generated by [Claude Code](https://claude.ai/code/session_011hPFVARAJddnfSf3kaamAj)_