### PR TITLE
fix(monitoring): unref periodic logging interval so it can't block shutdown

### DIFF
--- a/src/services/monitoring-service.ts
+++ b/src/services/monitoring-service.ts
@@ -216,6 +216,9 @@ export class MonitoringService {
       },
       60 * 60 * 1000,
     ); // Every hour
+
+    // Don't keep the event loop alive solely for this background logging.
+    this.periodicLoggingInterval.unref?.();
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #647.

`MonitoringService.startPeriodicLogging()` created an hourly `setInterval` but never called `.unref()` on the handle. That kept a reference in the Node.js event loop, so on a graceful shutdown (SIGTERM/SIGINT) the process could be held alive until the next tick fired — up to an hour — making clean shutdown unreliable.

## Change

Added `this.periodicLoggingInterval.unref?.()` immediately after the `setInterval` assignment, matching the pattern already used in `cooldown-manager.ts:26` and `bot-status-service.ts`. The optional chaining (`?.`) guards environments where `.unref` is absent (timer shims in tests).

## Acceptance criteria

- [x] `startPeriodicLogging()` calls `this.periodicLoggingInterval.unref?.()` after the `setInterval` assignment
- [x] Existing `destroy()` method is unchanged (still calls `clearInterval` for explicit cleanup)
- [x] No behaviour change to the logging itself

## Verification

- `npm run build` (typecheck) passes
- `prettier --check` and `eslint` clean on the changed file
- All 28 existing `monitoring-service` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhiGMjP1ozc3NG6xobRzcQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhiGMjP1ozc3NG6xobRzcQ)_