### PR TITLE
docs: note benign glob deprecation warning from Jest toolchain

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -14,6 +14,7 @@ Complete guide for developers extending or maintaining KoolBot.
 - [Adding New Features](#adding-new-features)
 - [Testing Guidelines](#testing-guidelines)
 - [Code Style](#code-style)
+- [Dependency Notes](#dependency-notes)
 
 ---
 
@@ -772,6 +773,35 @@ try {
   // Don't crash the bot - degrade gracefully
 }
 ```
+
+---
+
+## Dependency Notes
+
+### Benign `glob` deprecation warning on install
+
+`npm install` (and the Docker build) prints repeated deprecation warnings such as:
+
+```text
+npm warn deprecated glob@10.5.0: Old versions of glob are not supported, and contain widely
+publicized security vulnerabilities, which have been fixed in the current version. Please update…
+```
+
+This is **build-log noise, not an audit finding.** The offending copies (`glob@10.5.0` and `glob@7.2.3`)
+are transitive devDependencies pulled in by the Jest toolchain — `@jest/reporters`, `jest-config`,
+`jest-runtime` pin `glob@^10.5.0`, and `test-exclude` (Istanbul coverage) pulls `glob@^7.1.4`. We do not
+depend on `glob` directly. `npm audit` reports **0** glob vulnerabilities in our resolved tree; the
+warning text is the blanket deprecation message glob's author attaches to all sub-latest versions, not an
+advisory matching our pinned versions.
+
+We intentionally **do not** force a newer `glob` via the `overrides` block. Jest's internals are written
+against glob 10, and glob 11+ changed its API/defaults and raised its Node floor — overriding it risks
+breaking `npm test`. The warning will disappear for free once a future `jest` release moves to a newer
+glob; we take that via the normal dependency bump.
+
+Tracked in [issue #605](https://github.com/lonix/koolbot/issues/605). See also
+[#601](https://github.com/lonix/koolbot/issues/601) (`brace-expansion`, the actual audit finding) and
+[#602](https://github.com/lonix/koolbot/issues/602) (direct-dependency bumps).
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #605.

`npm install` (and the Docker build) emits repeated `glob` deprecation warnings (`glob@10.5.0` and `glob@7.2.3`) that come entirely from the Jest toolchain's transitive devDependencies. As the issue documents, `npm audit` reports **0** glob vulnerabilities in our resolved tree — this is build-log noise / hygiene, not a security finding.

This PR takes the recommended **option 1 (track upstream) + document** path from the issue rather than forcing a risky `overrides` bump:

- The override route (option 2) is explicitly gated on a full green `npm run check:all` on **both** Node 22 and 24, and the issue warns that glob 11+ changed its API/Node floor and could break Jest. That can't be safely verified in this environment, so I avoided it.
- Instead, a new **Dependency Notes** section in `DEVELOPER_GUIDE.md` documents that the warning is a benign transitive Jest artifact, explains why we don't override `glob`, and links this issue (plus #601 and #602).

## Changes

- `DEVELOPER_GUIDE.md`: new "Dependency Notes" section (and TOC entry) explaining the benign `glob` deprecation warning.

## Acceptance criteria

Satisfies the second branch of the acceptance criteria: a short note documenting the warning as a benign transitive Jest artifact, with the issue linked and parked until Jest updates upstream.

Docs-only change — no code or dependency changes.

https://claude.ai/code/session_01LBT2mCd6kasX8coss5b27U

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBT2mCd6kasX8coss5b27U)_