### PR TITLE
fix(voice): re-create lobby immediately after rename deletes the old one

### DIFF
--- a/__tests__/services/voice-channel-manager-lobby-rename-recreate.test.ts
+++ b/__tests__/services/voice-channel-manager-lobby-rename-recreate.test.ts
@@ -1,0 +1,132 @@
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import {
+  ChannelType,
+  Collection,
+  type Client,
+  type Guild,
+  type VoiceChannel,
+} from "discord.js";
+
+// Mock dependencies before importing
+jest.mock("../../src/utils/logger.js");
+jest.mock("../../src/services/voice-channel-tracker.js");
+jest.mock("../../src/services/config-service.js");
+
+// Import after mocks
+import { VoiceChannelManager } from "../../src/services/voice-channel-manager.js";
+import { ConfigService } from "../../src/services/config-service.js";
+
+const mockConfigService =
+  ConfigService.getInstance() as jest.Mocked<ConfigService>;
+
+/**
+ * Regression coverage for issue #631: when the lobby name is changed via
+ * /config, the periodic cleanup deletes the old channel (whose name no longer
+ * matches the configured name) as "unmanaged". The cleanup must then
+ * immediately re-create the lobby with the new name so the guild is never left
+ * without a lobby until the next (much slower) health check notices it.
+ */
+describe("VoiceChannelManager - lobby re-created after rename cleanup (issue #631)", () => {
+  let manager: VoiceChannelManager;
+  let mockClient: Partial<Client>;
+  let staleLobby: Partial<VoiceChannel>;
+  let createdName: string | undefined;
+  let createMock: ReturnType<typeof jest.fn>;
+
+  const NEW_LOBBY_NAME = "🟢 Lobby";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (VoiceChannelManager as any).instance = undefined;
+    createdName = undefined;
+
+    mockConfigService.getBoolean = jest
+      .fn()
+      .mockImplementation((key: string, defaultValue?: boolean) => {
+        if (key === "voicechannels.enabled") return Promise.resolve(true);
+        return Promise.resolve(defaultValue ?? false);
+      });
+
+    mockConfigService.getString = jest
+      .fn()
+      .mockImplementation((key: string, defaultValue?: string) => {
+        switch (key) {
+          case "GUILD_ID":
+            return Promise.resolve("guild-id");
+          case "voicechannels.lobby.name":
+            return Promise.resolve(NEW_LOBBY_NAME);
+          case "voicechannels.lobby.offlinename":
+            return Promise.resolve("🔴 Lobby");
+          case "voicechannels.category_id":
+            return Promise.resolve("category-id");
+          case "voicechannels.channel.prefix":
+            return Promise.resolve("🎮");
+          default:
+            return Promise.resolve(defaultValue ?? "");
+        }
+      });
+
+    // The old lobby, left over after the name was changed via /config. Its name
+    // no longer matches the configured "🟢 Lobby", so cleanup deletes it.
+    staleLobby = {
+      id: "stale-lobby-id",
+      name: "Lobby",
+      type: ChannelType.GuildVoice,
+      members: new Collection(),
+      delete: jest.fn<any>().mockResolvedValue(undefined),
+    } as any;
+
+    const channels = new Collection<string, VoiceChannel>();
+    channels.set(staleLobby.id as string, staleLobby as VoiceChannel);
+
+    const category = {
+      id: "category-id",
+      type: ChannelType.GuildCategory,
+      children: { cache: channels },
+    };
+
+    createMock = jest.fn<any>().mockImplementation((options: any) => {
+      createdName = options?.name;
+      return Promise.resolve({ id: "new-lobby-id", name: options?.name });
+    });
+
+    const guild: Partial<Guild> = {
+      roles: { everyone: { id: "everyone-id" } } as any,
+      channels: {
+        cache: new Collection([["category-id", category]]),
+        create: createMock,
+      } as any,
+    };
+
+    mockClient = {
+      guilds: {
+        fetch: jest.fn<any>().mockResolvedValue(guild),
+      } as any,
+    } as any;
+
+    manager = VoiceChannelManager.getInstance(mockClient as Client);
+  });
+
+  afterEach(() => {
+    (VoiceChannelManager as any).instance = undefined;
+  });
+
+  it("deletes the stale-named lobby and immediately re-creates it with the new name", async () => {
+    await manager.cleanupEmptyChannels();
+
+    // Old lobby removed because it no longer matches the configured name.
+    expect(staleLobby.delete).toHaveBeenCalled();
+
+    // A replacement lobby is created right away with the new configured name,
+    // rather than waiting for the periodic health check.
+    expect(createMock).toHaveBeenCalled();
+    expect(createdName).toBe(NEW_LOBBY_NAME);
+  });
+});

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -2003,6 +2003,13 @@ export class VoiceChannelManager {
           logger.error(`Error deleting channel ${channel.name}:`, error);
         }
       }
+
+      // After cleanup, make sure a lobby channel still exists. When the lobby
+      // name is changed via /config the old channel no longer matches the
+      // configured name and is deleted above as "unmanaged"; without this the
+      // guild is left with no lobby until the next (much slower) health check
+      // happens to notice it is missing. Re-ensuring here closes that gap.
+      await this.ensureLobbyChannelExists(guild);
     } catch (error) {
       logger.error("Error during voice channel cleanup:", error);
     }


### PR DESCRIPTION
## Summary

Fixes #631.

When the lobby channel name is changed via `/config` (`voicechannels.lobby.name`), the periodic cleanup
(`VoiceChannelManager.cleanupEmptyChannels()`) correctly deletes the old channel — its name no longer
matches the configured name, so it is classified as "unmanaged" — but it never re-created the lobby. The
guild was left with **no lobby channel at all** until the next periodic *health check*
(`checkLobbyHealth()`, every 15 min) happened to notice it was missing and recreate it, a gap of up to
~10–15 minutes.

## Change

- After `cleanupEmptyChannels()` finishes deleting unmanaged/empty managed channels, call
  `ensureLobbyChannelExists(guild)` so the lobby is re-created immediately with the new configured name.
  `ensureLobbyChannelExists()` is the gentle variant — it reuses an existing online/offline lobby and only
  creates one when none exists, so it's a no-op on the normal cleanup path.

## Testing

- Added `__tests__/services/voice-channel-manager-lobby-rename-recreate.test.ts`: asserts that after
  cleanup deletes a stale-named lobby, a replacement channel is created right away with the new configured
  name.
- `npm run build`, `npm run lint`, `npm run format:check` all pass.
- New test + the existing `voice-channel-manager-rename-cleanup.test.ts` pass (6/6).

https://claude.ai/code/session_01WHLDWvkC29HAgA6QjHpSX6

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHLDWvkC29HAgA6QjHpSX6)_