### PR TITLE
fix(wizard): correct interval type and harden cleanup timer

### DIFF
--- a/src/services/wizard-service.ts
+++ b/src/services/wizard-service.ts
@@ -33,7 +33,7 @@ export class WizardService {
   private static instance: WizardService;
   private sessions: Map<string, WizardState> = new Map();
   private readonly SESSION_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
-  private cleanupInterval: ReturnType<typeof setTimeout> | null = null;
+  private cleanupInterval: ReturnType<typeof setInterval> | null = null;
   private configService: ConfigService;
 
   private constructor() {
@@ -53,8 +53,15 @@ export class WizardService {
    */
   private startCleanupTimer(): void {
     this.cleanupInterval = setInterval(() => {
-      this.cleanupExpiredSessions();
+      try {
+        this.cleanupExpiredSessions();
+      } catch (error) {
+        logger.error("WizardService: error during session cleanup:", error);
+      }
     }, 60000); // Check every minute
+
+    // Don't keep the event loop alive solely for this background cleanup.
+    this.cleanupInterval.unref?.();
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes the two related issues in `src/services/wizard-service.ts` `startCleanupTimer()` reported in #645:

1. **Wrong type annotation** — `cleanupInterval` was typed `ReturnType<typeof setTimeout>` despite being assigned from `setInterval`. Changed to `ReturnType<typeof setInterval>` to match its usage and align with the other interval-holding services (`cooldown-manager.ts`, `voice-channel-manager.ts`, `monitoring-service.ts`).
2. **Missing error handling** — the interval callback now wraps `cleanupExpiredSessions()` in `try/catch` and logs errors via the logger, so a future throw can never propagate uncaught into the event loop. This follows the CLAUDE.md rule that periodic jobs "must never crash the process."

Also added `this.cleanupInterval.unref?.()` so the background cleanup timer does not keep the event loop alive and block clean process shutdown (matching `cooldown-manager.ts`).

## Acceptance Criteria

- [x] `cleanupInterval` field type changed to `ReturnType<typeof setInterval>`
- [x] `startCleanupTimer` callback wraps `cleanupExpiredSessions()` in `try/catch` and logs errors
- [x] Interval handle calls `.unref?.()`
- [x] `shutdown()` already calls `clearInterval` on the handle (no change needed)

## Testing

- `npm run build` ✅
- `npx eslint src/services/wizard-service.ts` ✅
- `npx prettier --check` ✅
- `__tests__/services/wizard-service.test.ts` — 23/23 passing ✅

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EyH4cVYbuBGteYVkMqLPWK)_