### PR TITLE
feat(webui): group admin sidebar nav into labelled sections

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -654,7 +654,8 @@ discovers settings from `defaultConfig` automatically.
 5. **Web UI surface** (if applicable)
    - [ ] Add a read-only view in `src/web/read-only-routes.ts` / `admin-views.ts`
    - [ ] Add write handlers in `src/web/write-routes.ts` (CSRF + session required)
-   - [ ] Link the page from `NAV_ITEMS` in `admin-layout.ts`
+   - [ ] Link the page from `NAV_ITEMS` in `admin-layout.ts` (set its `group`:
+     `Info`, `Settings`, or `Features`; gated pages go under `Features`)
    - [ ] Routes stay thin — no business logic outside services
 
 6. **Documentation**

--- a/__tests__/web/admin-layout.test.ts
+++ b/__tests__/web/admin-layout.test.ts
@@ -3,6 +3,7 @@ import {
   escapeHtml,
   getDisplayedRemainingMs,
   getInactivityWindowMs,
+  NAV_GROUP_ORDER,
   NAV_ITEMS,
   renderAdminPage,
   resolveNavFeatureStatus,
@@ -217,6 +218,80 @@ describe("renderAdminPage", () => {
       navFeatureStatus: {},
     });
     expect(html).toContain('href="/admin/notices"');
+  });
+});
+
+describe("renderAdminPage grouped sidebar (#613)", () => {
+  const render = (navFeatureStatus?: Record<string, boolean>): string =>
+    renderAdminPage({
+      title: "Dashboard",
+      active: "/admin/",
+      body: "",
+      csrfToken: "",
+      remainingMs: 0,
+      navFeatureStatus,
+    });
+
+  it("renders every group heading in the fixed order", () => {
+    const html = render();
+    const positions = NAV_GROUP_ORDER.map((g) =>
+      html.indexOf(`nav-group-heading">${g}<`),
+    );
+    // All present...
+    for (const pos of positions) expect(pos).toBeGreaterThan(-1);
+    // ...and in ascending (fixed) order.
+    const sorted = [...positions].sort((a, b) => a - b);
+    expect(positions).toEqual(sorted);
+  });
+
+  it("groups each nav item under its declared group heading", () => {
+    const html = render();
+    // Heading order maps to the fixed group order; an item must appear after
+    // its own group's heading and before the next group's heading.
+    const headingPos = (g: string): number =>
+      html.indexOf(`nav-group-heading">${g}<`);
+    for (const item of NAV_ITEMS) {
+      const groupIdx = NAV_GROUP_ORDER.indexOf(item.group);
+      const start = headingPos(item.group);
+      const nextGroup = NAV_GROUP_ORDER[groupIdx + 1];
+      const end = nextGroup === undefined ? html.length : headingPos(nextGroup);
+      const itemPos = html.indexOf(`href="${item.href}"`);
+      expect(itemPos).toBeGreaterThan(start);
+      expect(itemPos).toBeLessThan(end);
+    }
+  });
+
+  it("omits a group's heading when all of its items are filtered out", () => {
+    // Every Features-group item is feature-gated; turn them all off.
+    const html = render({
+      "announcements.enabled": false,
+      "polls.enabled": false,
+      "reactionroles.enabled": false,
+      "notices.enabled": false,
+      "voicechannels.enabled": false,
+    });
+    // The whole Features group disappears — no dangling header.
+    expect(html).not.toContain('nav-group-heading">Features<');
+    // The always-present groups remain.
+    expect(html).toContain('nav-group-heading">Info<');
+    expect(html).toContain('nav-group-heading">Settings<');
+  });
+
+  it("keeps a group's heading when at least one item survives filtering", () => {
+    const html = render({
+      "announcements.enabled": false,
+      "polls.enabled": true,
+      "reactionroles.enabled": false,
+      "notices.enabled": false,
+      "voicechannels.enabled": false,
+    });
+    expect(html).toContain('nav-group-heading">Features<');
+    expect(html).toContain('href="/admin/polls"');
+    expect(html).not.toContain('href="/admin/announcements"');
+  });
+
+  it("ships muted CSS for the group heading consistent with the sidebar", () => {
+    expect(render()).toContain("nav.side .nav-group-heading{");
   });
 });
 

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -194,7 +194,7 @@ const STYLE = [
   // Grouped sidebar sections (#613): a muted, small uppercase heading sits
   // above each group's <ul>, consistent with the dark sidebar palette.
   "nav.side .nav-group+.nav-group{margin-top:1rem}",
-  "nav.side .nav-group-heading{padding:.25rem .75rem;font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:#64748b}",
+  "nav.side .nav-group-heading{padding:.25rem .75rem;font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:#94a3b8}",
   "nav.side a{display:block;padding:.5rem .75rem;border-radius:6px;color:#cbd5e1}",
   "nav.side a:hover{background:#1f2937;text-decoration:none}",
   "nav.side a.active{background:#1d2a44;color:#fff}",

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -56,9 +56,28 @@ export function escapeJsInAttr(value: unknown): string {
   return escapeHtml(jsSafe);
 }
 
+/**
+ * Sidebar groups, rendered in this fixed order (#613). Splitting the
+ * formerly-flat list into a few labelled sections keeps related pages
+ * together as the page count grows:
+ *   - Info     — read-only diagnostics / status surfaces.
+ *   - Settings — configuration & setup surfaces.
+ *   - Features — the feature-gated pages (these line up with `featureKey`).
+ */
+export type NavGroup = "Info" | "Settings" | "Features";
+
+/** Fixed render order of the sidebar groups. */
+export const NAV_GROUP_ORDER: readonly NavGroup[] = [
+  "Info",
+  "Settings",
+  "Features",
+];
+
 interface NavItem {
   href: string;
   label: string;
+  /** Which sidebar section this item belongs to (#613). */
+  group: NavGroup;
   /**
    * Config key (a `<feature>.enabled` boolean) that gates this page. When
    * set and the feature resolves to `false`, the item is hidden from the
@@ -73,35 +92,47 @@ interface NavItem {
 }
 
 export const NAV_ITEMS: NavItem[] = [
-  { href: "/admin/", label: "Dashboard" },
-  { href: "/admin/settings", label: "Settings" },
-  { href: "/admin/permissions", label: "Permissions" },
-  { href: "/admin/wizard", label: "Setup Wizard" },
+  // Info — read-only diagnostics / status surfaces.
+  { href: "/admin/", label: "Dashboard", group: "Info" },
+  { href: "/admin/bot-status", label: "Bot Status", group: "Info" },
+  { href: "/admin/database", label: "Database", group: "Info" },
+  { href: "/admin/audit/commands", label: "Command Audit", group: "Info" },
+  { href: "/admin/bootstrap", label: "Bootstrap", group: "Info" },
+  // Settings — configuration & setup surfaces.
+  { href: "/admin/settings", label: "Settings", group: "Settings" },
+  { href: "/admin/permissions", label: "Permissions", group: "Settings" },
+  { href: "/admin/wizard", label: "Setup Wizard", group: "Settings" },
+  // Features — feature-gated pages (hidden when their feature is off).
   {
     href: "/admin/announcements",
     label: "Announcements",
+    group: "Features",
     featureKey: "announcements.enabled",
   },
-  { href: "/admin/polls", label: "Polls", featureKey: "polls.enabled" },
+  {
+    href: "/admin/polls",
+    label: "Polls",
+    group: "Features",
+    featureKey: "polls.enabled",
+  },
   {
     href: "/admin/reaction-roles",
     label: "Reaction Roles",
+    group: "Features",
     featureKey: "reactionroles.enabled",
   },
   {
     href: "/admin/notices",
     label: "Notices",
+    group: "Features",
     featureKey: "notices.enabled",
   },
   {
     href: "/admin/voice-channels",
     label: "Voice Channels",
+    group: "Features",
     featureKey: "voicechannels.enabled",
   },
-  { href: "/admin/bot-status", label: "Bot Status" },
-  { href: "/admin/database", label: "Database" },
-  { href: "/admin/audit/commands", label: "Command Audit" },
-  { href: "/admin/bootstrap", label: "Bootstrap" },
 ];
 
 /**
@@ -160,6 +191,10 @@ const STYLE = [
   ".shell{display:flex;min-height:calc(100vh - 41px)}",
   "nav.side{background:#161a22;border-right:1px solid #2d3748;width:220px;padding:1rem .5rem;flex-shrink:0}",
   "nav.side ul{list-style:none;padding:0;margin:0}",
+  // Grouped sidebar sections (#613): a muted, small uppercase heading sits
+  // above each group's <ul>, consistent with the dark sidebar palette.
+  "nav.side .nav-group+.nav-group{margin-top:1rem}",
+  "nav.side .nav-group-heading{padding:.25rem .75rem;font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:#64748b}",
   "nav.side a{display:block;padding:.5rem .75rem;border-radius:6px;color:#cbd5e1}",
   "nav.side a:hover{background:#1f2937;text-decoration:none}",
   "nav.side a.active{background:#1d2a44;color:#fff}",
@@ -459,21 +494,34 @@ function renderNav(
   active: string,
   navFeatureStatus?: NavFeatureStatus,
 ): string {
-  return NAV_ITEMS.filter((item) => {
-    // No status map → show everything. Otherwise hide items whose gating
-    // feature resolves to false. An unknown featureKey (missing from the
-    // map) is treated as enabled so a wiring gap never blanks the nav.
+  // No status map → show everything. Otherwise hide items whose gating
+  // feature resolves to false. An unknown featureKey (missing from the
+  // map) is treated as enabled so a wiring gap never blanks the nav.
+  const isVisible = (item: NavItem): boolean => {
     if (!navFeatureStatus || !item.featureKey) return true;
     return navFeatureStatus[item.featureKey] !== false;
-  })
-    .map((item) => {
-      const isActive =
-        item.href === active ||
-        (item.href === "/admin/" && active === "/admin");
-      const cls = isActive ? ' class="active"' : "";
-      return `<li><a href="${escapeHtml(item.href)}"${cls}>${escapeHtml(item.label)}</a></li>`;
-    })
-    .join("");
+  };
+  const renderItem = (item: NavItem): string => {
+    const isActive =
+      item.href === active || (item.href === "/admin/" && active === "/admin");
+    const cls = isActive ? ' class="active"' : "";
+    return `<li><a href="${escapeHtml(item.href)}"${cls}>${escapeHtml(item.label)}</a></li>`;
+  };
+  // One <ul> per group, preceded by a small heading. A group whose items
+  // are all filtered out by feature gating renders nothing at all — no
+  // dangling header (#613).
+  return NAV_GROUP_ORDER.map((group) => {
+    const items = NAV_ITEMS.filter(
+      (item) => item.group === group && isVisible(item),
+    );
+    if (items.length === 0) return "";
+    return (
+      `<div class="nav-group">` +
+      `<div class="nav-group-heading">${escapeHtml(group)}</div>` +
+      `<ul>${items.map(renderItem).join("")}</ul>` +
+      `</div>`
+    );
+  }).join("");
 }
 
 export function renderAdminPage(opts: AdminPageOptions): string {
@@ -502,7 +550,7 @@ export function renderAdminPage(opts: AdminPageOptions): string {
     '<button type="submit">Finish</button>',
     "</form></div></div>",
     '<div class="shell">',
-    `<nav class="side"><ul>${renderNav(opts.active, opts.navFeatureStatus)}</ul></nav>`,
+    `<nav class="side">${renderNav(opts.active, opts.navFeatureStatus)}</nav>`,
     `<main>${opts.body}</main></div>`,
     `<script>${SCRIPT}</script>`,
     `<script>${CRON_PICKER_SCRIPT}</script>`,


### PR DESCRIPTION
## Summary

Closes #613. The admin sidebar was a single flat list of ~13 links (`NAV_ITEMS` in `src/web/admin-layout.ts`). As more pages were added it became a long, undifferentiated column. This groups the nav into three labelled, fixed-order sections so related pages sit together:

| Group | Items |
|---|---|
| **Info** | Dashboard, Bot Status, Database, Command Audit, Bootstrap |
| **Settings** | Settings, Permissions, Setup Wizard |
| **Features** | Announcements, Polls, Reaction Roles, Notices, Voice Channels |

The "Features" boundary lines up naturally with the feature-gated items, as the issue noted.

## Changes

- Add a `group` field to `NavItem` and a `NAV_GROUP_ORDER` constant (`Info` → `Settings` → `Features`) defining the fixed render order.
- `renderNav` now emits one `<ul>` per group preceded by a small muted heading. The existing active-item highlighting and feature-filter logic are preserved unchanged. **A group whose items are all filtered out renders no header** (no dangling empty section when its features are off).
- `renderAdminPage` no longer wraps the nav in a single outer `<ul>` (each group brings its own).
- Add muted, small-uppercase heading CSS to `STYLE`, consistent with the dark sidebar (`#161a22` bar, `#cbd5e1` links).
- `resolveNavFeatureStatus` is unchanged — the grouping is purely presentational.
- Note the `group` requirement in the `DEVELOPER_GUIDE.md` "add a feature" checklist.

## Tests

Added a `renderAdminPage grouped sidebar` suite covering:
- All group headings render in the fixed order.
- Each nav item appears under its declared group's heading.
- A group's heading is omitted when all its items are filtered out (all Features disabled).
- A group's heading stays when at least one item survives.

All 29 tests in the file pass; `npm run build`, `lint`, and `format:check` are green.

## Acceptance criteria

- [x] Sidebar organised into a small number of labelled groups in a fixed order.
- [x] Feature-gated items still hide when disabled; a group whose items are all hidden renders no header.
- [x] Active-item highlighting and direct-URL reachability unchanged.
- [x] Group headings styled consistently with the dark sidebar.
- [x] Tests cover grouped render order and header omission.

https://claude.ai/code/session_01UEiesgYUkXmB7UaoJcJz6D

---
_Generated by [Claude Code](https://claude.ai/code/session_01UEiesgYUkXmB7UaoJcJz6D)_