### PR TITLE
build(deps): bump Docker base image to node:24-alpine

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           context: .
           push: true
-          # Always pull the latest node:22-alpine base layers instead of
+          # Always pull the latest node:24-alpine base layers instead of
           # reusing a cached digest. The Node team rebuilds the Alpine base
           # whenever Alpine ships security updates, so pulling fresh is how the
           # image absorbs patched system OpenSSL (libssl3/libcrypto3) — e.g. the

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 
 WORKDIR /app
 
@@ -16,7 +16,7 @@ COPY . .
 RUN npm run build
 
 # Production dependencies stage
-FROM node:22-alpine AS prod-deps
+FROM node:24-alpine AS prod-deps
 
 WORKDIR /app
 
@@ -25,14 +25,14 @@ COPY package*.json ./
 RUN npm ci --omit=dev
 
 # Production stage
-FROM node:22-alpine
+FROM node:24-alpine
 
 WORKDIR /app
 
 # Stopgap: pull patched OpenSSL libraries ahead of the base image so Trivy's
-# system-package scan stays clean (OpenSSL CVEs in node:22-alpine — High
+# system-package scan stays clean (OpenSSL CVEs in node:24-alpine — High
 # #57/#72, Medium #590, Low #62-#71/#77-#86). Runs as root before dropping to
-# USER node. Remove once node:22-alpine ships the fixed libssl3/libcrypto3.
+# USER node. Remove once node:24-alpine ships the fixed libssl3/libcrypto3.
 RUN apk --no-cache upgrade libssl3 libcrypto3
 
 # Copy only runtime artifacts

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,11 @@ FROM node:24-alpine
 WORKDIR /app
 
 # Stopgap: pull patched OpenSSL libraries ahead of the base image so Trivy's
-# system-package scan stays clean (OpenSSL CVEs in node:24-alpine — High
-# #57/#72, Medium #590, Low #62-#71/#77-#86). Runs as root before dropping to
-# USER node. Remove once node:24-alpine ships the fixed libssl3/libcrypto3.
+# system-package scan stays clean whenever the Alpine base lags upstream
+# OpenSSL fixes (historically flagged against libssl3/libcrypto3 — High
+# #57/#72, Medium #590, Low #62-#71/#77-#86 on node:22-alpine). Runs as root
+# before dropping to USER node. Drop once Trivy confirms node:24-alpine ships
+# the fixed libssl3/libcrypto3 (tracked in #604).
 RUN apk --no-cache upgrade libssl3 libcrypto3
 
 # Copy only runtime artifacts

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:24-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Bumps all Docker stages from `node:22-alpine` to `node:24-alpine`, aligning the shipped runtime with the newest Node version already covered by CI (`ci.yml` matrix `node: ['22', '24']`) and `engines.node` (`>=22.0.0`). `node:24-alpine` is the current Active LTS line.

Closes #603.

## Changes

- `Dockerfile:2` — `builder` stage → `node:24-alpine`
- `Dockerfile:19` — `prod-deps` stage → `node:24-alpine`
- `Dockerfile:28` — production stage → `node:24-alpine`
- `Dockerfile.dev:1` → `node:24-alpine`
- Updated stale `node:22-alpine` references in the OpenSSL stopgap comment (`Dockerfile`) and the pull-fresh comment in `.github/workflows/docker.yml` to match.

### Scope notes (per #603)

- **Stopgap left in place.** The `RUN apk --no-cache upgrade libssl3 libcrypto3` OpenSSL stopgap and the non-root `USER node` directive are intentionally unchanged. Whether `node:24-alpine` ships patched system OpenSSL (and therefore whether the stopgap can be removed) is handed off to #604 — see the Trivy section below.
- No application/source changes — Node 24 application code is already proven by the Jest suite running on the Node 24 CI leg.

## Test plan

**Automated (CI):**
- [x] `ci.yml` green — Jest on Node 22 **and** 24 (unchanged matrix), plus Lint, Typecheck, CodeQL, actionlint, zizmor, Dependency Review.
- [x] `docker.yml` green — hadolint + multi-arch (`amd64`/`arm64`) image **build** succeeds on `node:24-alpine`, signed (cosign) and pushed. Verified via `workflow_dispatch` run [#417](https://github.com/lonix/koolbot/actions/runs/27563953206) on this branch (built from `780f89a`; current HEAD `fda2fa4` differs only by a Dockerfile comment, so the image/scan are identical).
- [x] Trivy scan completes — **clean: no fixable High/Critical findings** (scan uses `severity: CRITICAL,HIGH` + `ignore-unfixed: true`; empty result → no code-scanning alerts). No `libssl3`/`libcrypto3` High alerts on the shipped image.

**Manual smoke test (not run — needs a human pass before merge):**

> ⚠️ The Docker daemon is not available in the execution environment used to prepare this PR, so the local `docker build` + end-to-end boot smoke test from the issue could not be performed here. The `docker.yml` build/scan covers the image build on the new base; the remaining manual checks still need a human pass before merge:
> - Bot boots end-to-end against a test guild (Discord + Mongo connect, slash commands register, no startup crash)
> - A representative slash command round-trips (e.g. `/config`)
> - Web UI (if enabled) serves — admin + user routers + Prometheus `/metrics`
> - Periodic jobs don't throw on first tick (cleanup/health intervals)
> - No new Node 24 runtime warnings/deprecations in logs
> - `Dockerfile.dev` still works for `npm run dev` (ts-node ESM loader)

## Trivy / OpenSSL handoff to #604

`docker.yml` run #417 built and scanned cleanly on `node:24-alpine`, with **no fixable High/Critical OpenSSL (`libssl3`/`libcrypto3`) findings** on the shipped image.

**Caveat for #604:** this image is built **with** the `apk upgrade libssl3 libcrypto3` stopgap still applied, so a clean scan here proves the *shipped image* is clean — it does **not** isolate whether `node:24-alpine`'s **base** OpenSSL is already patched. Deciding whether the stopgap can be dropped (#604) requires a Trivy scan of the **base** `node:24-alpine` directly, or a build with that `RUN` removed.

Refs #604

https://claude.ai/code/session_01XYvq9H59NFZhjo8MWmhK2M

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYvq9H59NFZhjo8MWmhK2M)_