### PR TITLE
feat(webui): surface disabled feature pages in admin nav with enable prompt

### DIFF
--- a/WEBUI.md
+++ b/WEBUI.md
@@ -757,6 +757,16 @@ No dashboard JSON ships with the bot — wire these up to taste:
 | **Command Audit**  | (new — read-only Discord slash-command audit log)                                                   |
 | **Bootstrap**      | (new — read-only env diagnostics)                                                                   |
 
+Feature pages (Announcements, Polls, Reaction Roles, Notices, Voice
+Channels) are gated by their `<feature>.enabled` config key. When a
+feature is **off**, its sidebar link is still shown — greyed with an
+"off" badge — rather than hidden, so the page stays discoverable (#610);
+hiding it created a chicken-and-egg where the natural place to enable a
+feature was the very page you couldn't reach. Opening a disabled feature's
+page renders a banner explaining the state with an inline **Enable** button
+(flips the flag via `/admin/settings/set` and returns you to the page) plus
+an **Open Settings** link.
+
 The **Bot Status** page (`/admin/bot-status`) edits the three "Watching …"
 presence message pools the bot rotates through, picked by how many users
 are in voice: the *empty*, *one user*, and *multiple users* pools. Each

--- a/__tests__/web/admin-layout.test.ts
+++ b/__tests__/web/admin-layout.test.ts
@@ -178,7 +178,7 @@ describe("renderAdminPage", () => {
     }
   });
 
-  it("hides feature-gated nav items whose feature is disabled", () => {
+  it("shows feature-gated nav items even when disabled, marked off (#610)", () => {
     const html = renderAdminPage({
       title: "Dashboard",
       active: "/admin/",
@@ -193,14 +193,23 @@ describe("renderAdminPage", () => {
         "voicechannels.enabled": true,
       },
     });
-    // Disabled features are gone.
-    expect(html).not.toContain('href="/admin/announcements"');
-    expect(html).not.toContain('href="/admin/reaction-roles"');
-    expect(html).not.toContain('href="/admin/notices"');
-    // Enabled features stay.
+    // Disabled features stay advertised so the page is discoverable...
+    expect(html).toContain('href="/admin/announcements"');
+    expect(html).toContain('href="/admin/reaction-roles"');
+    expect(html).toContain('href="/admin/notices"');
+    // ...but greyed and tagged "off".
+    expect(html).toContain('href="/admin/announcements" class="nav-disabled"');
+    expect(html).toContain('href="/admin/reaction-roles" class="nav-disabled"');
+    expect(html).toContain('href="/admin/notices" class="nav-disabled"');
+    expect(html).toContain('<span class="nav-badge">off</span>');
+    // Enabled features render as plain links (no disabled marker).
     expect(html).toContain('href="/admin/polls"');
+    expect(html).not.toContain('href="/admin/polls" class="nav-disabled"');
     expect(html).toContain('href="/admin/voice-channels"');
-    // Ungated items are always present.
+    expect(html).not.toContain(
+      'href="/admin/voice-channels" class="nav-disabled"',
+    );
+    // Ungated items are always present and never marked disabled.
     expect(html).toContain('href="/admin/settings"');
     expect(html).toContain('href="/admin/database"');
     expect(html).toContain('href="/admin/bootstrap"');
@@ -261,7 +270,7 @@ describe("renderAdminPage grouped sidebar (#613)", () => {
     }
   });
 
-  it("omits a group's heading when all of its items are filtered out", () => {
+  it("keeps the Features group with items greyed when all are disabled (#610)", () => {
     // Every Features-group item is feature-gated; turn them all off.
     const html = render({
       "announcements.enabled": false,
@@ -270,14 +279,17 @@ describe("renderAdminPage grouped sidebar (#613)", () => {
       "notices.enabled": false,
       "voicechannels.enabled": false,
     });
-    // The whole Features group disappears — no dangling header.
-    expect(html).not.toContain('nav-group-heading">Features<');
+    // The Features group stays visible — every item is shown, just greyed —
+    // so a disabled feature's page is still reachable from the sidebar.
+    expect(html).toContain('nav-group-heading">Features<');
+    expect(html).toContain('href="/admin/polls" class="nav-disabled"');
+    expect(html).toContain('href="/admin/announcements" class="nav-disabled"');
     // The always-present groups remain.
     expect(html).toContain('nav-group-heading">Info<');
     expect(html).toContain('nav-group-heading">Settings<');
   });
 
-  it("keeps a group's heading when at least one item survives filtering", () => {
+  it("renders every Features item, greying only the disabled ones (#610)", () => {
     const html = render({
       "announcements.enabled": false,
       "polls.enabled": true,
@@ -286,8 +298,11 @@ describe("renderAdminPage grouped sidebar (#613)", () => {
       "voicechannels.enabled": false,
     });
     expect(html).toContain('nav-group-heading">Features<');
+    // Enabled item: plain link.
     expect(html).toContain('href="/admin/polls"');
-    expect(html).not.toContain('href="/admin/announcements"');
+    expect(html).not.toContain('href="/admin/polls" class="nav-disabled"');
+    // Disabled item: still present, greyed.
+    expect(html).toContain('href="/admin/announcements" class="nav-disabled"');
   });
 
   it("ships muted CSS for the group heading consistent with the sidebar", () => {

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -915,6 +915,44 @@ describe("renderPollsPage", () => {
     expect(html).toContain("No poll questions");
   });
 
+  it("renders an enable banner with an inline action when disabled (#610)", () => {
+    const html = renderPollsPage({
+      ...COMMON,
+      enabled: false,
+      defaultDurationHours: 24,
+      cooldownDays: 7,
+      schedules: [],
+      items: [],
+      textChannels: [],
+      roles: [],
+    });
+    // The disabled page explains the state instead of looking blank...
+    expect(html).toContain('class="notice warn feature-disabled"');
+    expect(html).toContain("Polls are disabled");
+    // ...and offers an inline enable that flips polls.enabled and returns here.
+    expect(html).toContain('action="/admin/settings/set"');
+    expect(html).toContain('name="key" value="polls.enabled"');
+    expect(html).toContain('name="value" value="true"');
+    expect(html).toContain('name="redirect" value="/admin/polls"');
+    expect(html).toContain("Open Settings");
+  });
+
+  it("omits the enable banner when polls are enabled (#610)", () => {
+    const html = renderPollsPage({
+      ...COMMON,
+      enabled: true,
+      defaultDurationHours: 24,
+      cooldownDays: 7,
+      schedules: [],
+      items: [],
+      textChannels: [],
+      roles: [],
+    });
+    // The CSS rule for the banner is always present; assert on the rendered
+    // notice element rather than the bare class name.
+    expect(html).not.toContain('class="notice warn feature-disabled"');
+  });
+
   it("renders schedules and items with channel + role mentions", () => {
     const html = renderPollsPage({
       ...COMMON,

--- a/__tests__/web/write-routes.test.ts
+++ b/__tests__/web/write-routes.test.ts
@@ -11,6 +11,7 @@ import {
   firstLengthError,
   parseStringListImport,
   resetConfigToDefaults,
+  safeAdminRedirect,
   truncateFlash,
   wantsJson,
   TEXT_LIMITS,
@@ -457,6 +458,26 @@ describe("findSectionMasterKey", () => {
 
   it("returns null for an unknown key that merely ends with .enabled", () => {
     expect(findSectionMasterKey(["bogus.feature.enabled"])).toBeNull();
+  });
+});
+
+describe("safeAdminRedirect (#610)", () => {
+  it("allows a known feature-page nav target", () => {
+    expect(safeAdminRedirect("/admin/polls")).toBe("/admin/polls");
+    expect(safeAdminRedirect("/admin/voice-channels")).toBe(
+      "/admin/voice-channels",
+    );
+  });
+
+  it("falls back to /admin/settings for unknown or empty targets", () => {
+    expect(safeAdminRedirect("")).toBe("/admin/settings");
+    expect(safeAdminRedirect("/admin/unknown")).toBe("/admin/settings");
+  });
+
+  it("rejects off-site and protocol-relative targets (no open redirect)", () => {
+    expect(safeAdminRedirect("https://evil.example/")).toBe("/admin/settings");
+    expect(safeAdminRedirect("//evil.example")).toBe("/admin/settings");
+    expect(safeAdminRedirect("/etc/passwd")).toBe("/admin/settings");
   });
 });
 

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -80,10 +80,12 @@ interface NavItem {
   group: NavGroup;
   /**
    * Config key (a `<feature>.enabled` boolean) that gates this page. When
-   * set and the feature resolves to `false`, the item is hidden from the
-   * sidebar. Items without a `featureKey` — Dashboard, Settings, etc. —
-   * are always shown. The page URL itself stays reachable by direct
-   * navigation; only the nav advertisement is suppressed.
+   * set and the feature resolves to `false`, the item is still shown but
+   * rendered greyed with an "off" badge (#610) — hiding it left the page
+   * undiscoverable, since the natural place to enable a feature is its own
+   * page. Items without a `featureKey` — Dashboard, Settings, etc. — render
+   * as plain links. The page URL is reachable either way; the gating only
+   * changes how the nav advertises it.
    *
    * Typed as `keyof ConfigSchema` so a typo in `NAV_ITEMS` fails at
    * compile time rather than silently never matching at runtime.
@@ -198,6 +200,12 @@ const STYLE = [
   "nav.side a{display:block;padding:.5rem .75rem;border-radius:6px;color:#cbd5e1}",
   "nav.side a:hover{background:#1f2937;text-decoration:none}",
   "nav.side a.active{background:#1d2a44;color:#fff}",
+  // Feature-gated pages whose feature is off are shown but greyed with an
+  // "off" badge so they stay discoverable (#610). The active page keeps its
+  // highlight even when disabled, so the greying only applies when inactive.
+  "nav.side a.nav-disabled:not(.active){color:#6b7280}",
+  "nav.side a.nav-disabled:not(.active):hover{color:#94a3b8}",
+  "nav.side a .nav-badge{float:right;font-size:.6rem;font-weight:600;text-transform:uppercase;letter-spacing:.04em;color:#cbd5e1;background:#374151;border-radius:4px;padding:.05rem .3rem;margin-top:.1rem}",
   "main{flex:1;padding:1.5rem 2rem;max-width:1100px}",
   "h1{margin:0 0 .25rem;font-size:1.5rem}",
   "h2{margin:1.5rem 0 .5rem;font-size:1.15rem;color:#cbd5e1}",
@@ -232,6 +240,12 @@ const STYLE = [
   ".notice.ok{background:#14532d;color:#bbf7d0}",
   ".notice.warn{background:#4a3a0d;color:#fde68a}",
   ".notice.err{background:#4b1e1e;color:#fecaca}",
+  // Disabled-feature banner (#610): explanatory text on the left, inline
+  // enable action + Settings link on the right; wraps on narrow screens.
+  ".notice.feature-disabled{display:flex;flex-wrap:wrap;gap:.75rem;align-items:center;justify-content:space-between}",
+  ".notice.feature-disabled .fd-text{flex:1 1 280px}",
+  ".notice.feature-disabled .fd-actions{display:flex;gap:.5rem;align-items:center;flex-wrap:wrap}",
+  ".notice.feature-disabled form{margin:0}",
   "form.stack{display:flex;flex-direction:column;gap:.6rem}",
   "form.stack label{display:flex;flex-direction:column;gap:.25rem;font-size:.85rem;color:#cbd5e1}",
   "form.stack label.checkbox{flex-direction:row;align-items:center;gap:.5rem}",
@@ -494,26 +508,34 @@ function renderNav(
   active: string,
   navFeatureStatus?: NavFeatureStatus,
 ): string {
-  // No status map → show everything. Otherwise hide items whose gating
-  // feature resolves to false. An unknown featureKey (missing from the
-  // map) is treated as enabled so a wiring gap never blanks the nav.
-  const isVisible = (item: NavItem): boolean => {
-    if (!navFeatureStatus || !item.featureKey) return true;
-    return navFeatureStatus[item.featureKey] !== false;
+  // Feature-gated items are shown even when their feature is off (#610) so
+  // the page stays discoverable; a disabled item is greyed and tagged "off"
+  // but the link still works, and the page itself renders an "enable here"
+  // prompt. An unknown featureKey (missing from the map) and items without a
+  // featureKey render as plain links — a wiring gap fails open, not greyed.
+  const isDisabled = (item: NavItem): boolean => {
+    if (!navFeatureStatus || !item.featureKey) return false;
+    return navFeatureStatus[item.featureKey] === false;
   };
   const renderItem = (item: NavItem): string => {
     const isActive =
       item.href === active || (item.href === "/admin/" && active === "/admin");
-    const cls = isActive ? ' class="active"' : "";
-    return `<li><a href="${escapeHtml(item.href)}"${cls}>${escapeHtml(item.label)}</a></li>`;
+    const disabled = isDisabled(item);
+    const classes = [isActive ? "active" : "", disabled ? "nav-disabled" : ""]
+      .filter(Boolean)
+      .join(" ");
+    const cls = classes ? ` class="${classes}"` : "";
+    const title = disabled
+      ? ' title="This feature is disabled — open it to enable it"'
+      : "";
+    const badge = disabled ? '<span class="nav-badge">off</span>' : "";
+    return `<li><a href="${escapeHtml(item.href)}"${cls}${title}>${escapeHtml(item.label)}${badge}</a></li>`;
   };
-  // One <ul> per group, preceded by a small heading. A group whose items
-  // are all filtered out by feature gating renders nothing at all — no
-  // dangling header (#613).
+  // One <ul> per group, preceded by a small heading. Feature items are now
+  // always shown, so a group only renders empty if it genuinely has no items
+  // — no dangling header (#613).
   return NAV_GROUP_ORDER.map((group) => {
-    const items = NAV_ITEMS.filter(
-      (item) => item.group === group && isVisible(item),
-    );
+    const items = NAV_ITEMS.filter((item) => item.group === group);
     if (items.length === 0) return "";
     return (
       `<div class="nav-group">` +

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -1230,6 +1230,41 @@ function renderFlash(flash?: FlashMessage | null): string {
   return `<div class="notice ${cls}">${escapeHtml(flash.text)}</div>`;
 }
 
+/**
+ * Banner shown at the top of a feature page when that feature is disabled
+ * (#610). Feature pages are reachable even while off — their nav link is now
+ * greyed rather than hidden — so a disabled page must explain the state and
+ * offer a way to enable it instead of looking empty or broken. Renders a
+ * warning notice with an inline "Enable" action (flips the `<feature>.enabled`
+ * flag via the existing /admin/settings/set route and returns to this same
+ * page) plus a link to the full Settings surface.
+ *
+ * Returns "" when `enabled` is true so callers can drop it in unconditionally.
+ */
+function renderFeatureDisabledNotice(opts: {
+  enabled: boolean;
+  label: string;
+  featureKey: string;
+  returnTo: string;
+  csrfToken: string;
+}): string {
+  if (opts.enabled) return "";
+  const label = escapeHtml(opts.label);
+  return `<div class="notice warn feature-disabled">
+  <div class="fd-text"><strong>${label} are disabled.</strong> The settings below stay inactive until you turn the feature on. Enable it here, or from Settings.</div>
+  <div class="fd-actions">
+    <form method="POST" action="/admin/settings/set">
+      <input type="hidden" name="_csrf" value="${escapeHtml(opts.csrfToken)}">
+      <input type="hidden" name="key" value="${escapeHtml(opts.featureKey)}">
+      <input type="hidden" name="value" value="true">
+      <input type="hidden" name="redirect" value="${escapeHtml(opts.returnTo)}">
+      <button type="submit" class="btn btn-primary">Enable ${label}</button>
+    </form>
+    <a class="btn btn-secondary" href="/admin/settings">Open Settings</a>
+  </div>
+</div>`;
+}
+
 function channelOptionsHtml(
   options: ChannelOption[],
   selectedId?: string,
@@ -1332,6 +1367,7 @@ export function renderAnnouncementsPage(props: AnnouncementsProps): string {
 <h1>Announcements</h1>
 <p class="subtitle">Scheduled announcements posted on a cron. Replaces <code>/announce</code> and <code>/announce-vc-stats</code>; the slash commands still work in parallel during migration.</p>
 ${renderFlash(props.flash)}
+${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Announcements", featureKey: "announcements.enabled", returnTo: "/admin/announcements", csrfToken: props.csrfToken })}
 <div class="card">
   <h2>Status</h2>
   <dl class="kv">
@@ -1490,6 +1526,7 @@ export function renderPollsPage(props: PollsProps): string {
 <h1>Polls</h1>
 <p class="subtitle">Poll schedules and the question library. Replaces <code>/poll create|delete|test|add-item|delete-item|import-url|list|list-items</code>; the slash commands still work in parallel during migration.</p>
 ${renderFlash(props.flash)}
+${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Polls", featureKey: "polls.enabled", returnTo: "/admin/polls", csrfToken: props.csrfToken })}
 <div class="card">
   <h2>Status</h2>
   <dl class="kv">
@@ -1647,6 +1684,7 @@ export function renderReactionRolesPage(props: ReactionRolesProps): string {
 <h1>Reaction Roles</h1>
 <p class="subtitle">Per-message reaction-role mappings. Replaces <code>/reactrole create|archive|unarchive|delete|list|status</code>; the slash commands still work in parallel during migration.</p>
 ${renderFlash(props.flash)}
+${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Reaction Roles", featureKey: "reactionroles.enabled", returnTo: "/admin/reaction-roles", csrfToken: props.csrfToken })}
 <div class="card">
   <h2>Status</h2>
   <dl class="kv">
@@ -1778,6 +1816,7 @@ export function renderNoticesPage(props: NoticesProps): string {
 <h1>Notices</h1>
 <p class="subtitle">Notice posts grouped by category. Replaces <code>/notice add|edit|delete|sync</code>; the slash commands still work in parallel during migration. Edit the inline <em>Order</em> field to reorder within a category (lower numbers post first).</p>
 ${renderFlash(props.flash)}
+${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Notices", featureKey: "notices.enabled", returnTo: "/admin/notices", csrfToken: props.csrfToken })}
 <div class="card">
   <h2>Status</h2>
   <dl class="kv">
@@ -2150,6 +2189,7 @@ export function renderVoiceChannelsPage(props: VoiceChannelsProps): string {
 <h1>Voice Channels</h1>
 <p class="subtitle">Voice-channel category contents and live state. Replaces <code>/vc force-reload</code>; for the gentler empty-channel cleanup use <code>/vc reload</code>. The slash commands still work in parallel during migration.</p>
 ${renderFlash(props.flash)}
+${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Voice Channels", featureKey: "voicechannels.enabled", returnTo: "/admin/voice-channels", csrfToken: props.csrfToken })}
 <div class="card">
   <h2>Status</h2>
   <dl class="kv">

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -1251,7 +1251,7 @@ function renderFeatureDisabledNotice(opts: {
   if (opts.enabled) return "";
   const label = escapeHtml(opts.label);
   return `<div class="notice warn feature-disabled">
-  <div class="fd-text"><strong>${label} are disabled.</strong> The settings below stay inactive until you turn the feature on. Enable it here, or from Settings.</div>
+  <div class="fd-text"><strong>${label} are disabled.</strong> You can still configure things below, but they won't take effect until you enable the feature. Enable it here, or from Settings.</div>
   <div class="fd-actions">
     <form method="POST" action="/admin/settings/set">
       <input type="hidden" name="_csrf" value="${escapeHtml(opts.csrfToken)}">

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -64,6 +64,7 @@ import {
 import {
   getDisplayedRemainingMs,
   resolveNavFeatureStatus,
+  NAV_ITEMS,
 } from "./admin-layout.js";
 import {
   renderImportDiffPage,
@@ -153,6 +154,22 @@ function getString(req: AuthenticatedRequest, name: string): string {
   const raw = (req.body as Record<string, unknown> | undefined)?.[name];
   if (typeof raw !== "string") return "";
   return raw.trim();
+}
+
+/**
+ * Allowlisted post-action redirect targets (#610). The feature pages render an
+ * inline "Enable <feature>" form that POSTs to /admin/settings/set with a
+ * `redirect` field so the operator lands back on the page they enabled rather
+ * than on /admin/settings. Restricting the target to known nav hrefs closes
+ * the open-redirect door — an unrecognised value falls back to the Settings
+ * page that this route has always returned to.
+ */
+const ADMIN_REDIRECT_ALLOWLIST = new Set<string>(
+  NAV_ITEMS.map((item) => item.href),
+);
+
+export function safeAdminRedirect(raw: string): string {
+  return ADMIN_REDIRECT_ALLOWLIST.has(raw) ? raw : "/admin/settings";
 }
 
 function getCheckbox(req: AuthenticatedRequest, name: string): boolean {
@@ -518,6 +535,10 @@ export function createWriteRouter(
       const session = requireSessionContext(req);
       const key = getString(req, "key");
       const raw = (req.body as Record<string, unknown> | undefined)?.value;
+      // Where to land after the write. Defaults to /admin/settings (this
+      // route's historical target); the feature pages' inline "Enable"
+      // action passes their own page so the operator returns there (#610).
+      const redirectTo = safeAdminRedirect(getString(req, "redirect"));
 
       const coerced = coerceConfigValue(key, raw);
       if (!coerced.ok) {
@@ -528,7 +549,7 @@ export function createWriteRouter(
           result: "failure",
           errorMessage: coerced.reason,
         });
-        flashRedirect(res, "/admin/settings", {
+        flashRedirect(res, redirectTo, {
           type: "err",
           text: `Cannot set ${key || "(empty key)"}: ${coerced.reason}.`,
         });
@@ -567,7 +588,7 @@ export function createWriteRouter(
           unknown.length > 0
             ? ` Note: ${unknown.join(", ")} ${unknown.length === 1 ? "is not a" : "are not"} recognised emoji shortcode${unknown.length === 1 ? "" : "s"} (kept as typed; custom server emoji can't appear in channel names).`
             : "";
-        flashRedirect(res, "/admin/settings", {
+        flashRedirect(res, redirectTo, {
           type: unknown.length > 0 ? "warn" : "ok",
           text: `Set ${key} = ${String(coerced.value)}.${hint}`,
         });
@@ -581,7 +602,7 @@ export function createWriteRouter(
           result: "failure",
           errorMessage: text,
         });
-        flashRedirect(res, "/admin/settings", {
+        flashRedirect(res, redirectTo, {
           type: "err",
           text: `Failed to set ${key}: ${text}`,
         });


### PR DESCRIPTION
## Summary

Fixes #610. Feature-gated admin pages (Polls, Announcements, Reaction Roles, Notices, Voice Channels) were **hidden** from the sidebar when their `<feature>.enabled` flag was off — the default for most features. That made them undiscoverable: you had to enable a feature to reach the page that enables it (a chicken-and-egg the reporter hit with "I cannot see the edit/add/remove poll questions anywhere").

This implements the issue's recommended **option 1 + 3**: keep feature pages advertised in the nav even when disabled, and make the page itself explain the disabled state with a way out. The pattern generalises to every `featureKey`-gated nav item.

## Changes

- **`src/web/admin-layout.ts`** — `renderNav` now renders feature-gated items even when their feature is off, greyed with an `off` badge (instead of dropping them). The link still works; the Features group no longer collapses when everything is disabled. Added matching sidebar CSS and a disabled-banner layout rule.
- **`src/web/admin-views.ts`** — new reusable `renderFeatureDisabledNotice` helper, dropped into all five feature pages right below the flash slot. When the feature is off it renders a warning banner explaining the state with an inline **Enable** button (posts `<feature>.enabled = true` to `/admin/settings/set` and returns to the page) plus an **Open Settings** link. Returns `""` when enabled, so it's a no-op on active pages.
- **`src/web/write-routes.ts`** — `/admin/settings/set` now honours an optional `redirect` field so the inline Enable action lands back on the feature page. Targets are restricted to the known nav hrefs (`safeAdminRedirect`) to avoid an open redirect; unknown/empty values fall back to the historical `/admin/settings`.
- **`WEBUI.md`** — documents the new discoverability behaviour.

## Acceptance criteria

- [x] An admin can discover and reach a feature page from the sidebar even when the feature is disabled (greyed link + `off` badge).
- [x] Reaching a disabled feature page shows a clear "disabled — enable here" banner with an inline enable action, not an empty/confusing page.
- [x] The pattern generalises to every `featureKey`-gated nav item (all five feature pages get it via the shared helper).

## Testing

- `npm run build` ✅ · `npm run lint` ✅ · `npm run format:check` ✅ · `npx markdownlint WEBUI.md` ✅
- `npm run test:ci` ✅ — 107 suites / 1213 tests pass, coverage thresholds met.
- Updated `admin-layout.test.ts` (nav now shows-but-greys disabled items), added `admin-views.test.ts` cases for the polls enable banner, and added `safeAdminRedirect` unit tests (incl. open-redirect rejection).

https://claude.ai/code/session_01HpgJDbUQf2ZzZNjdk3AaaQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpgJDbUQf2ZzZNjdk3AaaQ)_