### PR TITLE
build(docker): drop no-op OpenSSL stopgap now node:24-alpine is patched

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -127,8 +127,8 @@ jobs:
           # whenever Alpine ships security updates, so pulling fresh is how the
           # image absorbs patched system OpenSSL (libssl3/libcrypto3) — e.g. the
           # High PKCS7_verify use-after-free (#57/#72). Without this, the gha
-          # build cache reuses the stale base + `apk upgrade` layers and a
-          # rebuild on main never clears the CVE.
+          # build cache could reuse a stale base and a rebuild on main would
+          # never pick up the fix.
           pull: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,14 +29,6 @@ FROM node:24-alpine
 
 WORKDIR /app
 
-# Stopgap: pull patched OpenSSL libraries ahead of the base image so Trivy's
-# system-package scan stays clean whenever the Alpine base lags upstream
-# OpenSSL fixes (historically flagged against libssl3/libcrypto3 — High
-# #57/#72, Medium #590, Low #62-#71/#77-#86 on node:22-alpine). Runs as root
-# before dropping to USER node. Drop once Trivy confirms node:24-alpine ships
-# the fixed libssl3/libcrypto3 (tracked in #604).
-RUN apk --no-cache upgrade libssl3 libcrypto3
-
 # Copy only runtime artifacts
 COPY --from=builder --chown=node:node /app/package*.json ./
 COPY --from=builder --chown=node:node /app/dist ./dist


### PR DESCRIPTION
## Summary

Closes #604.

The production image **already runs as the non-root `node` user (uid 1000)** — `USER node` was kept in place when the base bumped to `node:24-alpine` (#634). The remaining work tracked under #604 was removing the OpenSSL `apk upgrade` stopgap once the new base was confirmed to ship patched `libssl3`/`libcrypto3`.

This PR:
1. Removes the `RUN apk --no-cache upgrade libssl3 libcrypto3` stopgap (and its comment) from the production stage of `Dockerfile`.
2. Trims the `docker.yml` `pull: true` comment so it no longer references the now-removed `apk upgrade` layer (pulling the base fresh still keeps the image on the latest patched system OpenSSL).
3. Leaves `USER node` in place (already enabled).

## Precondition: base image confirmed clean

The stopgap existed to pull patched OpenSSL ahead of the base back when `node:22-alpine` lagged upstream fixes. On `node:24-alpine` it is a **confirmed no-op**.

Evidence — the first fresh build of the new base (the #634 merge, `docker.yml` run `27600999958`, sha `4881f06`) ran the step uncached and printed only the terminal summary, with **no** `Upgrading libssl3/libcrypto3` lines on either arch:

```
#18 [linux/amd64 stage-2 3/6] RUN apk --no-cache upgrade libssl3 libcrypto3
#18 1.256 OK: 10.8 MiB in 18 packages
```
```
#20 [linux/arm64 stage-2 3/6] RUN apk --no-cache upgrade libssl3 libcrypto3
#20 4.842 OK: 11.1 MiB in 18 packages
```

`apk` only prints `OK: ... in N packages` (with no `Upgrading ...` lines) when nothing needs upgrading — i.e. the base (Alpine 3.24.1) already ships the latest patched `libssl3`/`libcrypto3`. Removing the stopgap drops a dead build layer that ran as root.

> Note: I could not run a fresh Trivy scan inside this environment — the sandbox network policy blocks both the Docker Hub and GHCR blob CDNs, so `node:24-alpine` cannot be pulled here. The `apk` no-op output above is direct, independent evidence that the base ships the patched OpenSSL; the `docker.yml` Trivy step (CRITICAL,HIGH / ignore-unfixed) will continue to gate the result on every push to `main`.

## `Dockerfile.dev` — non-root parity decision

Left running as **root, intentionally**. It is a local-only dev image (never built, scanned, or pushed by the Trivy gate) that bind-mounts host source (`.:/app`) with an anonymous `node_modules` volume; switching it to a non-root uid would create ownership/`EACCES` friction in the dev workflow for no security benefit. The non-root hardening that #604 targets applies to the shipped production image.

## Test plan

- [x] Trivy precondition: `node:24-alpine` already ships patched OpenSSL — `apk upgrade libssl3 libcrypto3` is a no-op (evidence above).
- [x] Production stage keeps `USER node` (uid 1000); runtime artifacts are `COPY --chown=node:node`.
- [x] Web UI / health port is `3000` (>1024) — non-root can bind.
- [x] `Dockerfile.dev` reviewed — kept as root (rationale above).
- [ ] CI `docker.yml` build + Trivy scan on merge confirms 0 High OpenSSL findings without the stopgap.

https://claude.ai/code/session_01EHDAwQZwh3Nf5qPhp5dJ4Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHDAwQZwh3Nf5qPhp5dJ4Z)_