### PR TITLE
fix(webui): send settings section save as urlencoded so CSRF token survives

### DIFF
--- a/__tests__/web/admin-layout.test.ts
+++ b/__tests__/web/admin-layout.test.ts
@@ -114,6 +114,12 @@ describe("renderAdminPage", () => {
     expect(html).toContain("section-flash");
     // Reset buttons (formaction) must still submit natively.
     expect(html).toContain("getAttribute('formaction')");
+    // The body must be urlencoded, not raw multipart FormData: the router
+    // only mounts express.urlencoded, so a multipart body arrives empty and
+    // `_csrf` is lost, failing requireCsrf with "CSRF token missing"
+    // (issue #628). Wrapping FormData in URLSearchParams keeps it urlencoded.
+    expect(html).toContain("body:new URLSearchParams(new FormData(form))");
+    expect(html).not.toContain("body:new FormData(form)");
   });
 
   it("escapes the title", () => {

--- a/__tests__/web/admin-layout.test.ts
+++ b/__tests__/web/admin-layout.test.ts
@@ -118,7 +118,7 @@ describe("renderAdminPage", () => {
     // only mounts express.urlencoded, so a multipart body arrives empty and
     // `_csrf` is lost, failing requireCsrf with "CSRF token missing"
     // (issue #628). Wrapping FormData in URLSearchParams keeps it urlencoded.
-    expect(html).toContain("body:new URLSearchParams(new FormData(form))");
+    expect(html).toContain("URLSearchParams(new FormData(form))");
     expect(html).not.toContain("body:new FormData(form)");
   });
 

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -382,7 +382,9 @@ const CASCADE_DISABLE_SCRIPT =
 // server's flash inline inside the same card, and leave scroll position
 // untouched. The server returns JSON for these requests (Accept:
 // application/json) and keeps the redirect for the no-JS path, so browsers
-// without fetch/FormData fall back to the original full-page behaviour.
+// without fetch/FormData/URLSearchParams fall back to the original
+// full-page behaviour. The body is urlencoded (not multipart) so the
+// router's express.urlencoded parser can read `_csrf` — see the body line.
 //
 // Per-row Reset buttons retarget /admin/settings/reset via `formaction`;
 // those are left to submit natively (full reload). We track the clicked
@@ -403,13 +405,19 @@ const SETTINGS_SAVE_SCRIPT =
   "function submit(e,submitter){var form=e.currentTarget;" +
   // Reset buttons retarget via formaction — let those submit natively.
   "if(submitter&&submitter.getAttribute('formaction'))return;" +
-  "if(typeof fetch!=='function'||typeof FormData!=='function')return;" +
+  "if(typeof fetch!=='function'||typeof FormData!=='function'||typeof URLSearchParams!=='function')return;" +
   "e.preventDefault();" +
   "var save=form.querySelector('button[type=submit]:not([formaction])');" +
   "if(save)save.disabled=true;" +
+  // Send as application/x-www-form-urlencoded, NOT multipart. The router
+  // only mounts express.urlencoded (no multipart parser), so a multipart
+  // FormData body would arrive empty server-side — losing `_csrf` and
+  // tripping requireCsrf with "CSRF token missing" (issue #628). Wrapping
+  // the FormData in URLSearchParams makes fetch send urlencoded, so the
+  // CSRF token and every value_*/keys field round-trip through the parser.
   "fetch(form.action,{method:'POST',credentials:'same-origin',cache:'no-store'," +
   "headers:{'Accept':'application/json','X-Requested-With':'fetch'}," +
-  "body:new FormData(form)})" +
+  "body:new URLSearchParams(new FormData(form))})" +
   ".then(function(res){if(res.status===401){window.location.href='/admin/';return null}" +
   // Read the body once as text and try to parse it as JSON. The server's
   // happy path and its error paths (CSRF/rate-limit/payload/unhandled) all

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -406,18 +406,22 @@ const SETTINGS_SAVE_SCRIPT =
   // Reset buttons retarget via formaction — let those submit natively.
   "if(submitter&&submitter.getAttribute('formaction'))return;" +
   "if(typeof fetch!=='function'||typeof FormData!=='function'||typeof URLSearchParams!=='function')return;" +
-  "e.preventDefault();" +
-  "var save=form.querySelector('button[type=submit]:not([formaction])');" +
-  "if(save)save.disabled=true;" +
-  // Send as application/x-www-form-urlencoded, NOT multipart. The router
+  // Build the urlencoded body BEFORE preventDefault so a throw in a
+  // partially-supported browser falls back to the native (urlencoded) form
+  // POST instead of aborting a half-suppressed submit and breaking Save.
+  // Sent as application/x-www-form-urlencoded, NOT multipart: the router
   // only mounts express.urlencoded (no multipart parser), so a multipart
   // FormData body would arrive empty server-side — losing `_csrf` and
   // tripping requireCsrf with "CSRF token missing" (issue #628). Wrapping
   // the FormData in URLSearchParams makes fetch send urlencoded, so the
   // CSRF token and every value_*/keys field round-trip through the parser.
+  "var body;try{body=new URLSearchParams(new FormData(form))}catch(err){return}" +
+  "e.preventDefault();" +
+  "var save=form.querySelector('button[type=submit]:not([formaction])');" +
+  "if(save)save.disabled=true;" +
   "fetch(form.action,{method:'POST',credentials:'same-origin',cache:'no-store'," +
   "headers:{'Accept':'application/json','X-Requested-With':'fetch'}," +
-  "body:new URLSearchParams(new FormData(form))})" +
+  "body:body})" +
   ".then(function(res){if(res.status===401){window.location.href='/admin/';return null}" +
   // Read the body once as text and try to parse it as JSON. The server's
   // happy path and its error paths (CSRF/rate-limit/payload/unhandled) all


### PR DESCRIPTION
## Summary

Fixes #628. Saving **any** section on `/admin/settings` failed in a JS-enabled browser with:

> Security check failed (CSRF token missing). Reload the page and try again.

## Root cause

The per-section Save was progressively enhanced into an AJAX `fetch()` in #564 with `body: new FormData(form)`. A `FormData` fetch body is sent as **`multipart/form-data`**, but the WebUI router only mounts `express.urlencoded` (`src/web/index.ts:33`, `:206`) — there is no multipart parser. So `req.body` arrived empty, `req.body._csrf` was `undefined`, and `requireCsrf` (`src/web/csrf.ts:62`) rejected with 403 "CSRF token missing". #612 made that error legible (JSON) but didn't fix the cause. The no-JS native form POST (urlencoded) was unaffected, which is why it slipped through.

Confirmed empirically against the exact middleware:
```
multipart  -> {"bodyKeys":[],"csrf":null}
urlencoded -> {"bodyKeys":["_csrf"],"csrf":"TOKEN123"}
```

## Fix

Wrap the `FormData` in `URLSearchParams` so the request is `application/x-www-form-urlencoded`:

```js
body: new URLSearchParams(new FormData(form))
```

The CSRF token plus every `keys` / `value_*` field now round-trip through the existing `express.urlencoded` parser (verified: a `_csrf` + `category` + `keys` + `value_*` payload parses back intact server-side). The `URLSearchParams` guard joins the existing `fetch`/`FormData` capability check, so very old browsers still fall back to the native full-page form POST. Per-row Reset (native `formaction` submit) is untouched.

## Testing

- `__tests__/web/admin-layout.test.ts` updated to assert the body is `URLSearchParams(...)` and **not** raw `FormData` (regression guard).
- `npm run build`, ESLint, and Prettier all clean; `admin-layout` suite passes (24/24).

## Acceptance criteria (from #628)

- [x] Saving any settings section succeeds in a JS-enabled browser.
- [x] CSRF still rejects missing/mismatched tokens (unchanged `requireCsrf`).
- [x] No-JS native form POST fallback still works (already urlencoded).
- [x] Per-row Reset still works (native `formaction`).
- [x] A test exercises the AJAX body encoding so a multipart regression is caught.

https://claude.ai/code/session_015TSM7Q62WEp5H9nRc9bDsr

---
_Generated by [Claude Code](https://claude.ai/code/session_015TSM7Q62WEp5H9nRc9bDsr)_