### PR TITLE
feat(monitoring): persist command metrics to MongoDB with admin dashboard

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -989,6 +989,18 @@ above).
 - `ratelimit.window_seconds` (number, default: 10)
 - `ratelimit.bypass_admin` (bool, default: true)
 
+#### Command Metrics (persisted analytics)
+
+`MonitoringService` keeps live, in-memory per-command counters and also
+persists them to MongoDB in daily buckets so they survive restarts and feed
+the Web UI's **Command Metrics** dashboard (`/admin/metrics`). Writes are
+batched (every few minutes, never per-invocation) and pruned by a TTL index.
+
+- `monitoring.metrics_persistence.enabled` (bool, default: true) — when off,
+  command metrics stay in-memory only and nothing is written to MongoDB.
+- `monitoring.metrics_retention_days` (number, default: 30) — days to keep
+  persisted daily buckets before the TTL index prunes them.
+
 ### Bootstrap env vars (read-only in Web UI)
 
 - `DISCORD_TOKEN`, `CLIENT_ID`, `GUILD_ID`, `MONGODB_URI`

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -755,6 +755,7 @@ No dashboard JSON ships with the bot — wire these up to taste:
 | **Voice Channels** | `/vc force-reload` (single **Force VC cleanup** button)                                             |
 | **Database**       | `/dbtrunk status`, `/dbtrunk run`                                                                   |
 | **Command Audit**  | (new — read-only Discord slash-command audit log)                                                   |
+| **Command Metrics**| (new — historical per-command usage / error-rate / latency dashboard)                               |
 | **Bootstrap**      | (new — read-only env diagnostics)                                                                   |
 
 Feature pages (Announcements, Polls, Reaction Roles, Notices, Voice
@@ -780,6 +781,20 @@ use **Seed defaults into store** to start editing from those defaults.
 Entries in the *multiple users* pool must contain the `{count}`
 placeholder (replaced with the live user count); the editor rejects saves
 that omit it.
+
+The **Command Metrics** page (`/admin/metrics`) is a read-only analytics
+dashboard for slash-command usage over a trailing window (7- or 30-day
+toggle). `MonitoringService` accumulates per-command counters in memory and
+flushes them in batches to MongoDB as daily `{command, date, guildId}`
+buckets, so the data survives restarts (unlike the live in-memory view) and
+is pruned automatically by a TTL index. The page shows commands by usage,
+an error spotlight (commands at or above a 10% error rate), the slowest
+commands by average response time, and a per-day usage trend. Persistence
+is governed by `monitoring.metrics_persistence.enabled` (default on) and the
+window by `monitoring.metrics_retention_days` (default 30). This is
+complementary to the Prometheus `/metrics` endpoint, which exposes
+process-level gauges (uptime, memory) rather than historical per-command
+counters.
 
 ### User self-service (`/me/*`, both admin and user roles)
 

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -789,9 +789,11 @@ flushes them in batches to MongoDB as daily `{command, date, guildId}`
 buckets, so the data survives restarts (unlike the live in-memory view) and
 is pruned automatically by a TTL index. The page shows commands by usage,
 an error spotlight (commands at or above a 10% error rate), the slowest
-commands by average response time, and a per-day usage trend. Persistence
-is governed by `monitoring.metrics_persistence.enabled` (default on) and the
-window by `monitoring.metrics_retention_days` (default 30). This is
+commands by average response time, and a per-day usage trend. The 7d/30d
+toggle only selects the view window over already-persisted data; it is not a
+config key. Persistence is governed by `monitoring.metrics_persistence.enabled`
+(default on), while `monitoring.metrics_retention_days` (default 30) controls
+how long buckets are kept before the TTL index prunes them. This is
 complementary to the Prometheus `/metrics` endpoint, which exposes
 process-level gauges (uptime, memory) rather than historical per-command
 counters.

--- a/__tests__/commands/achievements.test.ts
+++ b/__tests__/commands/achievements.test.ts
@@ -1,73 +1,75 @@
-import { describe, it, expect, jest } from '@jest/globals';
-import { data, formatMetadata } from '../../src/commands/achievements.js';
+import { describe, it, expect, jest } from "@jest/globals";
+import { data, formatMetadata } from "../../src/commands/achievements.js";
 
-jest.mock('../../src/services/achievements-service.js');
-jest.mock('../../src/utils/logger.js');
+jest.mock("../../src/services/achievements-service.js");
+jest.mock("../../src/utils/logger.js");
 
-describe('Achievements Command', () => {
-  describe('command metadata', () => {
-    it('should have correct command name', () => {
-      expect(data.name).toBe('achievements');
+describe("Achievements Command", () => {
+  describe("command metadata", () => {
+    it("should have correct command name", () => {
+      expect(data.name).toBe("achievements");
     });
 
-    it('should have a description', () => {
+    it("should have a description", () => {
       expect(data.description).toBeTruthy();
-      expect(data.description).toBe('View earned badges and achievements');
+      expect(data.description).toBe("View earned badges and achievements");
     });
 
-    it('should be a valid slash command', () => {
+    it("should be a valid slash command", () => {
       const json = data.toJSON();
-      expect(json).toHaveProperty('name', 'achievements');
-      expect(json).toHaveProperty('description');
+      expect(json).toHaveProperty("name", "achievements");
+      expect(json).toHaveProperty("description");
     });
 
-    it('should have optional user parameter', () => {
+    it("should have optional user parameter", () => {
       const json = data.toJSON();
       expect(json.options).toBeDefined();
       expect(json.options?.length).toBe(1);
-      
+
       const userOption = json.options?.[0];
-      expect(userOption?.name).toBe('user');
+      expect(userOption?.name).toBe("user");
       expect(userOption?.type).toBe(6); // USER type
       expect(userOption?.required).toBe(false);
     });
 
-    it('should have description for user parameter', () => {
+    it("should have description for user parameter", () => {
       const json = data.toJSON();
       const userOption = json.options?.[0];
       expect(userOption?.description).toBeTruthy();
-      expect(userOption?.description).toContain('user');
+      expect(userOption?.description).toContain("user");
     });
   });
 
-  describe('embed chunking logic', () => {
-    it('should respect Discord 1024 character field limit', () => {
+  describe("embed chunking logic", () => {
+    it("should respect Discord 1024 character field limit", () => {
       // Test the chunking algorithm conceptually
       const MAX_FIELD_LENGTH = 1024;
-      
+
       // Create mock accolade texts that together exceed the limit
       const mockAccolades = [
-        'A'.repeat(300),
-        'B'.repeat(300),
-        'C'.repeat(300),
-        'D'.repeat(300),
+        "A".repeat(300),
+        "B".repeat(300),
+        "C".repeat(300),
+        "D".repeat(300),
       ];
 
       // Simulate chunking logic
       const chunks: string[] = [];
-      let currentChunk = '';
+      let currentChunk = "";
 
       for (const accoladeText of mockAccolades) {
-        const separator = currentChunk.length > 0 ? '\n\n' : '';
-        const potentialLength = currentChunk.length + separator.length + accoladeText.length;
+        const separator = currentChunk.length > 0 ? "\n\n" : "";
+        const potentialLength =
+          currentChunk.length + separator.length + accoladeText.length;
 
         if (potentialLength > MAX_FIELD_LENGTH) {
           if (currentChunk.length > 0) {
             chunks.push(currentChunk);
           }
-          currentChunk = accoladeText.length > MAX_FIELD_LENGTH
-            ? `${accoladeText.slice(0, MAX_FIELD_LENGTH - 3)}...`
-            : accoladeText;
+          currentChunk =
+            accoladeText.length > MAX_FIELD_LENGTH
+              ? `${accoladeText.slice(0, MAX_FIELD_LENGTH - 3)}...`
+              : accoladeText;
         } else {
           currentChunk += `${separator}${accoladeText}`;
         }
@@ -78,7 +80,7 @@ describe('Achievements Command', () => {
       }
 
       // Verify all chunks are within limit
-      chunks.forEach(chunk => {
+      chunks.forEach((chunk) => {
         expect(chunk.length).toBeLessThanOrEqual(MAX_FIELD_LENGTH);
       });
 
@@ -86,22 +88,23 @@ describe('Achievements Command', () => {
       expect(chunks.length).toBeGreaterThan(1);
     });
 
-    it('should handle single long accolade that exceeds limit', () => {
+    it("should handle single long accolade that exceeds limit", () => {
       const MAX_FIELD_LENGTH = 1024;
-      const longText = 'X'.repeat(1500);
+      const longText = "X".repeat(1500);
 
       // Truncate logic
-      const truncatedText = longText.length > MAX_FIELD_LENGTH
-        ? `${longText.slice(0, MAX_FIELD_LENGTH - 3)}...`
-        : longText;
+      const truncatedText =
+        longText.length > MAX_FIELD_LENGTH
+          ? `${longText.slice(0, MAX_FIELD_LENGTH - 3)}...`
+          : longText;
 
       expect(truncatedText.length).toBeLessThanOrEqual(MAX_FIELD_LENGTH);
-      expect(truncatedText.endsWith('...')).toBe(true);
+      expect(truncatedText.endsWith("...")).toBe(true);
     });
 
-    it('should handle empty accolade list', () => {
+    it("should handle empty accolade list", () => {
       const accoladesList: string[] = [];
-      
+
       // Should not create any chunks
       const chunks: string[] = [];
       if (accoladesList.length === 0) {
@@ -112,77 +115,77 @@ describe('Achievements Command', () => {
     });
   });
 
-  describe('metadata formatting', () => {
-    it('should use unit field when available', () => {
+  describe("metadata formatting", () => {
+    it("should use unit field when available", () => {
       const metadataText = formatMetadata({
         value: 100,
-        description: '100 hours milestone',
-        unit: 'hrs',
+        description: "100 hours milestone",
+        unit: "hrs",
       });
 
-      expect(metadataText).toBe(' - 100 hrs');
+      expect(metadataText).toBe(" - 100 hrs");
     });
 
-    it('should handle missing unit field gracefully', () => {
+    it("should handle missing unit field gracefully", () => {
       const metadataText = formatMetadata({
         value: 100,
-        description: '100 hours milestone',
+        description: "100 hours milestone",
       });
 
-      expect(metadataText).toBe(' - 100');
+      expect(metadataText).toBe(" - 100");
     });
 
-    it('should handle user count with users unit', () => {
+    it("should handle user count with users unit", () => {
       const metadataText = formatMetadata({
         value: 25,
-        description: '25+ unique users',
-        unit: 'users',
+        description: "25+ unique users",
+        unit: "users",
       });
 
-      expect(metadataText).toBe(' - 25 users');
+      expect(metadataText).toBe(" - 25 users");
     });
 
-    it('should handle missing metadata', () => {
+    it("should handle missing metadata", () => {
       const metadataText = formatMetadata(undefined);
 
-      expect(metadataText).toBe('');
+      expect(metadataText).toBe("");
     });
   });
 
-  describe('accolade text formatting', () => {
-    it('should format complete accolade text correctly', () => {
+  describe("accolade text formatting", () => {
+    it("should format complete accolade text correctly", () => {
       const mockDefinition = {
-        emoji: '🎉',
-        name: 'First Steps',
-        description: 'Spent your first hour in voice chat',
+        emoji: "🎉",
+        name: "First Steps",
+        description: "Spent your first hour in voice chat",
       };
 
-      const earnedDate = '1/19/2026';
-      const metadataText = ' - 12 hrs';
+      const earnedDate = "1/19/2026";
+      const metadataText = " - 12 hrs";
 
       const accoladeText = `${mockDefinition.emoji} **${mockDefinition.name}**${metadataText}\n*${mockDefinition.description}*\nEarned: ${earnedDate}`;
 
-      expect(accoladeText).toContain('🎉');
-      expect(accoladeText).toContain('**First Steps**');
-      expect(accoladeText).toContain('12 hrs');
-      expect(accoladeText).toContain('*Spent your first hour in voice chat*');
-      expect(accoladeText).toContain('Earned: 1/19/2026');
+      expect(accoladeText).toContain("🎉");
+      expect(accoladeText).toContain("**First Steps**");
+      expect(accoladeText).toContain("12 hrs");
+      expect(accoladeText).toContain("*Spent your first hour in voice chat*");
+      expect(accoladeText).toContain("Earned: 1/19/2026");
     });
 
-    it('should handle accolade without metadata', () => {
+    it("should handle accolade without metadata", () => {
       const mockDefinition = {
-        emoji: '🏆',
-        name: 'Some Badge',
-        description: 'A badge description',
+        emoji: "🏆",
+        name: "Some Badge",
+        description: "A badge description",
       };
 
-      const earnedDate = '1/19/2026';
-      const metadataText = '';
+      const earnedDate = "1/19/2026";
+      const metadataText = "";
 
       const accoladeText = `${mockDefinition.emoji} **${mockDefinition.name}**${metadataText}\n*${mockDefinition.description}*\nEarned: ${earnedDate}`;
 
-      expect(accoladeText).not.toContain(' - ');
-      expect(accoladeText).toContain('🏆 **Some Badge**\n');
+      expect(accoladeText).not.toContain(" - ");
+      expect(accoladeText).toContain("🏆 **Some Badge**\n");
     });
   });
 

--- a/__tests__/commands/command-options-validation.test.ts
+++ b/__tests__/commands/command-options-validation.test.ts
@@ -1,92 +1,114 @@
-import { describe, it, expect } from '@jest/globals';
-import { data as voiceStatsData } from '../../src/commands/voicestats.js';
-import { data as seenData } from '../../src/commands/seen.js';
+import { describe, it, expect } from "@jest/globals";
+import { data as voiceStatsData } from "../../src/commands/voicestats.js";
+import { data as seenData } from "../../src/commands/seen.js";
 
-describe('Command Options Validation', () => {
-  describe('VoiceStats Command Options', () => {
+describe("Command Options Validation", () => {
+  describe("VoiceStats Command Options", () => {
     const json = voiceStatsData.toJSON();
 
-    it('should have two subcommands', () => {
+    it("should have two subcommands", () => {
       expect(json.options).toBeDefined();
       expect(json.options?.length).toBe(2);
     });
 
-    it('should have top subcommand', () => {
-      const topSubcommand = json.options?.find((opt: any) => opt.name === 'top');
+    it("should have top subcommand", () => {
+      const topSubcommand = json.options?.find(
+        (opt: any) => opt.name === "top",
+      );
       expect(topSubcommand).toBeDefined();
       expect(topSubcommand?.type).toBe(1); // Subcommand type
-      expect(topSubcommand?.description).toBe('Show top voice channel users');
+      expect(topSubcommand?.description).toBe("Show top voice channel users");
     });
 
-    it('should have user subcommand', () => {
-      const userSubcommand = json.options?.find((opt: any) => opt.name === 'user');
+    it("should have user subcommand", () => {
+      const userSubcommand = json.options?.find(
+        (opt: any) => opt.name === "user",
+      );
       expect(userSubcommand).toBeDefined();
       expect(userSubcommand?.type).toBe(1); // Subcommand type
-      expect(userSubcommand?.description).toBe('Show voice channel statistics for a user');
+      expect(userSubcommand?.description).toBe(
+        "Show voice channel statistics for a user",
+      );
     });
 
-    it('top subcommand should have correct limit option', () => {
-      const topSubcommand = json.options?.find((opt: any) => opt.name === 'top');
-      const limitOption = topSubcommand?.options?.find((opt: any) => opt.name === 'limit');
+    it("top subcommand should have correct limit option", () => {
+      const topSubcommand = json.options?.find(
+        (opt: any) => opt.name === "top",
+      );
+      const limitOption = topSubcommand?.options?.find(
+        (opt: any) => opt.name === "limit",
+      );
       expect(limitOption).toBeDefined();
       expect(limitOption?.type).toBe(4); // Integer type
       expect(limitOption?.required).toBe(false);
-      expect(limitOption?.description).toBe('Number of users to show');
+      expect(limitOption?.description).toBe("Number of users to show");
       expect(limitOption?.min_value).toBe(1);
       expect(limitOption?.max_value).toBe(50);
     });
 
-    it('top subcommand should have correct period option', () => {
-      const topSubcommand = json.options?.find((opt: any) => opt.name === 'top');
-      const periodOption = topSubcommand?.options?.find((opt: any) => opt.name === 'period');
+    it("top subcommand should have correct period option", () => {
+      const topSubcommand = json.options?.find(
+        (opt: any) => opt.name === "top",
+      );
+      const periodOption = topSubcommand?.options?.find(
+        (opt: any) => opt.name === "period",
+      );
       expect(periodOption).toBeDefined();
       expect(periodOption?.type).toBe(3); // String type
       expect(periodOption?.required).toBe(false);
-      expect(periodOption?.description).toBe('Time period to show stats for');
+      expect(periodOption?.description).toBe("Time period to show stats for");
       expect(periodOption?.choices).toEqual([
-        { name: 'This Week', value: 'week' },
-        { name: 'This Month', value: 'month' },
-        { name: 'All Time', value: 'alltime' },
+        { name: "This Week", value: "week" },
+        { name: "This Month", value: "month" },
+        { name: "All Time", value: "alltime" },
       ]);
     });
 
-    it('user subcommand should have correct user option', () => {
-      const userSubcommand = json.options?.find((opt: any) => opt.name === 'user');
-      const userOption = userSubcommand?.options?.find((opt: any) => opt.name === 'user');
+    it("user subcommand should have correct user option", () => {
+      const userSubcommand = json.options?.find(
+        (opt: any) => opt.name === "user",
+      );
+      const userOption = userSubcommand?.options?.find(
+        (opt: any) => opt.name === "user",
+      );
       expect(userOption).toBeDefined();
       expect(userOption?.type).toBe(6); // User type
       expect(userOption?.required).toBe(false);
-      expect(userOption?.description).toBe('The user to show statistics for');
+      expect(userOption?.description).toBe("The user to show statistics for");
     });
 
-    it('user subcommand should have correct period option', () => {
-      const userSubcommand = json.options?.find((opt: any) => opt.name === 'user');
-      const periodOption = userSubcommand?.options?.find((opt: any) => opt.name === 'period');
+    it("user subcommand should have correct period option", () => {
+      const userSubcommand = json.options?.find(
+        (opt: any) => opt.name === "user",
+      );
+      const periodOption = userSubcommand?.options?.find(
+        (opt: any) => opt.name === "period",
+      );
       expect(periodOption).toBeDefined();
       expect(periodOption?.type).toBe(3); // String type
       expect(periodOption?.required).toBe(false);
-      expect(periodOption?.description).toBe('Time period to show stats for');
+      expect(periodOption?.description).toBe("Time period to show stats for");
       expect(periodOption?.choices).toEqual([
-        { name: 'This Week', value: 'week' },
-        { name: 'This Month', value: 'month' },
-        { name: 'All Time', value: 'alltime' },
+        { name: "This Week", value: "week" },
+        { name: "This Month", value: "month" },
+        { name: "All Time", value: "alltime" },
       ]);
     });
   });
 
-  describe('Seen Command Options', () => {
+  describe("Seen Command Options", () => {
     const json = seenData.toJSON();
 
-    it('should have required user option', () => {
+    it("should have required user option", () => {
       const userOption = json.options?.[0];
       expect(userOption).toBeDefined();
-      expect(userOption?.name).toBe('user');
+      expect(userOption?.name).toBe("user");
       expect(userOption?.type).toBe(6); // User type
       expect(userOption?.required).toBe(true);
-      expect(userOption?.description).toBe('The user to check');
+      expect(userOption?.description).toBe("The user to check");
     });
 
-    it('should have exactly 1 option', () => {
+    it("should have exactly 1 option", () => {
       expect(json.options?.length).toBe(1);
     });
   });

--- a/__tests__/commands/help.test.ts
+++ b/__tests__/commands/help.test.ts
@@ -1,47 +1,47 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import { data, execute } from '../../src/commands/help.js';
-import type { ChatInputCommandInteraction } from 'discord.js';
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { data, execute } from "../../src/commands/help.js";
+import type { ChatInputCommandInteraction } from "discord.js";
 
 // Mock logger
-jest.mock('../../src/utils/logger.js');
+jest.mock("../../src/utils/logger.js");
 
-describe('Help Command', () => {
-  describe('command metadata', () => {
-    it('should have correct command name', () => {
-      expect(data.name).toBe('help');
+describe("Help Command", () => {
+  describe("command metadata", () => {
+    it("should have correct command name", () => {
+      expect(data.name).toBe("help");
     });
 
-    it('should have a description', () => {
+    it("should have a description", () => {
       expect(data.description).toBeTruthy();
-      expect(data.description).toBe('Get help with KoolBot commands');
+      expect(data.description).toBe("Get help with KoolBot commands");
     });
 
-    it('should be a valid slash command', () => {
+    it("should be a valid slash command", () => {
       const json = data.toJSON();
-      expect(json).toHaveProperty('name', 'help');
-      expect(json).toHaveProperty('description');
+      expect(json).toHaveProperty("name", "help");
+      expect(json).toHaveProperty("description");
     });
 
-    it('should have optional command parameter', () => {
+    it("should have optional command parameter", () => {
       const json = data.toJSON();
       expect(json.options).toBeDefined();
       expect(json.options?.length).toBe(1);
-      
+
       const commandOption = json.options?.[0];
-      expect(commandOption?.name).toBe('command');
+      expect(commandOption?.name).toBe("command");
       expect(commandOption?.type).toBe(3); // STRING type
       expect(commandOption?.required).toBe(false);
     });
 
-    it('should have description for command parameter', () => {
+    it("should have description for command parameter", () => {
       const json = data.toJSON();
       const commandOption = json.options?.[0];
       expect(commandOption?.description).toBeTruthy();
-      expect(commandOption?.description).toContain('specific command');
+      expect(commandOption?.description).toContain("specific command");
     });
   });
 
-  describe('execute', () => {
+  describe("execute", () => {
     let mockInteraction: Partial<ChatInputCommandInteraction>;
 
     beforeEach(() => {
@@ -55,14 +55,14 @@ describe('Help Command', () => {
       };
     });
 
-    it('should show general help when no command is specified', async () => {
+    it("should show general help when no command is specified", async () => {
       await execute(mockInteraction as ChatInputCommandInteraction);
 
       expect(mockInteraction.reply).toHaveBeenCalledWith({
         embeds: expect.arrayContaining([
           expect.objectContaining({
             data: expect.objectContaining({
-              title: '📚 KoolBot Help',
+              title: "📚 KoolBot Help",
             }),
           }),
         ]),
@@ -70,8 +70,8 @@ describe('Help Command', () => {
       });
     });
 
-    it('should show specific command help when valid command is specified', async () => {
-      (mockInteraction.options!.getString as jest.Mock).mockReturnValue('ping');
+    it("should show specific command help when valid command is specified", async () => {
+      (mockInteraction.options!.getString as jest.Mock).mockReturnValue("ping");
 
       await execute(mockInteraction as ChatInputCommandInteraction);
 
@@ -79,7 +79,7 @@ describe('Help Command', () => {
         embeds: expect.arrayContaining([
           expect.objectContaining({
             data: expect.objectContaining({
-              title: '📖 Help: /ping',
+              title: "📖 Help: /ping",
             }),
           }),
         ]),
@@ -87,27 +87,33 @@ describe('Help Command', () => {
       });
     });
 
-    it('should show error for non-existent command', async () => {
-      (mockInteraction.options!.getString as jest.Mock).mockReturnValue('nonexistent');
+    it("should show error for non-existent command", async () => {
+      (mockInteraction.options!.getString as jest.Mock).mockReturnValue(
+        "nonexistent",
+      );
 
       await execute(mockInteraction as ChatInputCommandInteraction);
 
       expect(mockInteraction.reply).toHaveBeenCalledWith({
-        content: expect.stringContaining('Command `/nonexistent` not found'),
+        content: expect.stringContaining("Command `/nonexistent` not found"),
         ephemeral: true,
       });
     });
 
-    it('should handle commands without config keys', async () => {
-      (mockInteraction.options!.getString as jest.Mock).mockReturnValue('config');
+    it("should handle commands without config keys", async () => {
+      (mockInteraction.options!.getString as jest.Mock).mockReturnValue(
+        "config",
+      );
 
       await execute(mockInteraction as ChatInputCommandInteraction);
 
       expect(mockInteraction.reply).toHaveBeenCalled();
     });
 
-    it('should include usage information in specific command help', async () => {
-      (mockInteraction.options!.getString as jest.Mock).mockReturnValue('voicestats');
+    it("should include usage information in specific command help", async () => {
+      (mockInteraction.options!.getString as jest.Mock).mockReturnValue(
+        "voicestats",
+      );
 
       await execute(mockInteraction as ChatInputCommandInteraction);
 
@@ -117,7 +123,7 @@ describe('Help Command', () => {
             data: expect.objectContaining({
               fields: expect.arrayContaining([
                 expect.objectContaining({
-                  name: 'Usage',
+                  name: "Usage",
                 }),
               ]),
             }),
@@ -127,8 +133,8 @@ describe('Help Command', () => {
       });
     });
 
-    it('should handle multiple known commands', async () => {
-      const commands = ['ping', 'help', 'quote', 'achievements'];
+    it("should handle multiple known commands", async () => {
+      const commands = ["ping", "help", "quote", "achievements"];
 
       for (const cmd of commands) {
         mockInteraction.reply = jest.fn().mockResolvedValue(undefined);

--- a/__tests__/commands/ping.test.ts
+++ b/__tests__/commands/ping.test.ts
@@ -1,27 +1,27 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import { data, execute } from '../../src/commands/ping.js';
-import type { ChatInputCommandInteraction, Message, Client } from 'discord.js';
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { data, execute } from "../../src/commands/ping.js";
+import type { ChatInputCommandInteraction, Message, Client } from "discord.js";
 
 // Mock logger
-jest.mock('../../src/utils/logger.js');
+jest.mock("../../src/utils/logger.js");
 
-describe('Ping Command', () => {
-  describe('command metadata', () => {
-    it('should have correct command name', () => {
-      expect(data.name).toBe('ping');
+describe("Ping Command", () => {
+  describe("command metadata", () => {
+    it("should have correct command name", () => {
+      expect(data.name).toBe("ping");
     });
 
-    it('should have a description', () => {
-      expect(data.description).toBe('Replies with Pong!');
+    it("should have a description", () => {
+      expect(data.description).toBe("Replies with Pong!");
     });
 
-    it('should be a valid slash command', () => {
-      expect(data.toJSON()).toHaveProperty('name', 'ping');
-      expect(data.toJSON()).toHaveProperty('description', 'Replies with Pong!');
+    it("should be a valid slash command", () => {
+      expect(data.toJSON()).toHaveProperty("name", "ping");
+      expect(data.toJSON()).toHaveProperty("description", "Replies with Pong!");
     });
   });
 
-  describe('execute', () => {
+  describe("execute", () => {
     let mockInteraction: Partial<ChatInputCommandInteraction>;
     let mockMessage: Partial<Message>;
     let mockClient: Partial<Client>;
@@ -47,47 +47,47 @@ describe('Ping Command', () => {
       };
     });
 
-    it('should reply with latency information', async () => {
+    it("should reply with latency information", async () => {
       await execute(mockInteraction as ChatInputCommandInteraction);
 
       expect(mockInteraction.reply).toHaveBeenCalledWith({
-        content: 'Pinging...',
+        content: "Pinging...",
         fetchReply: true,
       });
 
       expect(mockInteraction.editReply).toHaveBeenCalledWith(
-        expect.stringContaining('Pong! 🏓')
+        expect.stringContaining("Pong! 🏓"),
       );
       expect(mockInteraction.editReply).toHaveBeenCalledWith(
-        expect.stringContaining('Bot Latency: 100ms')
+        expect.stringContaining("Bot Latency: 100ms"),
       );
       expect(mockInteraction.editReply).toHaveBeenCalledWith(
-        expect.stringContaining('API Latency: 50ms')
+        expect.stringContaining("API Latency: 50ms"),
       );
     });
 
-    it('should calculate correct bot latency', async () => {
+    it("should calculate correct bot latency", async () => {
       mockInteraction.createdTimestamp = 500;
       (mockMessage as any).createdTimestamp = 750;
 
       await execute(mockInteraction as ChatInputCommandInteraction);
 
       expect(mockInteraction.editReply).toHaveBeenCalledWith(
-        expect.stringContaining('Bot Latency: 250ms')
+        expect.stringContaining("Bot Latency: 250ms"),
       );
     });
 
-    it('should handle API latency from WebSocket', async () => {
+    it("should handle API latency from WebSocket", async () => {
       mockClient.ws = { ping: 125 } as any;
 
       await execute(mockInteraction as ChatInputCommandInteraction);
 
       expect(mockInteraction.editReply).toHaveBeenCalledWith(
-        expect.stringContaining('API Latency: 125ms')
+        expect.stringContaining("API Latency: 125ms"),
       );
     });
 
-    it('should handle very low latency', async () => {
+    it("should handle very low latency", async () => {
       mockInteraction.createdTimestamp = 999;
       (mockMessage as any).createdTimestamp = 1000;
       mockClient.ws = { ping: 1 } as any;
@@ -95,7 +95,7 @@ describe('Ping Command', () => {
       await execute(mockInteraction as ChatInputCommandInteraction);
 
       expect(mockInteraction.editReply).toHaveBeenCalledWith(
-        expect.stringContaining('Bot Latency: 1ms')
+        expect.stringContaining("Bot Latency: 1ms"),
       );
     });
   });

--- a/__tests__/commands/quote.test.ts
+++ b/__tests__/commands/quote.test.ts
@@ -1,105 +1,135 @@
-import { describe, it, expect } from '@jest/globals';
-import { data } from '../../src/commands/quote.js';
+import { describe, it, expect } from "@jest/globals";
+import { data } from "../../src/commands/quote.js";
 
-describe('Quote Command', () => {
-  describe('command metadata', () => {
-    it('should have correct command name', () => {
-      expect(data.name).toBe('quote');
+describe("Quote Command", () => {
+  describe("command metadata", () => {
+    it("should have correct command name", () => {
+      expect(data.name).toBe("quote");
     });
 
-    it('should have a description', () => {
+    it("should have a description", () => {
       expect(data.description).toBeTruthy();
-      expect(data.description).toContain('quote');
+      expect(data.description).toContain("quote");
     });
 
-    it('should be a valid slash command', () => {
+    it("should be a valid slash command", () => {
       const json = data.toJSON();
-      expect(json).toHaveProperty('name', 'quote');
-      expect(json).toHaveProperty('description');
+      expect(json).toHaveProperty("name", "quote");
+      expect(json).toHaveProperty("description");
     });
 
-    it('should have subcommands', () => {
+    it("should have subcommands", () => {
       const json = data.toJSON();
       expect(json.options).toBeDefined();
       expect(json.options?.length).toBeGreaterThanOrEqual(2);
-      
+
       // Check for 'add' subcommand
-      const addSubcommand = json.options?.find((opt: any) => opt.name === 'add');
+      const addSubcommand = json.options?.find(
+        (opt: any) => opt.name === "add",
+      );
       expect(addSubcommand).toBeDefined();
       expect(addSubcommand?.type).toBe(1); // SUBCOMMAND type
-      
+
       // Check for 'edit' subcommand
-      const editSubcommand = json.options?.find((opt: any) => opt.name === 'edit');
+      const editSubcommand = json.options?.find(
+        (opt: any) => opt.name === "edit",
+      );
       expect(editSubcommand).toBeDefined();
       expect(editSubcommand?.type).toBe(1); // SUBCOMMAND type
     });
   });
 
-  describe('add subcommand', () => {
-    it('should have text parameter', () => {
+  describe("add subcommand", () => {
+    it("should have text parameter", () => {
       const json = data.toJSON();
-      const addSubcommand = json.options?.find((opt: any) => opt.name === 'add');
+      const addSubcommand = json.options?.find(
+        (opt: any) => opt.name === "add",
+      );
       expect(addSubcommand).toBeDefined();
-      
-      const textOption = addSubcommand?.options?.find((opt: any) => opt.name === 'text');
+
+      const textOption = addSubcommand?.options?.find(
+        (opt: any) => opt.name === "text",
+      );
       expect(textOption).toBeDefined();
       expect(textOption?.type).toBe(3); // STRING type
       expect(textOption?.required).toBe(true);
-      expect(textOption?.description).toContain('quote text');
+      expect(textOption?.description).toContain("quote text");
     });
 
-    it('should have author parameter as user type', () => {
+    it("should have author parameter as user type", () => {
       const json = data.toJSON();
-      const addSubcommand = json.options?.find((opt: any) => opt.name === 'add');
+      const addSubcommand = json.options?.find(
+        (opt: any) => opt.name === "add",
+      );
       expect(addSubcommand).toBeDefined();
-      
-      const authorOption = addSubcommand?.options?.find((opt: any) => opt.name === 'author');
+
+      const authorOption = addSubcommand?.options?.find(
+        (opt: any) => opt.name === "author",
+      );
       expect(authorOption).toBeDefined();
       expect(authorOption?.type).toBe(6); // USER type
       expect(authorOption?.required).toBe(true);
-      expect(authorOption?.description).toContain('author');
+      expect(authorOption?.description).toContain("author");
     });
 
-    it('should require both text and author parameters', () => {
+    it("should require both text and author parameters", () => {
       const json = data.toJSON();
-      const addSubcommand = json.options?.find((opt: any) => opt.name === 'add');
-      const textOption = addSubcommand?.options?.find((opt: any) => opt.name === 'text');
-      const authorOption = addSubcommand?.options?.find((opt: any) => opt.name === 'author');
-      
+      const addSubcommand = json.options?.find(
+        (opt: any) => opt.name === "add",
+      );
+      const textOption = addSubcommand?.options?.find(
+        (opt: any) => opt.name === "text",
+      );
+      const authorOption = addSubcommand?.options?.find(
+        (opt: any) => opt.name === "author",
+      );
+
       expect(textOption?.required).toBe(true);
       expect(authorOption?.required).toBe(true);
     });
   });
 
-  describe('edit subcommand', () => {
-    it('should have id parameter', () => {
+  describe("edit subcommand", () => {
+    it("should have id parameter", () => {
       const json = data.toJSON();
-      const editSubcommand = json.options?.find((opt: any) => opt.name === 'edit');
+      const editSubcommand = json.options?.find(
+        (opt: any) => opt.name === "edit",
+      );
       expect(editSubcommand).toBeDefined();
-      
-      const idOption = editSubcommand?.options?.find((opt: any) => opt.name === 'id');
+
+      const idOption = editSubcommand?.options?.find(
+        (opt: any) => opt.name === "id",
+      );
       expect(idOption).toBeDefined();
       expect(idOption?.type).toBe(3); // STRING type
       expect(idOption?.required).toBe(true);
     });
 
-    it('should have optional text parameter', () => {
+    it("should have optional text parameter", () => {
       const json = data.toJSON();
-      const editSubcommand = json.options?.find((opt: any) => opt.name === 'edit');
+      const editSubcommand = json.options?.find(
+        (opt: any) => opt.name === "edit",
+      );
       expect(editSubcommand).toBeDefined();
-      
-      const textOption = editSubcommand?.options?.find((opt: any) => opt.name === 'text');
+
+      const textOption = editSubcommand?.options?.find(
+        (opt: any) => opt.name === "text",
+      );
       expect(textOption).toBeDefined();
       expect(textOption?.type).toBe(3); // STRING type
       expect(textOption?.required).toBe(false);
     });
 
-    it('should have optional author parameter as user type', () => {
+    it("should have optional author parameter as user type", () => {
       const json = data.toJSON();
-      const editSubcommand = json.options?.find((opt: any) => opt.name === 'edit');
+      const editSubcommand = json.options?.find(
+        (opt: any) => opt.name === "edit",
+      );
       expect(editSubcommand).toBeDefined();
-      
-      const authorOption = editSubcommand?.options?.find((opt: any) => opt.name === 'author');
+
+      const authorOption = editSubcommand?.options?.find(
+        (opt: any) => opt.name === "author",
+      );
       expect(authorOption).toBeDefined();
       expect(authorOption?.type).toBe(6); // USER type
       expect(authorOption?.required).toBe(false);

--- a/__tests__/commands/seen.test.ts
+++ b/__tests__/commands/seen.test.ts
@@ -1,27 +1,29 @@
-import { describe, it, expect } from '@jest/globals';
-import { data } from '../../src/commands/seen.js';
+import { describe, it, expect } from "@jest/globals";
+import { data } from "../../src/commands/seen.js";
 
-describe('Seen Command', () => {
-  describe('command metadata', () => {
-    it('should have correct command name', () => {
-      expect(data.name).toBe('seen');
+describe("Seen Command", () => {
+  describe("command metadata", () => {
+    it("should have correct command name", () => {
+      expect(data.name).toBe("seen");
     });
 
-    it('should have a description', () => {
-      expect(data.description).toBe('Shows when a user was last seen in a voice channel');
+    it("should have a description", () => {
+      expect(data.description).toBe(
+        "Shows when a user was last seen in a voice channel",
+      );
     });
 
-    it('should be a valid slash command', () => {
-      expect(data.toJSON()).toHaveProperty('name', 'seen');
-      expect(data.toJSON()).toHaveProperty('description');
+    it("should be a valid slash command", () => {
+      expect(data.toJSON()).toHaveProperty("name", "seen");
+      expect(data.toJSON()).toHaveProperty("description");
     });
 
-    it('should have required user parameter', () => {
+    it("should have required user parameter", () => {
       const json = data.toJSON();
       expect(json.options).toBeDefined();
       expect(json.options?.length).toBeGreaterThan(0);
       expect(json.options?.[0]).toMatchObject({
-        name: 'user',
+        name: "user",
         type: 6, // User type
         required: true,
       });

--- a/__tests__/commands/voicestats.test.ts
+++ b/__tests__/commands/voicestats.test.ts
@@ -1,51 +1,63 @@
-import { describe, it, expect } from '@jest/globals';
-import { data } from '../../src/commands/voicestats.js';
+import { describe, it, expect } from "@jest/globals";
+import { data } from "../../src/commands/voicestats.js";
 
-describe('VoiceStats Command', () => {
-  describe('command metadata', () => {
-    it('should have correct command name', () => {
-      expect(data.name).toBe('voicestats');
+describe("VoiceStats Command", () => {
+  describe("command metadata", () => {
+    it("should have correct command name", () => {
+      expect(data.name).toBe("voicestats");
     });
 
-    it('should have a description', () => {
-      expect(data.description).toBe('Voice channel statistics and leaderboards');
+    it("should have a description", () => {
+      expect(data.description).toBe(
+        "Voice channel statistics and leaderboards",
+      );
     });
 
-    it('should be a valid slash command', () => {
-      expect(data.toJSON()).toHaveProperty('name', 'voicestats');
-      expect(data.toJSON()).toHaveProperty('description');
+    it("should be a valid slash command", () => {
+      expect(data.toJSON()).toHaveProperty("name", "voicestats");
+      expect(data.toJSON()).toHaveProperty("description");
     });
 
-    it('should have two subcommands', () => {
+    it("should have two subcommands", () => {
       const json = data.toJSON();
       expect(json.options).toBeDefined();
       expect(json.options?.length).toBe(2);
     });
   });
 
-  describe('top subcommand', () => {
-    it('should have top subcommand', () => {
+  describe("top subcommand", () => {
+    it("should have top subcommand", () => {
       const json = data.toJSON();
-      const topSubcommand = json.options?.find((opt: any) => opt.name === 'top');
+      const topSubcommand = json.options?.find(
+        (opt: any) => opt.name === "top",
+      );
       expect(topSubcommand).toBeDefined();
       expect(topSubcommand?.type).toBe(1); // SUB_COMMAND type
-      expect(topSubcommand?.description).toBe('Show top voice channel users');
+      expect(topSubcommand?.description).toBe("Show top voice channel users");
     });
 
-    it('should have optional limit parameter with constraints', () => {
+    it("should have optional limit parameter with constraints", () => {
       const json = data.toJSON();
-      const topSubcommand = json.options?.find((opt: any) => opt.name === 'top');
-      const limitOption = topSubcommand?.options?.find((opt: any) => opt.name === 'limit');
+      const topSubcommand = json.options?.find(
+        (opt: any) => opt.name === "top",
+      );
+      const limitOption = topSubcommand?.options?.find(
+        (opt: any) => opt.name === "limit",
+      );
       expect(limitOption).toBeDefined();
       expect(limitOption?.required).toBe(false);
       expect(limitOption?.min_value).toBe(1);
       expect(limitOption?.max_value).toBe(50);
     });
 
-    it('should have optional period parameter with choices', () => {
+    it("should have optional period parameter with choices", () => {
       const json = data.toJSON();
-      const topSubcommand = json.options?.find((opt: any) => opt.name === 'top');
-      const periodOption = topSubcommand?.options?.find((opt: any) => opt.name === 'period');
+      const topSubcommand = json.options?.find(
+        (opt: any) => opt.name === "top",
+      );
+      const periodOption = topSubcommand?.options?.find(
+        (opt: any) => opt.name === "period",
+      );
       expect(periodOption).toBeDefined();
       expect(periodOption?.required).toBe(false);
       expect(periodOption?.choices).toBeDefined();
@@ -53,27 +65,39 @@ describe('VoiceStats Command', () => {
     });
   });
 
-  describe('user subcommand', () => {
-    it('should have user subcommand', () => {
+  describe("user subcommand", () => {
+    it("should have user subcommand", () => {
       const json = data.toJSON();
-      const userSubcommand = json.options?.find((opt: any) => opt.name === 'user');
+      const userSubcommand = json.options?.find(
+        (opt: any) => opt.name === "user",
+      );
       expect(userSubcommand).toBeDefined();
       expect(userSubcommand?.type).toBe(1); // SUB_COMMAND type
-      expect(userSubcommand?.description).toBe('Show voice channel statistics for a user');
+      expect(userSubcommand?.description).toBe(
+        "Show voice channel statistics for a user",
+      );
     });
 
-    it('should have optional user parameter', () => {
+    it("should have optional user parameter", () => {
       const json = data.toJSON();
-      const userSubcommand = json.options?.find((opt: any) => opt.name === 'user');
-      const userOption = userSubcommand?.options?.find((opt: any) => opt.name === 'user');
+      const userSubcommand = json.options?.find(
+        (opt: any) => opt.name === "user",
+      );
+      const userOption = userSubcommand?.options?.find(
+        (opt: any) => opt.name === "user",
+      );
       expect(userOption).toBeDefined();
       expect(userOption?.required).toBe(false);
     });
 
-    it('should have optional period parameter with choices', () => {
+    it("should have optional period parameter with choices", () => {
       const json = data.toJSON();
-      const userSubcommand = json.options?.find((opt: any) => opt.name === 'user');
-      const periodOption = userSubcommand?.options?.find((opt: any) => opt.name === 'period');
+      const userSubcommand = json.options?.find(
+        (opt: any) => opt.name === "user",
+      );
+      const periodOption = userSubcommand?.options?.find(
+        (opt: any) => opt.name === "period",
+      );
       expect(periodOption).toBeDefined();
       expect(periodOption?.required).toBe(false);
       expect(periodOption?.choices).toBeDefined();

--- a/__tests__/config/env.test.ts
+++ b/__tests__/config/env.test.ts
@@ -2,13 +2,8 @@ import { describe, it, expect, afterEach } from "@jest/globals";
 
 const ORIGINAL_ENV = { ...process.env };
 
-const {
-  env,
-  getEnv,
-  hasEnv,
-  requireEnv,
-  getMissingRequiredEnv,
-} = await import("../../src/config/env.js");
+const { env, getEnv, hasEnv, requireEnv, getMissingRequiredEnv } =
+  await import("../../src/config/env.js");
 
 describe("config/env", () => {
   afterEach(() => {

--- a/__tests__/content/statuses.test.ts
+++ b/__tests__/content/statuses.test.ts
@@ -30,7 +30,9 @@ describe("validateStatusEntry", () => {
 
   it("rejects text longer than the cap", () => {
     const tooLong = "x".repeat(STATUS_TEXT_MAX + 1);
-    expect(validateStatusEntry("lonely", tooLong)).toMatch(/characters or fewer/);
+    expect(validateStatusEntry("lonely", tooLong)).toMatch(
+      /characters or fewer/,
+    );
   });
 
   it("accepts a plain entry for non-count pools", () => {

--- a/__tests__/handlers/vc-control-button-handler.test.ts
+++ b/__tests__/handlers/vc-control-button-handler.test.ts
@@ -1,17 +1,25 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import { ChannelType, type ButtonInteraction, type Guild, type VoiceChannel, type Client } from 'discord.js';
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import {
+  ChannelType,
+  type ButtonInteraction,
+  type Guild,
+  type VoiceChannel,
+  type Client,
+} from "discord.js";
 
 // Mock dependencies before importing
-jest.mock('../../src/utils/logger.js');
-jest.mock('../../src/services/voice-channel-manager.js');
+jest.mock("../../src/utils/logger.js");
+jest.mock("../../src/services/voice-channel-manager.js");
 
 // Import after mocks
-import { VoiceChannelManager } from '../../src/services/voice-channel-manager.js';
-import { handleVCControlButton } from '../../src/handlers/vc-control-button-handler.js';
+import { VoiceChannelManager } from "../../src/services/voice-channel-manager.js";
+import { handleVCControlButton } from "../../src/handlers/vc-control-button-handler.js";
 
-const mockVoiceChannelManager = VoiceChannelManager as jest.Mocked<typeof VoiceChannelManager>;
+const mockVoiceChannelManager = VoiceChannelManager as jest.Mocked<
+  typeof VoiceChannelManager
+>;
 
-describe('VCControlButtonHandler', () => {
+describe("VCControlButtonHandler", () => {
   let mockInteraction: Partial<ButtonInteraction>;
   let mockGuild: Partial<Guild>;
   let mockChannel: Partial<VoiceChannel>;
@@ -30,10 +38,12 @@ describe('VCControlButtonHandler', () => {
     mockManagerInstance = {
       toggleLive: jest.fn().mockResolvedValue(true),
       getWaitingRoom: jest.fn().mockReturnValue(undefined),
-      createWaitingRoom: jest.fn().mockResolvedValue({ name: '⏳ Test Waiting' }),
+      createWaitingRoom: jest
+        .fn()
+        .mockResolvedValue({ name: "⏳ Test Waiting" }),
       removeWaitingRoom: jest.fn().mockResolvedValue(undefined),
       rebuildControlPanel: jest.fn().mockResolvedValue(undefined),
-      getUserChannel: jest.fn().mockReturnValue({ id: 'channel-id' }),
+      getUserChannel: jest.fn().mockReturnValue({ id: "channel-id" }),
     };
 
     (mockVoiceChannelManager.getInstance as unknown as jest.Mock) = jest.fn(
@@ -41,8 +51,8 @@ describe('VCControlButtonHandler', () => {
     );
 
     mockChannel = {
-      id: 'channel-id',
-      name: 'Test Channel',
+      id: "channel-id",
+      name: "Test Channel",
       type: ChannelType.GuildVoice,
       setName: jest.fn().mockResolvedValue(undefined),
       send: jest.fn().mockResolvedValue(undefined),
@@ -52,157 +62,189 @@ describe('VCControlButtonHandler', () => {
         create: jest.fn().mockResolvedValue(undefined),
       } as any,
       guild: {
-        roles: { everyone: { id: 'everyone-role-id' } },
+        roles: { everyone: { id: "everyone-role-id" } },
       } as any,
       parent: null,
     } as any;
 
     mockGuild = {
-      id: 'guild-id',
+      id: "guild-id",
       channels: {
         fetch: jest.fn().mockResolvedValue(mockChannel),
       } as any,
       members: {
         fetch: jest.fn().mockResolvedValue({
-          displayName: 'WaitingUser',
-          id: 'waiting-user-id',
-          voice: { channelId: 'waiting-room-id', setChannel: jest.fn().mockResolvedValue(undefined) },
+          displayName: "WaitingUser",
+          id: "waiting-user-id",
+          voice: {
+            channelId: "waiting-room-id",
+            setChannel: jest.fn().mockResolvedValue(undefined),
+          },
         }),
       } as any,
     } as any;
 
     mockInteraction = {
-      customId: 'vc_control_live_channel-id_owner-id',
+      customId: "vc_control_live_channel-id_owner-id",
       user: {
-        id: 'owner-id',
-        displayName: 'OwnerUser',
+        id: "owner-id",
+        displayName: "OwnerUser",
       } as any,
       reply: jest.fn().mockResolvedValue(undefined),
       guild: mockGuild as Guild,
       message: {
         edit: jest.fn().mockResolvedValue(undefined),
       } as any,
-      client: {
-      } as any as Client,
+      client: {} as any as Client,
     } as any;
   });
 
-  describe('Owner check', () => {
-    it('should reject non-owner interaction', async () => {
-      mockInteraction.user = { id: 'other-user-id', displayName: 'Other' } as any;
+  describe("Owner check", () => {
+    it("should reject non-owner interaction", async () => {
+      mockInteraction.user = {
+        id: "other-user-id",
+        displayName: "Other",
+      } as any;
 
       await handleVCControlButton(mockInteraction as ButtonInteraction);
 
       expect(mockInteraction.reply).toHaveBeenCalledWith(
-        expect.objectContaining({ content: expect.stringContaining('Only the channel owner') }),
+        expect.objectContaining({
+          content: expect.stringContaining("Only the channel owner"),
+        }),
       );
     });
   });
 
-  describe('Live toggle', () => {
-    it('should delegate to manager.toggleLive and report LIVE when going live', async () => {
+  describe("Live toggle", () => {
+    it("should delegate to manager.toggleLive and report LIVE when going live", async () => {
       mockManagerInstance.toggleLive.mockResolvedValue(true);
-      mockInteraction.customId = 'vc_control_live_channel-id_owner-id';
+      mockInteraction.customId = "vc_control_live_channel-id_owner-id";
 
       await handleVCControlButton(mockInteraction as ButtonInteraction);
 
       expect(mockManagerInstance.toggleLive).toHaveBeenCalledWith(mockChannel);
       expect(mockInteraction.reply).toHaveBeenCalledWith(
-        expect.objectContaining({ content: expect.stringContaining('LIVE') }),
+        expect.objectContaining({ content: expect.stringContaining("LIVE") }),
       );
     });
 
-    it('should delegate to manager.toggleLive and report offline when going offline', async () => {
+    it("should delegate to manager.toggleLive and report offline when going offline", async () => {
       mockManagerInstance.toggleLive.mockResolvedValue(false);
-      mockInteraction.customId = 'vc_control_live_channel-id_owner-id';
+      mockInteraction.customId = "vc_control_live_channel-id_owner-id";
 
       await handleVCControlButton(mockInteraction as ButtonInteraction);
 
       expect(mockManagerInstance.toggleLive).toHaveBeenCalledWith(mockChannel);
       expect(mockInteraction.reply).toHaveBeenCalledWith(
-        expect.objectContaining({ content: expect.stringContaining('offline') }),
+        expect.objectContaining({
+          content: expect.stringContaining("offline"),
+        }),
       );
     });
   });
 
-  describe('Waiting room toggle', () => {
-    it('should create waiting room when none exists', async () => {
+  describe("Waiting room toggle", () => {
+    it("should create waiting room when none exists", async () => {
       mockManagerInstance.getWaitingRoom.mockReturnValue(undefined);
-      mockInteraction.customId = 'vc_control_waitingroom_channel-id_owner-id';
+      mockInteraction.customId = "vc_control_waitingroom_channel-id_owner-id";
 
       await handleVCControlButton(mockInteraction as ButtonInteraction);
 
       expect(mockManagerInstance.createWaitingRoom).toHaveBeenCalledWith(
         mockChannel,
-        'owner-id',
+        "owner-id",
       );
       expect(mockInteraction.reply).toHaveBeenCalledWith(
-        expect.objectContaining({ content: expect.stringContaining('Waiting room') }),
+        expect.objectContaining({
+          content: expect.stringContaining("Waiting room"),
+        }),
       );
     });
 
-    it('should remove waiting room when one exists', async () => {
-      mockManagerInstance.getWaitingRoom.mockReturnValue('existing-waiting-room-id');
-      mockInteraction.customId = 'vc_control_waitingroom_channel-id_owner-id';
+    it("should remove waiting room when one exists", async () => {
+      mockManagerInstance.getWaitingRoom.mockReturnValue(
+        "existing-waiting-room-id",
+      );
+      mockInteraction.customId = "vc_control_waitingroom_channel-id_owner-id";
 
       await handleVCControlButton(mockInteraction as ButtonInteraction);
 
-      expect(mockManagerInstance.removeWaitingRoom).toHaveBeenCalledWith('channel-id');
+      expect(mockManagerInstance.removeWaitingRoom).toHaveBeenCalledWith(
+        "channel-id",
+      );
       expect(mockInteraction.reply).toHaveBeenCalledWith(
-        expect.objectContaining({ content: expect.stringContaining('removed') }),
+        expect.objectContaining({
+          content: expect.stringContaining("removed"),
+        }),
       );
     });
   });
 
-  describe('Let In action', () => {
-    it('should reject non-owner let-in attempt (stale button check)', async () => {
-      mockInteraction.customId = 'vc_control_letin_channel-id_waiting-user-id_owner-id';
-      mockInteraction.user = { id: 'someone-else', displayName: 'Other' } as any;
+  describe("Let In action", () => {
+    it("should reject non-owner let-in attempt (stale button check)", async () => {
+      mockInteraction.customId =
+        "vc_control_letin_channel-id_waiting-user-id_owner-id";
+      mockInteraction.user = {
+        id: "someone-else",
+        displayName: "Other",
+      } as any;
 
       await handleVCControlButton(mockInteraction as ButtonInteraction);
 
       expect(mockInteraction.reply).toHaveBeenCalledWith(
-        expect.objectContaining({ content: expect.stringContaining('Only the channel owner') }),
+        expect.objectContaining({
+          content: expect.stringContaining("Only the channel owner"),
+        }),
       );
     });
 
-    it('should reject if user is no longer the current owner', async () => {
+    it("should reject if user is no longer the current owner", async () => {
       // getUserChannel returns a different channel (ownership transferred)
-      mockManagerInstance.getUserChannel.mockReturnValue({ id: 'different-channel-id' });
-      mockManagerInstance.getWaitingRoom.mockReturnValue('waiting-room-id');
-      mockInteraction.customId = 'vc_control_letin_channel-id_waiting-user-id_owner-id';
-      mockInteraction.user = { id: 'owner-id', displayName: 'Owner' } as any;
+      mockManagerInstance.getUserChannel.mockReturnValue({
+        id: "different-channel-id",
+      });
+      mockManagerInstance.getWaitingRoom.mockReturnValue("waiting-room-id");
+      mockInteraction.customId =
+        "vc_control_letin_channel-id_waiting-user-id_owner-id";
+      mockInteraction.user = { id: "owner-id", displayName: "Owner" } as any;
 
       await handleVCControlButton(mockInteraction as ButtonInteraction);
 
       expect(mockInteraction.reply).toHaveBeenCalledWith(
-        expect.objectContaining({ content: expect.stringContaining('current owner') }),
+        expect.objectContaining({
+          content: expect.stringContaining("current owner"),
+        }),
       );
     });
 
-    it('should reject if waiting room no longer exists', async () => {
-      mockManagerInstance.getUserChannel.mockReturnValue({ id: 'channel-id' });
+    it("should reject if waiting room no longer exists", async () => {
+      mockManagerInstance.getUserChannel.mockReturnValue({ id: "channel-id" });
       mockManagerInstance.getWaitingRoom.mockReturnValue(undefined);
-      mockInteraction.customId = 'vc_control_letin_channel-id_waiting-user-id_owner-id';
-      mockInteraction.user = { id: 'owner-id', displayName: 'Owner' } as any;
+      mockInteraction.customId =
+        "vc_control_letin_channel-id_waiting-user-id_owner-id";
+      mockInteraction.user = { id: "owner-id", displayName: "Owner" } as any;
 
       await handleVCControlButton(mockInteraction as ButtonInteraction);
 
       expect(mockInteraction.reply).toHaveBeenCalledWith(
-        expect.objectContaining({ content: expect.stringContaining('waiting room') }),
+        expect.objectContaining({
+          content: expect.stringContaining("waiting room"),
+        }),
       );
     });
 
-    it('should move user when owner is valid and user is in waiting room', async () => {
-      mockManagerInstance.getUserChannel.mockReturnValue({ id: 'channel-id' });
-      mockManagerInstance.getWaitingRoom.mockReturnValue('waiting-room-id');
-      mockInteraction.customId = 'vc_control_letin_channel-id_waiting-user-id_owner-id';
-      mockInteraction.user = { id: 'owner-id', displayName: 'Owner' } as any;
+    it("should move user when owner is valid and user is in waiting room", async () => {
+      mockManagerInstance.getUserChannel.mockReturnValue({ id: "channel-id" });
+      mockManagerInstance.getWaitingRoom.mockReturnValue("waiting-room-id");
+      mockInteraction.customId =
+        "vc_control_letin_channel-id_waiting-user-id_owner-id";
+      mockInteraction.user = { id: "owner-id", displayName: "Owner" } as any;
 
       await handleVCControlButton(mockInteraction as ButtonInteraction);
 
       // Should fetch the main channel
-      expect(mockGuild!.channels!.fetch).toHaveBeenCalledWith('channel-id');
+      expect(mockGuild!.channels!.fetch).toHaveBeenCalledWith("channel-id");
     });
   });
 });

--- a/__tests__/handlers/vc-modal-handler.test.ts
+++ b/__tests__/handlers/vc-modal-handler.test.ts
@@ -1,17 +1,25 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import { ChannelType, type ModalSubmitInteraction, type Guild, type VoiceChannel, type Client } from 'discord.js';
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import {
+  ChannelType,
+  type ModalSubmitInteraction,
+  type Guild,
+  type VoiceChannel,
+  type Client,
+} from "discord.js";
 
 // Mock dependencies before importing
-jest.mock('../../src/utils/logger.js');
-jest.mock('../../src/services/voice-channel-manager.js');
+jest.mock("../../src/utils/logger.js");
+jest.mock("../../src/services/voice-channel-manager.js");
 
 // Import after mocks
-import { VoiceChannelManager } from '../../src/services/voice-channel-manager.js';
-import { handleVCModal } from '../../src/handlers/vc-modal-handler.js';
+import { VoiceChannelManager } from "../../src/services/voice-channel-manager.js";
+import { handleVCModal } from "../../src/handlers/vc-modal-handler.js";
 
-const mockVoiceChannelManager = VoiceChannelManager as jest.Mocked<typeof VoiceChannelManager>;
+const mockVoiceChannelManager = VoiceChannelManager as jest.Mocked<
+  typeof VoiceChannelManager
+>;
 
-describe('VCModalHandler - Custom Name Tracking', () => {
+describe("VCModalHandler - Custom Name Tracking", () => {
   let mockInteraction: Partial<ModalSubmitInteraction>;
   let mockGuild: Partial<Guild>;
   let mockChannel: Partial<VoiceChannel>;
@@ -27,68 +35,70 @@ describe('VCModalHandler - Custom Name Tracking', () => {
       setCustomChannelName: mockSetCustomChannelName,
     }));
 
-    (mockVoiceChannelManager.getInstance as unknown as jest.Mock) = mockGetInstance;
+    (mockVoiceChannelManager.getInstance as unknown as jest.Mock) =
+      mockGetInstance;
 
     mockChannel = {
-      id: 'test-channel-id',
-      name: 'Old Channel Name',
+      id: "test-channel-id",
+      name: "Old Channel Name",
       type: ChannelType.GuildVoice,
       setName: jest.fn().mockResolvedValue(undefined),
     } as any;
 
     mockGuild = {
-      id: 'test-guild-id',
-      name: 'Test Guild',
+      id: "test-guild-id",
+      name: "Test Guild",
       channels: {
         fetch: jest.fn().mockResolvedValue(mockChannel),
       } as any,
     } as any;
 
     mockInteraction = {
-      customId: 'vc_modal_name_test-channel-id_test-user-id',
+      customId: "vc_modal_name_test-channel-id_test-user-id",
       user: {
-        id: 'test-user-id',
-        displayName: 'TestUser',
+        id: "test-user-id",
+        displayName: "TestUser",
       } as any,
       fields: {
-        getTextInputValue: jest.fn().mockReturnValue('New Custom Name'),
+        getTextInputValue: jest.fn().mockReturnValue("New Custom Name"),
       } as any,
       reply: jest.fn().mockResolvedValue(undefined),
       guild: mockGuild as Guild,
-      client: {
-      } as any as Client,
+      client: {} as any as Client,
     } as any;
   });
 
-  describe('Custom name tracking on rename', () => {
-    it('should mark channel as having custom name after successful rename', async () => {
+  describe("Custom name tracking on rename", () => {
+    it("should mark channel as having custom name after successful rename", async () => {
       await handleVCModal(mockInteraction as ModalSubmitInteraction);
 
-      expect(mockChannel.setName).toHaveBeenCalledWith('New Custom Name');
+      expect(mockChannel.setName).toHaveBeenCalledWith("New Custom Name");
       expect(mockSetCustomChannelName).toHaveBeenCalledWith(
-        'test-channel-id',
-        'New Custom Name'
+        "test-channel-id",
+        "New Custom Name",
       );
       expect(mockInteraction.reply).toHaveBeenCalledWith({
-        content: '✅ Channel renamed to: **New Custom Name**',
+        content: "✅ Channel renamed to: **New Custom Name**",
         ephemeral: true,
       });
     });
 
-    it('should not mark channel as custom if rename fails', async () => {
-      mockChannel.setName = jest.fn().mockRejectedValue(new Error('Rename failed'));
+    it("should not mark channel as custom if rename fails", async () => {
+      mockChannel.setName = jest
+        .fn()
+        .mockRejectedValue(new Error("Rename failed"));
 
       await handleVCModal(mockInteraction as ModalSubmitInteraction);
 
       expect(mockSetCustomChannelName).not.toHaveBeenCalled();
       expect(mockInteraction.reply).toHaveBeenCalledWith({
-        content: '❌ Failed to rename channel. Please try again.',
+        content: "❌ Failed to rename channel. Please try again.",
         ephemeral: true,
       });
     });
 
-    it('should reject names longer than 100 characters', async () => {
-      const longName = 'a'.repeat(101);
+    it("should reject names longer than 100 characters", async () => {
+      const longName = "a".repeat(101);
       mockInteraction.fields = {
         getTextInputValue: jest.fn().mockReturnValue(longName),
       } as any;
@@ -98,14 +108,14 @@ describe('VCModalHandler - Custom Name Tracking', () => {
       expect(mockChannel.setName).not.toHaveBeenCalled();
       expect(mockSetCustomChannelName).not.toHaveBeenCalled();
       expect(mockInteraction.reply).toHaveBeenCalledWith({
-        content: '❌ Channel name must be 100 characters or less.',
+        content: "❌ Channel name must be 100 characters or less.",
         ephemeral: true,
       });
     });
 
-    it('should reject empty names', async () => {
+    it("should reject empty names", async () => {
       mockInteraction.fields = {
-        getTextInputValue: jest.fn().mockReturnValue(''),
+        getTextInputValue: jest.fn().mockReturnValue(""),
       } as any;
 
       await handleVCModal(mockInteraction as ModalSubmitInteraction);
@@ -113,7 +123,7 @@ describe('VCModalHandler - Custom Name Tracking', () => {
       expect(mockChannel.setName).not.toHaveBeenCalled();
       expect(mockSetCustomChannelName).not.toHaveBeenCalled();
       expect(mockInteraction.reply).toHaveBeenCalledWith({
-        content: '❌ Channel name cannot be empty.',
+        content: "❌ Channel name cannot be empty.",
         ephemeral: true,
       });
     });

--- a/__tests__/models/command-metrics.test.ts
+++ b/__tests__/models/command-metrics.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "@jest/globals";
+
+describe("CommandMetrics model (#648)", () => {
+  it("loads without throwing under the global mongoose mock", async () => {
+    const mod = await import("../../src/models/command-metrics.js");
+    expect(mod.CommandMetrics).toBeDefined();
+  });
+
+  it("accepts the canonical daily-bucket shape", () => {
+    // Type-only check that the interface compiles with the documented
+    // fields, matching what `MonitoringService.flushMetrics` upserts.
+    const sample = {
+      command: "quote",
+      date: "2026-06-22",
+      guildId: "g1",
+      usageCount: 12,
+      errorCount: 1,
+      totalResponseMs: 3400,
+      firstUsedAt: new Date(),
+      lastUsedAt: new Date(),
+      expiresAt: new Date(),
+    };
+    expect(sample.command).toBe("quote");
+    expect(sample.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});

--- a/__tests__/models/discord-command-audit-log.test.ts
+++ b/__tests__/models/discord-command-audit-log.test.ts
@@ -2,9 +2,7 @@ import { describe, it, expect } from "@jest/globals";
 
 describe("DiscordCommandAuditLog model", () => {
   it("loads without throwing under the global mongoose mock", async () => {
-    const mod = await import(
-      "../../src/models/discord-command-audit-log.js"
-    );
+    const mod = await import("../../src/models/discord-command-audit-log.js");
     expect(mod.DiscordCommandAuditLog).toBeDefined();
   });
 

--- a/__tests__/models/reaction-role-config.test.ts
+++ b/__tests__/models/reaction-role-config.test.ts
@@ -4,9 +4,8 @@ describe("ReactionRoleConfig Model Schema", () => {
   describe("schema definition", () => {
     it("should define required fields", () => {
       const schemaTest = async () => {
-        const { ReactionRoleConfig } = await import(
-          "../../src/models/reaction-role-config.js"
-        );
+        const { ReactionRoleConfig } =
+          await import("../../src/models/reaction-role-config.js");
         return ReactionRoleConfig.schema;
       };
 

--- a/__tests__/models/user-achievements.test.ts
+++ b/__tests__/models/user-achievements.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect } from "@jest/globals";
 
-describe('UserAchievements Model Schema', () => {
-  describe('schema definition', () => {
-    it('should define required fields', () => {
+describe("UserAchievements Model Schema", () => {
+  describe("schema definition", () => {
+    it("should define required fields", () => {
       const schemaTest = async () => {
-        const { UserAchievements } = await import('../../src/models/user-achievements.js');
+        const { UserAchievements } =
+          await import("../../src/models/user-achievements.js");
         return UserAchievements.schema;
       };
 

--- a/__tests__/models/user-voice-preferences.test.ts
+++ b/__tests__/models/user-voice-preferences.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect } from "@jest/globals";
 
-describe('UserVoicePreferences Model Schema', () => {
-  describe('schema definition', () => {
-    it('should define required fields', () => {
+describe("UserVoicePreferences Model Schema", () => {
+  describe("schema definition", () => {
+    it("should define required fields", () => {
       const schemaTest = async () => {
-        const { UserVoicePreferences } = await import('../../src/models/user-voice-preferences.js');
+        const { UserVoicePreferences } =
+          await import("../../src/models/user-voice-preferences.js");
         return UserVoicePreferences.schema;
       };
 
@@ -12,19 +13,19 @@ describe('UserVoicePreferences Model Schema', () => {
     });
   });
 
-  describe('interface types', () => {
-    it('should properly type the document interface', async () => {
-      await import('../../src/models/user-voice-preferences.js');
-      
+  describe("interface types", () => {
+    it("should properly type the document interface", async () => {
+      await import("../../src/models/user-voice-preferences.js");
+
       const testDoc = {
-        userId: 'test-user-123',
-        namePattern: '{username}\'s Room',
+        userId: "test-user-123",
+        namePattern: "{username}'s Room",
         userLimit: 10,
         bitrate: 96,
       };
 
-      expect(testDoc.userId).toBe('test-user-123');
-      expect(testDoc.namePattern).toBe('{username}\'s Room');
+      expect(testDoc.userId).toBe("test-user-123");
+      expect(testDoc.namePattern).toBe("{username}'s Room");
       expect(testDoc.userLimit).toBe(10);
       expect(testDoc.bitrate).toBe(96);
     });

--- a/__tests__/services/achievements-consecutive-days.test.ts
+++ b/__tests__/services/achievements-consecutive-days.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, jest } from '@jest/globals';
+import { describe, it, expect, jest } from "@jest/globals";
 
 // Mock mongoose connection before importing the service
-jest.mock('mongoose', () => ({
+jest.mock("mongoose", () => ({
   __esModule: true,
   default: {
     connection: {
@@ -11,10 +11,10 @@ jest.mock('mongoose', () => ({
   },
 }));
 
-jest.mock('../../src/utils/logger.js');
-jest.mock('../../src/services/config-service.js');
+jest.mock("../../src/utils/logger.js");
+jest.mock("../../src/services/config-service.js");
 
-describe('AchievementsService - Consecutive Days Calculation', () => {
+describe("AchievementsService - Consecutive Days Calculation", () => {
   // Helper to create a date in YYYY-MM-DD format
   const createDate = (daysAgo: number): Date => {
     const date = new Date();
@@ -25,12 +25,11 @@ describe('AchievementsService - Consecutive Days Calculation', () => {
 
   // Helper to format date as YYYY-MM-DD (matches implementation)
   const formatDateKeyUTC = (date: Date): string => {
-    return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}-${String(date.getUTCDate()).padStart(2, '0')}`;
+    return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`;
   };
 
-  describe('consecutive days streak logic', () => {
-
-    it('should calculate 0 streak for empty sessions', () => {
+  describe("consecutive days streak logic", () => {
+    it("should calculate 0 streak for empty sessions", () => {
       const sessions: Array<{ startTime: Date; duration?: number }> = [];
 
       // Simulate the calculation logic
@@ -42,7 +41,7 @@ describe('AchievementsService - Consecutive Days Calculation', () => {
       }
     });
 
-    it('should calculate 1 day streak for single qualifying day', () => {
+    it("should calculate 1 day streak for single qualifying day", () => {
       const sessions = [
         { startTime: createDate(0), duration: 400 }, // Today, 6 min 40 sec
       ];
@@ -67,7 +66,7 @@ describe('AchievementsService - Consecutive Days Calculation', () => {
       expect(qualifyingDays.length).toBe(1);
     });
 
-    it('should not count days below minimum duration', () => {
+    it("should not count days below minimum duration", () => {
       const sessions = [
         { startTime: createDate(0), duration: 200 }, // Today, 3 min 20 sec (below 5 min)
         { startTime: createDate(1), duration: 100 }, // Yesterday, 1 min 40 sec
@@ -92,7 +91,7 @@ describe('AchievementsService - Consecutive Days Calculation', () => {
       expect(qualifyingDays.length).toBe(0);
     });
 
-    it('should aggregate multiple sessions on same day', () => {
+    it("should aggregate multiple sessions on same day", () => {
       const today = createDate(0);
       const sessions = [
         { startTime: today, duration: 180 }, // 3 minutes
@@ -123,7 +122,7 @@ describe('AchievementsService - Consecutive Days Calculation', () => {
       expect(totalDuration).toBe(360); // 6 minutes total
     });
 
-    it('should calculate 7 day consecutive streak', () => {
+    it("should calculate 7 day consecutive streak", () => {
       const sessions = Array.from({ length: 7 }, (_, i) => ({
         startTime: createDate(6 - i), // 6 days ago to today
         duration: 400,
@@ -152,8 +151,8 @@ describe('AchievementsService - Consecutive Days Calculation', () => {
       let currentStreak = 1;
 
       for (let i = 1; i < qualifyingDays.length; i++) {
-        const prevDate = new Date(qualifyingDays[i - 1] + 'T00:00:00Z');
-        const currDate = new Date(qualifyingDays[i] + 'T00:00:00Z');
+        const prevDate = new Date(qualifyingDays[i - 1] + "T00:00:00Z");
+        const currDate = new Date(qualifyingDays[i] + "T00:00:00Z");
         const diffDays = Math.floor(
           (currDate.getTime() - prevDate.getTime()) / (1000 * 60 * 60 * 24),
         );
@@ -169,7 +168,7 @@ describe('AchievementsService - Consecutive Days Calculation', () => {
       expect(longestStreak).toBe(7);
     });
 
-    it('should handle broken streaks correctly', () => {
+    it("should handle broken streaks correctly", () => {
       const sessions = [
         { startTime: createDate(10), duration: 400 }, // 10 days ago
         { startTime: createDate(9), duration: 400 }, // 9 days ago
@@ -206,8 +205,8 @@ describe('AchievementsService - Consecutive Days Calculation', () => {
       let currentStreak = 1;
 
       for (let i = 1; i < qualifyingDays.length; i++) {
-        const prevDate = new Date(qualifyingDays[i - 1] + 'T00:00:00Z');
-        const currDate = new Date(qualifyingDays[i] + 'T00:00:00Z');
+        const prevDate = new Date(qualifyingDays[i - 1] + "T00:00:00Z");
+        const currDate = new Date(qualifyingDays[i] + "T00:00:00Z");
         const diffDays = Math.floor(
           (currDate.getTime() - prevDate.getTime()) / (1000 * 60 * 60 * 24),
         );
@@ -224,7 +223,7 @@ describe('AchievementsService - Consecutive Days Calculation', () => {
       expect(longestStreak).toBe(6);
     });
 
-    it('should calculate 30 day consecutive streak', () => {
+    it("should calculate 30 day consecutive streak", () => {
       const sessions = Array.from({ length: 30 }, (_, i) => ({
         startTime: createDate(29 - i), // 29 days ago to today
         duration: 400,
@@ -252,8 +251,8 @@ describe('AchievementsService - Consecutive Days Calculation', () => {
       let currentStreak = 1;
 
       for (let i = 1; i < qualifyingDays.length; i++) {
-        const prevDate = new Date(qualifyingDays[i - 1] + 'T00:00:00Z');
-        const currDate = new Date(qualifyingDays[i] + 'T00:00:00Z');
+        const prevDate = new Date(qualifyingDays[i - 1] + "T00:00:00Z");
+        const currDate = new Date(qualifyingDays[i] + "T00:00:00Z");
         const diffDays = Math.floor(
           (currDate.getTime() - prevDate.getTime()) / (1000 * 60 * 60 * 24),
         );
@@ -269,7 +268,7 @@ describe('AchievementsService - Consecutive Days Calculation', () => {
       expect(longestStreak).toBe(30);
     });
 
-    it('should handle sessions with missing duration', () => {
+    it("should handle sessions with missing duration", () => {
       const sessions = [
         { startTime: createDate(0), duration: 400 },
         { startTime: createDate(1), duration: undefined }, // Missing duration
@@ -296,7 +295,7 @@ describe('AchievementsService - Consecutive Days Calculation', () => {
       expect(qualifyingDays.length).toBe(2);
     });
 
-    it('should use correct minimum duration threshold', () => {
+    it("should use correct minimum duration threshold", () => {
       const sessions = [
         { startTime: createDate(0), duration: 300 }, // Exactly 5 minutes
         { startTime: createDate(1), duration: 299 }, // Just under 5 minutes
@@ -323,62 +322,62 @@ describe('AchievementsService - Consecutive Days Calculation', () => {
     });
   });
 
-  describe('accolade type definitions', () => {
-    it('should include consecutive day accolade types', () => {
+  describe("accolade type definitions", () => {
+    it("should include consecutive day accolade types", () => {
       const accoladeTypes = [
-        'first_hour',
-        'voice_veteran_100',
-        'voice_veteran_500',
-        'voice_veteran_1000',
-        'voice_legend_8765',
-        'marathon_runner',
-        'ultra_marathoner',
-        'social_butterfly',
-        'connector',
-        'night_owl',
-        'early_bird',
-        'weekend_warrior',
-        'weekday_warrior',
-        'consistent_week',
-        'consistent_fortnight',
-        'consistent_month',
+        "first_hour",
+        "voice_veteran_100",
+        "voice_veteran_500",
+        "voice_veteran_1000",
+        "voice_legend_8765",
+        "marathon_runner",
+        "ultra_marathoner",
+        "social_butterfly",
+        "connector",
+        "night_owl",
+        "early_bird",
+        "weekend_warrior",
+        "weekday_warrior",
+        "consistent_week",
+        "consistent_fortnight",
+        "consistent_month",
       ];
 
       // Verify new types are present
-      expect(accoladeTypes).toContain('consistent_week');
-      expect(accoladeTypes).toContain('consistent_fortnight');
-      expect(accoladeTypes).toContain('consistent_month');
+      expect(accoladeTypes).toContain("consistent_week");
+      expect(accoladeTypes).toContain("consistent_fortnight");
+      expect(accoladeTypes).toContain("consistent_month");
     });
   });
 
-  describe('accolade metadata', () => {
-    it('should format streak metadata correctly', () => {
+  describe("accolade metadata", () => {
+    it("should format streak metadata correctly", () => {
       const mockMetadata = {
         value: 7,
-        description: '7+ day streak',
-        unit: 'days',
+        description: "7+ day streak",
+        unit: "days",
       };
 
       expect(mockMetadata.value).toBe(7);
-      expect(mockMetadata.unit).toBe('days');
-      expect(mockMetadata.description).toContain('streak');
+      expect(mockMetadata.unit).toBe("days");
+      expect(mockMetadata.description).toContain("streak");
     });
 
-    it('should format different streak tiers correctly', () => {
+    it("should format different streak tiers correctly", () => {
       const weekStreak = {
         value: 7,
-        description: '7+ day streak',
-        unit: 'days',
+        description: "7+ day streak",
+        unit: "days",
       };
       const fortnightStreak = {
         value: 14,
-        description: '14+ day streak',
-        unit: 'days',
+        description: "14+ day streak",
+        unit: "days",
       };
       const monthStreak = {
         value: 30,
-        description: '30+ day streak',
-        unit: 'days',
+        description: "30+ day streak",
+        unit: "days",
       };
 
       expect(weekStreak.value).toBe(7);

--- a/__tests__/services/achievements-quote-accolades.test.ts
+++ b/__tests__/services/achievements-quote-accolades.test.ts
@@ -25,9 +25,7 @@ describe("AchievementsService - Quote Accolades", () => {
 
       // Ensure progression makes sense for adding quotes
       expect(thresholds.quotable).toBeLessThan(thresholds.quote_master);
-      expect(thresholds.quote_master).toBeLessThan(
-        thresholds.quote_collector,
-      );
+      expect(thresholds.quote_master).toBeLessThan(thresholds.quote_collector);
       expect(thresholds.quote_collector).toBeLessThan(thresholds.quote_legend);
 
       // Ensure progression makes sense for being quoted
@@ -63,11 +61,7 @@ describe("AchievementsService - Quote Accolades", () => {
     });
 
     it("should have three accolades for being quoted", () => {
-      const beingQuotedAccolades = [
-        "quotable",
-        "widely_quoted",
-        "quote_icon",
-      ];
+      const beingQuotedAccolades = ["quotable", "widely_quoted", "quote_icon"];
       expect(beingQuotedAccolades.length).toBe(3);
     });
 

--- a/__tests__/services/achievements-service.test.ts
+++ b/__tests__/services/achievements-service.test.ts
@@ -1,14 +1,19 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import type { Client } from 'discord.js';
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import type { Client } from "discord.js";
 
 // Do NOT override the global mongoose mock from setup.ts — rely on it for stable jest.fn() instances.
 
-jest.mock('../../src/utils/logger.js', () => ({
-  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+jest.mock("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
 }));
 
 // UserAchievements needs to be a callable constructor AND have static methods
-jest.mock('../../src/models/user-achievements.js', () => ({
+jest.mock("../../src/models/user-achievements.js", () => ({
   UserAchievements: Object.assign(
     jest.fn().mockImplementation(() => ({
       accolades: [],
@@ -19,11 +24,11 @@ jest.mock('../../src/models/user-achievements.js', () => ({
     {
       findOne: jest.fn(),
       find: jest.fn(),
-    }
+    },
   ),
 }));
 
-jest.mock('../../src/services/quote-service.js', () => ({
+jest.mock("../../src/services/quote-service.js", () => ({
   quoteService: {
     getQuotesAuthoredByUser: jest.fn().mockResolvedValue(0),
     getQuotesAddedByUser: jest.fn().mockResolvedValue(0),
@@ -32,10 +37,16 @@ jest.mock('../../src/services/quote-service.js', () => ({
 }));
 
 // Static imports — mocks are registered before these load (jest.mock is hoisted)
-import { AchievementsService, GamificationService } from '../../src/services/achievements-service.js';
-import { UserAchievements } from '../../src/models/user-achievements.js';
-import { VoiceChannelTracking, type IVoiceChannelTracking } from '../../src/models/voice-channel-tracking.js';
-import { UserNotificationPrefsService } from '../../src/services/user-notification-prefs-service.js';
+import {
+  AchievementsService,
+  GamificationService,
+} from "../../src/services/achievements-service.js";
+import { UserAchievements } from "../../src/models/user-achievements.js";
+import {
+  VoiceChannelTracking,
+  type IVoiceChannelTracking,
+} from "../../src/models/voice-channel-tracking.js";
+import { UserNotificationPrefsService } from "../../src/services/user-notification-prefs-service.js";
 
 // Helper that mimics a Mongoose query cursor over a fixed set of docs, so
 // tests can exercise the streaming `.find({}).cursor()` path.
@@ -56,20 +67,20 @@ function createAchievementsService(mockClient: Partial<Client>) {
   const service = AchievementsService.getInstance(mockClient as Client);
 
   const mockConfigService = {
-    getString: jest.fn().mockResolvedValue('mongodb://localhost/test'),
+    getString: jest.fn().mockResolvedValue("mongodb://localhost/test"),
     getBoolean: jest.fn().mockResolvedValue(false),
     get: jest.fn().mockResolvedValue(null),
     getNumber: jest.fn().mockResolvedValue(0),
     triggerReload: jest.fn().mockResolvedValue(undefined),
   };
   // Inject mock config service and mark as connected (established pattern from codebase)
-  (service as never)['configService'] = mockConfigService;
-  (service as never)['isConnected'] = true;
+  (service as never)["configService"] = mockConfigService;
+  (service as never)["isConnected"] = true;
 
   return { service, mockConfigService };
 }
 
-describe('AchievementsService', () => {
+describe("AchievementsService", () => {
   let mockClient: Partial<Client>;
 
   beforeEach(() => {
@@ -81,16 +92,19 @@ describe('AchievementsService', () => {
     mockClient = { users: { fetch: jest.fn() } as any };
 
     // Reset singleton between tests
-    (AchievementsService as unknown as { instance: unknown }).instance = undefined;
+    (AchievementsService as unknown as { instance: unknown }).instance =
+      undefined;
 
     // Default the per-user prefs gate to "all enabled" so existing tests
     // that don't care about #482 keep passing. `mockClear` resets the
     // call history (jest.spyOn returns the same spy across tests, so
     // without this `toHaveBeenCalled` assertions would see stale calls
     // from earlier tests in the suite).
-    (UserNotificationPrefsService as unknown as { instance: unknown }).instance = null;
+    (
+      UserNotificationPrefsService as unknown as { instance: unknown }
+    ).instance = null;
     const prefsSpy = jest
-      .spyOn(UserNotificationPrefsService.prototype, 'getPrefs')
+      .spyOn(UserNotificationPrefsService.prototype, "getPrefs")
       .mockResolvedValue({
         achievements: true,
         digest: true,
@@ -99,151 +113,181 @@ describe('AchievementsService', () => {
     prefsSpy.mockClear();
   });
 
-  describe('singleton pattern', () => {
-    it('should create a singleton instance', () => {
+  describe("singleton pattern", () => {
+    it("should create a singleton instance", () => {
       const instance1 = AchievementsService.getInstance(mockClient as Client);
       const instance2 = AchievementsService.getInstance(mockClient as Client);
       expect(instance1).toBe(instance2);
     });
 
-    it('should create an instance with a client', () => {
-      expect(AchievementsService.getInstance(mockClient as Client)).toBeDefined();
+    it("should create an instance with a client", () => {
+      expect(
+        AchievementsService.getInstance(mockClient as Client),
+      ).toBeDefined();
     });
   });
 
-  describe('getAccoladeDefinition', () => {
-    it('should return definition for first_hour', () => {
+  describe("getAccoladeDefinition", () => {
+    it("should return definition for first_hour", () => {
       const { service } = createAchievementsService(mockClient);
-      const def = service.getAccoladeDefinition('first_hour');
+      const def = service.getAccoladeDefinition("first_hour");
       expect(def).toBeDefined();
-      expect(def?.name).toBe('First Steps');
-      expect(def?.emoji).toBe('🎉');
+      expect(def?.name).toBe("First Steps");
+      expect(def?.emoji).toBe("🎉");
     });
 
-    it('should return definition for voice_veteran_100', () => {
+    it("should return definition for voice_veteran_100", () => {
       const { service } = createAchievementsService(mockClient);
-      const def = service.getAccoladeDefinition('voice_veteran_100');
+      const def = service.getAccoladeDefinition("voice_veteran_100");
       expect(def).toBeDefined();
-      expect(def?.name).toBe('Voice Veteran');
+      expect(def?.name).toBe("Voice Veteran");
     });
 
-    it('should return definition for social_butterfly', () => {
+    it("should return definition for social_butterfly", () => {
       const { service } = createAchievementsService(mockClient);
-      expect(service.getAccoladeDefinition('social_butterfly')).toBeDefined();
+      expect(service.getAccoladeDefinition("social_butterfly")).toBeDefined();
     });
 
-    it('should return definition for night_owl', () => {
+    it("should return definition for night_owl", () => {
       const { service } = createAchievementsService(mockClient);
-      expect(service.getAccoladeDefinition('night_owl')).toBeDefined();
+      expect(service.getAccoladeDefinition("night_owl")).toBeDefined();
     });
 
-    it('should return definition for early_bird', () => {
+    it("should return definition for early_bird", () => {
       const { service } = createAchievementsService(mockClient);
-      expect(service.getAccoladeDefinition('early_bird')).toBeDefined();
+      expect(service.getAccoladeDefinition("early_bird")).toBeDefined();
     });
 
-    it('should return definition for marathon_runner', () => {
+    it("should return definition for marathon_runner", () => {
       const { service } = createAchievementsService(mockClient);
-      expect(service.getAccoladeDefinition('marathon_runner')).toBeDefined();
+      expect(service.getAccoladeDefinition("marathon_runner")).toBeDefined();
     });
 
-    it('should return undefined for invalid accolade type', () => {
+    it("should return undefined for invalid accolade type", () => {
       const { service } = createAchievementsService(mockClient);
-      expect(service.getAccoladeDefinition('non_existent_type')).toBeUndefined();
+      expect(
+        service.getAccoladeDefinition("non_existent_type"),
+      ).toBeUndefined();
     });
   });
 
-  describe('getAchievementDefinition', () => {
-    it('should return definition for weekly_active', () => {
+  describe("getAchievementDefinition", () => {
+    it("should return definition for weekly_active", () => {
       const { service } = createAchievementsService(mockClient);
-      const def = service.getAchievementDefinition('weekly_active');
+      const def = service.getAchievementDefinition("weekly_active");
       expect(def).toBeDefined();
-      expect(def?.name).toBe('Active');
+      expect(def?.name).toBe("Active");
     });
 
-    it('should return undefined for invalid achievement type', () => {
+    it("should return undefined for invalid achievement type", () => {
       const { service } = createAchievementsService(mockClient);
-      expect(service.getAchievementDefinition('non_existent')).toBeUndefined();
+      expect(service.getAchievementDefinition("non_existent")).toBeUndefined();
     });
   });
 
-  describe('accolade metadata', () => {
+  describe("accolade metadata", () => {
     const emptyTrackingData = {
-      userId: 'user123',
-      username: 'TestUser',
+      userId: "user123",
+      username: "TestUser",
       totalTime: 0,
       lastSeen: new Date(),
       sessions: [],
       excludedChannels: [],
     } as unknown as IVoiceChannelTracking;
 
-    it('should return 0 marathon metadata value when sessions are empty', async () => {
+    it("should return 0 marathon metadata value when sessions are empty", async () => {
       const { service } = createAchievementsService(mockClient);
-      const metadataFunction = (service as never)['accoladeLogic'].marathon_runner
-        .metadataFunction as (userId: string, userData: unknown) => Promise<{ value?: number }>;
+      const metadataFunction = (service as never)["accoladeLogic"]
+        .marathon_runner.metadataFunction as (
+        userId: string,
+        userData: unknown,
+      ) => Promise<{ value?: number }>;
 
-      const metadata = await metadataFunction('user123', emptyTrackingData);
+      const metadata = await metadataFunction("user123", emptyTrackingData);
 
       expect(metadata.value).toBe(0);
     });
 
-    it('should return 0 ultra marathon metadata value when sessions are empty', async () => {
+    it("should return 0 ultra marathon metadata value when sessions are empty", async () => {
       const { service } = createAchievementsService(mockClient);
-      const metadataFunction = (service as never)['accoladeLogic'].ultra_marathoner
-        .metadataFunction as (userId: string, userData: unknown) => Promise<{ value?: number }>;
+      const metadataFunction = (service as never)["accoladeLogic"]
+        .ultra_marathoner.metadataFunction as (
+        userId: string,
+        userData: unknown,
+      ) => Promise<{ value?: number }>;
 
-      const metadata = await metadataFunction('user123', emptyTrackingData);
+      const metadata = await metadataFunction("user123", emptyTrackingData);
 
       expect(metadata.value).toBe(0);
     });
   });
 
-  describe('checkAndAwardAccolades', () => {
-    it('should return empty array when achievements are disabled', async () => {
-      const { service, mockConfigService } = createAchievementsService(mockClient);
+  describe("checkAndAwardAccolades", () => {
+    it("should return empty array when achievements are disabled", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
       mockConfigService.getBoolean.mockResolvedValue(false);
-      expect(await service.checkAndAwardAccolades('user123', 'TestUser')).toEqual([]);
+      expect(
+        await service.checkAndAwardAccolades("user123", "TestUser"),
+      ).toEqual([]);
     });
 
-    it('should check accolades when enabled with no existing user record', async () => {
-      const { service, mockConfigService } = createAchievementsService(mockClient);
+    it("should check accolades when enabled with no existing user record", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
       mockConfigService.getBoolean.mockResolvedValue(true);
       // Default mocks return null/empty — no accolades will be earned
-      const result = await service.checkAndAwardAccolades('user123', 'TestUser');
+      const result = await service.checkAndAwardAccolades(
+        "user123",
+        "TestUser",
+      );
       expect(Array.isArray(result)).toBe(true);
     });
 
-    it('should return empty when user has existing accolades already', async () => {
-      const { service, mockConfigService } = createAchievementsService(mockClient);
+    it("should return empty when user has existing accolades already", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
       mockConfigService.getBoolean.mockResolvedValue(true);
 
       (UserAchievements.findOne as jest.Mock).mockResolvedValue({
-        accolades: [{ type: 'first_hour', earnedAt: new Date(), metadata: {} }],
+        accolades: [{ type: "first_hour", earnedAt: new Date(), metadata: {} }],
         statistics: { totalAccolades: 1, totalAchievements: 0 },
         save: jest.fn().mockResolvedValue(undefined),
       });
 
-      const result = await service.checkAndAwardAccolades('user123', 'TestUser');
+      const result = await service.checkAndAwardAccolades(
+        "user123",
+        "TestUser",
+      );
       expect(Array.isArray(result)).toBe(true);
     });
 
-    it('should handle database errors gracefully', async () => {
-      const { service, mockConfigService } = createAchievementsService(mockClient);
+    it("should handle database errors gracefully", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
       mockConfigService.getBoolean.mockResolvedValue(true);
-      (UserAchievements.findOne as jest.Mock).mockRejectedValue(new Error('DB error'));
-      expect(await service.checkAndAwardAccolades('user123', 'TestUser')).toEqual([]);
+      (UserAchievements.findOne as jest.Mock).mockRejectedValue(
+        new Error("DB error"),
+      );
+      expect(
+        await service.checkAndAwardAccolades("user123", "TestUser"),
+      ).toEqual([]);
     });
   });
 
-  describe('checkAndAwardAchievements', () => {
-    it('should return empty array when achievements are disabled', async () => {
-      const { service, mockConfigService } = createAchievementsService(mockClient);
+  describe("checkAndAwardAchievements", () => {
+    it("should return empty array when achievements are disabled", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
       mockConfigService.getBoolean.mockResolvedValue(false);
-      expect(await service.checkAndAwardAchievements('user123', 'TestUser')).toEqual([]);
+      expect(
+        await service.checkAndAwardAchievements("user123", "TestUser"),
+      ).toEqual([]);
     });
 
-    it('should check achievements when enabled', async () => {
-      const { service, mockConfigService } = createAchievementsService(mockClient);
+    it("should check achievements when enabled", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
       mockConfigService.getBoolean.mockResolvedValue(true);
 
       (UserAchievements.findOne as jest.Mock).mockResolvedValue({
@@ -252,147 +296,188 @@ describe('AchievementsService', () => {
         save: jest.fn().mockResolvedValue(undefined),
       });
 
-      const result = await service.checkAndAwardAchievements('user123', 'TestUser');
+      const result = await service.checkAndAwardAchievements(
+        "user123",
+        "TestUser",
+      );
       expect(Array.isArray(result)).toBe(true);
     });
 
-    it('should handle database errors gracefully', async () => {
-      const { service, mockConfigService } = createAchievementsService(mockClient);
+    it("should handle database errors gracefully", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
       mockConfigService.getBoolean.mockResolvedValue(true);
-      (UserAchievements.findOne as jest.Mock).mockRejectedValue(new Error('DB error'));
-      expect(await service.checkAndAwardAchievements('user123', 'TestUser')).toEqual([]);
+      (UserAchievements.findOne as jest.Mock).mockRejectedValue(
+        new Error("DB error"),
+      );
+      expect(
+        await service.checkAndAwardAchievements("user123", "TestUser"),
+      ).toEqual([]);
     });
   });
 
-  describe('getUserAchievements', () => {
-    it('should return null when user not found', async () => {
+  describe("getUserAchievements", () => {
+    it("should return null when user not found", async () => {
       const { service } = createAchievementsService(mockClient);
       (UserAchievements.findOne as jest.Mock).mockResolvedValue(null);
-      expect(await service.getUserAchievements('unknown-user')).toBeNull();
+      expect(await service.getUserAchievements("unknown-user")).toBeNull();
     });
 
-    it('should return achievements when user found', async () => {
+    it("should return achievements when user found", async () => {
       const { service } = createAchievementsService(mockClient);
       (UserAchievements.findOne as jest.Mock).mockResolvedValue({
-        accolades: [{ type: 'first_hour', earnedAt: new Date(), metadata: {} }],
+        accolades: [{ type: "first_hour", earnedAt: new Date(), metadata: {} }],
         achievements: [],
         statistics: { totalAccolades: 1, totalAchievements: 0 },
       });
 
-      const result = await service.getUserAchievements('user123');
+      const result = await service.getUserAchievements("user123");
       expect(result).not.toBeNull();
       expect(result?.accolades).toHaveLength(1);
       expect(result?.statistics.totalAccolades).toBe(1);
     });
 
-    it('should handle database errors gracefully', async () => {
+    it("should handle database errors gracefully", async () => {
       const { service } = createAchievementsService(mockClient);
-      (UserAchievements.findOne as jest.Mock).mockRejectedValue(new Error('DB error'));
-      expect(await service.getUserAchievements('user123')).toBeNull();
+      (UserAchievements.findOne as jest.Mock).mockRejectedValue(
+        new Error("DB error"),
+      );
+      expect(await service.getUserAchievements("user123")).toBeNull();
     });
   });
 
-  describe('notifyUserOfAccolades', () => {
-    it('should not send DM when dm_notifications is disabled', async () => {
-      const { service, mockConfigService } = createAchievementsService(mockClient);
+  describe("notifyUserOfAccolades", () => {
+    it("should not send DM when dm_notifications is disabled", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
       mockConfigService.getBoolean.mockResolvedValue(false);
 
       await expect(
-        service.notifyUserOfAccolades('user123', [{ type: 'first_hour', earnedAt: new Date(), metadata: {} }])
+        service.notifyUserOfAccolades("user123", [
+          { type: "first_hour", earnedAt: new Date(), metadata: {} },
+        ]),
       ).resolves.not.toThrow();
       expect((mockClient.users as any).fetch).not.toHaveBeenCalled();
     });
 
-    it('should not send DM when accolades array is empty', async () => {
-      const { service, mockConfigService } = createAchievementsService(mockClient);
+    it("should not send DM when accolades array is empty", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
       mockConfigService.getBoolean.mockResolvedValue(true);
-      await expect(service.notifyUserOfAccolades('user123', [])).resolves.not.toThrow();
+      await expect(
+        service.notifyUserOfAccolades("user123", []),
+      ).resolves.not.toThrow();
       expect((mockClient.users as any).fetch).not.toHaveBeenCalled();
     });
 
-    it('should send DM when enabled with valid accolades', async () => {
-      const { service, mockConfigService } = createAchievementsService(mockClient);
+    it("should send DM when enabled with valid accolades", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
       mockConfigService.getBoolean.mockResolvedValue(true);
 
-      const mockUser = { username: 'TestUser', send: jest.fn().mockResolvedValue(undefined) };
+      const mockUser = {
+        username: "TestUser",
+        send: jest.fn().mockResolvedValue(undefined),
+      };
       (mockClient.users as any).fetch = jest.fn().mockResolvedValue(mockUser);
 
       await expect(
-        service.notifyUserOfAccolades('user123', [
-          { type: 'first_hour', earnedAt: new Date(), metadata: { description: '1 hour milestone' } },
-        ])
+        service.notifyUserOfAccolades("user123", [
+          {
+            type: "first_hour",
+            earnedAt: new Date(),
+            metadata: { description: "1 hour milestone" },
+          },
+        ]),
       ).resolves.not.toThrow();
 
-      expect((mockClient.users as any).fetch).toHaveBeenCalledWith('user123');
+      expect((mockClient.users as any).fetch).toHaveBeenCalledWith("user123");
       expect(mockUser.send).toHaveBeenCalled();
     });
 
-    it('should handle DM send errors gracefully', async () => {
-      const { service, mockConfigService } = createAchievementsService(mockClient);
+    it("should handle DM send errors gracefully", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
       mockConfigService.getBoolean.mockResolvedValue(true);
-      (mockClient.users as any).fetch = jest.fn().mockRejectedValue(new Error('Cannot send DM'));
+      (mockClient.users as any).fetch = jest
+        .fn()
+        .mockRejectedValue(new Error("Cannot send DM"));
 
       await expect(
-        service.notifyUserOfAccolades('user123', [{ type: 'first_hour', earnedAt: new Date(), metadata: {} }])
+        service.notifyUserOfAccolades("user123", [
+          { type: "first_hour", earnedAt: new Date(), metadata: {} },
+        ]),
       ).resolves.not.toThrow();
     });
 
-    it('skips DM when per-user notification prefs say achievements:false (#482)', async () => {
-      const { service, mockConfigService } = createAchievementsService(mockClient);
+    it("skips DM when per-user notification prefs say achievements:false (#482)", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
       mockConfigService.getBoolean.mockResolvedValue(true);
-      mockConfigService.getString.mockResolvedValue('guild-1');
+      mockConfigService.getString.mockResolvedValue("guild-1");
 
-      const mockUser = { username: 'TestUser', send: jest.fn().mockResolvedValue(undefined) };
+      const mockUser = {
+        username: "TestUser",
+        send: jest.fn().mockResolvedValue(undefined),
+      };
       (mockClient.users as any).fetch = jest.fn().mockResolvedValue(mockUser);
 
       const getPrefsSpy = jest
-        .spyOn(UserNotificationPrefsService.prototype, 'getPrefs')
+        .spyOn(UserNotificationPrefsService.prototype, "getPrefs")
         .mockResolvedValue({
           achievements: false,
           digest: true,
           rewind: true,
         });
 
-      await service.notifyUserOfAccolades('user123', [
-        { type: 'first_hour', earnedAt: new Date(), metadata: {} },
+      await service.notifyUserOfAccolades("user123", [
+        { type: "first_hour", earnedAt: new Date(), metadata: {} },
       ]);
 
-      expect(getPrefsSpy).toHaveBeenCalledWith('user123', 'guild-1');
+      expect(getPrefsSpy).toHaveBeenCalledWith("user123", "guild-1");
       expect(mockUser.send).not.toHaveBeenCalled();
     });
 
-    it('sends DM and appends the /config footer when prefs leave achievements on (#482)', async () => {
-      const { service, mockConfigService } = createAchievementsService(mockClient);
+    it("sends DM and appends the /config footer when prefs leave achievements on (#482)", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
       mockConfigService.getBoolean.mockResolvedValue(true);
-      mockConfigService.getString.mockResolvedValue('guild-1');
+      mockConfigService.getString.mockResolvedValue("guild-1");
 
-      const mockUser = { username: 'TestUser', send: jest.fn().mockResolvedValue(undefined) };
+      const mockUser = {
+        username: "TestUser",
+        send: jest.fn().mockResolvedValue(undefined),
+      };
       (mockClient.users as any).fetch = jest.fn().mockResolvedValue(mockUser);
 
-      await service.notifyUserOfAccolades('user123', [
-        { type: 'first_hour', earnedAt: new Date(), metadata: {} },
+      await service.notifyUserOfAccolades("user123", [
+        { type: "first_hour", earnedAt: new Date(), metadata: {} },
       ]);
 
       expect(mockUser.send).toHaveBeenCalledTimes(1);
       const sent = (mockUser.send as jest.Mock).mock.calls[0][0] as string;
-      expect(sent).toContain('Manage notifications: run `/config`');
+      expect(sent).toContain("Manage notifications: run `/config`");
     });
 
-    it('falls through and DMs when GUILD_ID is unset (no prefs lookup possible)', async () => {
-      const { service, mockConfigService } = createAchievementsService(mockClient);
+    it("falls through and DMs when GUILD_ID is unset (no prefs lookup possible)", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
       mockConfigService.getBoolean.mockResolvedValue(true);
-      mockConfigService.getString.mockResolvedValue('');
+      mockConfigService.getString.mockResolvedValue("");
 
-      const mockUser = { username: 'TestUser', send: jest.fn().mockResolvedValue(undefined) };
+      const mockUser = {
+        username: "TestUser",
+        send: jest.fn().mockResolvedValue(undefined),
+      };
       (mockClient.users as any).fetch = jest.fn().mockResolvedValue(mockUser);
 
       const getPrefsSpy = jest.spyOn(
         UserNotificationPrefsService.prototype,
-        'getPrefs',
+        "getPrefs",
       );
 
-      await service.notifyUserOfAccolades('user123', [
-        { type: 'first_hour', earnedAt: new Date(), metadata: {} },
+      await service.notifyUserOfAccolades("user123", [
+        { type: "first_hour", earnedAt: new Date(), metadata: {} },
       ]);
 
       expect(getPrefsSpy).not.toHaveBeenCalled();
@@ -400,42 +485,44 @@ describe('AchievementsService', () => {
     });
   });
 
-  describe('getNewAccoladesSinceLastWeek', () => {
-    it('should return empty array when no recent accolades', async () => {
+  describe("getNewAccoladesSinceLastWeek", () => {
+    it("should return empty array when no recent accolades", async () => {
       const { service } = createAchievementsService(mockClient);
       (UserAchievements.find as jest.Mock).mockReturnValue(mockFindCursor([]));
       expect(await service.getNewAccoladesSinceLastWeek()).toEqual([]);
     });
 
-    it('should return users with accolades earned in the past week', async () => {
+    it("should return users with accolades earned in the past week", async () => {
       const { service } = createAchievementsService(mockClient);
       const recentDate = new Date();
       (UserAchievements.find as jest.Mock).mockReturnValue(
         mockFindCursor([
           {
-            userId: 'user1',
-            username: 'User1',
-            accolades: [{ type: 'first_hour', earnedAt: recentDate, metadata: {} }],
+            userId: "user1",
+            username: "User1",
+            accolades: [
+              { type: "first_hour", earnedAt: recentDate, metadata: {} },
+            ],
           },
         ]),
       );
 
       const result = await service.getNewAccoladesSinceLastWeek();
       expect(result).toHaveLength(1);
-      expect(result[0].userId).toBe('user1');
+      expect(result[0].userId).toBe("user1");
     });
 
-    it('should handle database errors gracefully', async () => {
+    it("should handle database errors gracefully", async () => {
       const { service } = createAchievementsService(mockClient);
       (UserAchievements.find as jest.Mock).mockImplementation(() => {
-        throw new Error('DB error');
+        throw new Error("DB error");
       });
       expect(await service.getNewAccoladesSinceLastWeek()).toEqual([]);
     });
   });
 
-  describe('GamificationService export', () => {
-    it('should export GamificationService as alias for AchievementsService', () => {
+  describe("GamificationService export", () => {
+    it("should export GamificationService as alias for AchievementsService", () => {
       expect(GamificationService).toBe(AchievementsService);
     });
   });

--- a/__tests__/services/achievements-time-of-day.test.ts
+++ b/__tests__/services/achievements-time-of-day.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, jest } from '@jest/globals';
+import { describe, it, expect, jest } from "@jest/globals";
 
 // Mock mongoose connection before importing the service
-jest.mock('mongoose', () => ({
+jest.mock("mongoose", () => ({
   __esModule: true,
   default: {
     connection: {
@@ -11,173 +11,185 @@ jest.mock('mongoose', () => ({
   },
 }));
 
-jest.mock('../../src/utils/logger.js');
-jest.mock('../../src/services/config-service.js');
+jest.mock("../../src/utils/logger.js");
+jest.mock("../../src/services/config-service.js");
 
-describe('AchievementsService - Time of Day Calculations', () => {
+describe("AchievementsService - Time of Day Calculations", () => {
   /**
    * These tests document and verify the timezone behavior of time-based accolades.
-   * 
+   *
    * KEY FINDING: All time calculations use the server's local timezone via Date.getHours()
    * Since the bot typically runs in UTC, all time ranges are in UTC:
    * - Night Owl: 22:00 - 06:00 UTC (10 PM - 6 AM UTC)
    * - Early Bird: 06:00 - 10:00 UTC (6 AM - 10 AM UTC)
-   * 
+   *
    * This means:
    * - A user in PST (UTC-8) needs to be active 14:00-22:00 PST for Night Owl
    * - A user in EST (UTC-5) needs to be active 17:00-01:00 EST for Night Owl
    * - A user in CET (UTC+1) needs to be active 23:00-07:00 CET for Night Owl
    */
 
-  describe('Night Owl calculation (22:00 - 06:00 UTC)', () => {
-    it('should count time during late night hours in UTC', () => {
+  describe("Night Owl calculation (22:00 - 06:00 UTC)", () => {
+    it("should count time during late night hours in UTC", () => {
       // Create a session from 11 PM to 1 AM UTC (2 hours in night owl range)
-      const startTime = new Date('2026-01-29T23:00:00.000Z');
-      const endTime = new Date('2026-01-30T01:00:00.000Z');
-      
+      const startTime = new Date("2026-01-29T23:00:00.000Z");
+      const endTime = new Date("2026-01-30T01:00:00.000Z");
+
       // Verify the hours are in the expected range
       expect(startTime.getHours()).toBe(23); // 11 PM UTC
-      expect(endTime.getHours()).toBe(1);    // 1 AM UTC
-      
+      expect(endTime.getHours()).toBe(1); // 1 AM UTC
+
       // Both hours should qualify for Night Owl (22:00-06:00)
       expect(startTime.getHours() >= 22 || startTime.getHours() < 6).toBe(true);
       expect(endTime.getHours() >= 22 || endTime.getHours() < 6).toBe(true);
     });
 
-    it('should NOT count time during daytime hours', () => {
+    it("should NOT count time during daytime hours", () => {
       // Create a session from 2 PM to 4 PM UTC
-      const startTime = new Date('2026-01-29T14:00:00.000Z');
-      const endTime = new Date('2026-01-29T16:00:00.000Z');
-      
+      const startTime = new Date("2026-01-29T14:00:00.000Z");
+      const endTime = new Date("2026-01-29T16:00:00.000Z");
+
       // Verify hours are NOT in night owl range
       expect(startTime.getHours()).toBe(14);
       expect(endTime.getHours()).toBe(16);
-      expect(startTime.getHours() >= 22 || startTime.getHours() < 6).toBe(false);
+      expect(startTime.getHours() >= 22 || startTime.getHours() < 6).toBe(
+        false,
+      );
       expect(endTime.getHours() >= 22 || endTime.getHours() < 6).toBe(false);
     });
 
-    it('should use UTC time, not local time', () => {
+    it("should use UTC time, not local time", () => {
       // A session at 11 PM PST (UTC-8) would be 7 AM UTC (next day)
       // This would NOT count for Night Owl since 7 AM UTC is after 6 AM cutoff
-      const pstElevenPM = new Date('2026-01-30T07:00:00.000Z'); // 11 PM PST = 7 AM UTC
-      
+      const pstElevenPM = new Date("2026-01-30T07:00:00.000Z"); // 11 PM PST = 7 AM UTC
+
       expect(pstElevenPM.getHours()).toBe(7); // 7 AM UTC
-      expect(pstElevenPM.getHours() >= 22 || pstElevenPM.getHours() < 6).toBe(false);
-      
+      expect(pstElevenPM.getHours() >= 22 || pstElevenPM.getHours() < 6).toBe(
+        false,
+      );
+
       // However, 11 PM EST (UTC-5) would be 4 AM UTC
       // This WOULD count for Night Owl since 4 AM UTC is before 6 AM
-      const estElevenPM = new Date('2026-01-30T04:00:00.000Z'); // 11 PM EST = 4 AM UTC
-      
+      const estElevenPM = new Date("2026-01-30T04:00:00.000Z"); // 11 PM EST = 4 AM UTC
+
       expect(estElevenPM.getHours()).toBe(4); // 4 AM UTC
-      expect(estElevenPM.getHours() >= 22 || estElevenPM.getHours() < 6).toBe(true);
+      expect(estElevenPM.getHours() >= 22 || estElevenPM.getHours() < 6).toBe(
+        true,
+      );
     });
   });
 
-  describe('Early Bird calculation (06:00 - 10:00 UTC)', () => {
-    it('should count time during early morning hours in UTC', () => {
+  describe("Early Bird calculation (06:00 - 10:00 UTC)", () => {
+    it("should count time during early morning hours in UTC", () => {
       // Create a session from 7 AM to 9 AM UTC
-      const startTime = new Date('2026-01-29T07:00:00.000Z');
-      const endTime = new Date('2026-01-29T09:00:00.000Z');
-      
+      const startTime = new Date("2026-01-29T07:00:00.000Z");
+      const endTime = new Date("2026-01-29T09:00:00.000Z");
+
       expect(startTime.getHours()).toBe(7);
       expect(endTime.getHours()).toBe(9);
-      
+
       // Both hours should qualify for Early Bird (06:00-10:00)
       expect(startTime.getHours() >= 6 && startTime.getHours() < 10).toBe(true);
       expect(endTime.getHours() >= 6 && endTime.getHours() < 10).toBe(true);
     });
 
-    it('should NOT count time outside early morning hours', () => {
+    it("should NOT count time outside early morning hours", () => {
       // Create a session from 11 AM to 1 PM UTC
-      const startTime = new Date('2026-01-29T11:00:00.000Z');
-      const endTime = new Date('2026-01-29T13:00:00.000Z');
-      
+      const startTime = new Date("2026-01-29T11:00:00.000Z");
+      const endTime = new Date("2026-01-29T13:00:00.000Z");
+
       expect(startTime.getHours()).toBe(11);
       expect(endTime.getHours()).toBe(13);
-      expect(startTime.getHours() >= 6 && startTime.getHours() < 10).toBe(false);
+      expect(startTime.getHours() >= 6 && startTime.getHours() < 10).toBe(
+        false,
+      );
       expect(endTime.getHours() >= 6 && endTime.getHours() < 10).toBe(false);
     });
 
-    it('should use UTC time, not local time', () => {
+    it("should use UTC time, not local time", () => {
       // 7 AM PST (UTC-8) would be 3 PM UTC - NOT Early Bird hours
-      const pstSevenAM = new Date('2026-01-29T15:00:00.000Z'); // 7 AM PST = 3 PM UTC
-      
+      const pstSevenAM = new Date("2026-01-29T15:00:00.000Z"); // 7 AM PST = 3 PM UTC
+
       expect(pstSevenAM.getHours()).toBe(15);
-      expect(pstSevenAM.getHours() >= 6 && pstSevenAM.getHours() < 10).toBe(false);
-      
+      expect(pstSevenAM.getHours() >= 6 && pstSevenAM.getHours() < 10).toBe(
+        false,
+      );
+
       // 7 AM CET (UTC+1) would be 6 AM UTC - WOULD count as Early Bird
-      const cetSevenAM = new Date('2026-01-29T06:00:00.000Z'); // 7 AM CET = 6 AM UTC
-      
+      const cetSevenAM = new Date("2026-01-29T06:00:00.000Z"); // 7 AM CET = 6 AM UTC
+
       expect(cetSevenAM.getHours()).toBe(6);
-      expect(cetSevenAM.getHours() >= 6 && cetSevenAM.getHours() < 10).toBe(true);
+      expect(cetSevenAM.getHours() >= 6 && cetSevenAM.getHours() < 10).toBe(
+        true,
+      );
     });
   });
 
-  describe('Weekend Warrior calculation', () => {
-    it('should use UTC day of week for determining weekends', () => {
+  describe("Weekend Warrior calculation", () => {
+    it("should use UTC day of week for determining weekends", () => {
       // Saturday in UTC
-      const saturdayUTC = new Date('2026-01-31T12:00:00.000Z'); // Saturday
+      const saturdayUTC = new Date("2026-01-31T12:00:00.000Z"); // Saturday
       expect(saturdayUTC.getDay()).toBe(6); // 6 = Saturday
-      
+
       // Sunday in UTC
-      const sundayUTC = new Date('2026-02-01T12:00:00.000Z'); // Sunday
+      const sundayUTC = new Date("2026-02-01T12:00:00.000Z"); // Sunday
       expect(sundayUTC.getDay()).toBe(0); // 0 = Sunday
-      
+
       // Friday late night in PST could be Saturday in UTC
-      const fridayPST = new Date('2026-01-31T02:00:00.000Z'); // Friday 6 PM PST = Saturday 2 AM UTC
+      const fridayPST = new Date("2026-01-31T02:00:00.000Z"); // Friday 6 PM PST = Saturday 2 AM UTC
       expect(fridayPST.getDay()).toBe(6); // Would count as Saturday (weekend) in UTC
     });
   });
 
-  describe('Documentation of timezone behavior', () => {
-    it('documents that Date.getHours() returns server local time', () => {
+  describe("Documentation of timezone behavior", () => {
+    it("documents that Date.getHours() returns server local time", () => {
       // This test documents the key behavior:
       // JavaScript's Date.getHours() returns hours in the SYSTEM'S local timezone
       // NOT UTC, unless explicitly using getUTCHours()
-      
-      const testDate = new Date('2026-01-29T14:00:00.000Z'); // 2 PM UTC
-      
+
+      const testDate = new Date("2026-01-29T14:00:00.000Z"); // 2 PM UTC
+
       // In a UTC environment (like the bot's server):
       // getHours() returns 14 (2 PM)
       // getUTCHours() also returns 14 (2 PM)
-      
+
       // In a PST environment (UTC-8):
       // getHours() would return 6 (6 AM PST)
       // getUTCHours() would return 14 (2 PM UTC)
-      
+
       // Since the bot runs in UTC, getHours() === getUTCHours()
       expect(testDate.getUTCHours()).toBe(14);
-      
+
       // This confirms all time calculations use the server's timezone (UTC)
     });
 
-    it('provides timezone conversion examples for users', () => {
+    it("provides timezone conversion examples for users", () => {
       // Example: Night Owl times in different timezones
       const nightOwlUTC = {
         start: 22, // 10 PM UTC
-        end: 6,    // 6 AM UTC
+        end: 6, // 6 AM UTC
       };
-      
+
       // For PST (UTC-8) users:
       const nightOwlPST = {
         start: (nightOwlUTC.start - 8 + 24) % 24, // 2 PM PST
-        end: (nightOwlUTC.end - 8 + 24) % 24,     // 10 PM PST
+        end: (nightOwlUTC.end - 8 + 24) % 24, // 10 PM PST
       };
       expect(nightOwlPST.start).toBe(14);
       expect(nightOwlPST.end).toBe(22);
-      
+
       // For EST (UTC-5) users:
       const nightOwlEST = {
         start: (nightOwlUTC.start - 5 + 24) % 24, // 5 PM EST
-        end: (nightOwlUTC.end - 5 + 24) % 24,     // 1 AM EST
+        end: (nightOwlUTC.end - 5 + 24) % 24, // 1 AM EST
       };
       expect(nightOwlEST.start).toBe(17);
       expect(nightOwlEST.end).toBe(1);
-      
+
       // For CET (UTC+1) users:
       const nightOwlCET = {
         start: (nightOwlUTC.start + 1) % 24, // 11 PM CET
-        end: (nightOwlUTC.end + 1) % 24,     // 7 AM CET
+        end: (nightOwlUTC.end + 1) % 24, // 7 AM CET
       };
       expect(nightOwlCET.start).toBe(23);
       expect(nightOwlCET.end).toBe(7);

--- a/__tests__/services/bot-status-pools.test.ts
+++ b/__tests__/services/bot-status-pools.test.ts
@@ -96,7 +96,9 @@ describe("BotStatusService status pools", () => {
   });
 
   it("substitutes {count} for the live user count in the multiple pool", async () => {
-    setStoredRows([{ pool: "multiple", text: "{count} folks online", order: 0 }]);
+    setStoredRows([
+      { pool: "multiple", text: "{count} folks online", order: 0 },
+    ]);
     await service.refreshStatusPools();
 
     service.updateVcUserCount(0);

--- a/__tests__/services/bot-status-service.test.ts
+++ b/__tests__/services/bot-status-service.test.ts
@@ -1,88 +1,95 @@
-import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
-import { BotStatusService } from '../../src/services/bot-status-service.js';
-import { lonelyStatuses } from '../../src/content/statuses.js';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+import { BotStatusService } from "../../src/services/bot-status-service.js";
+import { lonelyStatuses } from "../../src/content/statuses.js";
 
 // Mock dependencies
-jest.mock('../../src/services/config-service.js');
-jest.mock('../../src/utils/logger.js');
+jest.mock("../../src/services/config-service.js");
+jest.mock("../../src/utils/logger.js");
 
-describe('BotStatusService', () => {
-  describe('singleton pattern', () => {
-    it('should create a singleton instance', () => {
+describe("BotStatusService", () => {
+  describe("singleton pattern", () => {
+    it("should create a singleton instance", () => {
       const mockClient = { user: { setPresence: jest.fn() } } as any;
       const instance1 = BotStatusService.getInstance(mockClient);
       const instance2 = BotStatusService.getInstance(mockClient);
-      
+
       expect(instance1).toBe(instance2);
     });
   });
 
-  describe('initialization', () => {
-    it('should create an instance with a client', () => {
+  describe("initialization", () => {
+    it("should create an instance with a client", () => {
       const mockClient = { user: { setPresence: jest.fn() } } as any;
       const service = BotStatusService.getInstance(mockClient);
-      
+
       expect(service).toBeDefined();
       expect(service).toBeInstanceOf(BotStatusService);
     });
   });
 
-  describe('public methods', () => {
+  describe("public methods", () => {
     let service: BotStatusService;
     let mockClient: any;
 
     beforeEach(() => {
       jest.clearAllMocks();
-      mockClient = { 
-        user: { 
-          setPresence: jest.fn() 
-        } 
+      mockClient = {
+        user: {
+          setPresence: jest.fn(),
+        },
       };
       service = BotStatusService.getInstance(mockClient);
     });
 
-    it('should have setConnectingStatus method', () => {
-      expect(typeof service.setConnectingStatus).toBe('function');
+    it("should have setConnectingStatus method", () => {
+      expect(typeof service.setConnectingStatus).toBe("function");
     });
 
-    it('should have setOperationalStatus method', () => {
-      expect(typeof service.setOperationalStatus).toBe('function');
+    it("should have setOperationalStatus method", () => {
+      expect(typeof service.setOperationalStatus).toBe("function");
     });
 
-    it('should have setConfigReloadStatus method', () => {
-      expect(typeof service.setConfigReloadStatus).toBe('function');
+    it("should have setConfigReloadStatus method", () => {
+      expect(typeof service.setConfigReloadStatus).toBe("function");
     });
 
-    it('should have setShutdownStatus method', () => {
-      expect(typeof service.setShutdownStatus).toBe('function');
+    it("should have setShutdownStatus method", () => {
+      expect(typeof service.setShutdownStatus).toBe("function");
     });
 
-    it('should set connecting status', () => {
+    it("should set connecting status", () => {
       service.setConnectingStatus();
       // Method should execute without errors
       expect(true).toBe(true);
     });
 
-    it('should set operational status', () => {
+    it("should set operational status", () => {
       service.setOperationalStatus();
       // Method should execute without errors
       expect(true).toBe(true);
     });
 
-    it('should set config reload status', () => {
+    it("should set config reload status", () => {
       service.setConfigReloadStatus();
       // Method should execute without errors
       expect(true).toBe(true);
     });
 
-    it('should set shutdown status', () => {
+    it("should set shutdown status", () => {
       service.setShutdownStatus();
       // Method should execute without errors
       expect(true).toBe(true);
     });
   });
 
-  describe('VC user count priming (#614)', () => {
+  describe("VC user count priming (#614)", () => {
     let service: BotStatusService;
     let mockClient: any;
 
@@ -104,7 +111,7 @@ describe('BotStatusService', () => {
       service.stopVcMonitoring();
     });
 
-    it('reflects users already in voice when primed at startup', async () => {
+    it("reflects users already in voice when primed at startup", async () => {
       // Simulates a restart with 4 users already sitting in voice: the
       // provider reports the live count and priming applies it before the
       // operational status is rendered.
@@ -113,11 +120,11 @@ describe('BotStatusService', () => {
       service.setOperationalStatus();
 
       expect(service.getStatusInfo().currentVcUserCount).toBe(4);
-      expect(lastActivityName()).toContain('4');
+      expect(lastActivityName()).toContain("4");
       expect(lonelyStatuses).not.toContain(lastActivityName());
     });
 
-    it('still shows the lonely status when no users are in voice', async () => {
+    it("still shows the lonely status when no users are in voice", async () => {
       service.setVcUserCountProvider(async () => 0);
       await service.refreshVcUserCount();
       service.setOperationalStatus();
@@ -126,21 +133,21 @@ describe('BotStatusService', () => {
       expect(lonelyStatuses).toContain(lastActivityName());
     });
 
-    it('is a no-op when no provider is registered', async () => {
+    it("is a no-op when no provider is registered", async () => {
       // Explicitly clearing the provider should neither throw nor change
       // the count (a fresh service also starts with no provider).
       service.setVcUserCountProvider(null);
       await expect(service.refreshVcUserCount()).resolves.toBeUndefined();
     });
 
-    it('swallows provider errors without throwing', async () => {
+    it("swallows provider errors without throwing", async () => {
       service.setVcUserCountProvider(async () => {
-        throw new Error('cache walk failed');
+        throw new Error("cache walk failed");
       });
       await expect(service.refreshVcUserCount()).resolves.toBeUndefined();
     });
 
-    it('starts a self-healing monitor interval', () => {
+    it("starts a self-healing monitor interval", () => {
       service.startVcMonitoring();
       expect(service.getStatusInfo().isMonitoring).toBe(true);
       service.stopVcMonitoring();

--- a/__tests__/services/channel-initializer-methods.test.ts
+++ b/__tests__/services/channel-initializer-methods.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import type { Client } from 'discord.js';
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import type { Client } from "discord.js";
 
 // Mock dependencies
-jest.mock('../../src/services/config-service.js');
-jest.mock('../../src/services/discord-logger.js');
-jest.mock('../../src/utils/logger.js');
+jest.mock("../../src/services/config-service.js");
+jest.mock("../../src/services/discord-logger.js");
+jest.mock("../../src/utils/logger.js");
 
-describe('ChannelInitializer Methods', () => {
+describe("ChannelInitializer Methods", () => {
   let mockClient: Partial<Client>;
 
   beforeEach(() => {
@@ -22,34 +22,38 @@ describe('ChannelInitializer Methods', () => {
     } as Client;
   });
 
-  it('should have getInstance method', async () => {
-    const { ChannelInitializer } = await import('../../src/services/channel-initializer.js');
-    
-    expect(typeof ChannelInitializer.getInstance).toBe('function');
+  it("should have getInstance method", async () => {
+    const { ChannelInitializer } =
+      await import("../../src/services/channel-initializer.js");
+
+    expect(typeof ChannelInitializer.getInstance).toBe("function");
   });
 
-  it('should return singleton instance', async () => {
-    const { ChannelInitializer } = await import('../../src/services/channel-initializer.js');
-    
+  it("should return singleton instance", async () => {
+    const { ChannelInitializer } =
+      await import("../../src/services/channel-initializer.js");
+
     const instance1 = ChannelInitializer.getInstance(mockClient as Client);
     const instance2 = ChannelInitializer.getInstance(mockClient as Client);
 
     expect(instance1).toBe(instance2);
   });
 
-  it('should have initialize method', async () => {
-    const { ChannelInitializer } = await import('../../src/services/channel-initializer.js');
-    
+  it("should have initialize method", async () => {
+    const { ChannelInitializer } =
+      await import("../../src/services/channel-initializer.js");
+
     const instance = ChannelInitializer.getInstance(mockClient as Client);
 
-    expect(typeof instance.initialize).toBe('function');
+    expect(typeof instance.initialize).toBe("function");
   });
 
-  it('should have forceReinitialize method', async () => {
-    const { ChannelInitializer } = await import('../../src/services/channel-initializer.js');
-    
+  it("should have forceReinitialize method", async () => {
+    const { ChannelInitializer } =
+      await import("../../src/services/channel-initializer.js");
+
     const instance = ChannelInitializer.getInstance(mockClient as Client);
 
-    expect(typeof instance.forceReinitialize).toBe('function');
+    expect(typeof instance.forceReinitialize).toBe("function");
   });
 });

--- a/__tests__/services/channel-initializer.test.ts
+++ b/__tests__/services/channel-initializer.test.ts
@@ -1,18 +1,18 @@
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
-import { ChannelInitializer } from '../../src/services/channel-initializer.js';
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import { ChannelInitializer } from "../../src/services/channel-initializer.js";
 
 // Mock dependencies
-jest.mock('../../src/services/config-service.js');
-jest.mock('../../src/services/voice-channel-manager.js');
-jest.mock('../../src/utils/logger.js');
+jest.mock("../../src/services/config-service.js");
+jest.mock("../../src/services/voice-channel-manager.js");
+jest.mock("../../src/utils/logger.js");
 
-describe('ChannelInitializer', () => {
+describe("ChannelInitializer", () => {
   let service: ChannelInitializer;
   let mockClient: any;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockClient = { 
+    mockClient = {
       guilds: {
         fetch: jest.fn(),
       },
@@ -20,33 +20,33 @@ describe('ChannelInitializer', () => {
     service = ChannelInitializer.getInstance(mockClient);
   });
 
-  describe('singleton pattern', () => {
-    it('should create a singleton instance', () => {
+  describe("singleton pattern", () => {
+    it("should create a singleton instance", () => {
       const instance1 = ChannelInitializer.getInstance(mockClient);
       const instance2 = ChannelInitializer.getInstance(mockClient);
-      
+
       expect(instance1).toBe(instance2);
     });
   });
 
-  describe('initialization', () => {
-    it('should create an instance with a client', () => {
+  describe("initialization", () => {
+    it("should create an instance with a client", () => {
       expect(service).toBeDefined();
       expect(service).toBeInstanceOf(ChannelInitializer);
     });
   });
 
-  describe('public methods', () => {
-    it('should have initialize method', () => {
-      expect(typeof service.initialize).toBe('function');
+  describe("public methods", () => {
+    it("should have initialize method", () => {
+      expect(typeof service.initialize).toBe("function");
     });
 
-    it('should have initializeChannels method', () => {
-      expect(typeof service.initializeChannels).toBe('function');
+    it("should have initializeChannels method", () => {
+      expect(typeof service.initializeChannels).toBe("function");
     });
 
-    it('should have forceReinitialize method', () => {
-      expect(typeof service.forceReinitialize).toBe('function');
+    it("should have forceReinitialize method", () => {
+      expect(typeof service.forceReinitialize).toBe("function");
     });
   });
 });

--- a/__tests__/services/command-audit-cleanup.test.ts
+++ b/__tests__/services/command-audit-cleanup.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 
-const mockGetBoolean = jest.fn<(key: string, def: boolean) => Promise<boolean>>();
+const mockGetBoolean =
+  jest.fn<(key: string, def: boolean) => Promise<boolean>>();
 const mockGetNumber = jest.fn<(key: string, def: number) => Promise<number>>();
 
 jest.unstable_mockModule("../../src/services/config-service.js", () => ({
@@ -12,8 +13,7 @@ jest.unstable_mockModule("../../src/services/config-service.js", () => ({
   },
 }));
 
-const mockDeleteMany =
-  jest.fn<() => Promise<{ deletedCount: number }>>();
+const mockDeleteMany = jest.fn<() => Promise<{ deletedCount: number }>>();
 
 jest.unstable_mockModule(
   "../../src/models/discord-command-audit-log.js",
@@ -38,9 +38,8 @@ jest.unstable_mockModule("cron", () => ({
   },
 }));
 
-const { CommandAuditCleanupService } = await import(
-  "../../src/services/command-audit-cleanup.js"
-);
+const { CommandAuditCleanupService } =
+  await import("../../src/services/command-audit-cleanup.js");
 
 describe("CommandAuditCleanupService", () => {
   beforeEach(() => {

--- a/__tests__/services/command-manager.test.ts
+++ b/__tests__/services/command-manager.test.ts
@@ -1,15 +1,15 @@
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
-import { CommandManager } from '../../src/services/command-manager.js';
-import { PermissionsService } from '../../src/services/permissions-service.js';
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import { CommandManager } from "../../src/services/command-manager.js";
+import { PermissionsService } from "../../src/services/permissions-service.js";
 
 // Mock dependencies
-jest.mock('../../src/services/config-service.js');
-jest.mock('../../src/services/monitoring-service.js');
-jest.mock('../../src/services/cooldown-manager.js');
-jest.mock('../../src/services/permissions-service.js');
-jest.mock('../../src/utils/logger.js');
+jest.mock("../../src/services/config-service.js");
+jest.mock("../../src/services/monitoring-service.js");
+jest.mock("../../src/services/cooldown-manager.js");
+jest.mock("../../src/services/permissions-service.js");
+jest.mock("../../src/utils/logger.js");
 
-describe('CommandManager', () => {
+describe("CommandManager", () => {
   let service: CommandManager;
   let mockClient: any;
 
@@ -18,52 +18,52 @@ describe('CommandManager', () => {
     CommandManager.reset();
     PermissionsService.reset();
     mockClient = {
-      user: { id: '123' },
-      application: { id: '456' },
+      user: { id: "123" },
+      application: { id: "456" },
     };
     service = CommandManager.getInstance(mockClient);
   });
 
-  describe('singleton pattern', () => {
-    it('should create a singleton instance', () => {
+  describe("singleton pattern", () => {
+    it("should create a singleton instance", () => {
       const instance1 = CommandManager.getInstance(mockClient);
       const instance2 = CommandManager.getInstance(mockClient);
-      
+
       expect(instance1).toBe(instance2);
     });
   });
 
-  describe('initialization', () => {
-    it('should create an instance with a client', () => {
+  describe("initialization", () => {
+    it("should create an instance with a client", () => {
       expect(service).toBeDefined();
       expect(service).toBeInstanceOf(CommandManager);
     });
   });
 
-  describe('public methods', () => {
-    it('should have initialize method', () => {
-      expect(typeof service.initialize).toBe('function');
+  describe("public methods", () => {
+    it("should have initialize method", () => {
+      expect(typeof service.initialize).toBe("function");
     });
 
-    it('should have registerCommands method', () => {
-      expect(typeof service.registerCommands).toBe('function');
+    it("should have registerCommands method", () => {
+      expect(typeof service.registerCommands).toBe("function");
     });
 
-    it('should have populateClientCommands method', () => {
-      expect(typeof service.populateClientCommands).toBe('function');
+    it("should have populateClientCommands method", () => {
+      expect(typeof service.populateClientCommands).toBe("function");
     });
 
-    it('should have unregisterCommands method', () => {
-      expect(typeof service.unregisterCommands).toBe('function');
+    it("should have unregisterCommands method", () => {
+      expect(typeof service.unregisterCommands).toBe("function");
     });
 
-    it('should have executeCommand method', () => {
-      expect(typeof service.executeCommand).toBe('function');
+    it("should have executeCommand method", () => {
+      expect(typeof service.executeCommand).toBe("function");
     });
   });
 
-  describe('command collection', () => {
-    it('should start with empty commands', () => {
+  describe("command collection", () => {
+    it("should start with empty commands", () => {
       // Service is initialized, commands should be defined
       expect(true).toBe(true);
     });

--- a/__tests__/services/command-metrics-query.test.ts
+++ b/__tests__/services/command-metrics-query.test.ts
@@ -5,9 +5,8 @@ jest.unstable_mockModule("../../src/models/command-metrics.js", () => ({
   CommandMetrics: { aggregate: mockAggregate },
 }));
 
-const { getCommandMetricsSummary, dayKeyDaysAgo } = await import(
-  "../../src/services/command-metrics-query.js"
-);
+const { getCommandMetricsSummary, dayKeyDaysAgo } =
+  await import("../../src/services/command-metrics-query.js");
 
 describe("getCommandMetricsSummary (#648)", () => {
   beforeEach(() => {

--- a/__tests__/services/command-metrics-query.test.ts
+++ b/__tests__/services/command-metrics-query.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+
+const mockAggregate = jest.fn<(pipeline: unknown[]) => Promise<unknown[]>>();
+jest.unstable_mockModule("../../src/models/command-metrics.js", () => ({
+  CommandMetrics: { aggregate: mockAggregate },
+}));
+
+const { getCommandMetricsSummary, dayKeyDaysAgo } = await import(
+  "../../src/services/command-metrics-query.js"
+);
+
+describe("getCommandMetricsSummary (#648)", () => {
+  beforeEach(() => {
+    mockAggregate.mockReset();
+  });
+
+  it("matches the guild and a window-bounded date range", async () => {
+    mockAggregate.mockResolvedValue([]);
+    await getCommandMetricsSummary("guild-1", 7);
+
+    expect(mockAggregate).toHaveBeenCalledTimes(2);
+    const pipeline = mockAggregate.mock.calls[0]?.[0] as Array<{
+      $match?: { guildId: string; date: { $gte: string } };
+    }>;
+    const match = pipeline[0]?.$match;
+    expect(match?.guildId).toBe("guild-1");
+    // A 7-day window is inclusive of today, so the lower bound is 6 days ago.
+    expect(match?.date.$gte).toBe(dayKeyDaysAgo(6));
+  });
+
+  it("derives error rate and average response time per command", async () => {
+    mockAggregate
+      .mockResolvedValueOnce([
+        {
+          _id: "quote",
+          usageCount: 10,
+          errorCount: 2,
+          totalResponseMs: 1000,
+          lastUsedAt: new Date("2026-06-20T12:00:00Z"),
+        },
+        {
+          _id: "ping",
+          usageCount: 4,
+          errorCount: 0,
+          totalResponseMs: 200,
+          lastUsedAt: new Date("2026-06-21T08:00:00Z"),
+        },
+      ])
+      .mockResolvedValueOnce([
+        { _id: "2026-06-20", usageCount: 8, errorCount: 2 },
+        { _id: "2026-06-21", usageCount: 6, errorCount: 0 },
+      ]);
+
+    const summary = await getCommandMetricsSummary("guild-1", 30);
+
+    expect(summary.rows).toHaveLength(2);
+    const quote = summary.rows[0];
+    expect(quote.command).toBe("quote");
+    expect(quote.errorRate).toBeCloseTo(0.2);
+    expect(quote.avgResponseMs).toBe(100);
+    expect(quote.lastUsedAt).toBe("2026-06-20T12:00:00.000Z");
+
+    const ping = summary.rows[1];
+    expect(ping.errorRate).toBe(0);
+    expect(ping.avgResponseMs).toBe(50);
+
+    expect(summary.totalUsage).toBe(14);
+    expect(summary.totalErrors).toBe(2);
+    expect(summary.dailyTotals).toEqual([
+      { date: "2026-06-20", usageCount: 8, errorCount: 2 },
+      { date: "2026-06-21", usageCount: 6, errorCount: 0 },
+    ]);
+  });
+
+  it("guards against divide-by-zero for empty buckets", async () => {
+    mockAggregate
+      .mockResolvedValueOnce([
+        {
+          _id: "idle",
+          usageCount: 0,
+          errorCount: 0,
+          totalResponseMs: 0,
+          lastUsedAt: null,
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const summary = await getCommandMetricsSummary("guild-1", 30);
+    expect(summary.rows[0].errorRate).toBe(0);
+    expect(summary.rows[0].avgResponseMs).toBe(0);
+    expect(summary.rows[0].lastUsedAt).toBeNull();
+  });
+});

--- a/__tests__/services/config-schema-structure.test.ts
+++ b/__tests__/services/config-schema-structure.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect } from "@jest/globals";
 
-describe('Config Schema', () => {
-  it('placeholder test', () => {
+describe("Config Schema", () => {
+  it("placeholder test", () => {
     expect(true).toBe(true);
   });
 });

--- a/__tests__/services/config-schema.test.ts
+++ b/__tests__/services/config-schema.test.ts
@@ -1,81 +1,97 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect } from "@jest/globals";
 import {
   defaultConfig,
   settingsMetadata,
   categoryMetadata,
   REWIND_RETENTION_MIN_DAYS,
-} from '../../src/services/config-schema.js';
+} from "../../src/services/config-schema.js";
 
-describe('Config Schema', () => {
-  describe('defaultConfig', () => {
-    it('should have all core features disabled by default for security', () => {
-      expect(defaultConfig['voicechannels.enabled']).toBe(false);
-      expect(defaultConfig['voicetracking.enabled']).toBe(false);
-      expect(defaultConfig['ping.enabled']).toBe(false);
-      expect(defaultConfig['quotes.enabled']).toBe(false);
+describe("Config Schema", () => {
+  describe("defaultConfig", () => {
+    it("should have all core features disabled by default for security", () => {
+      expect(defaultConfig["voicechannels.enabled"]).toBe(false);
+      expect(defaultConfig["voicetracking.enabled"]).toBe(false);
+      expect(defaultConfig["ping.enabled"]).toBe(false);
+      expect(defaultConfig["quotes.enabled"]).toBe(false);
     });
 
-    it('should have reasonable default values for voice channel settings', () => {
-      expect(defaultConfig['voicechannels.category_id']).toBe('');
-      expect(defaultConfig['voicechannels.lobby.name']).toBe('Lobby');
-      expect(defaultConfig['voicechannels.channel.prefix']).toBe('🎮');
+    it("should have reasonable default values for voice channel settings", () => {
+      expect(defaultConfig["voicechannels.category_id"]).toBe("");
+      expect(defaultConfig["voicechannels.lobby.name"]).toBe("Lobby");
+      expect(defaultConfig["voicechannels.channel.prefix"]).toBe("🎮");
     });
 
-    it('should have reasonable default values for cleanup retention', () => {
-      expect(defaultConfig['voicetracking.cleanup.retention.detailed_sessions_days']).toBeGreaterThan(0);
-      expect(defaultConfig['voicetracking.cleanup.retention.monthly_summaries_months']).toBeGreaterThan(0);
-      expect(defaultConfig['voicetracking.cleanup.retention.yearly_summaries_years']).toBeGreaterThan(0);
+    it("should have reasonable default values for cleanup retention", () => {
+      expect(
+        defaultConfig["voicetracking.cleanup.retention.detailed_sessions_days"],
+      ).toBeGreaterThan(0);
+      expect(
+        defaultConfig[
+          "voicetracking.cleanup.retention.monthly_summaries_months"
+        ],
+      ).toBeGreaterThan(0);
+      expect(
+        defaultConfig["voicetracking.cleanup.retention.yearly_summaries_years"],
+      ).toBeGreaterThan(0);
     });
 
-    it('keeps Rewind-relevant retention defaults at or above a full year (#575)', () => {
+    it("keeps Rewind-relevant retention defaults at or above a full year (#575)", () => {
       // Rewind is built live from detailed voice sessions and per-message
       // detail; out-of-the-box defaults must cover a full year-in-review.
       expect(
-        defaultConfig['voicetracking.cleanup.retention.detailed_sessions_days'],
+        defaultConfig["voicetracking.cleanup.retention.detailed_sessions_days"],
       ).toBeGreaterThanOrEqual(REWIND_RETENTION_MIN_DAYS);
       expect(
-        defaultConfig['messagetracking.cleanup.retention.detailed_days'],
+        defaultConfig["messagetracking.cleanup.retention.detailed_days"],
       ).toBeGreaterThanOrEqual(REWIND_RETENTION_MIN_DAYS);
     });
 
-    it('should have reasonable default values for quote system', () => {
-      expect(defaultConfig['quotes.max_length']).toBeGreaterThan(0);
-      expect(defaultConfig['quotes.cooldown']).toBeGreaterThanOrEqual(0);
+    it("should have reasonable default values for quote system", () => {
+      expect(defaultConfig["quotes.max_length"]).toBeGreaterThan(0);
+      expect(defaultConfig["quotes.cooldown"]).toBeGreaterThanOrEqual(0);
     });
 
-    it('should have valid cron schedule defaults', () => {
+    it("should have valid cron schedule defaults", () => {
       // Default schedules should be strings (even if empty)
-      expect(typeof defaultConfig['voicetracking.announcements.schedule']).toBe('string');
-      expect(typeof defaultConfig['voicetracking.cleanup.schedule']).toBe('string');
+      expect(typeof defaultConfig["voicetracking.announcements.schedule"]).toBe(
+        "string",
+      );
+      expect(typeof defaultConfig["voicetracking.cleanup.schedule"]).toBe(
+        "string",
+      );
     });
 
-    it('should have channel_id fields as strings', () => {
-      expect(typeof defaultConfig['quotes.channel_id']).toBe('string');
-      expect(typeof defaultConfig['reactionroles.message_channel_id']).toBe('string');
+    it("should have channel_id fields as strings", () => {
+      expect(typeof defaultConfig["quotes.channel_id"]).toBe("string");
+      expect(typeof defaultConfig["reactionroles.message_channel_id"]).toBe(
+        "string",
+      );
     });
 
-    it('should have string fields for comma-separated values', () => {
-      expect(typeof defaultConfig['voicetracking.excluded_channels']).toBe('string');
-      expect(typeof defaultConfig['quotes.delete_roles']).toBe('string');
+    it("should have string fields for comma-separated values", () => {
+      expect(typeof defaultConfig["voicetracking.excluded_channels"]).toBe(
+        "string",
+      );
+      expect(typeof defaultConfig["quotes.delete_roles"]).toBe("string");
     });
 
-    it('should have voicetracking.excluded_channels default to empty string', () => {
-      expect(defaultConfig['voicetracking.excluded_channels']).toBe('');
+    it("should have voicetracking.excluded_channels default to empty string", () => {
+      expect(defaultConfig["voicetracking.excluded_channels"]).toBe("");
     });
 
-    it('should have rate limiting disabled by default for security', () => {
-      expect(defaultConfig['ratelimit.enabled']).toBe(false);
+    it("should have rate limiting disabled by default for security", () => {
+      expect(defaultConfig["ratelimit.enabled"]).toBe(false);
     });
 
-    it('should have reasonable default values for rate limiting', () => {
-      expect(defaultConfig['ratelimit.max_commands']).toBeGreaterThan(0);
-      expect(defaultConfig['ratelimit.window_seconds']).toBeGreaterThan(0);
-      expect(typeof defaultConfig['ratelimit.bypass_admin']).toBe('boolean');
+    it("should have reasonable default values for rate limiting", () => {
+      expect(defaultConfig["ratelimit.max_commands"]).toBeGreaterThan(0);
+      expect(defaultConfig["ratelimit.window_seconds"]).toBeGreaterThan(0);
+      expect(typeof defaultConfig["ratelimit.bypass_admin"]).toBe("boolean");
     });
   });
 
-  describe('settingsMetadata', () => {
-    it('has a non-empty label, description, category, and type for every key in defaultConfig', () => {
+  describe("settingsMetadata", () => {
+    it("has a non-empty label, description, category, and type for every key in defaultConfig", () => {
       const missingLabel: string[] = [];
       const missingDescription: string[] = [];
       const missingCategory: string[] = [];
@@ -89,12 +105,12 @@ describe('Config Schema', () => {
           missingType.push(key);
           continue;
         }
-        if (!meta.label || meta.label.trim() === '') missingLabel.push(key);
-        if (!meta.description || meta.description.trim() === '')
+        if (!meta.label || meta.label.trim() === "") missingLabel.push(key);
+        if (!meta.description || meta.description.trim() === "")
           missingDescription.push(key);
-        if (!meta.category || meta.category.trim() === '')
+        if (!meta.category || meta.category.trim() === "")
           missingCategory.push(key);
-        if (!meta.type || (meta.type as string).trim() === '')
+        if (!meta.type || (meta.type as string).trim() === "")
           missingType.push(key);
       }
       expect(missingLabel).toEqual([]);
@@ -103,7 +119,7 @@ describe('Config Schema', () => {
       expect(missingType).toEqual([]);
     });
 
-    it('declares a `type` consistent with the runtime defaultConfig value shape', () => {
+    it("declares a `type` consistent with the runtime defaultConfig value shape", () => {
       // The schema-declared type must not contradict the runtime shape:
       // a `boolean`-typed key has a boolean default, a `number`-typed key
       // has a numeric default, and every other kind ("string", "cron",
@@ -115,33 +131,34 @@ describe('Config Schema', () => {
         const meta = settingsMetadata[key as keyof typeof settingsMetadata];
         if (!meta) continue;
         const dv = typeof defaultValue;
-        if (meta.type === 'boolean' && dv !== 'boolean') mismatches.push(key);
-        else if (meta.type === 'number' && dv !== 'number') mismatches.push(key);
+        if (meta.type === "boolean" && dv !== "boolean") mismatches.push(key);
+        else if (meta.type === "number" && dv !== "number")
+          mismatches.push(key);
         else if (
-          meta.type !== 'boolean' &&
-          meta.type !== 'number' &&
-          dv !== 'string'
+          meta.type !== "boolean" &&
+          meta.type !== "number" &&
+          dv !== "string"
         )
           mismatches.push(key);
       }
       expect(mismatches).toEqual([]);
     });
 
-    it('attaches a warnBelow hint at the Rewind threshold to both detailed-retention keys (#575)', () => {
+    it("attaches a warnBelow hint at the Rewind threshold to both detailed-retention keys (#575)", () => {
       const voice =
         settingsMetadata[
-          'voicetracking.cleanup.retention.detailed_sessions_days'
+          "voicetracking.cleanup.retention.detailed_sessions_days"
         ];
       const message =
-        settingsMetadata['messagetracking.cleanup.retention.detailed_days'];
+        settingsMetadata["messagetracking.cleanup.retention.detailed_days"];
       for (const meta of [voice, message]) {
         expect(meta.warnBelow).toBeDefined();
         expect(meta.warnBelow?.value).toBe(REWIND_RETENTION_MIN_DAYS);
-        expect(meta.warnBelow?.message.trim()).not.toBe('');
+        expect(meta.warnBelow?.message.trim()).not.toBe("");
       }
     });
 
-    it('does not have stale entries for keys that no longer exist in defaultConfig', () => {
+    it("does not have stale entries for keys that no longer exist in defaultConfig", () => {
       const orphans = Object.keys(settingsMetadata).filter(
         (k) => !(k in defaultConfig),
       );
@@ -149,8 +166,8 @@ describe('Config Schema', () => {
     });
   });
 
-  describe('categoryMetadata', () => {
-    it('covers every category referenced by settingsMetadata', () => {
+  describe("categoryMetadata", () => {
+    it("covers every category referenced by settingsMetadata", () => {
       const usedCategories = new Set(
         Object.values(settingsMetadata).map((m) => m.category),
       );
@@ -165,7 +182,7 @@ describe('Config Schema', () => {
     });
   });
 
-  describe('enabled-default audit (#445)', () => {
+  describe("enabled-default audit (#445)", () => {
     // The audit's principle (documented in defaultConfig's leading comment):
     //   1. Top-level feature gates default to false (opt-in).
     //   2. Sub-feature toggles may default to true if they're inert
@@ -179,72 +196,72 @@ describe('Config Schema', () => {
 
     const EXPECTED_ENABLED_DEFAULTS: Record<string, boolean> = {
       // ─── Top-level feature gates (rule 1: must be false) ────────────
-      'voicechannels.enabled': false,
-      'voicetracking.enabled': false,
-      'ping.enabled': false,
-      'quotes.enabled': false,
-      'ratelimit.enabled': false,
-      'announcements.enabled': false,
-      'achievements.enabled': false,
-      'digest.enabled': false,
-      'rewind.enabled': false,
-      'reactionroles.enabled': false,
-      'notices.enabled': false,
-      'polls.enabled': false,
-      'leaderboard_roles.enabled': false,
-      'messagetracking.enabled': false,
-      'reactiontracking.enabled': false,
+      "voicechannels.enabled": false,
+      "voicetracking.enabled": false,
+      "ping.enabled": false,
+      "quotes.enabled": false,
+      "ratelimit.enabled": false,
+      "announcements.enabled": false,
+      "achievements.enabled": false,
+      "digest.enabled": false,
+      "rewind.enabled": false,
+      "reactionroles.enabled": false,
+      "notices.enabled": false,
+      "polls.enabled": false,
+      "leaderboard_roles.enabled": false,
+      "messagetracking.enabled": false,
+      "reactiontracking.enabled": false,
 
       // ─── Sub-features that default off (auxiliary opt-ins) ──────────
-      'voicechannels.presets.enabled': false,
-      'voicetracking.stats.top.enabled': false,
-      'voicetracking.stats.user.enabled': false,
-      'voicetracking.seen.enabled': false,
-      'voicetracking.companions.enabled': false,
-      'voicetracking.announcements.enabled': false,
-      'voicetracking.cleanup.enabled': false,
-      'messagetracking.cleanup.enabled': false,
-      'polls.participation.enabled': false,
+      "voicechannels.presets.enabled": false,
+      "voicetracking.stats.top.enabled": false,
+      "voicetracking.stats.user.enabled": false,
+      "voicetracking.seen.enabled": false,
+      "voicetracking.companions.enabled": false,
+      "voicetracking.announcements.enabled": false,
+      "voicetracking.cleanup.enabled": false,
+      "messagetracking.cleanup.enabled": false,
+      "polls.participation.enabled": false,
       // Rewind end-of-year DM nudge — auxiliary opt-in under the rewind
       // feature gate, independent of `rewind.enabled` (#608).
-      'rewind.nudge.enabled': false,
+      "rewind.nudge.enabled": false,
 
       // ─── Sub-features that default on (rule 2: parent-gated) ────────
-      'voicechannels.controlpanel.enabled': true,
-      'quotes.header_enabled': true,
-      'quotes.header_pin_enabled': true,
-      'achievements.announcements.enabled': true,
-      'achievements.dm_notifications.enabled': true,
-      'digest.include_achievements': true,
-      'notices.header_enabled': true,
-      'notices.header_pin_enabled': true,
+      "voicechannels.controlpanel.enabled": true,
+      "quotes.header_enabled": true,
+      "quotes.header_pin_enabled": true,
+      "achievements.announcements.enabled": true,
+      "achievements.dm_notifications.enabled": true,
+      "digest.include_achievements": true,
+      "notices.header_enabled": true,
+      "notices.header_pin_enabled": true,
 
       // ─── Core infrastructure (always on; not feature-gated) ─────────
       // Audit logging is a cross-cutting operator-visibility feature
       // rather than a user-facing toggle, so it ships on by default —
       // analogous to how WebAuditLog records every WebUI write without
       // requiring opt-in.
-      'core.command_audit.enabled': true,
+      "core.command_audit.enabled": true,
       // Persisted command metrics (#648) — same rationale as audit logging:
       // a cross-cutting operator-visibility feature, on by default so fresh
       // installs get historical command analytics out of the box.
-      'monitoring.metrics_persistence.enabled': true,
+      "monitoring.metrics_persistence.enabled": true,
     };
 
     // Parent feature each rule-2 (default-true) sub-feature is gated by.
     // Used to prove the sub-feature is inert on a fresh install.
     const PARENT_OF_DEFAULT_TRUE: Record<string, string> = {
-      'voicechannels.controlpanel.enabled': 'voicechannels.enabled',
-      'quotes.header_enabled': 'quotes.enabled',
-      'quotes.header_pin_enabled': 'quotes.enabled',
-      'achievements.announcements.enabled': 'achievements.enabled',
-      'achievements.dm_notifications.enabled': 'achievements.enabled',
-      'digest.include_achievements': 'digest.enabled',
-      'notices.header_enabled': 'notices.enabled',
-      'notices.header_pin_enabled': 'notices.enabled',
+      "voicechannels.controlpanel.enabled": "voicechannels.enabled",
+      "quotes.header_enabled": "quotes.enabled",
+      "quotes.header_pin_enabled": "quotes.enabled",
+      "achievements.announcements.enabled": "achievements.enabled",
+      "achievements.dm_notifications.enabled": "achievements.enabled",
+      "digest.include_achievements": "digest.enabled",
+      "notices.header_enabled": "notices.enabled",
+      "notices.header_pin_enabled": "notices.enabled",
     };
 
-    it('audits every `*enabled` key in defaultConfig (no drift)', () => {
+    it("audits every `*enabled` key in defaultConfig (no drift)", () => {
       // Derive the live set so a new toggle added to defaultConfig
       // without an entry above immediately fails this test.
       const liveEnabledKeys = Object.keys(defaultConfig).filter((k) =>
@@ -259,27 +276,21 @@ describe('Config Schema', () => {
       expect(stale).toEqual([]);
     });
 
-    it('every audited `*enabled` key matches its expected default value', () => {
-      for (const [key, expected] of Object.entries(
-        EXPECTED_ENABLED_DEFAULTS,
-      )) {
-        expect(defaultConfig[key as keyof typeof defaultConfig]).toBe(
-          expected,
-        );
+    it("every audited `*enabled` key matches its expected default value", () => {
+      for (const [key, expected] of Object.entries(EXPECTED_ENABLED_DEFAULTS)) {
+        expect(defaultConfig[key as keyof typeof defaultConfig]).toBe(expected);
       }
     });
 
-    it('every default-true sub-feature has a parent gate that defaults to false', () => {
+    it("every default-true sub-feature has a parent gate that defaults to false", () => {
       for (const [key, parent] of Object.entries(PARENT_OF_DEFAULT_TRUE)) {
         expect(defaultConfig[key as keyof typeof defaultConfig]).toBe(true);
-        expect(defaultConfig[parent as keyof typeof defaultConfig]).toBe(
-          false,
-        );
+        expect(defaultConfig[parent as keyof typeof defaultConfig]).toBe(false);
       }
     });
 
-    it('does not declare wizard.enabled (#434 / #445 — wizard is always on)', () => {
-      expect('wizard.enabled' in defaultConfig).toBe(false);
+    it("does not declare wizard.enabled (#434 / #445 — wizard is always on)", () => {
+      expect("wizard.enabled" in defaultConfig).toBe(false);
     });
   });
 });

--- a/__tests__/services/config-schema.test.ts
+++ b/__tests__/services/config-schema.test.ts
@@ -225,6 +225,10 @@ describe('Config Schema', () => {
       // analogous to how WebAuditLog records every WebUI write without
       // requiring opt-in.
       'core.command_audit.enabled': true,
+      // Persisted command metrics (#648) — same rationale as audit logging:
+      // a cross-cutting operator-visibility feature, on by default so fresh
+      // installs get historical command analytics out of the box.
+      'monitoring.metrics_persistence.enabled': true,
     };
 
     // Parent feature each rule-2 (default-true) sub-feature is gated by.

--- a/__tests__/services/config-service-cleanup.test.ts
+++ b/__tests__/services/config-service-cleanup.test.ts
@@ -66,9 +66,7 @@ jest.unstable_mockModule("mongoose", () => ({
 }));
 
 // Import after mocking
-const { ConfigService } = await import(
-  "../../src/services/config-service.js"
-);
+const { ConfigService } = await import("../../src/services/config-service.js");
 
 describe("ConfigService - Cleanup Unknown Settings", () => {
   beforeEach(() => {

--- a/__tests__/services/config-service-methods.test.ts
+++ b/__tests__/services/config-service-methods.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
-import type { ConfigService as ConfigServiceType } from '../../src/services/config-service.js';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+import type { ConfigService as ConfigServiceType } from "../../src/services/config-service.js";
 
 const mockFindOne = jest.fn();
 const mockFind = jest.fn();
@@ -7,7 +14,7 @@ const mockFindOneAndUpdate = jest.fn();
 const mockDeleteOne = jest.fn();
 const mockUpdateOne = jest.fn();
 
-jest.unstable_mockModule('../../src/models/config.js', () => ({
+jest.unstable_mockModule("../../src/models/config.js", () => ({
   Config: {
     findOne: mockFindOne,
     find: mockFind,
@@ -16,31 +23,31 @@ jest.unstable_mockModule('../../src/models/config.js', () => ({
     updateOne: mockUpdateOne,
   },
   CONFIG_CATEGORIES: [
-    'achievements',
-    'amikool',
-    'announcements',
-    'core',
-    'digest',
-    'fun',
-    'gamification',
-    'help',
-    'leaderboard_roles',
-    'messagetracking',
-    'notices',
-    'ping',
-    'polls',
-    'quotes',
-    'ratelimit',
-    'reactionroles',
-    'reactiontracking',
-    'rewind',
-    'voicechannels',
-    'voicetracking',
-    'wizard',
+    "achievements",
+    "amikool",
+    "announcements",
+    "core",
+    "digest",
+    "fun",
+    "gamification",
+    "help",
+    "leaderboard_roles",
+    "messagetracking",
+    "notices",
+    "ping",
+    "polls",
+    "quotes",
+    "ratelimit",
+    "reactionroles",
+    "reactiontracking",
+    "rewind",
+    "voicechannels",
+    "voicetracking",
+    "wizard",
   ],
 }));
 
-jest.unstable_mockModule('../../src/utils/logger.js', () => ({
+jest.unstable_mockModule("../../src/utils/logger.js", () => ({
   default: {
     info: jest.fn(),
     error: jest.fn(),
@@ -57,14 +64,14 @@ const mongooseMock = {
   connect: jest.fn(),
 };
 
-jest.unstable_mockModule('mongoose', () => ({
+jest.unstable_mockModule("mongoose", () => ({
   ...mongooseMock,
   default: mongooseMock,
 }));
 
-const { ConfigService } = await import('../../src/services/config-service.js');
+const { ConfigService } = await import("../../src/services/config-service.js");
 
-describe('ConfigService - Methods', () => {
+describe("ConfigService - Methods", () => {
   let service: ConfigServiceType;
   const originalEnv = process.env;
 
@@ -89,301 +96,306 @@ describe('ConfigService - Methods', () => {
     (ConfigService as unknown as { instance: unknown }).instance = undefined;
   });
 
-  describe('get()', () => {
-    it('should return value from cache when available', async () => {
+  describe("get()", () => {
+    it("should return value from cache when available", async () => {
       // Pre-populate the cache via set
       mockFindOneAndUpdate.mockResolvedValue({});
-      await service.set('test.key', 'cached-value', 'Test key', 'test');
+      await service.set("test.key", "cached-value", "Test key", "test");
 
-      const result = await service.get('test.key');
-      expect(result).toBe('cached-value');
+      const result = await service.get("test.key");
+      expect(result).toBe("cached-value");
     });
 
-    it('should return value from database when not in cache', async () => {
-      mockFindOne.mockResolvedValue({ key: 'db.key', value: 'db-value' });
+    it("should return value from database when not in cache", async () => {
+      mockFindOne.mockResolvedValue({ key: "db.key", value: "db-value" });
 
-      const result = await service.get('db.key');
-      expect(result).toBe('db-value');
+      const result = await service.get("db.key");
+      expect(result).toBe("db-value");
     });
 
-    it('should return null when key not found anywhere', async () => {
+    it("should return null when key not found anywhere", async () => {
       mockFindOne.mockResolvedValue(null);
 
-      const result = await service.get('nonexistent.key');
+      const result = await service.get("nonexistent.key");
       expect(result).toBeNull();
     });
 
-    it('should return boolean true from environment variable', async () => {
-      process.env['TEST_BOOL_KEY'] = 'true';
+    it("should return boolean true from environment variable", async () => {
+      process.env["TEST_BOOL_KEY"] = "true";
       mockFindOne.mockResolvedValue(null);
 
-      const result = await service.get('TEST_BOOL_KEY');
+      const result = await service.get("TEST_BOOL_KEY");
       expect(result).toBe(true);
     });
 
-    it('should return boolean false from environment variable', async () => {
-      process.env['TEST_BOOL_FALSE'] = 'false';
+    it("should return boolean false from environment variable", async () => {
+      process.env["TEST_BOOL_FALSE"] = "false";
       mockFindOne.mockResolvedValue(null);
 
-      const result = await service.get('TEST_BOOL_FALSE');
+      const result = await service.get("TEST_BOOL_FALSE");
       expect(result).toBe(false);
     });
 
-    it('should return numeric value from environment variable', async () => {
-      process.env['TEST_NUM_KEY'] = '42';
+    it("should return numeric value from environment variable", async () => {
+      process.env["TEST_NUM_KEY"] = "42";
       mockFindOne.mockResolvedValue(null);
 
-      const result = await service.get('TEST_NUM_KEY');
+      const result = await service.get("TEST_NUM_KEY");
       expect(result).toBe(42);
     });
 
-    it('should return string value from environment variable', async () => {
-      process.env['TEST_STR_KEY'] = 'hello world';
+    it("should return string value from environment variable", async () => {
+      process.env["TEST_STR_KEY"] = "hello world";
       mockFindOne.mockResolvedValue(null);
 
-      const result = await service.get('TEST_STR_KEY');
-      expect(result).toBe('hello world');
+      const result = await service.get("TEST_STR_KEY");
+      expect(result).toBe("hello world");
     });
 
-    it('should treat empty-string env var as absent (not numeric 0)', async () => {
-      process.env['TEST_EMPTY_KEY'] = '';
+    it("should treat empty-string env var as absent (not numeric 0)", async () => {
+      process.env["TEST_EMPTY_KEY"] = "";
       mockFindOne.mockResolvedValue(null);
 
-      const result = await service.get('TEST_EMPTY_KEY');
+      const result = await service.get("TEST_EMPTY_KEY");
       expect(result).toBeNull();
     });
 
-    it('should treat whitespace-only env var as absent', async () => {
-      process.env['TEST_WHITESPACE_KEY'] = '   ';
+    it("should treat whitespace-only env var as absent", async () => {
+      process.env["TEST_WHITESPACE_KEY"] = "   ";
       mockFindOne.mockResolvedValue(null);
 
-      const result = await service.get('TEST_WHITESPACE_KEY');
+      const result = await service.get("TEST_WHITESPACE_KEY");
       expect(result).toBeNull();
     });
 
-    it('should handle database errors gracefully', async () => {
-      mockFindOne.mockRejectedValue(new Error('DB error'));
+    it("should handle database errors gracefully", async () => {
+      mockFindOne.mockRejectedValue(new Error("DB error"));
 
-      const result = await service.get('error.key');
+      const result = await service.get("error.key");
       expect(result).toBeNull();
     });
   });
 
-  describe('getBoolean()', () => {
-    it('should return boolean value directly', async () => {
-      mockFindOne.mockResolvedValue({ key: 'bool.key', value: true });
+  describe("getBoolean()", () => {
+    it("should return boolean value directly", async () => {
+      mockFindOne.mockResolvedValue({ key: "bool.key", value: true });
 
-      const result = await service.getBoolean('bool.key');
+      const result = await service.getBoolean("bool.key");
       expect(result).toBe(true);
     });
 
-    it('should return false when value is boolean false', async () => {
-      mockFindOne.mockResolvedValue({ key: 'bool.key', value: false });
+    it("should return false when value is boolean false", async () => {
+      mockFindOne.mockResolvedValue({ key: "bool.key", value: false });
 
-      const result = await service.getBoolean('bool.key');
+      const result = await service.getBoolean("bool.key");
       expect(result).toBe(false);
     });
 
     it('should convert string "true" to boolean true', async () => {
-      mockFindOne.mockResolvedValue({ key: 'bool.key', value: 'true' });
+      mockFindOne.mockResolvedValue({ key: "bool.key", value: "true" });
 
-      const result = await service.getBoolean('bool.key');
+      const result = await service.getBoolean("bool.key");
       expect(result).toBe(true);
     });
 
     it('should convert string "false" to boolean false', async () => {
-      mockFindOne.mockResolvedValue({ key: 'bool.key', value: 'false' });
+      mockFindOne.mockResolvedValue({ key: "bool.key", value: "false" });
 
-      const result = await service.getBoolean('bool.key');
+      const result = await service.getBoolean("bool.key");
       expect(result).toBe(false);
     });
 
-    it('should convert non-zero number to true', async () => {
-      mockFindOne.mockResolvedValue({ key: 'bool.key', value: 1 });
+    it("should convert non-zero number to true", async () => {
+      mockFindOne.mockResolvedValue({ key: "bool.key", value: 1 });
 
-      const result = await service.getBoolean('bool.key');
+      const result = await service.getBoolean("bool.key");
       expect(result).toBe(true);
     });
 
-    it('should convert zero to false', async () => {
-      mockFindOne.mockResolvedValue({ key: 'bool.key', value: 0 });
+    it("should convert zero to false", async () => {
+      mockFindOne.mockResolvedValue({ key: "bool.key", value: 0 });
 
-      const result = await service.getBoolean('bool.key');
+      const result = await service.getBoolean("bool.key");
       expect(result).toBe(false);
     });
 
-    it('should return defaultValue when key not found', async () => {
+    it("should return defaultValue when key not found", async () => {
       mockFindOne.mockResolvedValue(null);
 
-      const result = await service.getBoolean('nonexistent.key', true);
+      const result = await service.getBoolean("nonexistent.key", true);
       expect(result).toBe(true);
     });
 
-    it('should return false as default when no defaultValue provided', async () => {
+    it("should return false as default when no defaultValue provided", async () => {
       mockFindOne.mockResolvedValue(null);
 
-      const result = await service.getBoolean('nonexistent.key');
+      const result = await service.getBoolean("nonexistent.key");
       expect(result).toBe(false);
     });
   });
 
-  describe('getString()', () => {
-    it('should return string value directly', async () => {
-      mockFindOne.mockResolvedValue({ key: 'str.key', value: 'hello' });
+  describe("getString()", () => {
+    it("should return string value directly", async () => {
+      mockFindOne.mockResolvedValue({ key: "str.key", value: "hello" });
 
-      const result = await service.getString('str.key');
-      expect(result).toBe('hello');
+      const result = await service.getString("str.key");
+      expect(result).toBe("hello");
     });
 
-    it('should convert number to string', async () => {
-      mockFindOne.mockResolvedValue({ key: 'num.key', value: 42 });
+    it("should convert number to string", async () => {
+      mockFindOne.mockResolvedValue({ key: "num.key", value: 42 });
 
-      const result = await service.getString('num.key');
-      expect(result).toBe('42');
+      const result = await service.getString("num.key");
+      expect(result).toBe("42");
     });
 
-    it('should convert boolean to string', async () => {
-      mockFindOne.mockResolvedValue({ key: 'bool.key', value: true });
+    it("should convert boolean to string", async () => {
+      mockFindOne.mockResolvedValue({ key: "bool.key", value: true });
 
-      const result = await service.getString('bool.key');
-      expect(result).toBe('true');
+      const result = await service.getString("bool.key");
+      expect(result).toBe("true");
     });
 
-    it('should return defaultValue when key not found', async () => {
+    it("should return defaultValue when key not found", async () => {
       mockFindOne.mockResolvedValue(null);
 
-      const result = await service.getString('nonexistent.key', 'default-value');
-      expect(result).toBe('default-value');
+      const result = await service.getString(
+        "nonexistent.key",
+        "default-value",
+      );
+      expect(result).toBe("default-value");
     });
 
-    it('should return empty string as default when no defaultValue provided', async () => {
+    it("should return empty string as default when no defaultValue provided", async () => {
       mockFindOne.mockResolvedValue(null);
 
-      const result = await service.getString('nonexistent.key');
-      expect(result).toBe('');
+      const result = await service.getString("nonexistent.key");
+      expect(result).toBe("");
     });
   });
 
-  describe('getNumber()', () => {
-    it('should return number value directly', async () => {
-      mockFindOne.mockResolvedValue({ key: 'num.key', value: 42 });
+  describe("getNumber()", () => {
+    it("should return number value directly", async () => {
+      mockFindOne.mockResolvedValue({ key: "num.key", value: 42 });
 
-      const result = await service.getNumber('num.key');
+      const result = await service.getNumber("num.key");
       expect(result).toBe(42);
     });
 
-    it('should convert numeric string to number', async () => {
-      mockFindOne.mockResolvedValue({ key: 'num.key', value: '123' });
+    it("should convert numeric string to number", async () => {
+      mockFindOne.mockResolvedValue({ key: "num.key", value: "123" });
 
-      const result = await service.getNumber('num.key');
+      const result = await service.getNumber("num.key");
       expect(result).toBe(123);
     });
 
-    it('should return defaultValue for non-numeric string', async () => {
-      mockFindOne.mockResolvedValue({ key: 'str.key', value: 'not-a-number' });
+    it("should return defaultValue for non-numeric string", async () => {
+      mockFindOne.mockResolvedValue({ key: "str.key", value: "not-a-number" });
 
-      const result = await service.getNumber('str.key', 99);
+      const result = await service.getNumber("str.key", 99);
       expect(result).toBe(99);
     });
 
-    it('should convert boolean true to 1', async () => {
-      mockFindOne.mockResolvedValue({ key: 'bool.key', value: true });
+    it("should convert boolean true to 1", async () => {
+      mockFindOne.mockResolvedValue({ key: "bool.key", value: true });
 
-      const result = await service.getNumber('bool.key');
+      const result = await service.getNumber("bool.key");
       expect(result).toBe(1);
     });
 
-    it('should convert boolean false to 0', async () => {
-      mockFindOne.mockResolvedValue({ key: 'bool.key', value: false });
+    it("should convert boolean false to 0", async () => {
+      mockFindOne.mockResolvedValue({ key: "bool.key", value: false });
 
-      const result = await service.getNumber('bool.key');
+      const result = await service.getNumber("bool.key");
       expect(result).toBe(0);
     });
 
-    it('should return defaultValue when key not found', async () => {
+    it("should return defaultValue when key not found", async () => {
       mockFindOne.mockResolvedValue(null);
 
-      const result = await service.getNumber('nonexistent.key', 100);
+      const result = await service.getNumber("nonexistent.key", 100);
       expect(result).toBe(100);
     });
 
-    it('should return 0 as default when no defaultValue provided', async () => {
+    it("should return 0 as default when no defaultValue provided", async () => {
       mockFindOne.mockResolvedValue(null);
 
-      const result = await service.getNumber('nonexistent.key');
+      const result = await service.getNumber("nonexistent.key");
       expect(result).toBe(0);
     });
 
-    it('should honor defaultValue when env var is set to empty string', async () => {
-      process.env['EMPTY_NUM_KEY'] = '';
+    it("should honor defaultValue when env var is set to empty string", async () => {
+      process.env["EMPTY_NUM_KEY"] = "";
       mockFindOne.mockResolvedValue(null);
 
-      const result = await service.getNumber('EMPTY_NUM_KEY', 60);
+      const result = await service.getNumber("EMPTY_NUM_KEY", 60);
       expect(result).toBe(60);
     });
   });
 
-  describe('set()', () => {
-    it('should save value to database and update cache', async () => {
+  describe("set()", () => {
+    it("should save value to database and update cache", async () => {
       mockFindOneAndUpdate.mockResolvedValue({});
 
-      await service.set('new.key', 'new-value', 'New setting', 'core');
+      await service.set("new.key", "new-value", "New setting", "core");
 
       expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
-        { key: 'new.key' },
+        { key: "new.key" },
         expect.objectContaining({
-          key: 'new.key',
-          value: 'new-value',
-          description: 'New setting',
-          category: 'core',
+          key: "new.key",
+          value: "new-value",
+          description: "New setting",
+          category: "core",
         }),
-        { upsert: true, new: true }
+        { upsert: true, new: true },
       );
 
       // Verify the cache was updated
-      const result = await service.get('new.key');
-      expect(result).toBe('new-value');
+      const result = await service.get("new.key");
+      expect(result).toBe("new-value");
     });
 
-    it('should throw when database operation fails', async () => {
-      mockFindOneAndUpdate.mockRejectedValue(new Error('DB write error'));
+    it("should throw when database operation fails", async () => {
+      mockFindOneAndUpdate.mockRejectedValue(new Error("DB write error"));
 
       await expect(
-        service.set('error.key', 'value', 'description', 'category')
-      ).rejects.toThrow('DB write error');
+        service.set("error.key", "value", "description", "category"),
+      ).rejects.toThrow("DB write error");
     });
   });
 
-  describe('delete()', () => {
-    it('should delete key from database and cache', async () => {
+  describe("delete()", () => {
+    it("should delete key from database and cache", async () => {
       // First set a value in cache
       mockFindOneAndUpdate.mockResolvedValue({});
-      await service.set('delete.key', 'value', 'description', 'test');
+      await service.set("delete.key", "value", "description", "test");
 
       mockDeleteOne.mockResolvedValue({ deletedCount: 1 });
       mockFindOne.mockResolvedValue(null);
 
-      await service.delete('delete.key');
+      await service.delete("delete.key");
 
-      expect(mockDeleteOne).toHaveBeenCalledWith({ key: 'delete.key' });
+      expect(mockDeleteOne).toHaveBeenCalledWith({ key: "delete.key" });
 
       // Verify the cache was cleared (get should not return cached value)
-      const result = await service.get('delete.key');
+      const result = await service.get("delete.key");
       expect(result).toBeNull();
     });
 
-    it('should throw when database operation fails', async () => {
-      mockDeleteOne.mockRejectedValue(new Error('DB delete error'));
+    it("should throw when database operation fails", async () => {
+      mockDeleteOne.mockRejectedValue(new Error("DB delete error"));
 
-      await expect(service.delete('error.key')).rejects.toThrow('DB delete error');
+      await expect(service.delete("error.key")).rejects.toThrow(
+        "DB delete error",
+      );
     });
   });
 
-  describe('getAll()', () => {
-    it('should return all configs from database', async () => {
+  describe("getAll()", () => {
+    it("should return all configs from database", async () => {
       const mockConfigs = [
-        { key: 'key1', value: 'val1', category: 'test' },
-        { key: 'key2', value: 'val2', category: 'core' },
+        { key: "key1", value: "val1", category: "test" },
+        { key: "key2", value: "val2", category: "core" },
       ];
       mockFind.mockReturnValue({
         sort: jest.fn().mockResolvedValue(mockConfigs),
@@ -394,8 +406,8 @@ describe('ConfigService - Methods', () => {
     });
   });
 
-  describe('triggerReload()', () => {
-    it('should clear cache and reinitialize', async () => {
+  describe("triggerReload()", () => {
+    it("should clear cache and reinitialize", async () => {
       mockFind.mockResolvedValue([]);
 
       // First set the service as initialized (to test that it resets)
@@ -404,10 +416,12 @@ describe('ConfigService - Methods', () => {
       await service.triggerReload();
 
       // After reload, initialized should be true again (it re-initialized)
-      expect((service as unknown as { initialized: boolean }).initialized).toBe(true);
+      expect((service as unknown as { initialized: boolean }).initialized).toBe(
+        true,
+      );
     });
 
-    it('should call registered reload callbacks', async () => {
+    it("should call registered reload callbacks", async () => {
       mockFind.mockResolvedValue([]);
       const callback = jest.fn().mockResolvedValue(undefined);
 
@@ -417,16 +431,18 @@ describe('ConfigService - Methods', () => {
       expect(callback).toHaveBeenCalled();
     });
 
-    it('should handle callback errors gracefully', async () => {
+    it("should handle callback errors gracefully", async () => {
       mockFind.mockResolvedValue([]);
-      const failingCallback = jest.fn().mockRejectedValue(new Error('Callback failed'));
+      const failingCallback = jest
+        .fn()
+        .mockRejectedValue(new Error("Callback failed"));
 
       service.registerReloadCallback(failingCallback);
       // Should not throw even if callback fails
       await expect(service.triggerReload()).resolves.not.toThrow();
     });
 
-    it('should remove reload callback correctly', async () => {
+    it("should remove reload callback correctly", async () => {
       mockFind.mockResolvedValue([]);
       const callback = jest.fn().mockResolvedValue(undefined);
 
@@ -438,8 +454,8 @@ describe('ConfigService - Methods', () => {
     });
   });
 
-  describe('initialize()', () => {
-    it('should skip initialization if already initialized', async () => {
+  describe("initialize()", () => {
+    it("should skip initialization if already initialized", async () => {
       mockFind.mockResolvedValue([]);
 
       // First initialization
@@ -451,24 +467,26 @@ describe('ConfigService - Methods', () => {
       expect(mockFind.mock.calls.length).toBe(callCount);
     });
 
-    it('should load configs from database on initialization', async () => {
+    it("should load configs from database on initialization", async () => {
       // Use a key that exists in defaultConfig so cleanupUnknownSettings doesn't evict it
       mockFind.mockResolvedValue([
-        { key: 'voicechannels.enabled', value: true, category: 'voicechannels' },
+        {
+          key: "voicechannels.enabled",
+          value: true,
+          category: "voicechannels",
+        },
       ]);
 
       await service.initialize();
 
-      const result = await service.get('voicechannels.enabled');
+      const result = await service.get("voicechannels.enabled");
       expect(result).toBe(true);
     });
 
-    it('should prioritize critical env settings over database', async () => {
-      process.env['GUILD_ID'] = 'env-guild-123';
+    it("should prioritize critical env settings over database", async () => {
+      process.env["GUILD_ID"] = "env-guild-123";
 
-      mockFind.mockResolvedValue([
-        { key: 'GUILD_ID', value: 'db-guild-456' },
-      ]);
+      mockFind.mockResolvedValue([{ key: "GUILD_ID", value: "db-guild-456" }]);
 
       // Reset so we can re-initialize with the new env
       (service as unknown as { initialized: boolean }).initialized = false;
@@ -476,10 +494,10 @@ describe('ConfigService - Methods', () => {
       await service.initialize();
 
       // Env value should take priority
-      const result = await service.get('GUILD_ID');
-      expect(result).toBe('env-guild-123');
+      const result = await service.get("GUILD_ID");
+      expect(result).toBe("env-guild-123");
 
-      delete process.env['GUILD_ID'];
+      delete process.env["GUILD_ID"];
     });
   });
 });

--- a/__tests__/services/config-service.test.ts
+++ b/__tests__/services/config-service.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
-import { ConfigService } from '../../src/services/config-service.js';
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import { ConfigService } from "../../src/services/config-service.js";
 
 // Mock dependencies
-jest.mock('../../src/models/config.js');
-jest.mock('../../src/utils/logger.js');
-jest.mock('mongoose');
+jest.mock("../../src/models/config.js");
+jest.mock("../../src/utils/logger.js");
+jest.mock("mongoose");
 
-describe('ConfigService', () => {
+describe("ConfigService", () => {
   let service: ConfigService;
 
   beforeEach(() => {
@@ -14,88 +14,88 @@ describe('ConfigService', () => {
     service = ConfigService.getInstance();
   });
 
-  describe('singleton pattern', () => {
-    it('should create a singleton instance', () => {
+  describe("singleton pattern", () => {
+    it("should create a singleton instance", () => {
       const instance1 = ConfigService.getInstance();
       const instance2 = ConfigService.getInstance();
-      
+
       expect(instance1).toBe(instance2);
     });
   });
 
-  describe('initialization', () => {
-    it('should create an instance', () => {
+  describe("initialization", () => {
+    it("should create an instance", () => {
       expect(service).toBeDefined();
       expect(service).toBeInstanceOf(ConfigService);
     });
   });
 
-  describe('public methods', () => {
-    it('should have setClient method', () => {
-      expect(typeof service.setClient).toBe('function');
+  describe("public methods", () => {
+    it("should have setClient method", () => {
+      expect(typeof service.setClient).toBe("function");
     });
 
-    it('should have registerReloadCallback method', () => {
-      expect(typeof service.registerReloadCallback).toBe('function');
+    it("should have registerReloadCallback method", () => {
+      expect(typeof service.registerReloadCallback).toBe("function");
     });
 
-    it('should have removeReloadCallback method', () => {
-      expect(typeof service.removeReloadCallback).toBe('function');
+    it("should have removeReloadCallback method", () => {
+      expect(typeof service.removeReloadCallback).toBe("function");
     });
 
-    it('should have triggerReload method', () => {
-      expect(typeof service.triggerReload).toBe('function');
+    it("should have triggerReload method", () => {
+      expect(typeof service.triggerReload).toBe("function");
     });
 
-    it('should have initialize method', () => {
-      expect(typeof service.initialize).toBe('function');
+    it("should have initialize method", () => {
+      expect(typeof service.initialize).toBe("function");
     });
 
-    it('should have getBoolean method', () => {
-      expect(typeof service.getBoolean).toBe('function');
+    it("should have getBoolean method", () => {
+      expect(typeof service.getBoolean).toBe("function");
     });
 
-    it('should have getString method', () => {
-      expect(typeof service.getString).toBe('function');
+    it("should have getString method", () => {
+      expect(typeof service.getString).toBe("function");
     });
 
-    it('should have getNumber method', () => {
-      expect(typeof service.getNumber).toBe('function');
+    it("should have getNumber method", () => {
+      expect(typeof service.getNumber).toBe("function");
     });
 
-    it('should have set method', () => {
-      expect(typeof service.set).toBe('function');
+    it("should have set method", () => {
+      expect(typeof service.set).toBe("function");
     });
 
-    it('should have getAll method', () => {
-      expect(typeof service.getAll).toBe('function');
+    it("should have getAll method", () => {
+      expect(typeof service.getAll).toBe("function");
     });
   });
 
-  describe('client management', () => {
-    it('should set client', () => {
-      const mockClient = { user: { id: '123' } } as any;
+  describe("client management", () => {
+    it("should set client", () => {
+      const mockClient = { user: { id: "123" } } as any;
       service.setClient(mockClient);
-      
+
       // Method should execute without errors
       expect(true).toBe(true);
     });
   });
 
-  describe('callback management', () => {
-    it('should register reload callback', () => {
+  describe("callback management", () => {
+    it("should register reload callback", () => {
       const callback = jest.fn(async () => {});
       service.registerReloadCallback(callback);
-      
+
       // Method should execute without errors
       expect(true).toBe(true);
     });
 
-    it('should remove reload callback', () => {
+    it("should remove reload callback", () => {
       const callback = jest.fn(async () => {});
       service.registerReloadCallback(callback);
       service.removeReloadCallback(callback);
-      
+
       // Method should execute without errors
       expect(true).toBe(true);
     });

--- a/__tests__/services/cooldown-manager.test.ts
+++ b/__tests__/services/cooldown-manager.test.ts
@@ -1,7 +1,14 @@
-import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
-import { CooldownManager } from '../../src/services/cooldown-manager.js';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+import { CooldownManager } from "../../src/services/cooldown-manager.js";
 
-describe('CooldownManager', () => {
+describe("CooldownManager", () => {
   let cooldownManager: CooldownManager;
 
   beforeEach(() => {
@@ -14,347 +21,390 @@ describe('CooldownManager', () => {
     jest.useRealTimers();
   });
 
-  describe('isOnCooldown', () => {
-    it('should return false when user has no cooldown set', () => {
-      const result = cooldownManager.isOnCooldown('user1', 'command1', 60);
+  describe("isOnCooldown", () => {
+    it("should return false when user has no cooldown set", () => {
+      const result = cooldownManager.isOnCooldown("user1", "command1", 60);
       expect(result).toBe(false);
     });
 
-    it('should return true when user is on cooldown', () => {
-      cooldownManager.setCooldown('user1', 'command1');
-      const result = cooldownManager.isOnCooldown('user1', 'command1', 60);
+    it("should return true when user is on cooldown", () => {
+      cooldownManager.setCooldown("user1", "command1");
+      const result = cooldownManager.isOnCooldown("user1", "command1", 60);
       expect(result).toBe(true);
     });
 
-    it('should return false when cooldown has expired', () => {
-      cooldownManager.setCooldown('user1', 'command1');
-      
+    it("should return false when cooldown has expired", () => {
+      cooldownManager.setCooldown("user1", "command1");
+
       // Advance time by 61 seconds
       jest.advanceTimersByTime(61000);
-      
-      const result = cooldownManager.isOnCooldown('user1', 'command1', 60);
+
+      const result = cooldownManager.isOnCooldown("user1", "command1", 60);
       expect(result).toBe(false);
     });
 
-    it('should handle different commands independently', () => {
-      cooldownManager.setCooldown('user1', 'command1');
-      
-      const result1 = cooldownManager.isOnCooldown('user1', 'command1', 60);
-      const result2 = cooldownManager.isOnCooldown('user1', 'command2', 60);
-      
+    it("should handle different commands independently", () => {
+      cooldownManager.setCooldown("user1", "command1");
+
+      const result1 = cooldownManager.isOnCooldown("user1", "command1", 60);
+      const result2 = cooldownManager.isOnCooldown("user1", "command2", 60);
+
       expect(result1).toBe(true);
       expect(result2).toBe(false);
     });
 
-    it('should handle different users independently', () => {
-      cooldownManager.setCooldown('user1', 'command1');
-      
-      const result1 = cooldownManager.isOnCooldown('user1', 'command1', 60);
-      const result2 = cooldownManager.isOnCooldown('user2', 'command1', 60);
-      
+    it("should handle different users independently", () => {
+      cooldownManager.setCooldown("user1", "command1");
+
+      const result1 = cooldownManager.isOnCooldown("user1", "command1", 60);
+      const result2 = cooldownManager.isOnCooldown("user2", "command1", 60);
+
       expect(result1).toBe(true);
       expect(result2).toBe(false);
     });
 
-    it('should handle zero cooldown duration', () => {
-      cooldownManager.setCooldown('user1', 'command1');
-      const result = cooldownManager.isOnCooldown('user1', 'command1', 0);
+    it("should handle zero cooldown duration", () => {
+      cooldownManager.setCooldown("user1", "command1");
+      const result = cooldownManager.isOnCooldown("user1", "command1", 0);
       expect(result).toBe(false);
     });
 
-    it('should handle very long cooldown durations', () => {
-      cooldownManager.setCooldown('user1', 'command1');
-      const result = cooldownManager.isOnCooldown('user1', 'command1', 86400); // 24 hours
+    it("should handle very long cooldown durations", () => {
+      cooldownManager.setCooldown("user1", "command1");
+      const result = cooldownManager.isOnCooldown("user1", "command1", 86400); // 24 hours
       expect(result).toBe(true);
     });
   });
 
-  describe('setCooldown', () => {
-    it('should set cooldown for user and command', () => {
-      cooldownManager.setCooldown('user1', 'command1');
-      const result = cooldownManager.isOnCooldown('user1', 'command1', 60);
+  describe("setCooldown", () => {
+    it("should set cooldown for user and command", () => {
+      cooldownManager.setCooldown("user1", "command1");
+      const result = cooldownManager.isOnCooldown("user1", "command1", 60);
       expect(result).toBe(true);
     });
 
-    it('should update existing cooldown', () => {
-      cooldownManager.setCooldown('user1', 'command1');
+    it("should update existing cooldown", () => {
+      cooldownManager.setCooldown("user1", "command1");
       jest.advanceTimersByTime(30000); // 30 seconds
-      cooldownManager.setCooldown('user1', 'command1');
-      
+      cooldownManager.setCooldown("user1", "command1");
+
       // Should still be on cooldown for another 60 seconds from the reset
       jest.advanceTimersByTime(30000); // Total 60 seconds from initial
-      const result = cooldownManager.isOnCooldown('user1', 'command1', 60);
+      const result = cooldownManager.isOnCooldown("user1", "command1", 60);
       expect(result).toBe(true);
     });
 
-    it('should handle multiple commands for same user', () => {
-      cooldownManager.setCooldown('user1', 'command1');
-      cooldownManager.setCooldown('user1', 'command2');
-      
-      expect(cooldownManager.isOnCooldown('user1', 'command1', 60)).toBe(true);
-      expect(cooldownManager.isOnCooldown('user1', 'command2', 60)).toBe(true);
+    it("should handle multiple commands for same user", () => {
+      cooldownManager.setCooldown("user1", "command1");
+      cooldownManager.setCooldown("user1", "command2");
+
+      expect(cooldownManager.isOnCooldown("user1", "command1", 60)).toBe(true);
+      expect(cooldownManager.isOnCooldown("user1", "command2", 60)).toBe(true);
     });
 
-    it('should handle special characters in user IDs', () => {
-      cooldownManager.setCooldown('user-123!@#', 'command1');
-      expect(cooldownManager.isOnCooldown('user-123!@#', 'command1', 60)).toBe(true);
+    it("should handle special characters in user IDs", () => {
+      cooldownManager.setCooldown("user-123!@#", "command1");
+      expect(cooldownManager.isOnCooldown("user-123!@#", "command1", 60)).toBe(
+        true,
+      );
     });
 
-    it('should handle special characters in command names', () => {
-      cooldownManager.setCooldown('user1', 'command-test_1');
-      expect(cooldownManager.isOnCooldown('user1', 'command-test_1', 60)).toBe(true);
+    it("should handle special characters in command names", () => {
+      cooldownManager.setCooldown("user1", "command-test_1");
+      expect(cooldownManager.isOnCooldown("user1", "command-test_1", 60)).toBe(
+        true,
+      );
     });
   });
 
-  describe('getRemainingCooldown', () => {
-    it('should return 0 when no cooldown is set', () => {
-      const result = cooldownManager.getRemainingCooldown('user1', 'command1', 60);
+  describe("getRemainingCooldown", () => {
+    it("should return 0 when no cooldown is set", () => {
+      const result = cooldownManager.getRemainingCooldown(
+        "user1",
+        "command1",
+        60,
+      );
       expect(result).toBe(0);
     });
 
-    it('should return remaining seconds when on cooldown', () => {
-      cooldownManager.setCooldown('user1', 'command1');
-      const result = cooldownManager.getRemainingCooldown('user1', 'command1', 60);
+    it("should return remaining seconds when on cooldown", () => {
+      cooldownManager.setCooldown("user1", "command1");
+      const result = cooldownManager.getRemainingCooldown(
+        "user1",
+        "command1",
+        60,
+      );
       expect(result).toBe(60);
     });
 
-    it('should decrease remaining time as time passes', () => {
-      cooldownManager.setCooldown('user1', 'command1');
+    it("should decrease remaining time as time passes", () => {
+      cooldownManager.setCooldown("user1", "command1");
       jest.advanceTimersByTime(30000); // 30 seconds
-      
-      const result = cooldownManager.getRemainingCooldown('user1', 'command1', 60);
+
+      const result = cooldownManager.getRemainingCooldown(
+        "user1",
+        "command1",
+        60,
+      );
       expect(result).toBe(30);
     });
 
-    it('should return 0 when cooldown has expired', () => {
-      cooldownManager.setCooldown('user1', 'command1');
+    it("should return 0 when cooldown has expired", () => {
+      cooldownManager.setCooldown("user1", "command1");
       jest.advanceTimersByTime(61000); // 61 seconds
-      
-      const result = cooldownManager.getRemainingCooldown('user1', 'command1', 60);
+
+      const result = cooldownManager.getRemainingCooldown(
+        "user1",
+        "command1",
+        60,
+      );
       expect(result).toBe(0);
     });
 
-    it('should round up partial seconds', () => {
-      cooldownManager.setCooldown('user1', 'command1');
+    it("should round up partial seconds", () => {
+      cooldownManager.setCooldown("user1", "command1");
       jest.advanceTimersByTime(59100); // 59.1 seconds
-      
-      const result = cooldownManager.getRemainingCooldown('user1', 'command1', 60);
+
+      const result = cooldownManager.getRemainingCooldown(
+        "user1",
+        "command1",
+        60,
+      );
       expect(result).toBe(1);
     });
 
-    it('should handle exactly at cooldown boundary', () => {
-      cooldownManager.setCooldown('user1', 'command1');
+    it("should handle exactly at cooldown boundary", () => {
+      cooldownManager.setCooldown("user1", "command1");
       jest.advanceTimersByTime(60000); // Exactly 60 seconds
-      
-      const result = cooldownManager.getRemainingCooldown('user1', 'command1', 60);
+
+      const result = cooldownManager.getRemainingCooldown(
+        "user1",
+        "command1",
+        60,
+      );
       expect(result).toBe(0);
     });
 
-    it('should return 0 for zero cooldown duration', () => {
-      cooldownManager.setCooldown('user1', 'command1');
-      const result = cooldownManager.getRemainingCooldown('user1', 'command1', 0);
+    it("should return 0 for zero cooldown duration", () => {
+      cooldownManager.setCooldown("user1", "command1");
+      const result = cooldownManager.getRemainingCooldown(
+        "user1",
+        "command1",
+        0,
+      );
       expect(result).toBe(0);
     });
   });
 
-  describe('clearCooldown', () => {
-    it('should clear specific cooldown', () => {
-      cooldownManager.setCooldown('user1', 'command1');
-      cooldownManager.clearCooldown('user1', 'command1');
-      
-      const result = cooldownManager.isOnCooldown('user1', 'command1', 60);
+  describe("clearCooldown", () => {
+    it("should clear specific cooldown", () => {
+      cooldownManager.setCooldown("user1", "command1");
+      cooldownManager.clearCooldown("user1", "command1");
+
+      const result = cooldownManager.isOnCooldown("user1", "command1", 60);
       expect(result).toBe(false);
     });
 
-    it('should not affect other commands', () => {
-      cooldownManager.setCooldown('user1', 'command1');
-      cooldownManager.setCooldown('user1', 'command2');
-      cooldownManager.clearCooldown('user1', 'command1');
-      
-      expect(cooldownManager.isOnCooldown('user1', 'command1', 60)).toBe(false);
-      expect(cooldownManager.isOnCooldown('user1', 'command2', 60)).toBe(true);
+    it("should not affect other commands", () => {
+      cooldownManager.setCooldown("user1", "command1");
+      cooldownManager.setCooldown("user1", "command2");
+      cooldownManager.clearCooldown("user1", "command1");
+
+      expect(cooldownManager.isOnCooldown("user1", "command1", 60)).toBe(false);
+      expect(cooldownManager.isOnCooldown("user1", "command2", 60)).toBe(true);
     });
 
-    it('should not affect other users', () => {
-      cooldownManager.setCooldown('user1', 'command1');
-      cooldownManager.setCooldown('user2', 'command1');
-      cooldownManager.clearCooldown('user1', 'command1');
-      
-      expect(cooldownManager.isOnCooldown('user1', 'command1', 60)).toBe(false);
-      expect(cooldownManager.isOnCooldown('user2', 'command1', 60)).toBe(true);
+    it("should not affect other users", () => {
+      cooldownManager.setCooldown("user1", "command1");
+      cooldownManager.setCooldown("user2", "command1");
+      cooldownManager.clearCooldown("user1", "command1");
+
+      expect(cooldownManager.isOnCooldown("user1", "command1", 60)).toBe(false);
+      expect(cooldownManager.isOnCooldown("user2", "command1", 60)).toBe(true);
     });
 
-    it('should handle clearing non-existent cooldown gracefully', () => {
+    it("should handle clearing non-existent cooldown gracefully", () => {
       expect(() => {
-        cooldownManager.clearCooldown('user1', 'command1');
+        cooldownManager.clearCooldown("user1", "command1");
       }).not.toThrow();
     });
 
-    it('should allow setting cooldown after clearing', () => {
-      cooldownManager.setCooldown('user1', 'command1');
-      cooldownManager.clearCooldown('user1', 'command1');
-      cooldownManager.setCooldown('user1', 'command1');
-      
-      expect(cooldownManager.isOnCooldown('user1', 'command1', 60)).toBe(true);
+    it("should allow setting cooldown after clearing", () => {
+      cooldownManager.setCooldown("user1", "command1");
+      cooldownManager.clearCooldown("user1", "command1");
+      cooldownManager.setCooldown("user1", "command1");
+
+      expect(cooldownManager.isOnCooldown("user1", "command1", 60)).toBe(true);
     });
   });
 
-  describe('clearAllCooldowns', () => {
-    it('should clear all cooldowns', () => {
-      cooldownManager.setCooldown('user1', 'command1');
-      cooldownManager.setCooldown('user1', 'command2');
-      cooldownManager.setCooldown('user2', 'command1');
-      
+  describe("clearAllCooldowns", () => {
+    it("should clear all cooldowns", () => {
+      cooldownManager.setCooldown("user1", "command1");
+      cooldownManager.setCooldown("user1", "command2");
+      cooldownManager.setCooldown("user2", "command1");
+
       cooldownManager.clearAllCooldowns();
-      
-      expect(cooldownManager.isOnCooldown('user1', 'command1', 60)).toBe(false);
-      expect(cooldownManager.isOnCooldown('user1', 'command2', 60)).toBe(false);
-      expect(cooldownManager.isOnCooldown('user2', 'command1', 60)).toBe(false);
+
+      expect(cooldownManager.isOnCooldown("user1", "command1", 60)).toBe(false);
+      expect(cooldownManager.isOnCooldown("user1", "command2", 60)).toBe(false);
+      expect(cooldownManager.isOnCooldown("user2", "command1", 60)).toBe(false);
     });
 
-    it('should work on empty cooldown manager', () => {
+    it("should work on empty cooldown manager", () => {
       expect(() => {
         cooldownManager.clearAllCooldowns();
       }).not.toThrow();
     });
 
-    it('should allow setting new cooldowns after clearing all', () => {
-      cooldownManager.setCooldown('user1', 'command1');
+    it("should allow setting new cooldowns after clearing all", () => {
+      cooldownManager.setCooldown("user1", "command1");
       cooldownManager.clearAllCooldowns();
-      cooldownManager.setCooldown('user1', 'command1');
-      
-      expect(cooldownManager.isOnCooldown('user1', 'command1', 60)).toBe(true);
+      cooldownManager.setCooldown("user1", "command1");
+
+      expect(cooldownManager.isOnCooldown("user1", "command1", 60)).toBe(true);
     });
 
-    it('should clear many cooldowns efficiently', () => {
+    it("should clear many cooldowns efficiently", () => {
       // Set cooldowns for many users and commands
       for (let i = 0; i < 100; i++) {
         cooldownManager.setCooldown(`user${i}`, `command${i}`);
       }
-      
+
       cooldownManager.clearAllCooldowns();
-      
+
       // Verify all are cleared
       for (let i = 0; i < 100; i++) {
-        expect(cooldownManager.isOnCooldown(`user${i}`, `command${i}`, 60)).toBe(false);
+        expect(
+          cooldownManager.isOnCooldown(`user${i}`, `command${i}`, 60),
+        ).toBe(false);
       }
     });
   });
 
-  describe('edge cases', () => {
-    it('should handle rapid consecutive setCooldown calls', () => {
-      cooldownManager.setCooldown('user1', 'command1');
-      cooldownManager.setCooldown('user1', 'command1');
-      cooldownManager.setCooldown('user1', 'command1');
-      
-      expect(cooldownManager.isOnCooldown('user1', 'command1', 60)).toBe(true);
+  describe("edge cases", () => {
+    it("should handle rapid consecutive setCooldown calls", () => {
+      cooldownManager.setCooldown("user1", "command1");
+      cooldownManager.setCooldown("user1", "command1");
+      cooldownManager.setCooldown("user1", "command1");
+
+      expect(cooldownManager.isOnCooldown("user1", "command1", 60)).toBe(true);
     });
 
-    it('should handle empty user ID', () => {
-      cooldownManager.setCooldown('', 'command1');
-      expect(cooldownManager.isOnCooldown('', 'command1', 60)).toBe(true);
+    it("should handle empty user ID", () => {
+      cooldownManager.setCooldown("", "command1");
+      expect(cooldownManager.isOnCooldown("", "command1", 60)).toBe(true);
     });
 
-    it('should handle empty command name', () => {
-      cooldownManager.setCooldown('user1', '');
-      expect(cooldownManager.isOnCooldown('user1', '', 60)).toBe(true);
+    it("should handle empty command name", () => {
+      cooldownManager.setCooldown("user1", "");
+      expect(cooldownManager.isOnCooldown("user1", "", 60)).toBe(true);
     });
 
-    it('should handle very short time intervals', () => {
-      cooldownManager.setCooldown('user1', 'command1');
+    it("should handle very short time intervals", () => {
+      cooldownManager.setCooldown("user1", "command1");
       jest.advanceTimersByTime(1); // 1ms
 
-      const result = cooldownManager.getRemainingCooldown('user1', 'command1', 1);
+      const result = cooldownManager.getRemainingCooldown(
+        "user1",
+        "command1",
+        1,
+      );
       expect(result).toBeGreaterThanOrEqual(0);
     });
   });
 
-  describe('memory management', () => {
-    const cooldownsOf = (m: CooldownManager): Map<string, Map<string, number>> =>
-      (m as unknown as { cooldowns: Map<string, Map<string, number>> }).cooldowns;
+  describe("memory management", () => {
+    const cooldownsOf = (
+      m: CooldownManager,
+    ): Map<string, Map<string, number>> =>
+      (m as unknown as { cooldowns: Map<string, Map<string, number>> })
+        .cooldowns;
     const rateLimitsOf = (m: CooldownManager): Map<string, number[]> =>
       (m as unknown as { rateLimits: Map<string, number[]> }).rateLimits;
 
-    it('evicts an expired cooldown entry when read via isOnCooldown', () => {
-      cooldownManager.setCooldown('user1', 'command1');
-      expect(cooldownsOf(cooldownManager).has('user1')).toBe(true);
+    it("evicts an expired cooldown entry when read via isOnCooldown", () => {
+      cooldownManager.setCooldown("user1", "command1");
+      expect(cooldownsOf(cooldownManager).has("user1")).toBe(true);
 
       jest.advanceTimersByTime(61000);
-      expect(cooldownManager.isOnCooldown('user1', 'command1', 60)).toBe(false);
-      expect(cooldownsOf(cooldownManager).has('user1')).toBe(false);
+      expect(cooldownManager.isOnCooldown("user1", "command1", 60)).toBe(false);
+      expect(cooldownsOf(cooldownManager).has("user1")).toBe(false);
     });
 
-    it('evicts an expired cooldown entry when read via getRemainingCooldown', () => {
-      cooldownManager.setCooldown('user1', 'command1');
+    it("evicts an expired cooldown entry when read via getRemainingCooldown", () => {
+      cooldownManager.setCooldown("user1", "command1");
 
       jest.advanceTimersByTime(61000);
-      expect(cooldownManager.getRemainingCooldown('user1', 'command1', 60)).toBe(0);
-      expect(cooldownsOf(cooldownManager).has('user1')).toBe(false);
+      expect(
+        cooldownManager.getRemainingCooldown("user1", "command1", 60),
+      ).toBe(0);
+      expect(cooldownsOf(cooldownManager).has("user1")).toBe(false);
     });
 
-    it('keeps the user bucket while another command is still active', () => {
-      cooldownManager.setCooldown('user1', 'command1');
-      cooldownManager.setCooldown('user1', 'command2');
+    it("keeps the user bucket while another command is still active", () => {
+      cooldownManager.setCooldown("user1", "command1");
+      cooldownManager.setCooldown("user1", "command2");
 
       jest.advanceTimersByTime(61000);
-      cooldownManager.setCooldown('user1', 'command2'); // refresh command2
+      cooldownManager.setCooldown("user1", "command2"); // refresh command2
 
-      expect(cooldownManager.isOnCooldown('user1', 'command1', 60)).toBe(false);
-      const bucket = cooldownsOf(cooldownManager).get('user1');
-      expect(bucket?.has('command1')).toBe(false);
-      expect(bucket?.has('command2')).toBe(true);
+      expect(cooldownManager.isOnCooldown("user1", "command1", 60)).toBe(false);
+      const bucket = cooldownsOf(cooldownManager).get("user1");
+      expect(bucket?.has("command1")).toBe(false);
+      expect(bucket?.has("command2")).toBe(true);
     });
 
-    it('evicts the rate-limit key on read once the window has fully expired', () => {
-      cooldownManager.trackCommandExecution('user1', 60);
-      expect(rateLimitsOf(cooldownManager).has('user1')).toBe(true);
+    it("evicts the rate-limit key on read once the window has fully expired", () => {
+      cooldownManager.trackCommandExecution("user1", 60);
+      expect(rateLimitsOf(cooldownManager).has("user1")).toBe(true);
 
       jest.advanceTimersByTime(61000);
-      expect(cooldownManager.isRateLimited('user1', 3, 60)).toBe(false);
-      expect(rateLimitsOf(cooldownManager).has('user1')).toBe(false);
+      expect(cooldownManager.isRateLimited("user1", 3, 60)).toBe(false);
+      expect(rateLimitsOf(cooldownManager).has("user1")).toBe(false);
     });
 
-    it('prunes expired timestamps in-place on isRateLimited without trackCommandExecution', () => {
-      cooldownManager.trackCommandExecution('user1', 60); // t=0
+    it("prunes expired timestamps in-place on isRateLimited without trackCommandExecution", () => {
+      cooldownManager.trackCommandExecution("user1", 60); // t=0
       jest.advanceTimersByTime(40000);
-      cooldownManager.trackCommandExecution('user1', 60); // t=40s
-      expect(rateLimitsOf(cooldownManager).get('user1')).toHaveLength(2);
+      cooldownManager.trackCommandExecution("user1", 60); // t=40s
+      expect(rateLimitsOf(cooldownManager).get("user1")).toHaveLength(2);
 
       // Advance so only the second timestamp remains in the window.
       jest.advanceTimersByTime(30000); // t=70s, window cutoff = 10s
-      expect(cooldownManager.isRateLimited('user1', 5, 60)).toBe(false);
+      expect(cooldownManager.isRateLimited("user1", 5, 60)).toBe(false);
 
       // The expired first timestamp must have been written back out.
-      expect(rateLimitsOf(cooldownManager).get('user1')).toHaveLength(1);
+      expect(rateLimitsOf(cooldownManager).get("user1")).toHaveLength(1);
     });
 
-    it('periodically sweeps cooldown entries for inactive users', () => {
-      cooldownManager.setCooldown('user1', 'command1');
+    it("periodically sweeps cooldown entries for inactive users", () => {
+      cooldownManager.setCooldown("user1", "command1");
       // Observe the cooldown window so the sweep knows the cutoff.
-      cooldownManager.isOnCooldown('user1', 'command1', 60);
-      expect(cooldownsOf(cooldownManager).has('user1')).toBe(true);
+      cooldownManager.isOnCooldown("user1", "command1", 60);
+      expect(cooldownsOf(cooldownManager).has("user1")).toBe(true);
 
       // Advance past the 5-minute sweep interval without further reads.
       jest.advanceTimersByTime(5 * 60 * 1000 + 1);
-      expect(cooldownsOf(cooldownManager).has('user1')).toBe(false);
+      expect(cooldownsOf(cooldownManager).has("user1")).toBe(false);
     });
 
-    it('periodically sweeps rate-limit entries for inactive users', () => {
-      cooldownManager.trackCommandExecution('user1', 60);
-      expect(rateLimitsOf(cooldownManager).has('user1')).toBe(true);
+    it("periodically sweeps rate-limit entries for inactive users", () => {
+      cooldownManager.trackCommandExecution("user1", 60);
+      expect(rateLimitsOf(cooldownManager).has("user1")).toBe(true);
 
       jest.advanceTimersByTime(5 * 60 * 1000 + 1);
-      expect(rateLimitsOf(cooldownManager).has('user1')).toBe(false);
+      expect(rateLimitsOf(cooldownManager).has("user1")).toBe(false);
     });
 
-    it('does not sweep entries whose window is still active', () => {
-      cooldownManager.trackCommandExecution('user1', 3600); // 1 hour window
+    it("does not sweep entries whose window is still active", () => {
+      cooldownManager.trackCommandExecution("user1", 3600); // 1 hour window
       jest.advanceTimersByTime(5 * 60 * 1000 + 1);
-      expect(rateLimitsOf(cooldownManager).has('user1')).toBe(true);
+      expect(rateLimitsOf(cooldownManager).has("user1")).toBe(true);
     });
 
-    it('destroy clears the cleanup interval and is idempotent', () => {
-      const clearIntervalSpy = jest.spyOn(globalThis, 'clearInterval');
+    it("destroy clears the cleanup interval and is idempotent", () => {
+      const clearIntervalSpy = jest.spyOn(globalThis, "clearInterval");
       const handle = (
         cooldownManager as unknown as {
           cleanupInterval: ReturnType<typeof setInterval> | null;
@@ -365,7 +415,8 @@ describe('CooldownManager', () => {
       cooldownManager.destroy();
       expect(clearIntervalSpy).toHaveBeenCalledWith(handle);
       expect(
-        (cooldownManager as unknown as { cleanupInterval: unknown }).cleanupInterval,
+        (cooldownManager as unknown as { cleanupInterval: unknown })
+          .cleanupInterval,
       ).toBeNull();
       expect(() => cooldownManager.destroy()).not.toThrow();
 

--- a/__tests__/services/digest-service.test.ts
+++ b/__tests__/services/digest-service.test.ts
@@ -87,9 +87,7 @@ jest.unstable_mockModule("../../src/utils/logger.js", () => ({
   },
 }));
 
-const { DigestService } = await import(
-  "../../src/services/digest-service.js"
-);
+const { DigestService } = await import("../../src/services/digest-service.js");
 
 type ServiceInstance = InstanceType<typeof DigestService>;
 
@@ -119,12 +117,14 @@ describe("DigestService", () => {
       if (k === "digest.cron") return "0 9 * * 1";
       return "";
     });
-    mockConfigGetNumber.mockImplementation(async (key: unknown, def: unknown) => {
-      const k = key as string;
-      if (k === "digest.min_active_minutes") return 30;
-      if (k === "digest.streak_min_minutes") return 30;
-      return (def as number) ?? 0;
-    });
+    mockConfigGetNumber.mockImplementation(
+      async (key: unknown, def: unknown) => {
+        const k = key as string;
+        if (k === "digest.min_active_minutes") return 30;
+        if (k === "digest.streak_min_minutes") return 30;
+        return (def as number) ?? 0;
+      },
+    );
     mockGetPrefs.mockResolvedValue({
       achievements: true,
       digest: true,
@@ -224,7 +224,8 @@ describe("DigestService", () => {
       expect(result!.skippedOptOut).toBe(0);
       expect(mockUserSend).toHaveBeenCalledTimes(1);
       expect(mockDigestStateFindOneAndUpdate).toHaveBeenCalledTimes(1);
-      const [filter, update] = mockDigestStateFindOneAndUpdate.mock.calls[0] as [
+      const [filter, update] = mockDigestStateFindOneAndUpdate.mock
+        .calls[0] as [
         Record<string, unknown>,
         { $set: Record<string, unknown> },
       ];

--- a/__tests__/services/discord-logger-initialization.test.ts
+++ b/__tests__/services/discord-logger-initialization.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import type { Client } from 'discord.js';
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import type { Client } from "discord.js";
 
 // Mock dependencies
-jest.mock('../../src/services/config-service.js');
-jest.mock('../../src/utils/logger.js');
+jest.mock("../../src/services/config-service.js");
+jest.mock("../../src/utils/logger.js");
 
-describe('DiscordLogger Initialization', () => {
+describe("DiscordLogger Initialization", () => {
   let mockClient: Partial<Client>;
 
   beforeEach(() => {
@@ -18,35 +18,39 @@ describe('DiscordLogger Initialization', () => {
     } as Client;
   });
 
-  it('should have getInstance method', async () => {
-    const { DiscordLogger } = await import('../../src/services/discord-logger.js');
-    
-    expect(typeof DiscordLogger.getInstance).toBe('function');
+  it("should have getInstance method", async () => {
+    const { DiscordLogger } =
+      await import("../../src/services/discord-logger.js");
+
+    expect(typeof DiscordLogger.getInstance).toBe("function");
   });
 
-  it('should create singleton instance', async () => {
-    const { DiscordLogger } = await import('../../src/services/discord-logger.js');
-    
+  it("should create singleton instance", async () => {
+    const { DiscordLogger } =
+      await import("../../src/services/discord-logger.js");
+
     const instance1 = DiscordLogger.getInstance(mockClient as Client);
     const instance2 = DiscordLogger.getInstance(mockClient as Client);
 
     expect(instance1).toBe(instance2);
   });
 
-  it('should have isReady method', async () => {
-    const { DiscordLogger } = await import('../../src/services/discord-logger.js');
-    
+  it("should have isReady method", async () => {
+    const { DiscordLogger } =
+      await import("../../src/services/discord-logger.js");
+
     const instance = DiscordLogger.getInstance(mockClient as Client);
 
-    expect(typeof instance.isReady).toBe('function');
+    expect(typeof instance.isReady).toBe("function");
     expect(instance.isReady()).toBe(false);
   });
 
-  it('should have initialize method', async () => {
-    const { DiscordLogger } = await import('../../src/services/discord-logger.js');
-    
+  it("should have initialize method", async () => {
+    const { DiscordLogger } =
+      await import("../../src/services/discord-logger.js");
+
     const instance = DiscordLogger.getInstance(mockClient as Client);
 
-    expect(typeof instance.initialize).toBe('function');
+    expect(typeof instance.initialize).toBe("function");
   });
 });

--- a/__tests__/services/discord-logger.test.ts
+++ b/__tests__/services/discord-logger.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect } from "@jest/globals";
 
-describe('DiscordLogger', () => {
-  it('placeholder test', () => {
+describe("DiscordLogger", () => {
+  it("placeholder test", () => {
     expect(true).toBe(true);
   });
 });

--- a/__tests__/services/message-activity-cleanup.test.ts
+++ b/__tests__/services/message-activity-cleanup.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 import type { Client } from "discord.js";
 
 jest.mock("../../src/utils/logger.js", () => ({
-  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+  default: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
   isDebugMode: jest.fn(() => false),
 }));
 
@@ -83,7 +88,10 @@ describe("MessageActivityCleanupService", () => {
 
     const now = Date.now();
     const oldEntry = { sentAt: new Date(now - 500 * DAY_MS), channelId: "c1" };
-    const recentEntry = { sentAt: new Date(now - 10 * DAY_MS), channelId: "c1" };
+    const recentEntry = {
+      sentAt: new Date(now - 10 * DAY_MS),
+      channelId: "c1",
+    };
 
     const userDoc = {
       _id: "id1",

--- a/__tests__/services/monitoring-service-flush.test.ts
+++ b/__tests__/services/monitoring-service-flush.test.ts
@@ -1,0 +1,155 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+
+// Mock the persisted-metrics model so we can assert on the batched upserts
+// without a real Mongo connection (issue #648).
+const mockFindOneAndUpdate =
+  jest.fn<(...args: unknown[]) => Promise<unknown>>();
+jest.unstable_mockModule("../../src/models/command-metrics.js", () => ({
+  CommandMetrics: { findOneAndUpdate: mockFindOneAndUpdate },
+}));
+
+const mockGetBoolean =
+  jest.fn<(key: string, def: boolean) => Promise<boolean>>();
+const mockGetNumber = jest.fn<(key: string, def: number) => Promise<number>>();
+jest.unstable_mockModule("../../src/services/config-service.js", () => ({
+  ConfigService: {
+    getInstance: jest.fn(() => ({
+      getBoolean: mockGetBoolean,
+      getNumber: mockGetNumber,
+    })),
+  },
+}));
+
+jest.unstable_mockModule("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const mongoose = (await import("mongoose")).default as unknown as {
+  connection: { readyState: number };
+};
+const { MonitoringService } = await import(
+  "../../src/services/monitoring-service.js"
+);
+
+describe("MonitoringService — metrics persistence (#648)", () => {
+  let service: InstanceType<typeof MonitoringService>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    (MonitoringService as unknown as { instance: unknown }).instance =
+      undefined;
+    mockFindOneAndUpdate.mockReset().mockResolvedValue(null);
+    mockGetBoolean.mockReset().mockResolvedValue(true);
+    mockGetNumber.mockReset().mockResolvedValue(30);
+    mongoose.connection.readyState = 1;
+    service = MonitoringService.getInstance();
+  });
+
+  afterEach(() => {
+    service.destroy();
+    (MonitoringService as unknown as { instance: unknown }).instance =
+      undefined;
+    jest.useRealTimers();
+  });
+
+  it("does not write when there is nothing pending", async () => {
+    await service.flushMetrics();
+    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it("only buffers invocations that carry a guildId", async () => {
+    // No guildId → in-memory only, nothing to persist.
+    service.trackCommandStart("ping");
+    service.trackCommandEnd("ping", "tid", Date.now() - 10, true);
+    await service.flushMetrics();
+    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it("batches accumulated counters into a single upsert per bucket", async () => {
+    service.trackCommandStart("quote");
+    service.trackCommandEnd("quote", "t1", Date.now() - 100, true, "guild-1");
+    service.trackCommandEnd("quote", "t2", Date.now() - 50, false, "guild-1");
+
+    await service.flushMetrics();
+
+    expect(mockFindOneAndUpdate).toHaveBeenCalledTimes(1);
+    const [filter, update, options] = mockFindOneAndUpdate.mock.calls[0] as [
+      Record<string, unknown>,
+      Record<string, Record<string, unknown>>,
+      Record<string, unknown>,
+    ];
+    expect(filter.command).toBe("quote");
+    expect(filter.guildId).toBe("guild-1");
+    expect(typeof filter.date).toBe("string");
+    expect(update.$inc.usageCount).toBe(2);
+    expect(update.$inc.errorCount).toBe(1);
+    expect(update.$inc.totalResponseMs as number).toBeGreaterThan(0);
+    expect(update.$min.firstUsedAt).toBeInstanceOf(Date);
+    expect(update.$max.lastUsedAt).toBeInstanceOf(Date);
+    expect(update.$max.expiresAt).toBeInstanceOf(Date);
+    expect(options.upsert).toBe(true);
+
+    // The expiry anchor sits ~retentionDays after lastUsedAt.
+    const last = update.$max.lastUsedAt as Date;
+    const expires = update.$max.expiresAt as Date;
+    const deltaDays = (expires.getTime() - last.getTime()) / (24 * 60 * 60 * 1000);
+    expect(Math.round(deltaDays)).toBe(30);
+  });
+
+  it("clears the buffer after a successful flush", async () => {
+    service.trackCommandEnd("quote", "t1", Date.now() - 10, true, "guild-1");
+    await service.flushMetrics();
+    mockFindOneAndUpdate.mockClear();
+    await service.flushMetrics();
+    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it("skips writing while the DB is disconnected and keeps the buffer", async () => {
+    mongoose.connection.readyState = 0;
+    service.trackCommandEnd("quote", "t1", Date.now() - 10, true, "guild-1");
+    await service.flushMetrics();
+    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+
+    // Reconnect — the buffered counts should now flush.
+    mongoose.connection.readyState = 1;
+    await service.flushMetrics();
+    expect(mockFindOneAndUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops the buffer when persistence is disabled", async () => {
+    mockGetBoolean.mockResolvedValue(false);
+    service.trackCommandEnd("quote", "t1", Date.now() - 10, true, "guild-1");
+    await service.flushMetrics();
+    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+
+    // Re-enable: nothing should remain to flush.
+    mockGetBoolean.mockResolvedValue(true);
+    await service.flushMetrics();
+    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it("re-queues a bucket when its write fails", async () => {
+    mockFindOneAndUpdate.mockRejectedValueOnce(new Error("mongo down"));
+    service.trackCommandEnd("quote", "t1", Date.now() - 10, true, "guild-1");
+
+    await service.flushMetrics();
+    expect(mockFindOneAndUpdate).toHaveBeenCalledTimes(1);
+
+    // The failed batch was re-buffered, so a retry writes it again.
+    mockFindOneAndUpdate.mockResolvedValueOnce(null);
+    await service.flushMetrics();
+    expect(mockFindOneAndUpdate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/__tests__/services/monitoring-service-flush.test.ts
+++ b/__tests__/services/monitoring-service-flush.test.ts
@@ -9,10 +9,9 @@ import {
 
 // Mock the persisted-metrics model so we can assert on the batched upserts
 // without a real Mongo connection (issue #648).
-const mockFindOneAndUpdate =
-  jest.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockBulkWrite = jest.fn<(...args: unknown[]) => Promise<unknown>>();
 jest.unstable_mockModule("../../src/models/command-metrics.js", () => ({
-  CommandMetrics: { findOneAndUpdate: mockFindOneAndUpdate },
+  CommandMetrics: { bulkWrite: mockBulkWrite },
 }));
 
 const mockGetBoolean =
@@ -39,9 +38,8 @@ jest.unstable_mockModule("../../src/utils/logger.js", () => ({
 const mongoose = (await import("mongoose")).default as unknown as {
   connection: { readyState: number };
 };
-const { MonitoringService } = await import(
-  "../../src/services/monitoring-service.js"
-);
+const { MonitoringService, MAX_PENDING_BUCKETS } =
+  await import("../../src/services/monitoring-service.js");
 
 describe("MonitoringService — metrics persistence (#648)", () => {
   let service: InstanceType<typeof MonitoringService>;
@@ -50,7 +48,7 @@ describe("MonitoringService — metrics persistence (#648)", () => {
     jest.useFakeTimers();
     (MonitoringService as unknown as { instance: unknown }).instance =
       undefined;
-    mockFindOneAndUpdate.mockReset().mockResolvedValue(null);
+    mockBulkWrite.mockReset().mockResolvedValue(null);
     mockGetBoolean.mockReset().mockResolvedValue(true);
     mockGetNumber.mockReset().mockResolvedValue(30);
     mongoose.connection.readyState = 1;
@@ -66,7 +64,7 @@ describe("MonitoringService — metrics persistence (#648)", () => {
 
   it("does not write when there is nothing pending", async () => {
     await service.flushMetrics();
-    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+    expect(mockBulkWrite).not.toHaveBeenCalled();
   });
 
   it("only buffers invocations that carry a guildId", async () => {
@@ -74,82 +72,130 @@ describe("MonitoringService — metrics persistence (#648)", () => {
     service.trackCommandStart("ping");
     service.trackCommandEnd("ping", "tid", Date.now() - 10, true);
     await service.flushMetrics();
-    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+    expect(mockBulkWrite).not.toHaveBeenCalled();
   });
 
-  it("batches accumulated counters into a single upsert per bucket", async () => {
+  it("writes one bulk batch with an upsert op per bucket", async () => {
     service.trackCommandStart("quote");
     service.trackCommandEnd("quote", "t1", Date.now() - 100, true, "guild-1");
     service.trackCommandEnd("quote", "t2", Date.now() - 50, false, "guild-1");
+    service.trackCommandEnd("ping", "t3", Date.now() - 5, true, "guild-1");
 
     await service.flushMetrics();
 
-    expect(mockFindOneAndUpdate).toHaveBeenCalledTimes(1);
-    const [filter, update, options] = mockFindOneAndUpdate.mock.calls[0] as [
-      Record<string, unknown>,
-      Record<string, Record<string, unknown>>,
+    expect(mockBulkWrite).toHaveBeenCalledTimes(1);
+    const [ops, options] = mockBulkWrite.mock.calls[0] as [
+      Array<{
+        updateOne: {
+          filter: Record<string, unknown>;
+          update: Record<string, Record<string, unknown>>;
+          upsert: boolean;
+        };
+      }>,
       Record<string, unknown>,
     ];
-    expect(filter.command).toBe("quote");
-    expect(filter.guildId).toBe("guild-1");
-    expect(typeof filter.date).toBe("string");
+    expect(options.ordered).toBe(false);
+    // Two distinct commands → two upsert ops; the two quote calls merged.
+    expect(ops).toHaveLength(2);
+
+    const quoteOp = ops.find((o) => o.updateOne.filter.command === "quote")!;
+    expect(quoteOp.updateOne.filter.guildId).toBe("guild-1");
+    expect(typeof quoteOp.updateOne.filter.date).toBe("string");
+    expect(quoteOp.updateOne.upsert).toBe(true);
+    const update = quoteOp.updateOne.update;
     expect(update.$inc.usageCount).toBe(2);
     expect(update.$inc.errorCount).toBe(1);
     expect(update.$inc.totalResponseMs as number).toBeGreaterThan(0);
     expect(update.$min.firstUsedAt).toBeInstanceOf(Date);
     expect(update.$max.lastUsedAt).toBeInstanceOf(Date);
     expect(update.$max.expiresAt).toBeInstanceOf(Date);
-    expect(options.upsert).toBe(true);
 
     // The expiry anchor sits ~retentionDays after lastUsedAt.
     const last = update.$max.lastUsedAt as Date;
     const expires = update.$max.expiresAt as Date;
-    const deltaDays = (expires.getTime() - last.getTime()) / (24 * 60 * 60 * 1000);
+    const deltaDays =
+      (expires.getTime() - last.getTime()) / (24 * 60 * 60 * 1000);
     expect(Math.round(deltaDays)).toBe(30);
   });
 
   it("clears the buffer after a successful flush", async () => {
     service.trackCommandEnd("quote", "t1", Date.now() - 10, true, "guild-1");
     await service.flushMetrics();
-    mockFindOneAndUpdate.mockClear();
+    mockBulkWrite.mockClear();
     await service.flushMetrics();
-    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+    expect(mockBulkWrite).not.toHaveBeenCalled();
   });
 
   it("skips writing while the DB is disconnected and keeps the buffer", async () => {
     mongoose.connection.readyState = 0;
     service.trackCommandEnd("quote", "t1", Date.now() - 10, true, "guild-1");
     await service.flushMetrics();
-    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+    expect(mockBulkWrite).not.toHaveBeenCalled();
 
     // Reconnect — the buffered counts should now flush.
     mongoose.connection.readyState = 1;
     await service.flushMetrics();
-    expect(mockFindOneAndUpdate).toHaveBeenCalledTimes(1);
+    expect(mockBulkWrite).toHaveBeenCalledTimes(1);
   });
 
   it("drops the buffer when persistence is disabled", async () => {
     mockGetBoolean.mockResolvedValue(false);
     service.trackCommandEnd("quote", "t1", Date.now() - 10, true, "guild-1");
     await service.flushMetrics();
-    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+    expect(mockBulkWrite).not.toHaveBeenCalled();
 
     // Re-enable: nothing should remain to flush.
     mockGetBoolean.mockResolvedValue(true);
     await service.flushMetrics();
-    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+    expect(mockBulkWrite).not.toHaveBeenCalled();
   });
 
-  it("re-queues a bucket when its write fails", async () => {
-    mockFindOneAndUpdate.mockRejectedValueOnce(new Error("mongo down"));
+  it("re-queues the batch when the write fails", async () => {
+    mockBulkWrite.mockRejectedValueOnce(new Error("mongo down"));
     service.trackCommandEnd("quote", "t1", Date.now() - 10, true, "guild-1");
 
     await service.flushMetrics();
-    expect(mockFindOneAndUpdate).toHaveBeenCalledTimes(1);
+    expect(mockBulkWrite).toHaveBeenCalledTimes(1);
 
     // The failed batch was re-buffered, so a retry writes it again.
-    mockFindOneAndUpdate.mockResolvedValueOnce(null);
+    mockBulkWrite.mockResolvedValueOnce(null);
     await service.flushMetrics();
-    expect(mockFindOneAndUpdate).toHaveBeenCalledTimes(2);
+    expect(mockBulkWrite).toHaveBeenCalledTimes(2);
+  });
+
+  it("caps the pending buffer so a DB outage can't grow it without bound", () => {
+    // Pre-fill the buffer to its cap directly (cheaper than driving
+    // MAX_PENDING_BUCKETS real invocations), then prove new buckets are
+    // shed while merges into existing buckets still apply.
+    const map = (service as unknown as { pendingBuckets: Map<string, unknown> })
+      .pendingBuckets;
+    const now = new Date();
+    const dateKey = now.toISOString().slice(0, 10);
+    // Mirror the service's internal `${guildId}<NUL>${command}<NUL>${date}`
+    // key so a merge actually finds the pre-seeded bucket.
+    const key = (cmd: string): string => `g\u0000${cmd}\u0000${dateKey}`;
+    for (let i = 0; i < MAX_PENDING_BUCKETS; i++) {
+      map.set(key(`cmd${i}`), {
+        command: `cmd${i}`,
+        guildId: "g",
+        date: dateKey,
+        usageCount: 1,
+        errorCount: 0,
+        totalResponseMs: 1,
+        firstUsedAt: now,
+        lastUsedAt: now,
+      });
+    }
+    expect(map.size).toBe(MAX_PENDING_BUCKETS);
+
+    // A brand-new bucket is dropped at the cap.
+    service.trackCommandEnd("brand-new", "t", Date.now() - 1, true, "g");
+    expect(map.size).toBe(MAX_PENDING_BUCKETS);
+
+    // But an invocation of an already-tracked bucket still merges.
+    const before = (map.get(key("cmd0")) as { usageCount: number }).usageCount;
+    service.trackCommandEnd("cmd0", "t", Date.now() - 1, true, "g");
+    const after = (map.get(key("cmd0")) as { usageCount: number }).usageCount;
+    expect(after).toBe(before + 1);
   });
 });

--- a/__tests__/services/monitoring-service.test.ts
+++ b/__tests__/services/monitoring-service.test.ts
@@ -226,9 +226,11 @@ describe('MonitoringService', () => {
         fresh.destroy();
       }).not.toThrow();
 
-      // Only the first call should have anything to clear.
-      expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+      // Only the first call should have anything to clear: the periodic
+      // logging interval and the metrics-flush interval (#648) — two handles.
+      expect(clearIntervalSpy).toHaveBeenCalledTimes(2);
       expect((fresh as any).periodicLoggingInterval).toBeNull();
+      expect((fresh as any).flushInterval).toBeNull();
 
       clearIntervalSpy.mockRestore();
     });

--- a/__tests__/services/monitoring-service.test.ts
+++ b/__tests__/services/monitoring-service.test.ts
@@ -1,10 +1,17 @@
-import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
-import { MonitoringService } from '../../src/services/monitoring-service.js';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+import { MonitoringService } from "../../src/services/monitoring-service.js";
 
 // Mock logger
-jest.mock('../../src/utils/logger.js');
+jest.mock("../../src/utils/logger.js");
 
-describe('MonitoringService', () => {
+describe("MonitoringService", () => {
   let service: MonitoringService;
 
   beforeEach(() => {
@@ -12,159 +19,159 @@ describe('MonitoringService', () => {
     service = MonitoringService.getInstance();
   });
 
-  describe('singleton pattern', () => {
-    it('should create a singleton instance', () => {
+  describe("singleton pattern", () => {
+    it("should create a singleton instance", () => {
       const instance1 = MonitoringService.getInstance();
       const instance2 = MonitoringService.getInstance();
-      
+
       expect(instance1).toBe(instance2);
     });
   });
 
-  describe('initialization', () => {
-    it('should create an instance', () => {
+  describe("initialization", () => {
+    it("should create an instance", () => {
       expect(service).toBeDefined();
       expect(service).toBeInstanceOf(MonitoringService);
     });
   });
 
-  describe('public methods', () => {
-    it('should have trackCommandStart method', () => {
-      expect(typeof service.trackCommandStart).toBe('function');
+  describe("public methods", () => {
+    it("should have trackCommandStart method", () => {
+      expect(typeof service.trackCommandStart).toBe("function");
     });
 
-    it('should have trackCommandEnd method', () => {
-      expect(typeof service.trackCommandEnd).toBe('function');
+    it("should have trackCommandEnd method", () => {
+      expect(typeof service.trackCommandEnd).toBe("function");
     });
 
-    it('should have trackError method', () => {
-      expect(typeof service.trackError).toBe('function');
+    it("should have trackError method", () => {
+      expect(typeof service.trackError).toBe("function");
     });
 
-    it('should have getCommandMetrics method', () => {
-      expect(typeof service.getCommandMetrics).toBe('function');
+    it("should have getCommandMetrics method", () => {
+      expect(typeof service.getCommandMetrics).toBe("function");
     });
 
-    it('should have getAllCommandMetrics method', () => {
-      expect(typeof service.getAllCommandMetrics).toBe('function');
+    it("should have getAllCommandMetrics method", () => {
+      expect(typeof service.getAllCommandMetrics).toBe("function");
     });
 
-    it('should have getPerformanceMetrics method', () => {
-      expect(typeof service.getPerformanceMetrics).toBe('function');
+    it("should have getPerformanceMetrics method", () => {
+      expect(typeof service.getPerformanceMetrics).toBe("function");
     });
 
-    it('should have getTopCommands method', () => {
-      expect(typeof service.getTopCommands).toBe('function');
+    it("should have getTopCommands method", () => {
+      expect(typeof service.getTopCommands).toBe("function");
     });
 
-    it('should have getCommandsWithErrors method', () => {
-      expect(typeof service.getCommandsWithErrors).toBe('function');
+    it("should have getCommandsWithErrors method", () => {
+      expect(typeof service.getCommandsWithErrors).toBe("function");
     });
 
-    it('should have getSlowestCommands method', () => {
-      expect(typeof service.getSlowestCommands).toBe('function');
+    it("should have getSlowestCommands method", () => {
+      expect(typeof service.getSlowestCommands).toBe("function");
     });
 
-    it('should have formatUptime method', () => {
-      expect(typeof service.formatUptime).toBe('function');
+    it("should have formatUptime method", () => {
+      expect(typeof service.formatUptime).toBe("function");
     });
   });
 
-  describe('command tracking', () => {
-    it('should track command start and return tracking ID', () => {
-      const trackingId = service.trackCommandStart('test-command');
-      
+  describe("command tracking", () => {
+    it("should track command start and return tracking ID", () => {
+      const trackingId = service.trackCommandStart("test-command");
+
       expect(trackingId).toBeDefined();
-      expect(typeof trackingId).toBe('string');
-      expect(trackingId).toContain('test-command');
+      expect(typeof trackingId).toBe("string");
+      expect(trackingId).toContain("test-command");
     });
 
-    it('should generate unique tracking IDs', () => {
-      const id1 = service.trackCommandStart('test-command');
-      const id2 = service.trackCommandStart('test-command');
-      
+    it("should generate unique tracking IDs", () => {
+      const id1 = service.trackCommandStart("test-command");
+      const id2 = service.trackCommandStart("test-command");
+
       expect(id1).not.toBe(id2);
     });
 
-    it('should track command completion', () => {
-      const trackingId = service.trackCommandStart('test-command');
-      service.trackCommandEnd('test-command', trackingId, 100);
-      
+    it("should track command completion", () => {
+      const trackingId = service.trackCommandStart("test-command");
+      service.trackCommandEnd("test-command", trackingId, 100);
+
       // Method should execute without errors
       expect(true).toBe(true);
     });
 
-    it('should track command errors', () => {
-      const error = new Error('Test error');
-      service.trackError('test-command', error);
-      
+    it("should track command errors", () => {
+      const error = new Error("Test error");
+      service.trackError("test-command", error);
+
       // Method should execute without errors
       expect(true).toBe(true);
     });
 
-    it('should get command metrics', () => {
-      service.trackCommandStart('test-command');
-      const metrics = service.getCommandMetrics('test-command');
-      
+    it("should get command metrics", () => {
+      service.trackCommandStart("test-command");
+      const metrics = service.getCommandMetrics("test-command");
+
       expect(metrics).toBeDefined();
     });
 
-    it('should get all command metrics', () => {
-      service.trackCommandStart('test-command-1');
-      service.trackCommandStart('test-command-2');
+    it("should get all command metrics", () => {
+      service.trackCommandStart("test-command-1");
+      service.trackCommandStart("test-command-2");
       const metrics = service.getAllCommandMetrics();
-      
+
       expect(Array.isArray(metrics)).toBe(true);
     });
   });
 
-  describe('performance metrics', () => {
-    it('should return performance metrics', () => {
+  describe("performance metrics", () => {
+    it("should return performance metrics", () => {
       const metrics = service.getPerformanceMetrics();
-      
+
       expect(metrics).toBeDefined();
-      expect(metrics).toHaveProperty('memoryUsage');
-      expect(metrics).toHaveProperty('uptime');
-      expect(metrics).toHaveProperty('totalCommands');
-      expect(metrics).toHaveProperty('totalErrors');
-      expect(metrics).toHaveProperty('averageResponseTime');
+      expect(metrics).toHaveProperty("memoryUsage");
+      expect(metrics).toHaveProperty("uptime");
+      expect(metrics).toHaveProperty("totalCommands");
+      expect(metrics).toHaveProperty("totalErrors");
+      expect(metrics).toHaveProperty("averageResponseTime");
     });
 
-    it('should have valid memory usage metrics', () => {
+    it("should have valid memory usage metrics", () => {
       const metrics = service.getPerformanceMetrics();
-      
-      expect(metrics.memoryUsage).toHaveProperty('heapUsed');
-      expect(metrics.memoryUsage).toHaveProperty('heapTotal');
-      expect(metrics.memoryUsage).toHaveProperty('external');
-      expect(metrics.memoryUsage).toHaveProperty('rss');
+
+      expect(metrics.memoryUsage).toHaveProperty("heapUsed");
+      expect(metrics.memoryUsage).toHaveProperty("heapTotal");
+      expect(metrics.memoryUsage).toHaveProperty("external");
+      expect(metrics.memoryUsage).toHaveProperty("rss");
     });
 
-    it('should return top commands', () => {
+    it("should return top commands", () => {
       const topCommands = service.getTopCommands(5);
-      
+
       expect(Array.isArray(topCommands)).toBe(true);
     });
 
-    it('should return commands with errors', () => {
+    it("should return commands with errors", () => {
       const commandsWithErrors = service.getCommandsWithErrors(3);
-      
+
       expect(Array.isArray(commandsWithErrors)).toBe(true);
     });
 
-    it('should return slowest commands', () => {
+    it("should return slowest commands", () => {
       const slowestCommands = service.getSlowestCommands(3);
-      
+
       expect(Array.isArray(slowestCommands)).toBe(true);
     });
 
-    it('should format uptime as string', () => {
+    it("should format uptime as string", () => {
       const uptime = service.formatUptime();
 
-      expect(typeof uptime).toBe('string');
+      expect(typeof uptime).toBe("string");
     });
   });
 
-  describe('destroy', () => {
+  describe("destroy", () => {
     let fresh: MonitoringService;
 
     beforeEach(() => {
@@ -187,14 +194,14 @@ describe('MonitoringService', () => {
       jest.useRealTimers();
     });
 
-    it('captures the periodic logging interval handle on construction', () => {
+    it("captures the periodic logging interval handle on construction", () => {
       const handle = (fresh as any).periodicLoggingInterval;
       expect(handle).not.toBeNull();
       expect(handle).toBeDefined();
     });
 
-    it('clears the periodic logging interval and nulls the handle', () => {
-      const clearIntervalSpy = jest.spyOn(globalThis, 'clearInterval');
+    it("clears the periodic logging interval and nulls the handle", () => {
+      const clearIntervalSpy = jest.spyOn(globalThis, "clearInterval");
       const handle = (fresh as any).periodicLoggingInterval;
 
       fresh.destroy();
@@ -205,8 +212,8 @@ describe('MonitoringService', () => {
       clearIntervalSpy.mockRestore();
     });
 
-    it('does not fire the periodic logger after destroy()', () => {
-      const getPerfSpy = jest.spyOn(fresh, 'getPerformanceMetrics');
+    it("does not fire the periodic logger after destroy()", () => {
+      const getPerfSpy = jest.spyOn(fresh, "getPerformanceMetrics");
 
       fresh.destroy();
       // Advance well past the 1-hour interval.
@@ -217,8 +224,8 @@ describe('MonitoringService', () => {
       getPerfSpy.mockRestore();
     });
 
-    it('is idempotent — repeated calls are safe', () => {
-      const clearIntervalSpy = jest.spyOn(globalThis, 'clearInterval');
+    it("is idempotent — repeated calls are safe", () => {
+      const clearIntervalSpy = jest.spyOn(globalThis, "clearInterval");
 
       expect(() => {
         fresh.destroy();
@@ -235,5 +242,4 @@ describe('MonitoringService', () => {
       clearIntervalSpy.mockRestore();
     });
   });
-
 });

--- a/__tests__/services/permissions-service.test.ts
+++ b/__tests__/services/permissions-service.test.ts
@@ -69,8 +69,7 @@ describe("PermissionsService", () => {
         roleIds: ["role1", "role2", "role3"],
       });
 
-      (CommandPermission.findOneAndUpdate as jest.Mock) =
-        mockFindOneAndUpdate;
+      (CommandPermission.findOneAndUpdate as jest.Mock) = mockFindOneAndUpdate;
 
       await service.setCommandPermissions("guild123", "quote", [
         "role1",
@@ -101,8 +100,7 @@ describe("PermissionsService", () => {
       });
 
       (CommandPermission.findOne as jest.Mock) = mockFindOne;
-      (CommandPermission.findOneAndUpdate as jest.Mock) =
-        mockFindOneAndUpdate;
+      (CommandPermission.findOneAndUpdate as jest.Mock) = mockFindOneAndUpdate;
 
       await service.addCommandPermissions("guild123", "quote", ["role2"]);
 
@@ -121,8 +119,7 @@ describe("PermissionsService", () => {
       });
 
       (CommandPermission.findOne as jest.Mock) = mockFindOne;
-      (CommandPermission.findOneAndUpdate as jest.Mock) =
-        mockFindOneAndUpdate;
+      (CommandPermission.findOneAndUpdate as jest.Mock) = mockFindOneAndUpdate;
 
       await service.addCommandPermissions("guild123", "newcmd", ["role1"]);
 
@@ -145,8 +142,7 @@ describe("PermissionsService", () => {
       });
 
       (CommandPermission.findOne as jest.Mock) = mockFindOne;
-      (CommandPermission.findOneAndUpdate as jest.Mock) =
-        mockFindOneAndUpdate;
+      (CommandPermission.findOneAndUpdate as jest.Mock) = mockFindOneAndUpdate;
 
       await service.removeCommandPermissions("guild123", "quote", ["role2"]);
 
@@ -279,8 +275,7 @@ describe("PermissionsService", () => {
 
       (CommandPermission.find as jest.Mock) = mockFind;
       (CommandPermission.deleteOne as jest.Mock) = mockDeleteOne;
-      (CommandPermission.findOneAndUpdate as jest.Mock) =
-        mockFindOneAndUpdate;
+      (CommandPermission.findOneAndUpdate as jest.Mock) = mockFindOneAndUpdate;
 
       const clearedCount = await service.clearRoleFromAllCommands(
         "guild123",
@@ -338,13 +333,12 @@ describe("PermissionsService", () => {
       const mockFindOneAndUpdate = jest.fn().mockResolvedValue({});
 
       (CommandPermission.find as jest.Mock) = mockFind;
-      (CommandPermission.findOneAndUpdate as jest.Mock) =
-        mockFindOneAndUpdate;
+      (CommandPermission.findOneAndUpdate as jest.Mock) = mockFindOneAndUpdate;
 
-      const clearedCount = await service.clearRolesFromAllCommands(
-        "guild123",
-        ["role1", "role2"],
-      );
+      const clearedCount = await service.clearRolesFromAllCommands("guild123", [
+        "role1",
+        "role2",
+      ]);
 
       expect(clearedCount).toBe(2); // quote and vcstats affected
       expect(mockFind).toHaveBeenCalledWith({ guildId: "guild123" });
@@ -365,10 +359,10 @@ describe("PermissionsService", () => {
       (CommandPermission.find as jest.Mock) = mockFind;
       (CommandPermission.deleteOne as jest.Mock) = mockDeleteOne;
 
-      const clearedCount = await service.clearRolesFromAllCommands(
-        "guild123",
-        ["role1", "role2"],
-      );
+      const clearedCount = await service.clearRolesFromAllCommands("guild123", [
+        "role1",
+        "role2",
+      ]);
 
       expect(clearedCount).toBe(1);
       expect(mockDeleteOne).toHaveBeenCalledWith({

--- a/__tests__/services/poll-participation-tracker.test.ts
+++ b/__tests__/services/poll-participation-tracker.test.ts
@@ -14,9 +14,8 @@ jest.mock("../../src/utils/logger.js", () => ({
 import { PollParticipationTracker } from "../../src/services/poll-participation-tracker.js";
 import { PollParticipationTracking } from "../../src/models/poll-participation-tracking.js";
 
-(
-  PollParticipationTracking as unknown as { updateOne: jest.Mock }
-).updateOne = jest.fn();
+(PollParticipationTracking as unknown as { updateOne: jest.Mock }).updateOne =
+  jest.fn();
 
 function createTracker(voter: { username: string; bot: boolean } | null) {
   const usersFetch = jest
@@ -64,9 +63,8 @@ describe("PollParticipationTracker", () => {
       PollParticipationTracking as unknown as { updateOne: jest.Mock }
     ).updateOne;
     updateOne.mockResolvedValue({ matchedCount: 1 });
-    (
-      PollParticipationTracker as unknown as { instance: unknown }
-    ).instance = undefined;
+    (PollParticipationTracker as unknown as { instance: unknown }).instance =
+      undefined;
   });
 
   describe("singleton pattern", () => {

--- a/__tests__/services/quote-channel-manager-backup.test.ts
+++ b/__tests__/services/quote-channel-manager-backup.test.ts
@@ -5,8 +5,8 @@ import {
   jest,
   beforeEach,
   afterEach,
-} from '@jest/globals';
-import { Collection } from 'discord.js';
+} from "@jest/globals";
+import { Collection } from "discord.js";
 
 const mockRegisterReloadCallback = jest.fn();
 const mockGetBoolean = jest.fn();
@@ -17,10 +17,10 @@ const mockSetVoteCountsByMessageId = jest.fn();
 const mockListQuotes = jest.fn();
 const mockUpdateQuoteMessageId = jest.fn();
 
-jest.mock('../../src/utils/logger.js');
-jest.mock('cron');
+jest.mock("../../src/utils/logger.js");
+jest.mock("cron");
 
-jest.unstable_mockModule('../../src/services/config-service.js', () => ({
+jest.unstable_mockModule("../../src/services/config-service.js", () => ({
   ConfigService: {
     getInstance: jest.fn(() => ({
       registerReloadCallback: mockRegisterReloadCallback,
@@ -31,7 +31,7 @@ jest.unstable_mockModule('../../src/services/config-service.js', () => ({
   },
 }));
 
-jest.unstable_mockModule('../../src/services/quote-service.js', () => ({
+jest.unstable_mockModule("../../src/services/quote-service.js", () => ({
   quoteService: {
     setVoteCountsByMessageId: mockSetVoteCountsByMessageId,
     listQuotes: mockListQuotes,
@@ -39,13 +39,13 @@ jest.unstable_mockModule('../../src/services/quote-service.js', () => ({
   },
 }));
 
-const HEADER_TITLE = '📝 Welcome to the Quote Channel!';
-const HEADER_FOOTER = 'KoolBot Quote System';
+const HEADER_TITLE = "📝 Welcome to the Quote Channel!";
+const HEADER_FOOTER = "KoolBot Quote System";
 
 function headerMessage(id: string) {
   return {
     id,
-    author: { id: 'bot123' },
+    author: { id: "bot123" },
     embeds: [{ title: HEADER_TITLE, footer: { text: HEADER_FOOTER } }],
   };
 }
@@ -53,69 +53,68 @@ function headerMessage(id: string) {
 function userMessage(id: string) {
   return {
     id,
-    author: { id: 'user999' },
-    embeds: [{ title: 'something else', footer: { text: 'nope' } }],
+    author: { id: "user999" },
+    embeds: [{ title: "something else", footer: { text: "nope" } }],
   };
 }
 
 const mockClient: any = {
   isReady: jest.fn().mockReturnValue(true),
-  user: { id: 'bot123' },
+  user: { id: "bot123" },
   channels: { fetch: jest.fn() },
   on: jest.fn(),
   removeListener: jest.fn(),
 };
 
 async function loadManager() {
-  const { QuoteChannelManager } = await import(
-    '../../src/services/quote-channel-manager.js'
-  );
+  const { QuoteChannelManager } =
+    await import("../../src/services/quote-channel-manager.js");
   return QuoteChannelManager.getInstance(mockClient);
 }
 
-describe('QuoteChannelManager - header idempotency & vote persistence', () => {
+describe("QuoteChannelManager - header idempotency & vote persistence", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSet.mockResolvedValue(undefined);
   });
 
-  describe('findExistingHeader', () => {
-    it('finds a pinned bot header', async () => {
+  describe("findExistingHeader", () => {
+    it("finds a pinned bot header", async () => {
       const manager = await loadManager();
       const channel = {
         messages: {
           fetchPinned: jest
             .fn()
-            .mockResolvedValue([userMessage('u1'), headerMessage('h1')]),
+            .mockResolvedValue([userMessage("u1"), headerMessage("h1")]),
           fetch: jest.fn().mockResolvedValue([]),
         },
       };
       const result = await (manager as any).findExistingHeader(channel);
-      expect(result).toEqual({ id: 'h1' });
+      expect(result).toEqual({ id: "h1" });
       // Found in pins → no need to scan recent messages.
       expect(channel.messages.fetch).not.toHaveBeenCalled();
     });
 
-    it('falls back to a recent-message scan when no pin matches', async () => {
+    it("falls back to a recent-message scan when no pin matches", async () => {
       const manager = await loadManager();
       const channel = {
         messages: {
-          fetchPinned: jest.fn().mockResolvedValue([userMessage('u1')]),
+          fetchPinned: jest.fn().mockResolvedValue([userMessage("u1")]),
           fetch: jest
             .fn()
-            .mockResolvedValue([userMessage('u2'), headerMessage('h2')]),
+            .mockResolvedValue([userMessage("u2"), headerMessage("h2")]),
         },
       };
       const result = await (manager as any).findExistingHeader(channel);
-      expect(result).toEqual({ id: 'h2' });
+      expect(result).toEqual({ id: "h2" });
     });
 
-    it('returns null when no header exists anywhere', async () => {
+    it("returns null when no header exists anywhere", async () => {
       const manager = await loadManager();
       const channel = {
         messages: {
-          fetchPinned: jest.fn().mockResolvedValue([userMessage('u1')]),
-          fetch: jest.fn().mockResolvedValue([userMessage('u2')]),
+          fetchPinned: jest.fn().mockResolvedValue([userMessage("u1")]),
+          fetch: jest.fn().mockResolvedValue([userMessage("u2")]),
         },
       };
       const result = await (manager as any).findExistingHeader(channel);
@@ -123,17 +122,17 @@ describe('QuoteChannelManager - header idempotency & vote persistence', () => {
     });
   });
 
-  describe('ensureHeaderPost adoption', () => {
-    it('adopts an existing header instead of creating a duplicate', async () => {
+  describe("ensureHeaderPost adoption", () => {
+    it("adopts an existing header instead of creating a duplicate", async () => {
       // Header enabled, but the stored ID is gone (e.g. after a reinstall).
       mockGetBoolean.mockResolvedValue(true);
-      mockGetString.mockResolvedValue(''); // no stored header id
+      mockGetString.mockResolvedValue(""); // no stored header id
 
       const manager = await loadManager();
       const channel = {
         send: jest.fn(),
         messages: {
-          fetchPinned: jest.fn().mockResolvedValue([headerMessage('existing')]),
+          fetchPinned: jest.fn().mockResolvedValue([headerMessage("existing")]),
           fetch: jest.fn().mockResolvedValue([]),
         },
       };
@@ -143,23 +142,29 @@ describe('QuoteChannelManager - header idempotency & vote persistence', () => {
       // Adopted the existing header id, did NOT post a second welcome message.
       expect(channel.send).not.toHaveBeenCalled();
       expect(mockSet).toHaveBeenCalledWith(
-        'quotes.header_message_id',
-        'existing',
+        "quotes.header_message_id",
+        "existing",
         expect.any(String),
-        'quotes',
+        "quotes",
       );
     });
   });
 
-  describe('clearChannel', () => {
-    it('deletes messages bulkDelete skips (older than 14 days) individually', async () => {
+  describe("clearChannel", () => {
+    it("deletes messages bulkDelete skips (older than 14 days) individually", async () => {
       const manager = await loadManager();
 
-      const m1: any = { id: 'm1', delete: jest.fn().mockResolvedValue(undefined) };
-      const m2: any = { id: 'm2', delete: jest.fn().mockResolvedValue(undefined) };
+      const m1: any = {
+        id: "m1",
+        delete: jest.fn().mockResolvedValue(undefined),
+      };
+      const m2: any = {
+        id: "m2",
+        delete: jest.fn().mockResolvedValue(undefined),
+      };
       const firstBatch = new Collection<string, any>([
-        ['m1', m1],
-        ['m2', m2],
+        ["m1", m1],
+        ["m2", m2],
       ]);
       const empty = new Collection<string, any>();
 
@@ -182,7 +187,7 @@ describe('QuoteChannelManager - header idempotency & vote persistence', () => {
     });
   });
 
-  describe('scheduleVotePersist (debounced)', () => {
+  describe("scheduleVotePersist (debounced)", () => {
     beforeEach(() => {
       jest.useFakeTimers();
     });
@@ -190,13 +195,13 @@ describe('QuoteChannelManager - header idempotency & vote persistence', () => {
       jest.useRealTimers();
     });
 
-    it('coalesces a burst into a single write with the latest values', async () => {
+    it("coalesces a burst into a single write with the latest values", async () => {
       const manager = await loadManager();
       mockSetVoteCountsByMessageId.mockResolvedValue(undefined);
 
-      (manager as any).scheduleVotePersist('msg1', 1, 0);
-      (manager as any).scheduleVotePersist('msg1', 2, 0);
-      (manager as any).scheduleVotePersist('msg1', 3, 1);
+      (manager as any).scheduleVotePersist("msg1", 1, 0);
+      (manager as any).scheduleVotePersist("msg1", 2, 0);
+      (manager as any).scheduleVotePersist("msg1", 3, 1);
 
       expect(mockSetVoteCountsByMessageId).not.toHaveBeenCalled();
 
@@ -204,7 +209,7 @@ describe('QuoteChannelManager - header idempotency & vote persistence', () => {
       await Promise.resolve();
 
       expect(mockSetVoteCountsByMessageId).toHaveBeenCalledTimes(1);
-      expect(mockSetVoteCountsByMessageId).toHaveBeenCalledWith('msg1', 3, 1);
+      expect(mockSetVoteCountsByMessageId).toHaveBeenCalledWith("msg1", 3, 1);
     });
   });
 });

--- a/__tests__/services/quote-channel-manager-header.test.ts
+++ b/__tests__/services/quote-channel-manager-header.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 
 // Mock dependencies before importing
-jest.mock('../../src/utils/logger.js');
-jest.mock('../../src/services/quote-service.js');
-jest.mock('cron');
+jest.mock("../../src/utils/logger.js");
+jest.mock("../../src/services/quote-service.js");
+jest.mock("cron");
 
-describe('QuoteChannelManager - Header Post', () => {
+describe("QuoteChannelManager - Header Post", () => {
   let mockClient: any;
   let mockChannel: any;
   let mockMessage: any;
@@ -16,26 +16,26 @@ describe('QuoteChannelManager - Header Post', () => {
 
     // Mock message
     mockMessage = {
-      id: 'header123',
+      id: "header123",
       author: {
-        id: 'bot123',
+        id: "bot123",
       },
       pin: jest.fn().mockResolvedValue(undefined),
     };
 
     // Mock channel
     mockChannel = {
-      id: 'channel123',
-      name: 'quotes',
+      id: "channel123",
+      name: "quotes",
       guild: {
         members: {
           me: {
-            id: 'bot123',
+            id: "bot123",
           },
         },
         roles: {
           everyone: {
-            id: 'everyone',
+            id: "everyone",
           },
         },
       },
@@ -57,7 +57,7 @@ describe('QuoteChannelManager - Header Post', () => {
     // Mock Discord client
     mockClient = {
       isReady: jest.fn().mockReturnValue(true),
-      user: { id: 'bot123', tag: 'TestBot#1234' },
+      user: { id: "bot123", tag: "TestBot#1234" },
       channels: {
         fetch: jest.fn().mockResolvedValue(mockChannel),
       },
@@ -65,24 +65,26 @@ describe('QuoteChannelManager - Header Post', () => {
     };
   });
 
-  describe('ensureHeaderPost', () => {
-    it('should have ensureHeaderPost as a private method', async () => {
-      const { QuoteChannelManager } = await import('../../src/services/quote-channel-manager.js');
-      
+  describe("ensureHeaderPost", () => {
+    it("should have ensureHeaderPost as a private method", async () => {
+      const { QuoteChannelManager } =
+        await import("../../src/services/quote-channel-manager.js");
+
       const manager = QuoteChannelManager.getInstance(mockClient);
-      
+
       // We can't directly test private methods, but we can verify initialization doesn't throw
       expect(manager).toBeDefined();
-      expect(typeof manager.initialize).toBe('function');
+      expect(typeof manager.initialize).toBe("function");
     });
   });
 
-  describe('header post integration', () => {
-    it('should successfully initialize when headers are enabled', async () => {
-      const { QuoteChannelManager } = await import('../../src/services/quote-channel-manager.js');
-      
+  describe("header post integration", () => {
+    it("should successfully initialize when headers are enabled", async () => {
+      const { QuoteChannelManager } =
+        await import("../../src/services/quote-channel-manager.js");
+
       const manager = QuoteChannelManager.getInstance(mockClient);
-      
+
       // Just verify initialization doesn't throw errors
       await expect(manager.initialize()).resolves.not.toThrow();
     });

--- a/__tests__/services/quote-channel-manager-methods.test.ts
+++ b/__tests__/services/quote-channel-manager-methods.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import type { Client } from 'discord.js';
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import type { Client } from "discord.js";
 
 // Mock dependencies
-jest.mock('../../src/services/config-service.js');
-jest.mock('../../src/utils/logger.js');
+jest.mock("../../src/services/config-service.js");
+jest.mock("../../src/utils/logger.js");
 
-describe('QuoteChannelManager Methods', () => {
+describe("QuoteChannelManager Methods", () => {
   let mockClient: Partial<Client>;
 
   beforeEach(() => {
@@ -21,26 +21,29 @@ describe('QuoteChannelManager Methods', () => {
     } as Client;
   });
 
-  it('should have getInstance method', async () => {
-    const { QuoteChannelManager } = await import('../../src/services/quote-channel-manager.js');
-    
-    expect(typeof QuoteChannelManager.getInstance).toBe('function');
+  it("should have getInstance method", async () => {
+    const { QuoteChannelManager } =
+      await import("../../src/services/quote-channel-manager.js");
+
+    expect(typeof QuoteChannelManager.getInstance).toBe("function");
   });
 
-  it('should return singleton instance', async () => {
-    const { QuoteChannelManager } = await import('../../src/services/quote-channel-manager.js');
-    
+  it("should return singleton instance", async () => {
+    const { QuoteChannelManager } =
+      await import("../../src/services/quote-channel-manager.js");
+
     const instance1 = QuoteChannelManager.getInstance(mockClient as Client);
     const instance2 = QuoteChannelManager.getInstance(mockClient as Client);
 
     expect(instance1).toBe(instance2);
   });
 
-  it('should have postQuote method', async () => {
-    const { QuoteChannelManager } = await import('../../src/services/quote-channel-manager.js');
-    
+  it("should have postQuote method", async () => {
+    const { QuoteChannelManager } =
+      await import("../../src/services/quote-channel-manager.js");
+
     const instance = QuoteChannelManager.getInstance(mockClient as Client);
 
-    expect(typeof instance.postQuote).toBe('function');
+    expect(typeof instance.postQuote).toBe("function");
   });
 });

--- a/__tests__/services/quote-channel-manager.test.ts
+++ b/__tests__/services/quote-channel-manager.test.ts
@@ -1,13 +1,13 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import { QuoteChannelManager } from '../../src/services/quote-channel-manager.js';
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { QuoteChannelManager } from "../../src/services/quote-channel-manager.js";
 
 // Mock dependencies
-jest.mock('../../src/services/config-service.js');
-jest.mock('../../src/services/quote-service.js');
-jest.mock('../../src/utils/logger.js');
-jest.mock('cron');
+jest.mock("../../src/services/config-service.js");
+jest.mock("../../src/services/quote-service.js");
+jest.mock("../../src/utils/logger.js");
+jest.mock("cron");
 
-describe('QuoteChannelManager', () => {
+describe("QuoteChannelManager", () => {
   let mockClient: any;
 
   beforeEach(() => {
@@ -16,7 +16,7 @@ describe('QuoteChannelManager', () => {
     // Mock Discord client
     mockClient = {
       isReady: jest.fn().mockReturnValue(true),
-      user: { id: 'bot123', tag: 'TestBot#1234' },
+      user: { id: "bot123", tag: "TestBot#1234" },
       channels: {
         fetch: jest.fn(),
       },
@@ -24,57 +24,57 @@ describe('QuoteChannelManager', () => {
     };
   });
 
-  describe('initialization', () => {
-    it('should create a singleton instance', () => {
+  describe("initialization", () => {
+    it("should create a singleton instance", () => {
       const instance1 = QuoteChannelManager.getInstance(mockClient);
       const instance2 = QuoteChannelManager.getInstance(mockClient);
-      
+
       expect(instance1).toBeDefined();
       expect(instance1).toBe(instance2);
     });
 
-    it('should have required methods', () => {
+    it("should have required methods", () => {
       const manager = QuoteChannelManager.getInstance(mockClient);
-      
-      expect(typeof manager.initialize).toBe('function');
-      expect(typeof manager.postQuote).toBe('function');
-      expect(typeof manager.deleteQuoteMessage).toBe('function');
-      expect(typeof manager.updateQuoteReactions).toBe('function');
-      expect(typeof manager.syncExistingQuotes).toBe('function');
-      expect(typeof manager.stop).toBe('function');
+
+      expect(typeof manager.initialize).toBe("function");
+      expect(typeof manager.postQuote).toBe("function");
+      expect(typeof manager.deleteQuoteMessage).toBe("function");
+      expect(typeof manager.updateQuoteReactions).toBe("function");
+      expect(typeof manager.syncExistingQuotes).toBe("function");
+      expect(typeof manager.stop).toBe("function");
     });
   });
 
-  describe('method signatures', () => {
+  describe("method signatures", () => {
     let manager: QuoteChannelManager;
 
     beforeEach(() => {
       manager = QuoteChannelManager.getInstance(mockClient);
     });
 
-    it('initialize should accept no parameters', () => {
+    it("initialize should accept no parameters", () => {
       expect(manager.initialize.length).toBe(0);
     });
 
-    it('postQuote should accept 4 required parameters (plus an optional votes arg)', () => {
+    it("postQuote should accept 4 required parameters (plus an optional votes arg)", () => {
       // quoteId, content, authorId, addedById are required; the 5th `votes`
       // param is optional and used when restoring tallies on re-sync.
       expect(manager.postQuote.length).toBe(5);
     });
 
-    it('deleteQuoteMessage should accept message ID', () => {
+    it("deleteQuoteMessage should accept message ID", () => {
       expect(manager.deleteQuoteMessage.length).toBe(1);
     });
 
-    it('updateQuoteReactions should accept message ID', () => {
+    it("updateQuoteReactions should accept message ID", () => {
       expect(manager.updateQuoteReactions.length).toBe(1);
     });
 
-    it('syncExistingQuotes should accept no parameters', () => {
+    it("syncExistingQuotes should accept no parameters", () => {
       expect(manager.syncExistingQuotes.length).toBe(0);
     });
 
-    it('stop should accept no parameters', () => {
+    it("stop should accept no parameters", () => {
       expect(manager.stop.length).toBe(0);
     });
   });

--- a/__tests__/services/quote-service-backup.test.ts
+++ b/__tests__/services/quote-service-backup.test.ts
@@ -1,15 +1,15 @@
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
-import { QuoteService } from '../../src/services/quote-service.js';
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import { QuoteService } from "../../src/services/quote-service.js";
 
-jest.mock('mongoose');
-jest.mock('../../src/database/schema.js');
-jest.mock('../../src/services/config-service.js');
-jest.mock('../../src/services/cooldown-manager.js');
-jest.mock('../../src/utils/logger.js');
+jest.mock("mongoose");
+jest.mock("../../src/database/schema.js");
+jest.mock("../../src/services/config-service.js");
+jest.mock("../../src/services/cooldown-manager.js");
+jest.mock("../../src/utils/logger.js");
 
-const VALID_ID = '0123456789abcdef01234567';
+const VALID_ID = "0123456789abcdef01234567";
 
-describe('QuoteService backup & vote persistence', () => {
+describe("QuoteService backup & vote persistence", () => {
   let service: QuoteService;
   let model: any;
 
@@ -26,45 +26,45 @@ describe('QuoteService backup & vote persistence', () => {
     (service as any).model = model;
   });
 
-  describe('setVoteCountsByMessageId', () => {
-    it('writes the tally keyed by messageId', async () => {
+  describe("setVoteCountsByMessageId", () => {
+    it("writes the tally keyed by messageId", async () => {
       model.findOneAndUpdate.mockResolvedValue({});
-      await service.setVoteCountsByMessageId('msg1', 3, 1);
+      await service.setVoteCountsByMessageId("msg1", 3, 1);
       expect(model.findOneAndUpdate).toHaveBeenCalledWith(
-        { messageId: 'msg1' },
+        { messageId: "msg1" },
         { likes: 3, dislikes: 1 },
       );
     });
 
-    it('clamps negative counts to zero', async () => {
+    it("clamps negative counts to zero", async () => {
       model.findOneAndUpdate.mockResolvedValue({});
-      await service.setVoteCountsByMessageId('msg1', -2, -5);
+      await service.setVoteCountsByMessageId("msg1", -2, -5);
       expect(model.findOneAndUpdate).toHaveBeenCalledWith(
-        { messageId: 'msg1' },
+        { messageId: "msg1" },
         { likes: 0, dislikes: 0 },
       );
     });
 
-    it('is a no-op when messageId is empty', async () => {
-      await service.setVoteCountsByMessageId('', 1, 1);
+    it("is a no-op when messageId is empty", async () => {
+      await service.setVoteCountsByMessageId("", 1, 1);
       expect(model.findOneAndUpdate).not.toHaveBeenCalled();
     });
   });
 
-  describe('exportQuotes', () => {
-    it('serialises quotes including vote tallies', async () => {
+  describe("exportQuotes", () => {
+    it("serialises quotes including vote tallies", async () => {
       const docs = [
         {
           _id: { toString: () => VALID_ID },
-          content: 'hi',
-          authorId: 'a',
-          addedById: 'b',
-          channelId: 'c',
-          messageId: 'm',
+          content: "hi",
+          authorId: "a",
+          addedById: "b",
+          channelId: "c",
+          messageId: "m",
           likes: 2,
           dislikes: 1,
-          createdAt: new Date('2020-01-01T00:00:00Z'),
-          addedAt: new Date('2020-01-02T00:00:00Z'),
+          createdAt: new Date("2020-01-01T00:00:00Z"),
+          addedAt: new Date("2020-01-02T00:00:00Z"),
         },
       ];
       model.find.mockReturnValue({ sort: jest.fn().mockResolvedValue(docs) });
@@ -75,29 +75,29 @@ describe('QuoteService backup & vote persistence', () => {
       expect(out.quotes).toHaveLength(1);
       expect(out.quotes[0]).toMatchObject({
         id: VALID_ID,
-        content: 'hi',
+        content: "hi",
         likes: 2,
         dislikes: 1,
       });
     });
   });
 
-  describe('importQuotes', () => {
-    it('imports new entries and preserves id + votes', async () => {
+  describe("importQuotes", () => {
+    it("imports new entries and preserves id + votes", async () => {
       model.findOne.mockResolvedValue(null);
       model.create.mockResolvedValue({});
 
       const res = await service.importQuotes({
         version: 1,
-        exportedAt: 'x',
+        exportedAt: "x",
         quotes: [
           {
             id: VALID_ID,
-            content: 'hi',
-            authorId: 'a',
-            addedById: 'b',
-            channelId: 'c',
-            messageId: 'm',
+            content: "hi",
+            authorId: "a",
+            addedById: "b",
+            channelId: "c",
+            messageId: "m",
             likes: 2,
             dislikes: 1,
           },
@@ -109,26 +109,26 @@ describe('QuoteService backup & vote persistence', () => {
       expect(model.create).toHaveBeenCalledWith(
         expect.objectContaining({
           _id: VALID_ID,
-          content: 'hi',
+          content: "hi",
           likes: 2,
           dislikes: 1,
         }),
       );
     });
 
-    it('round-trips an export back into an import', async () => {
+    it("round-trips an export back into an import", async () => {
       const docs = [
         {
           _id: { toString: () => VALID_ID },
-          content: 'round trip',
-          authorId: 'a',
-          addedById: 'b',
-          channelId: 'c',
-          messageId: 'm',
+          content: "round trip",
+          authorId: "a",
+          addedById: "b",
+          channelId: "c",
+          messageId: "m",
           likes: 5,
           dislikes: 2,
-          createdAt: new Date('2021-01-01T00:00:00Z'),
-          addedAt: new Date('2021-01-01T00:00:00Z'),
+          createdAt: new Date("2021-01-01T00:00:00Z"),
+          addedAt: new Date("2021-01-01T00:00:00Z"),
         },
       ];
       model.find.mockReturnValue({ sort: jest.fn().mockResolvedValue(docs) });
@@ -140,16 +140,20 @@ describe('QuoteService backup & vote persistence', () => {
 
       expect(res.imported).toBe(1);
       expect(model.create).toHaveBeenCalledWith(
-        expect.objectContaining({ content: 'round trip', likes: 5, dislikes: 2 }),
+        expect.objectContaining({
+          content: "round trip",
+          likes: 5,
+          dislikes: 2,
+        }),
       );
     });
 
-    it('skips an entry whose original id already exists', async () => {
-      model.findOne.mockResolvedValue({ _id: 'exists' });
+    it("skips an entry whose original id already exists", async () => {
+      model.findOne.mockResolvedValue({ _id: "exists" });
 
       const res = await service.importQuotes({
         quotes: [
-          { id: VALID_ID, content: 'hi', authorId: 'a', addedById: 'b' },
+          { id: VALID_ID, content: "hi", authorId: "a", addedById: "b" },
         ],
       });
 
@@ -158,13 +162,13 @@ describe('QuoteService backup & vote persistence', () => {
       expect(model.create).not.toHaveBeenCalled();
     });
 
-    it('dedups on content+author even when the entry has a valid id', async () => {
+    it("dedups on content+author even when the entry has a valid id", async () => {
       // A matching content+author already exists under a different id.
-      model.findOne.mockResolvedValue({ _id: 'someOtherId' });
+      model.findOne.mockResolvedValue({ _id: "someOtherId" });
 
       const res = await service.importQuotes({
         quotes: [
-          { id: VALID_ID, content: 'dup', authorId: 'a', addedById: 'b' },
+          { id: VALID_ID, content: "dup", authorId: "a", addedById: "b" },
         ],
       });
 
@@ -172,19 +176,19 @@ describe('QuoteService backup & vote persistence', () => {
       expect(model.create).not.toHaveBeenCalled();
       // The dedup query must consider both the id AND content+author.
       expect(model.findOne).toHaveBeenCalledWith({
-        $or: [{ _id: VALID_ID }, { content: 'dup', authorId: 'a' }],
+        $or: [{ _id: VALID_ID }, { content: "dup", authorId: "a" }],
       });
     });
 
-    it('rejects a structurally invalid payload', async () => {
+    it("rejects a structurally invalid payload", async () => {
       const res = await service.importQuotes(null);
       expect(res.imported).toBe(0);
       expect(res.errors.length).toBeGreaterThan(0);
     });
 
-    it('records an error for an entry missing content', async () => {
+    it("records an error for an entry missing content", async () => {
       const res = await service.importQuotes({
-        quotes: [{ authorId: 'a', addedById: 'b' }],
+        quotes: [{ authorId: "a", addedById: "b" }],
       });
       expect(res.skipped).toBe(1);
       expect(res.errors[0]).toMatch(/content/i);

--- a/__tests__/services/quote-service.test.ts
+++ b/__tests__/services/quote-service.test.ts
@@ -1,13 +1,13 @@
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
-import { QuoteService } from '../../src/services/quote-service.js';
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import { QuoteService } from "../../src/services/quote-service.js";
 
 // Mock mongoose and dependencies
-jest.mock('mongoose');
-jest.mock('../../src/database/schema.js');
-jest.mock('../../src/services/config-service.js');
-jest.mock('../../src/services/cooldown-manager.js');
+jest.mock("mongoose");
+jest.mock("../../src/database/schema.js");
+jest.mock("../../src/services/config-service.js");
+jest.mock("../../src/services/cooldown-manager.js");
 
-describe('QuoteService', () => {
+describe("QuoteService", () => {
   let quoteService: QuoteService;
 
   beforeEach(() => {
@@ -15,66 +15,66 @@ describe('QuoteService', () => {
     quoteService = new QuoteService();
   });
 
-  describe('initialization', () => {
-    it('should create a new instance', () => {
+  describe("initialization", () => {
+    it("should create a new instance", () => {
       expect(quoteService).toBeDefined();
       expect(quoteService).toBeInstanceOf(QuoteService);
     });
 
-    it('should have required methods', () => {
-      expect(typeof quoteService.addQuote).toBe('function');
-      expect(typeof quoteService.getRandomQuote).toBe('function');
-      expect(typeof quoteService.searchQuotes).toBe('function');
-      expect(typeof quoteService.deleteQuote).toBe('function');
-      expect(typeof quoteService.likeQuote).toBe('function');
-      expect(typeof quoteService.dislikeQuote).toBe('function');
-      expect(typeof quoteService.listQuotes).toBe('function');
-      expect(typeof quoteService.getQuoteById).toBe('function');
-      expect(typeof quoteService.updateQuoteMessageId).toBe('function');
-      expect(typeof quoteService.getAllQuotes).toBe('function');
+    it("should have required methods", () => {
+      expect(typeof quoteService.addQuote).toBe("function");
+      expect(typeof quoteService.getRandomQuote).toBe("function");
+      expect(typeof quoteService.searchQuotes).toBe("function");
+      expect(typeof quoteService.deleteQuote).toBe("function");
+      expect(typeof quoteService.likeQuote).toBe("function");
+      expect(typeof quoteService.dislikeQuote).toBe("function");
+      expect(typeof quoteService.listQuotes).toBe("function");
+      expect(typeof quoteService.getQuoteById).toBe("function");
+      expect(typeof quoteService.updateQuoteMessageId).toBe("function");
+      expect(typeof quoteService.getAllQuotes).toBe("function");
     });
   });
 
-  describe('method signatures', () => {
-    it('addQuote should accept correct parameters', () => {
+  describe("method signatures", () => {
+    it("addQuote should accept correct parameters", () => {
       expect(quoteService.addQuote.length).toBe(5);
     });
 
-    it('getRandomQuote should accept no parameters', () => {
+    it("getRandomQuote should accept no parameters", () => {
       expect(quoteService.getRandomQuote.length).toBe(0);
     });
 
-    it('searchQuotes should accept query parameter', () => {
+    it("searchQuotes should accept query parameter", () => {
       expect(quoteService.searchQuotes.length).toBe(1);
     });
 
-    it('deleteQuote should accept quote ID, user ID, and roles', () => {
+    it("deleteQuote should accept quote ID, user ID, and roles", () => {
       expect(quoteService.deleteQuote.length).toBe(3);
     });
 
-    it('likeQuote should accept quote ID', () => {
+    it("likeQuote should accept quote ID", () => {
       expect(quoteService.likeQuote.length).toBe(1);
     });
 
-    it('dislikeQuote should accept quote ID', () => {
+    it("dislikeQuote should accept quote ID", () => {
       expect(quoteService.dislikeQuote.length).toBe(1);
     });
 
-    it('listQuotes should have default parameters', () => {
+    it("listQuotes should have default parameters", () => {
       // TypeScript default parameters make .length return 0
       // Just verify the method exists
-      expect(typeof quoteService.listQuotes).toBe('function');
+      expect(typeof quoteService.listQuotes).toBe("function");
     });
 
-    it('getQuoteById should accept quote ID', () => {
+    it("getQuoteById should accept quote ID", () => {
       expect(quoteService.getQuoteById.length).toBe(1);
     });
 
-    it('updateQuoteMessageId should accept quote ID and message ID', () => {
+    it("updateQuoteMessageId should accept quote ID and message ID", () => {
       expect(quoteService.updateQuoteMessageId.length).toBe(2);
     });
 
-    it('getAllQuotes should accept no parameters', () => {
+    it("getAllQuotes should accept no parameters", () => {
       expect(quoteService.getAllQuotes.length).toBe(0);
     });
   });

--- a/__tests__/services/reaction-activity-tracker.test.ts
+++ b/__tests__/services/reaction-activity-tracker.test.ts
@@ -16,9 +16,8 @@ import { ReactionActivityTracking } from "../../src/models/reaction-activity-tra
 
 // The global mongoose mock does not provide updateOne; attach it to the
 // shared model object so the tracker can call it.
-(
-  ReactionActivityTracking as unknown as { updateOne: jest.Mock }
-).updateOne = jest.fn();
+(ReactionActivityTracking as unknown as { updateOne: jest.Mock }).updateOne =
+  jest.fn();
 
 function createTracker() {
   const mockClient = {} as Client;
@@ -80,9 +79,8 @@ describe("ReactionActivityTracker", () => {
       ReactionActivityTracking as unknown as { updateOne: jest.Mock }
     ).updateOne;
     updateOne.mockResolvedValue({ matchedCount: 1 });
-    (
-      ReactionActivityTracker as unknown as { instance: unknown }
-    ).instance = undefined;
+    (ReactionActivityTracker as unknown as { instance: unknown }).instance =
+      undefined;
   });
 
   describe("singleton pattern", () => {
@@ -177,9 +175,9 @@ describe("ReactionActivityTracker", () => {
       const fetched = makeReaction();
       const partialReaction = {
         partial: true,
-        fetch: jest.fn<() => Promise<MessageReaction>>().mockResolvedValue(
-          fetched,
-        ),
+        fetch: jest
+          .fn<() => Promise<MessageReaction>>()
+          .mockResolvedValue(fetched),
       } as unknown as MessageReaction;
       const fetchedUser = makeUser();
       const partialUser = {

--- a/__tests__/services/reaction-role-service-methods.test.ts
+++ b/__tests__/services/reaction-role-service-methods.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect } from "@jest/globals";
 
-describe('ReactionRoleService Methods', () => {
-  it('placeholder test', () => {
+describe("ReactionRoleService Methods", () => {
+  it("placeholder test", () => {
     expect(true).toBe(true);
   });
 });

--- a/__tests__/services/rewind-nudge-service.test.ts
+++ b/__tests__/services/rewind-nudge-service.test.ts
@@ -81,9 +81,8 @@ jest.unstable_mockModule("../../src/utils/logger.js", () => ({
   },
 }));
 
-const { RewindNudgeService } = await import(
-  "../../src/services/rewind-nudge-service.js"
-);
+const { RewindNudgeService } =
+  await import("../../src/services/rewind-nudge-service.js");
 
 type ServiceInstance = InstanceType<typeof RewindNudgeService>;
 
@@ -271,11 +270,10 @@ describe("RewindNudgeService", () => {
       expect(result!.sent).toBe(1);
       expect(mockUserSend).toHaveBeenCalledTimes(1);
       expect(mockNudgeStateFindOneAndUpdate).toHaveBeenCalledTimes(1);
-      const [filter, update] =
-        mockNudgeStateFindOneAndUpdate.mock.calls[0] as [
-          Record<string, unknown>,
-          { $set: Record<string, unknown> },
-        ];
+      const [filter, update] = mockNudgeStateFindOneAndUpdate.mock.calls[0] as [
+        Record<string, unknown>,
+        { $set: Record<string, unknown> },
+      ];
       const year = new Date().getUTCFullYear();
       expect(filter).toEqual({ userId: "u1", guildId: "guild-1", year });
       expect(update.$set).toMatchObject({
@@ -352,7 +350,12 @@ describe("RewindNudgeService", () => {
 
       const year = new Date().getUTCFullYear();
       expect(mockSnapshotYear).toHaveBeenCalledTimes(2);
-      expect(mockSnapshotYear).toHaveBeenCalledWith("u1", "guild-1", year, null);
+      expect(mockSnapshotYear).toHaveBeenCalledWith(
+        "u1",
+        "guild-1",
+        year,
+        null,
+      );
       expect(result!.snapshotsCreated).toBe(1);
       expect(result!.snapshotsExisting).toBe(1);
     });

--- a/__tests__/services/rewind-service.test.ts
+++ b/__tests__/services/rewind-service.test.ts
@@ -639,7 +639,9 @@ describe("RewindService.getSummary", () => {
                   members: {
                     cache: {
                       get: (uid: string) =>
-                        uid === "bob" ? { displayName: "Bob the Builder" } : undefined,
+                        uid === "bob"
+                          ? { displayName: "Bob the Builder" }
+                          : undefined,
                     },
                   },
                 }

--- a/__tests__/services/scheduled-announcement-initialization.test.ts
+++ b/__tests__/services/scheduled-announcement-initialization.test.ts
@@ -1,16 +1,16 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import type { Client } from 'discord.js';
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import type { Client } from "discord.js";
 
 // Mock all dependencies before importing
-jest.mock('../../src/services/config-service.js');
-jest.mock('../../src/utils/logger.js');
-jest.mock('../../src/models/scheduled-announcement.js', () => ({
+jest.mock("../../src/services/config-service.js");
+jest.mock("../../src/utils/logger.js");
+jest.mock("../../src/models/scheduled-announcement.js", () => ({
   ScheduledAnnouncement: {
     find: jest.fn().mockResolvedValue([]),
   },
 }));
 
-describe('ScheduledAnnouncementService', () => {
+describe("ScheduledAnnouncementService", () => {
   let mockClient: Partial<Client>;
 
   beforeEach(() => {
@@ -24,17 +24,23 @@ describe('ScheduledAnnouncementService', () => {
     } as Client;
   });
 
-  it('should have getInstance method', async () => {
-    const { ScheduledAnnouncementService } = await import('../../src/services/scheduled-announcement-service.js');
-    
-    expect(typeof ScheduledAnnouncementService.getInstance).toBe('function');
+  it("should have getInstance method", async () => {
+    const { ScheduledAnnouncementService } =
+      await import("../../src/services/scheduled-announcement-service.js");
+
+    expect(typeof ScheduledAnnouncementService.getInstance).toBe("function");
   });
 
-  it('should create singleton instance', async () => {
-    const { ScheduledAnnouncementService } = await import('../../src/services/scheduled-announcement-service.js');
-    
-    const instance1 = ScheduledAnnouncementService.getInstance(mockClient as Client);
-    const instance2 = ScheduledAnnouncementService.getInstance(mockClient as Client);
+  it("should create singleton instance", async () => {
+    const { ScheduledAnnouncementService } =
+      await import("../../src/services/scheduled-announcement-service.js");
+
+    const instance1 = ScheduledAnnouncementService.getInstance(
+      mockClient as Client,
+    );
+    const instance2 = ScheduledAnnouncementService.getInstance(
+      mockClient as Client,
+    );
 
     expect(instance1).toBe(instance2);
   });

--- a/__tests__/services/scheduled-announcement-service.test.ts
+++ b/__tests__/services/scheduled-announcement-service.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect } from "@jest/globals";
 
-describe('ScheduledAnnouncementService', () => {
-  it('placeholder test', () => {
+describe("ScheduledAnnouncementService", () => {
+  it("placeholder test", () => {
     expect(true).toBe(true);
   });
 });

--- a/__tests__/services/startup-migrator-methods.test.ts
+++ b/__tests__/services/startup-migrator-methods.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect } from "@jest/globals";
 
-describe('StartupMigrator Methods', () => {
-  it('placeholder test', () => {
+describe("StartupMigrator Methods", () => {
+  it("placeholder test", () => {
     expect(true).toBe(true);
   });
 });

--- a/__tests__/services/startup-migrator.test.ts
+++ b/__tests__/services/startup-migrator.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect } from "@jest/globals";
 
-describe('StartupMigrator', () => {
-  it('placeholder test', () => {
+describe("StartupMigrator", () => {
+  it("placeholder test", () => {
     expect(true).toBe(true);
   });
 });

--- a/__tests__/services/user-notification-prefs-service.test.ts
+++ b/__tests__/services/user-notification-prefs-service.test.ts
@@ -12,233 +12,303 @@
  *    read path
  */
 
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 
-jest.mock('../../src/utils/logger.js', () => ({
-  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+jest.mock("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
 }));
 
 // Mock the model so we can control find/upsert outcomes per test.
-jest.mock('../../src/models/user-notification-prefs.js', () => ({
+jest.mock("../../src/models/user-notification-prefs.js", () => ({
   UserNotificationPrefs: {
     findOne: jest.fn(),
     findOneAndUpdate: jest.fn(),
   },
 }));
 
-import { UserNotificationPrefs } from '../../src/models/user-notification-prefs.js';
+import { UserNotificationPrefs } from "../../src/models/user-notification-prefs.js";
 import {
   DEFAULT_PREFS,
   NOTIFICATION_PREF_KEYS,
   UserNotificationPrefsService,
-} from '../../src/services/user-notification-prefs-service.js';
+} from "../../src/services/user-notification-prefs-service.js";
 
 const findOne = UserNotificationPrefs.findOne as jest.Mock;
 const findOneAndUpdate = UserNotificationPrefs.findOneAndUpdate as jest.Mock;
 
-describe('UserNotificationPrefsService', () => {
+describe("UserNotificationPrefsService", () => {
   beforeEach(() => {
     findOne.mockReset();
     findOneAndUpdate.mockReset();
-    (UserNotificationPrefsService as unknown as { instance: unknown }).instance = null;
+    (
+      UserNotificationPrefsService as unknown as { instance: unknown }
+    ).instance = null;
   });
 
-  describe('getPrefs', () => {
-    it('returns all defaults when no row exists', async () => {
+  describe("getPrefs", () => {
+    it("returns all defaults when no row exists", async () => {
       findOne.mockResolvedValueOnce(null);
-      const prefs = await UserNotificationPrefsService.getInstance().getPrefs('u1', 'g1');
+      const prefs = await UserNotificationPrefsService.getInstance().getPrefs(
+        "u1",
+        "g1",
+      );
       expect(prefs).toEqual(DEFAULT_PREFS);
-      expect(findOne).toHaveBeenCalledWith({ userId: 'u1', guildId: 'g1' });
+      expect(findOne).toHaveBeenCalledWith({ userId: "u1", guildId: "g1" });
     });
 
-    it('returns the stored row when present', async () => {
+    it("returns the stored row when present", async () => {
       findOne.mockResolvedValueOnce({
-        userId: 'u1',
-        guildId: 'g1',
+        userId: "u1",
+        guildId: "g1",
         achievements: false,
         digest: true,
         rewind: false,
         updatedAt: new Date(),
       });
-      const prefs = await UserNotificationPrefsService.getInstance().getPrefs('u1', 'g1');
-      expect(prefs).toEqual({ achievements: false, digest: true, rewind: false });
+      const prefs = await UserNotificationPrefsService.getInstance().getPrefs(
+        "u1",
+        "g1",
+      );
+      expect(prefs).toEqual({
+        achievements: false,
+        digest: true,
+        rewind: false,
+      });
     });
 
-    it('collapses to defaults on DB error so a transient outage cannot silence DMs', async () => {
-      findOne.mockRejectedValueOnce(new Error('mongo down'));
-      const prefs = await UserNotificationPrefsService.getInstance().getPrefs('u1', 'g1');
+    it("collapses to defaults on DB error so a transient outage cannot silence DMs", async () => {
+      findOne.mockRejectedValueOnce(new Error("mongo down"));
+      const prefs = await UserNotificationPrefsService.getInstance().getPrefs(
+        "u1",
+        "g1",
+      );
       expect(prefs).toEqual(DEFAULT_PREFS);
     });
 
-    it('returns defaults for empty userId/guildId without touching the DB', async () => {
+    it("returns defaults for empty userId/guildId without touching the DB", async () => {
       const svc = UserNotificationPrefsService.getInstance();
-      expect(await svc.getPrefs('', 'g1')).toEqual(DEFAULT_PREFS);
-      expect(await svc.getPrefs('u1', '')).toEqual(DEFAULT_PREFS);
+      expect(await svc.getPrefs("", "g1")).toEqual(DEFAULT_PREFS);
+      expect(await svc.getPrefs("u1", "")).toEqual(DEFAULT_PREFS);
       expect(findOne).not.toHaveBeenCalled();
     });
   });
 
-  describe('setPrefs', () => {
-    it('writes only the keys present in the patch and returns the merged row', async () => {
+  describe("setPrefs", () => {
+    it("writes only the keys present in the patch and returns the merged row", async () => {
       findOneAndUpdate.mockResolvedValueOnce({
-        userId: 'u1',
-        guildId: 'g1',
+        userId: "u1",
+        guildId: "g1",
         achievements: false,
         digest: true,
         rewind: true,
         updatedAt: new Date(),
       });
       const result = await UserNotificationPrefsService.getInstance().setPrefs(
-        'u1',
-        'g1',
+        "u1",
+        "g1",
         { achievements: false },
       );
-      expect(result).toEqual({ achievements: false, digest: true, rewind: true });
+      expect(result).toEqual({
+        achievements: false,
+        digest: true,
+        rewind: true,
+      });
       const [filter, update, opts] = findOneAndUpdate.mock.calls[0] as [
         Record<string, unknown>,
         { $set: Record<string, unknown> },
         Record<string, unknown>,
       ];
-      expect(filter).toEqual({ userId: 'u1', guildId: 'g1' });
-      expect(update.$set).toHaveProperty('achievements', false);
-      expect(update.$set).not.toHaveProperty('digest');
-      expect(update.$set).not.toHaveProperty('rewind');
+      expect(filter).toEqual({ userId: "u1", guildId: "g1" });
+      expect(update.$set).toHaveProperty("achievements", false);
+      expect(update.$set).not.toHaveProperty("digest");
+      expect(update.$set).not.toHaveProperty("rewind");
       expect(opts).toMatchObject({ upsert: true, new: true });
     });
 
-    it('drops non-boolean values silently rather than coercing', async () => {
+    it("drops non-boolean values silently rather than coercing", async () => {
       findOneAndUpdate.mockResolvedValueOnce({
-        userId: 'u1',
-        guildId: 'g1',
+        userId: "u1",
+        guildId: "g1",
         achievements: true,
         digest: true,
         rewind: true,
         updatedAt: new Date(),
       });
-      await UserNotificationPrefsService.getInstance().setPrefs('u1', 'g1', {
+      await UserNotificationPrefsService.getInstance().setPrefs("u1", "g1", {
         // @ts-expect-error - test bad input on purpose
-        achievements: 'true',
+        achievements: "true",
         // @ts-expect-error - test bad input on purpose
         digest: 1,
         rewind: true,
       });
-      const update = findOneAndUpdate.mock.calls[0][1] as { $set: Record<string, unknown> };
-      expect(update.$set).not.toHaveProperty('achievements');
-      expect(update.$set).not.toHaveProperty('digest');
-      expect(update.$set).toHaveProperty('rewind', true);
+      const update = findOneAndUpdate.mock.calls[0][1] as {
+        $set: Record<string, unknown>;
+      };
+      expect(update.$set).not.toHaveProperty("achievements");
+      expect(update.$set).not.toHaveProperty("digest");
+      expect(update.$set).toHaveProperty("rewind", true);
     });
 
-    it('throws on empty userId/guildId — write path must not silently no-op', async () => {
+    it("throws on empty userId/guildId — write path must not silently no-op", async () => {
       const svc = UserNotificationPrefsService.getInstance();
-      await expect(svc.setPrefs('', 'g1', { achievements: false })).rejects.toThrow();
-      await expect(svc.setPrefs('u1', '', { achievements: false })).rejects.toThrow();
+      await expect(
+        svc.setPrefs("", "g1", { achievements: false }),
+      ).rejects.toThrow();
+      await expect(
+        svc.setPrefs("u1", "", { achievements: false }),
+      ).rejects.toThrow();
       expect(findOneAndUpdate).not.toHaveBeenCalled();
     });
   });
 
-  describe('getPrefsWithTimezone', () => {
-    it('returns prefs and timezone from a single read', async () => {
+  describe("getPrefsWithTimezone", () => {
+    it("returns prefs and timezone from a single read", async () => {
       findOne.mockResolvedValueOnce({
         achievements: false,
         digest: true,
         rewind: true,
-        timezone: 'Europe/Berlin',
+        timezone: "Europe/Berlin",
       });
-      const out = await UserNotificationPrefsService.getInstance().getPrefsWithTimezone('u1', 'g1');
+      const out =
+        await UserNotificationPrefsService.getInstance().getPrefsWithTimezone(
+          "u1",
+          "g1",
+        );
       expect(out).toEqual({
         prefs: { achievements: false, digest: true, rewind: true },
-        timezone: 'Europe/Berlin',
+        timezone: "Europe/Berlin",
       });
       expect(findOne).toHaveBeenCalledTimes(1);
     });
 
-    it('returns defaults + null timezone when no row exists', async () => {
+    it("returns defaults + null timezone when no row exists", async () => {
       findOne.mockResolvedValueOnce(null);
-      const out = await UserNotificationPrefsService.getInstance().getPrefsWithTimezone('u1', 'g1');
+      const out =
+        await UserNotificationPrefsService.getInstance().getPrefsWithTimezone(
+          "u1",
+          "g1",
+        );
       expect(out).toEqual({ prefs: DEFAULT_PREFS, timezone: null });
     });
 
-    it('collapses to defaults + null timezone on DB error', async () => {
-      findOne.mockRejectedValueOnce(new Error('mongo down'));
-      const out = await UserNotificationPrefsService.getInstance().getPrefsWithTimezone('u1', 'g1');
+    it("collapses to defaults + null timezone on DB error", async () => {
+      findOne.mockRejectedValueOnce(new Error("mongo down"));
+      const out =
+        await UserNotificationPrefsService.getInstance().getPrefsWithTimezone(
+          "u1",
+          "g1",
+        );
       expect(out).toEqual({ prefs: DEFAULT_PREFS, timezone: null });
     });
   });
 
-  describe('getTimezone', () => {
-    it('returns the stored zone when present', async () => {
-      findOne.mockResolvedValueOnce({ timezone: 'Europe/Berlin' });
-      const tz = await UserNotificationPrefsService.getInstance().getTimezone('u1', 'g1');
-      expect(tz).toBe('Europe/Berlin');
+  describe("getTimezone", () => {
+    it("returns the stored zone when present", async () => {
+      findOne.mockResolvedValueOnce({ timezone: "Europe/Berlin" });
+      const tz = await UserNotificationPrefsService.getInstance().getTimezone(
+        "u1",
+        "g1",
+      );
+      expect(tz).toBe("Europe/Berlin");
     });
 
-    it('returns null when unset or row missing', async () => {
+    it("returns null when unset or row missing", async () => {
       findOne.mockResolvedValueOnce(null);
-      expect(await UserNotificationPrefsService.getInstance().getTimezone('u1', 'g1')).toBeNull();
-      findOne.mockResolvedValueOnce({ timezone: '' });
-      expect(await UserNotificationPrefsService.getInstance().getTimezone('u1', 'g1')).toBeNull();
+      expect(
+        await UserNotificationPrefsService.getInstance().getTimezone(
+          "u1",
+          "g1",
+        ),
+      ).toBeNull();
+      findOne.mockResolvedValueOnce({ timezone: "" });
+      expect(
+        await UserNotificationPrefsService.getInstance().getTimezone(
+          "u1",
+          "g1",
+        ),
+      ).toBeNull();
     });
 
-    it('returns null on DB error', async () => {
-      findOne.mockRejectedValueOnce(new Error('mongo down'));
-      expect(await UserNotificationPrefsService.getInstance().getTimezone('u1', 'g1')).toBeNull();
+    it("returns null on DB error", async () => {
+      findOne.mockRejectedValueOnce(new Error("mongo down"));
+      expect(
+        await UserNotificationPrefsService.getInstance().getTimezone(
+          "u1",
+          "g1",
+        ),
+      ).toBeNull();
     });
 
-    it('returns null for empty userId/guildId without touching the DB', async () => {
+    it("returns null for empty userId/guildId without touching the DB", async () => {
       const svc = UserNotificationPrefsService.getInstance();
-      expect(await svc.getTimezone('', 'g1')).toBeNull();
-      expect(await svc.getTimezone('u1', '')).toBeNull();
+      expect(await svc.getTimezone("", "g1")).toBeNull();
+      expect(await svc.getTimezone("u1", "")).toBeNull();
       expect(findOne).not.toHaveBeenCalled();
     });
   });
 
-  describe('setTimezone', () => {
-    it('validates and stores a recognized zone', async () => {
-      findOneAndUpdate.mockResolvedValueOnce({ timezone: 'America/New_York' });
-      const result = await UserNotificationPrefsService.getInstance().setTimezone(
-        'u1',
-        'g1',
-        'America/New_York',
-      );
-      expect(result).toBe('America/New_York');
+  describe("setTimezone", () => {
+    it("validates and stores a recognized zone", async () => {
+      findOneAndUpdate.mockResolvedValueOnce({ timezone: "America/New_York" });
+      const result =
+        await UserNotificationPrefsService.getInstance().setTimezone(
+          "u1",
+          "g1",
+          "America/New_York",
+        );
+      expect(result).toBe("America/New_York");
       const [filter, update] = findOneAndUpdate.mock.calls[0] as [
         Record<string, unknown>,
         { $set: Record<string, unknown> },
       ];
-      expect(filter).toEqual({ userId: 'u1', guildId: 'g1' });
-      expect(update.$set).toHaveProperty('timezone', 'America/New_York');
+      expect(filter).toEqual({ userId: "u1", guildId: "g1" });
+      expect(update.$set).toHaveProperty("timezone", "America/New_York");
     });
 
-    it('rejects an invalid zone before hitting the DB', async () => {
+    it("rejects an invalid zone before hitting the DB", async () => {
       await expect(
-        UserNotificationPrefsService.getInstance().setTimezone('u1', 'g1', 'Mars/Phobos'),
+        UserNotificationPrefsService.getInstance().setTimezone(
+          "u1",
+          "g1",
+          "Mars/Phobos",
+        ),
       ).rejects.toThrow(/not a recognized IANA timezone/);
       expect(findOneAndUpdate).not.toHaveBeenCalled();
     });
 
-    it('clears the preference with $unset when passed null', async () => {
+    it("clears the preference with $unset when passed null", async () => {
       findOneAndUpdate.mockResolvedValueOnce({});
-      const result = await UserNotificationPrefsService.getInstance().setTimezone(
-        'u1',
-        'g1',
-        null,
-      );
+      const result =
+        await UserNotificationPrefsService.getInstance().setTimezone(
+          "u1",
+          "g1",
+          null,
+        );
       expect(result).toBeNull();
       const update = findOneAndUpdate.mock.calls[0][1] as {
         $unset?: Record<string, unknown>;
       };
-      expect(update.$unset).toHaveProperty('timezone');
+      expect(update.$unset).toHaveProperty("timezone");
     });
 
-    it('throws on empty userId/guildId', async () => {
+    it("throws on empty userId/guildId", async () => {
       const svc = UserNotificationPrefsService.getInstance();
-      await expect(svc.setTimezone('', 'g1', 'UTC')).rejects.toThrow();
-      await expect(svc.setTimezone('u1', '', 'UTC')).rejects.toThrow();
+      await expect(svc.setTimezone("", "g1", "UTC")).rejects.toThrow();
+      await expect(svc.setTimezone("u1", "", "UTC")).rejects.toThrow();
       expect(findOneAndUpdate).not.toHaveBeenCalled();
     });
   });
 
-  it('exposes a stable list of known pref keys', () => {
-    expect(NOTIFICATION_PREF_KEYS).toEqual(['achievements', 'digest', 'rewind']);
+  it("exposes a stable list of known pref keys", () => {
+    expect(NOTIFICATION_PREF_KEYS).toEqual([
+      "achievements",
+      "digest",
+      "rewind",
+    ]);
   });
 });

--- a/__tests__/services/voice-channel-announcer-methods.test.ts
+++ b/__tests__/services/voice-channel-announcer-methods.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect } from "@jest/globals";
 
-describe('VoiceChannelAnnouncer Methods', () => {
-  it('placeholder test', () => {
+describe("VoiceChannelAnnouncer Methods", () => {
+  it("placeholder test", () => {
     expect(true).toBe(true);
   });
 });

--- a/__tests__/services/voice-channel-announcer.test.ts
+++ b/__tests__/services/voice-channel-announcer.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
-import { VoiceChannelAnnouncer } from '../../src/services/voice-channel-announcer.js';
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import { VoiceChannelAnnouncer } from "../../src/services/voice-channel-announcer.js";
 
 // Mock dependencies
-jest.mock('../../src/services/config-service.js');
-jest.mock('../../src/services/voice-channel-tracker.js');
-jest.mock('../../src/utils/logger.js');
+jest.mock("../../src/services/config-service.js");
+jest.mock("../../src/services/voice-channel-tracker.js");
+jest.mock("../../src/utils/logger.js");
 
-describe('VoiceChannelAnnouncer', () => {
+describe("VoiceChannelAnnouncer", () => {
   let service: VoiceChannelAnnouncer;
   let mockClient: any;
 
@@ -14,39 +14,39 @@ describe('VoiceChannelAnnouncer', () => {
     jest.clearAllMocks();
     VoiceChannelAnnouncer.reset();
     mockClient = {
-      user: { id: '123' },
+      user: { id: "123" },
       channels: { fetch: jest.fn() },
     };
     service = VoiceChannelAnnouncer.getInstance(mockClient);
   });
 
-  describe('singleton pattern', () => {
-    it('should create a singleton instance', () => {
+  describe("singleton pattern", () => {
+    it("should create a singleton instance", () => {
       const instance1 = VoiceChannelAnnouncer.getInstance(mockClient);
       const instance2 = VoiceChannelAnnouncer.getInstance(mockClient);
-      
+
       expect(instance1).toBe(instance2);
     });
   });
 
-  describe('initialization', () => {
-    it('should create an instance with a client', () => {
+  describe("initialization", () => {
+    it("should create an instance with a client", () => {
       expect(service).toBeDefined();
       expect(service).toBeInstanceOf(VoiceChannelAnnouncer);
     });
   });
 
-  describe('public methods', () => {
-    it('should have start method', () => {
-      expect(typeof service.start).toBe('function');
+  describe("public methods", () => {
+    it("should have start method", () => {
+      expect(typeof service.start).toBe("function");
     });
 
-    it('should have makeAnnouncement method', () => {
-      expect(typeof service.makeAnnouncement).toBe('function');
+    it("should have makeAnnouncement method", () => {
+      expect(typeof service.makeAnnouncement).toBe("function");
     });
 
-    it('should have destroy method', () => {
-      expect(typeof service.destroy).toBe('function');
+    it("should have destroy method", () => {
+      expect(typeof service.destroy).toBe("function");
     });
   });
 });

--- a/__tests__/services/voice-channel-manager-category-resolver.test.ts
+++ b/__tests__/services/voice-channel-manager-category-resolver.test.ts
@@ -18,7 +18,9 @@ import { ConfigService } from "../../src/services/config-service.js";
  * cache.
  */
 describe("resolveManagedCategory", () => {
-  let getStringSpy: jest.SpiedFunction<typeof ConfigService.prototype.getString>;
+  let getStringSpy: jest.SpiedFunction<
+    typeof ConfigService.prototype.getString
+  >;
 
   beforeEach(() => {
     getStringSpy = jest.spyOn(ConfigService.prototype, "getString");
@@ -28,7 +30,9 @@ describe("resolveManagedCategory", () => {
     getStringSpy.mockRestore();
   });
 
-  function mockGuild(channels: Record<string, { type: ChannelType; name: string }>) {
+  function mockGuild(
+    channels: Record<string, { type: ChannelType; name: string }>,
+  ) {
     return {
       channels: {
         cache: {

--- a/__tests__/services/voice-channel-manager-control-panel.test.ts
+++ b/__tests__/services/voice-channel-manager-control-panel.test.ts
@@ -1,16 +1,33 @@
-import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
-import { ChannelType, PermissionFlagsBits, type Client, type VoiceChannel, type GuildMember, type Collection, type Message, type Guild, type Role } from 'discord.js';
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import {
+  ChannelType,
+  PermissionFlagsBits,
+  type Client,
+  type VoiceChannel,
+  type GuildMember,
+  type Collection,
+  type Message,
+  type Guild,
+  type Role,
+} from "discord.js";
 
 // Mock dependencies before importing
-jest.mock('../../src/utils/logger.js');
-jest.mock('../../src/services/voice-channel-tracker.js');
-jest.mock('../../src/services/config-service.js');
+jest.mock("../../src/utils/logger.js");
+jest.mock("../../src/services/voice-channel-tracker.js");
+jest.mock("../../src/services/config-service.js");
 
 // Import after mocks
-import { VoiceChannelManager } from '../../src/services/voice-channel-manager.js';
-import { ConfigService } from '../../src/services/config-service.js';
+import { VoiceChannelManager } from "../../src/services/voice-channel-manager.js";
+import { ConfigService } from "../../src/services/config-service.js";
 
-describe('VoiceChannelManager - Control Panel Update', () => {
+describe("VoiceChannelManager - Control Panel Update", () => {
   let manager: VoiceChannelManager;
   let mockClient: Partial<Client>;
   let mockChannel: Partial<VoiceChannel>;
@@ -36,8 +53,8 @@ describe('VoiceChannelManager - Control Panel Update', () => {
 
     // Mock everyone role
     mockEveryoneRole = {
-      id: 'everyone-role-id',
-      name: '@everyone',
+      id: "everyone-role-id",
+      name: "@everyone",
     } as any;
 
     // Mock guild
@@ -49,13 +66,13 @@ describe('VoiceChannelManager - Control Panel Update', () => {
 
     // Mock control panel message
     mockControlPanelMessage = {
-      id: 'control-panel-message-id',
+      id: "control-panel-message-id",
       author: {
-        id: 'bot-user-id',
+        id: "bot-user-id",
       } as any,
       embeds: [
         {
-          title: '🎮 Voice Channel Controls',
+          title: "🎮 Voice Channel Controls",
         } as any,
       ],
       edit: jest.fn().mockResolvedValue(undefined),
@@ -63,10 +80,12 @@ describe('VoiceChannelManager - Control Panel Update', () => {
 
     // Mock messages fetch
     const messagesCollection = new Map([
-      ['control-panel-message-id', mockControlPanelMessage as Message],
+      ["control-panel-message-id", mockControlPanelMessage as Message],
     ]);
     // Add find method to the map to simulate Collection behavior
-    (messagesCollection as any).find = function(predicate: (msg: Message) => boolean) {
+    (messagesCollection as any).find = function (
+      predicate: (msg: Message) => boolean,
+    ) {
       for (const msg of this.values()) {
         if (predicate(msg)) {
           return msg;
@@ -81,28 +100,30 @@ describe('VoiceChannelManager - Control Panel Update', () => {
 
     // Mock new owner
     mockNewOwner = {
-      id: 'new-owner-id',
-      displayName: 'NewOwner',
+      id: "new-owner-id",
+      displayName: "NewOwner",
     } as any;
 
     // Mock old owner
     mockOldOwner = {
-      id: 'old-owner-id',
-      displayName: 'OldOwner',
+      id: "old-owner-id",
+      displayName: "OldOwner",
     } as any;
 
     // Mock members collection
     mockMembers = {
       get: jest.fn((id: string) => {
-        if (id === 'new-owner-id') {
+        if (id === "new-owner-id") {
           return mockNewOwner as GuildMember;
         }
-        if (id === 'old-owner-id') {
+        if (id === "old-owner-id") {
           return mockOldOwner as GuildMember;
         }
         return undefined;
       }),
-      has: jest.fn((id: string) => id === 'new-owner-id' || id === 'old-owner-id'),
+      has: jest.fn(
+        (id: string) => id === "new-owner-id" || id === "old-owner-id",
+      ),
     } as any;
 
     // Mock permission overwrites
@@ -113,8 +134,8 @@ describe('VoiceChannelManager - Control Panel Update', () => {
 
     // Mock channel
     mockChannel = {
-      id: 'channel-id',
-      name: 'Test Channel',
+      id: "channel-id",
+      name: "Test Channel",
       type: ChannelType.GuildVoice,
       permissionOverwrites: mockPermissionOverwrites,
       members: mockMembers as Collection<string, GuildMember>,
@@ -127,7 +148,7 @@ describe('VoiceChannelManager - Control Panel Update', () => {
     // Mock client
     mockClient = {
       user: {
-        id: 'bot-user-id',
+        id: "bot-user-id",
       } as any,
       channels: {
         cache: {
@@ -138,7 +159,8 @@ describe('VoiceChannelManager - Control Panel Update', () => {
     } as any;
 
     // Mock ConfigService
-    const mockConfigService = ConfigService.getInstance() as jest.Mocked<ConfigService>;
+    const mockConfigService =
+      ConfigService.getInstance() as jest.Mocked<ConfigService>;
     mockConfigService.getBoolean = jest.fn().mockResolvedValue(true);
     mockConfigService.getNumber = jest.fn().mockResolvedValue(30);
 
@@ -146,7 +168,7 @@ describe('VoiceChannelManager - Control Panel Update', () => {
     manager = VoiceChannelManager.getInstance(mockClient as Client);
 
     // Set up the channel ownership
-    (manager as any).userChannels.set('old-owner-id', mockChannel);
+    (manager as any).userChannels.set("old-owner-id", mockChannel);
   });
 
   afterEach(() => {
@@ -154,12 +176,12 @@ describe('VoiceChannelManager - Control Panel Update', () => {
     (VoiceChannelManager as any).instance = undefined;
   });
 
-  describe('Control Panel Update on Ownership Transfer', () => {
-    it('should update control panel message when transferring ownership', async () => {
+  describe("Control Panel Update on Ownership Transfer", () => {
+    it("should update control panel message when transferring ownership", async () => {
       // Manually trigger ownership update (simulating automatic transfer)
       await (manager as any).updateChannelOwnership(
         mockChannel as VoiceChannel,
-        mockNewOwner as GuildMember
+        mockNewOwner as GuildMember,
       );
 
       // Verify messages were fetched
@@ -167,90 +189,97 @@ describe('VoiceChannelManager - Control Panel Update', () => {
 
       // Verify control panel message was updated
       expect(mockControlPanelMessage.edit).toHaveBeenCalled();
-      
+
       // Verify the edit call had the new owner ID in the content and buttons
-      const editCall = (mockControlPanelMessage.edit as jest.Mock).mock.calls[0][0];
-      expect(editCall.content).toBe('<@new-owner-id>');
-      
+      const editCall = (mockControlPanelMessage.edit as jest.Mock).mock
+        .calls[0][0];
+      expect(editCall.content).toBe("<@new-owner-id>");
+
       // Verify buttons have new owner ID
       const buttons = editCall.components[0].components;
-      expect(buttons[0].data.custom_id).toContain('new-owner-id');
-      expect(buttons[1].data.custom_id).toContain('new-owner-id');
-      expect(buttons[2].data.custom_id).toContain('new-owner-id');
-      expect(buttons[3].data.custom_id).toContain('new-owner-id');
+      expect(buttons[0].data.custom_id).toContain("new-owner-id");
+      expect(buttons[1].data.custom_id).toContain("new-owner-id");
+      expect(buttons[2].data.custom_id).toContain("new-owner-id");
+      expect(buttons[3].data.custom_id).toContain("new-owner-id");
     });
 
-    it('should update permissions when transferring ownership', async () => {
+    it("should update permissions when transferring ownership", async () => {
       await (manager as any).updateChannelOwnership(
         mockChannel as VoiceChannel,
-        mockNewOwner as GuildMember
+        mockNewOwner as GuildMember,
       );
 
       // Verify new owner got ManageChannels permission
       expect(mockPermissionOverwrites.create).toHaveBeenCalledWith(
-        'new-owner-id',
+        "new-owner-id",
         expect.objectContaining({
           ManageChannels: true,
-        })
+        }),
       );
 
       // Verify old owner lost ManageChannels permission
       expect(mockPermissionOverwrites.create).toHaveBeenCalledWith(
-        'old-owner-id',
+        "old-owner-id",
         expect.objectContaining({
           ManageChannels: false,
-        })
+        }),
       );
     });
 
-    it('should send notification message after ownership transfer', async () => {
+    it("should send notification message after ownership transfer", async () => {
       await (manager as any).updateChannelOwnership(
         mockChannel as VoiceChannel,
-        mockNewOwner as GuildMember
+        mockNewOwner as GuildMember,
       );
 
       // Verify notification was sent
       expect(mockChannel.send).toHaveBeenCalledWith(
-        expect.stringContaining('NewOwner')
+        expect.stringContaining("NewOwner"),
       );
     });
 
-    it('should reflect privacy state in updated control panel', async () => {
+    it("should reflect privacy state in updated control panel", async () => {
       // Make channel private
       const everyonePermissions = {
         deny: {
           has: jest.fn((perm: bigint) => perm === PermissionFlagsBits.Connect),
         },
       };
-      mockPermissionOverwrites.cache.set('everyone-role-id', everyonePermissions);
+      mockPermissionOverwrites.cache.set(
+        "everyone-role-id",
+        everyonePermissions,
+      );
 
       await (manager as any).updateChannelOwnership(
         mockChannel as VoiceChannel,
-        mockNewOwner as GuildMember
+        mockNewOwner as GuildMember,
       );
 
       // Verify control panel was updated
       expect(mockControlPanelMessage.edit).toHaveBeenCalled();
-      
-      const editCall = (mockControlPanelMessage.edit as jest.Mock).mock.calls[0][0];
-      
+
+      const editCall = (mockControlPanelMessage.edit as jest.Mock).mock
+        .calls[0][0];
+
       // Verify privacy is reflected in description
-      expect(editCall.embeds[0].data.description).toContain('🔒 Invite-Only');
-      
+      expect(editCall.embeds[0].data.description).toContain("🔒 Invite-Only");
+
       // Verify privacy button label
       const privacyButton = editCall.components[0].components[1];
-      expect(privacyButton.data.label).toBe('Make Public');
+      expect(privacyButton.data.label).toBe("Make Public");
     });
 
-    it('should handle missing control panel gracefully', async () => {
+    it("should handle missing control panel gracefully", async () => {
       // Mock no control panel message found
       mockMessages.fetch = jest.fn().mockResolvedValue(new Map());
 
       // This should not throw
-      await expect((manager as any).updateChannelOwnership(
-        mockChannel as VoiceChannel,
-        mockNewOwner as GuildMember
-      )).resolves.not.toThrow();
+      await expect(
+        (manager as any).updateChannelOwnership(
+          mockChannel as VoiceChannel,
+          mockNewOwner as GuildMember,
+        ),
+      ).resolves.not.toThrow();
     });
   });
 });

--- a/__tests__/services/voice-channel-manager-create-failure.test.ts
+++ b/__tests__/services/voice-channel-manager-create-failure.test.ts
@@ -58,7 +58,8 @@ describe("VoiceChannelManager.createUserChannel - setChannel failure", () => {
           return Promise.resolve("category-id");
         if (key === "voicechannels.channel.suffix")
           return Promise.resolve("'s Room");
-        if (key === "voicechannels.channel.prefix") return Promise.resolve("🎮");
+        if (key === "voicechannels.channel.prefix")
+          return Promise.resolve("🎮");
         return Promise.resolve(defaultValue ?? "");
       });
 
@@ -134,9 +135,9 @@ describe("VoiceChannelManager.createUserChannel - setChannel failure", () => {
       type: ChannelType.GuildVoice,
       delete: jest.fn().mockResolvedValue(undefined),
     } as any;
-    (
-      mockGuild.channels!.create as jest.Mock
-    ).mockResolvedValueOnce(secondChannel);
+    (mockGuild.channels!.create as jest.Mock).mockResolvedValueOnce(
+      secondChannel,
+    );
 
     await (manager as any).createUserChannel(mockMember as GuildMember);
 

--- a/__tests__/services/voice-channel-manager-initialization.test.ts
+++ b/__tests__/services/voice-channel-manager-initialization.test.ts
@@ -1,13 +1,20 @@
-import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
-import type { Client } from 'discord.js';
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import type { Client } from "discord.js";
 
 // Mock all dependencies
-jest.mock('../../src/services/config-service.js');
-jest.mock('../../src/services/voice-channel-tracker.js');
-jest.mock('../../src/utils/logger.js');
-jest.mock('../../src/models/user-voice-preferences.js');
+jest.mock("../../src/services/config-service.js");
+jest.mock("../../src/services/voice-channel-tracker.js");
+jest.mock("../../src/utils/logger.js");
+jest.mock("../../src/models/user-voice-preferences.js");
 
-describe('VoiceChannelManager Initialization', () => {
+describe("VoiceChannelManager Initialization", () => {
   let mockClient: Partial<Client>;
 
   beforeEach(() => {
@@ -28,15 +35,17 @@ describe('VoiceChannelManager Initialization', () => {
     jest.useRealTimers();
   });
 
-  it('should have getInstance method', async () => {
-    const { VoiceChannelManager } = await import('../../src/services/voice-channel-manager.js');
-    
-    expect(typeof VoiceChannelManager.getInstance).toBe('function');
+  it("should have getInstance method", async () => {
+    const { VoiceChannelManager } =
+      await import("../../src/services/voice-channel-manager.js");
+
+    expect(typeof VoiceChannelManager.getInstance).toBe("function");
   });
 
-  it('should return singleton instance', async () => {
-    const { VoiceChannelManager } = await import('../../src/services/voice-channel-manager.js');
-    
+  it("should return singleton instance", async () => {
+    const { VoiceChannelManager } =
+      await import("../../src/services/voice-channel-manager.js");
+
     const instance1 = VoiceChannelManager.getInstance(mockClient as Client);
     const instance2 = VoiceChannelManager.getInstance(mockClient as Client);
 

--- a/__tests__/services/voice-channel-manager-live-waitingroom.test.ts
+++ b/__tests__/services/voice-channel-manager-live-waitingroom.test.ts
@@ -1,18 +1,24 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import { ChannelType, type Client, type VoiceChannel, type Guild, type GuildChannel } from 'discord.js';
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import {
+  ChannelType,
+  type Client,
+  type VoiceChannel,
+  type Guild,
+  type GuildChannel,
+} from "discord.js";
 
 // Mock dependencies before importing
-jest.mock('../../src/utils/logger.js');
-jest.mock('../../src/services/voice-channel-tracker.js');
-jest.mock('../../src/services/config-service.js');
+jest.mock("../../src/utils/logger.js");
+jest.mock("../../src/services/voice-channel-tracker.js");
+jest.mock("../../src/services/config-service.js");
 
 // Import after mocks
-import { VoiceChannelManager } from '../../src/services/voice-channel-manager.js';
-import { ConfigService } from '../../src/services/config-service.js';
+import { VoiceChannelManager } from "../../src/services/voice-channel-manager.js";
+import { ConfigService } from "../../src/services/config-service.js";
 
 const mockConfigService = ConfigService as jest.Mocked<typeof ConfigService>;
 
-describe('VoiceChannelManager - Live & Waiting Room', () => {
+describe("VoiceChannelManager - Live & Waiting Room", () => {
   let manager: VoiceChannelManager;
   let mockClient: Partial<Client>;
   let mockChannel: Partial<VoiceChannel>;
@@ -26,19 +32,19 @@ describe('VoiceChannelManager - Live & Waiting Room', () => {
 
     (mockConfigService.getInstance as unknown as jest.Mock) = jest.fn(() => ({
       getBoolean: jest.fn().mockResolvedValue(false),
-      getString: jest.fn().mockResolvedValue(''),
+      getString: jest.fn().mockResolvedValue(""),
       getNumber: jest.fn().mockResolvedValue(0),
     }));
 
     mockGuild = {
-      id: 'guild-id',
+      id: "guild-id",
       roles: {
-        everyone: { id: 'everyone-role-id' },
+        everyone: { id: "everyone-role-id" },
       } as any,
       channels: {
         create: jest.fn().mockResolvedValue({
-          id: 'waiting-room-id',
-          name: '⏳ Test Channel Waiting',
+          id: "waiting-room-id",
+          name: "⏳ Test Channel Waiting",
           type: ChannelType.GuildVoice,
           delete: jest.fn().mockResolvedValue(undefined),
           members: { size: 0, values: jest.fn().mockReturnValue([]) },
@@ -47,8 +53,8 @@ describe('VoiceChannelManager - Live & Waiting Room', () => {
     } as any;
 
     mockChannel = {
-      id: 'channel-id',
-      name: '🎮 Test Channel',
+      id: "channel-id",
+      name: "🎮 Test Channel",
       type: ChannelType.GuildVoice,
       parent: null,
       setName: jest.fn().mockResolvedValue(undefined),
@@ -61,7 +67,7 @@ describe('VoiceChannelManager - Live & Waiting Room', () => {
     } as any;
 
     mockClient = {
-      user: { id: 'bot-user-id' } as any,
+      user: { id: "bot-user-id" } as any,
       channels: {
         cache: new Map<string, GuildChannel>(),
       } as any,
@@ -72,115 +78,119 @@ describe('VoiceChannelManager - Live & Waiting Room', () => {
 
   // ── Live indicator ─────────────────────────────────────────────────────────
 
-  describe('isLive / setLiveStatus', () => {
-    it('should return false for an untracked channel', () => {
-      expect(manager.isLive('channel-id')).toBe(false);
+  describe("isLive / setLiveStatus", () => {
+    it("should return false for an untracked channel", () => {
+      expect(manager.isLive("channel-id")).toBe(false);
     });
 
-    it('should return true after setLiveStatus(true)', () => {
-      manager.setLiveStatus('channel-id', true);
-      expect(manager.isLive('channel-id')).toBe(true);
+    it("should return true after setLiveStatus(true)", () => {
+      manager.setLiveStatus("channel-id", true);
+      expect(manager.isLive("channel-id")).toBe(true);
     });
 
-    it('should return false after setLiveStatus(false)', () => {
-      manager.setLiveStatus('channel-id', true);
-      manager.setLiveStatus('channel-id', false);
-      expect(manager.isLive('channel-id')).toBe(false);
+    it("should return false after setLiveStatus(false)", () => {
+      manager.setLiveStatus("channel-id", true);
+      manager.setLiveStatus("channel-id", false);
+      expect(manager.isLive("channel-id")).toBe(false);
     });
   });
 
-  describe('toggleLive', () => {
-    it('should toggle from offline to live and apply suffix to channel name', async () => {
+  describe("toggleLive", () => {
+    it("should toggle from offline to live and apply suffix to channel name", async () => {
       const result = await manager.toggleLive(mockChannel as VoiceChannel);
 
       expect(result).toBe(true);
-      expect(manager.isLive('channel-id')).toBe(true);
+      expect(manager.isLive("channel-id")).toBe(true);
       // Suffix is appended, preserving the managed prefix
-      expect(mockChannel.setName).toHaveBeenCalledWith('🎮 Test Channel 🔴');
+      expect(mockChannel.setName).toHaveBeenCalledWith("🎮 Test Channel 🔴");
     });
 
-    it('should toggle from live to offline and remove suffix', async () => {
+    it("should toggle from live to offline and remove suffix", async () => {
       // Pre-mark as live and give it the suffix name
-      manager.setLiveStatus('channel-id', true);
-      (mockChannel as any).name = '🎮 Test Channel 🔴';
+      manager.setLiveStatus("channel-id", true);
+      (mockChannel as any).name = "🎮 Test Channel 🔴";
 
       const result = await manager.toggleLive(mockChannel as VoiceChannel);
 
       expect(result).toBe(false);
-      expect(manager.isLive('channel-id')).toBe(false);
-      expect(mockChannel.setName).toHaveBeenCalledWith('🎮 Test Channel');
+      expect(manager.isLive("channel-id")).toBe(false);
+      expect(mockChannel.setName).toHaveBeenCalledWith("🎮 Test Channel");
     });
 
-    it('should NOT prepend 🔴 to channel name (suffix-only to preserve managed prefix)', async () => {
+    it("should NOT prepend 🔴 to channel name (suffix-only to preserve managed prefix)", async () => {
       await manager.toggleLive(mockChannel as VoiceChannel);
 
       const calls = (mockChannel.setName as jest.Mock).mock.calls;
       expect(calls.length).toBeGreaterThan(0);
       // New name must NOT start with 🔴
       const newName = calls[0][0] as string;
-      expect(newName.startsWith('🔴')).toBe(false);
+      expect(newName.startsWith("🔴")).toBe(false);
       // New name must END with 🔴
-      expect(newName.endsWith('🔴')).toBe(true);
+      expect(newName.endsWith("🔴")).toBe(true);
     });
 
-    it('should post a live announcement message when going live', async () => {
+    it("should post a live announcement message when going live", async () => {
       await manager.toggleLive(mockChannel as VoiceChannel);
       expect(mockChannel.send).toHaveBeenCalledWith(
-        expect.stringContaining('LIVE'),
+        expect.stringContaining("LIVE"),
       );
     });
 
-    it('should post an offline announcement message when going offline', async () => {
-      manager.setLiveStatus('channel-id', true);
-      (mockChannel as any).name = '🎮 Test Channel 🔴';
+    it("should post an offline announcement message when going offline", async () => {
+      manager.setLiveStatus("channel-id", true);
+      (mockChannel as any).name = "🎮 Test Channel 🔴";
 
       await manager.toggleLive(mockChannel as VoiceChannel);
       expect(mockChannel.send).toHaveBeenCalledWith(
-        expect.stringContaining('no longer live'),
+        expect.stringContaining("no longer live"),
       );
     });
   });
 
   // ── Waiting room ───────────────────────────────────────────────────────────
 
-  describe('getWaitingRoom / getMainChannelForWaitingRoom', () => {
-    it('should return undefined for untracked channels', () => {
-      expect(manager.getWaitingRoom('channel-id')).toBeUndefined();
-      expect(manager.getMainChannelForWaitingRoom('waiting-room-id')).toBeUndefined();
+  describe("getWaitingRoom / getMainChannelForWaitingRoom", () => {
+    it("should return undefined for untracked channels", () => {
+      expect(manager.getWaitingRoom("channel-id")).toBeUndefined();
+      expect(
+        manager.getMainChannelForWaitingRoom("waiting-room-id"),
+      ).toBeUndefined();
     });
   });
 
-  describe('createWaitingRoom', () => {
-    it('should create a waiting room and track it', async () => {
+  describe("createWaitingRoom", () => {
+    it("should create a waiting room and track it", async () => {
       const waitingRoom = await manager.createWaitingRoom(
         mockChannel as VoiceChannel,
-        'owner-id',
+        "owner-id",
       );
 
       expect(waitingRoom).not.toBeNull();
-      expect(manager.getWaitingRoom('channel-id')).toBe('waiting-room-id');
-      expect(manager.getMainChannelForWaitingRoom('waiting-room-id')).toBe('channel-id');
+      expect(manager.getWaitingRoom("channel-id")).toBe("waiting-room-id");
+      expect(manager.getMainChannelForWaitingRoom("waiting-room-id")).toBe(
+        "channel-id",
+      );
     });
 
-    it('should return null if a waiting room already exists', async () => {
-      await manager.createWaitingRoom(mockChannel as VoiceChannel, 'owner-id');
+    it("should return null if a waiting room already exists", async () => {
+      await manager.createWaitingRoom(mockChannel as VoiceChannel, "owner-id");
 
       const second = await manager.createWaitingRoom(
         mockChannel as VoiceChannel,
-        'owner-id',
+        "owner-id",
       );
       expect(second).toBeNull();
     });
   });
 
-  describe('removeWaitingRoom', () => {
-    it('should remove tracking after deletion', async () => {
+  describe("removeWaitingRoom", () => {
+    it("should remove tracking after deletion", async () => {
       // Create first
-      await manager.createWaitingRoom(mockChannel as VoiceChannel, 'owner-id');
-      expect(manager.getWaitingRoom('channel-id')).toBeDefined();
+      await manager.createWaitingRoom(mockChannel as VoiceChannel, "owner-id");
+      expect(manager.getWaitingRoom("channel-id")).toBeDefined();
 
       // Point the channel cache to the waiting room so delete is called
-      const waitingRoomId = manager.getWaitingRoom('channel-id')!;
+      const waitingRoomId = manager.getWaitingRoom("channel-id")!;
       const mockWaitingRoom = {
         id: waitingRoomId,
         type: ChannelType.GuildVoice,
@@ -189,15 +199,19 @@ describe('VoiceChannelManager - Live & Waiting Room', () => {
       } as any;
       (mockClient.channels!.cache as any).set(waitingRoomId, mockWaitingRoom);
 
-      await manager.removeWaitingRoom('channel-id');
+      await manager.removeWaitingRoom("channel-id");
 
-      expect(manager.getWaitingRoom('channel-id')).toBeUndefined();
-      expect(manager.getMainChannelForWaitingRoom(waitingRoomId)).toBeUndefined();
+      expect(manager.getWaitingRoom("channel-id")).toBeUndefined();
+      expect(
+        manager.getMainChannelForWaitingRoom(waitingRoomId),
+      ).toBeUndefined();
     });
 
-    it('should be a no-op when no waiting room exists', async () => {
+    it("should be a no-op when no waiting room exists", async () => {
       // Should not throw
-      await expect(manager.removeWaitingRoom('nonexistent-id')).resolves.toBeUndefined();
+      await expect(
+        manager.removeWaitingRoom("nonexistent-id"),
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/__tests__/services/voice-channel-manager-transfer.test.ts
+++ b/__tests__/services/voice-channel-manager-transfer.test.ts
@@ -1,15 +1,22 @@
-import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
-import type { Client, VoiceChannel, GuildMember, Collection } from 'discord.js';
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import type { Client, VoiceChannel, GuildMember, Collection } from "discord.js";
 
 // Mock dependencies before importing
-jest.mock('../../src/utils/logger.js');
-jest.mock('../../src/services/voice-channel-tracker.js');
-jest.mock('../../src/services/config-service.js');
+jest.mock("../../src/utils/logger.js");
+jest.mock("../../src/services/voice-channel-tracker.js");
+jest.mock("../../src/services/config-service.js");
 
 // Import after mocks
-import { VoiceChannelManager } from '../../src/services/voice-channel-manager.js';
+import { VoiceChannelManager } from "../../src/services/voice-channel-manager.js";
 
-describe('VoiceChannelManager - Transfer Ownership', () => {
+describe("VoiceChannelManager - Transfer Ownership", () => {
   let manager: VoiceChannelManager;
   let mockClient: Partial<Client>;
   let mockChannel: Partial<VoiceChannel>;
@@ -33,7 +40,7 @@ describe('VoiceChannelManager - Transfer Ownership', () => {
     // Mock members collection
     mockMembers = {
       get: jest.fn((id: string) => {
-        if (id === 'new-owner-id') {
+        if (id === "new-owner-id") {
           return mockNewOwner as GuildMember;
         }
         return undefined;
@@ -41,14 +48,14 @@ describe('VoiceChannelManager - Transfer Ownership', () => {
     } as any;
 
     mockNewOwner = {
-      id: 'new-owner-id',
-      displayName: 'NewOwner',
+      id: "new-owner-id",
+      displayName: "NewOwner",
     } as any;
 
     // Mock channel
     mockChannel = {
-      id: 'channel-id',
-      name: 'Custom Channel Name',
+      id: "channel-id",
+      name: "Custom Channel Name",
       permissionOverwrites: mockPermissionOverwrites,
       members: mockMembers as Collection<string, GuildMember>,
       setName: jest.fn().mockResolvedValue(undefined),
@@ -73,54 +80,80 @@ describe('VoiceChannelManager - Transfer Ownership', () => {
     (VoiceChannelManager as any).instance = undefined;
   });
 
-  describe('transferOwnership', () => {
-    it('should grant ManageChannels permission to new owner', async () => {
-      await manager.transferOwnership('channel-id', 'old-owner-id', 'new-owner-id');
+  describe("transferOwnership", () => {
+    it("should grant ManageChannels permission to new owner", async () => {
+      await manager.transferOwnership(
+        "channel-id",
+        "old-owner-id",
+        "new-owner-id",
+      );
 
-      expect(mockPermissionOverwrites.create).toHaveBeenCalledWith('new-owner-id', {
-        ManageChannels: true,
-        Connect: true,
-        Speak: true,
-        ViewChannel: true,
-      });
+      expect(mockPermissionOverwrites.create).toHaveBeenCalledWith(
+        "new-owner-id",
+        {
+          ManageChannels: true,
+          Connect: true,
+          Speak: true,
+          ViewChannel: true,
+        },
+      );
     });
 
-    it('should remove ManageChannels permission from old owner', async () => {
-      await manager.transferOwnership('channel-id', 'old-owner-id', 'new-owner-id');
+    it("should remove ManageChannels permission from old owner", async () => {
+      await manager.transferOwnership(
+        "channel-id",
+        "old-owner-id",
+        "new-owner-id",
+      );
 
-      expect(mockPermissionOverwrites.create).toHaveBeenCalledWith('old-owner-id', {
-        ManageChannels: false,
-        Connect: true,
-        Speak: true,
-        ViewChannel: true,
-      });
+      expect(mockPermissionOverwrites.create).toHaveBeenCalledWith(
+        "old-owner-id",
+        {
+          ManageChannels: false,
+          Connect: true,
+          Speak: true,
+          ViewChannel: true,
+        },
+      );
     });
 
-    it('should not rename channel when it has a custom name', async () => {
+    it("should not rename channel when it has a custom name", async () => {
       // Mark channel as having a custom name
-      manager.setCustomChannelName('channel-id', 'Custom Channel Name');
+      manager.setCustomChannelName("channel-id", "Custom Channel Name");
 
-      await manager.transferOwnership('channel-id', 'old-owner-id', 'new-owner-id');
+      await manager.transferOwnership(
+        "channel-id",
+        "old-owner-id",
+        "new-owner-id",
+      );
 
       expect(mockChannel.setName).not.toHaveBeenCalled();
     });
 
-    it('should rename channel when it does not have a custom name', async () => {
+    it("should rename channel when it does not have a custom name", async () => {
       // Do not mark channel as having a custom name
-      await manager.transferOwnership('channel-id', 'old-owner-id', 'new-owner-id');
+      await manager.transferOwnership(
+        "channel-id",
+        "old-owner-id",
+        "new-owner-id",
+      );
 
       expect(mockChannel.setName).toHaveBeenCalledWith("NewOwner's Channel");
     });
 
-    it('should send notification to channel', async () => {
-      await manager.transferOwnership('channel-id', 'old-owner-id', 'new-owner-id');
+    it("should send notification to channel", async () => {
+      await manager.transferOwnership(
+        "channel-id",
+        "old-owner-id",
+        "new-owner-id",
+      );
 
       expect(mockChannel.send).toHaveBeenCalledWith(
-        'Channel ownership has been transferred to NewOwner'
+        "Channel ownership has been transferred to NewOwner",
       );
     });
 
-    it('should throw error when channel is not found', async () => {
+    it("should throw error when channel is not found", async () => {
       mockClient.channels = {
         cache: {
           get: jest.fn().mockReturnValue(undefined),
@@ -128,30 +161,30 @@ describe('VoiceChannelManager - Transfer Ownership', () => {
       } as any;
 
       await expect(
-        manager.transferOwnership('channel-id', 'old-owner-id', 'new-owner-id')
-      ).rejects.toThrow('Channel not found');
+        manager.transferOwnership("channel-id", "old-owner-id", "new-owner-id"),
+      ).rejects.toThrow("Channel not found");
     });
 
-    it('should throw error when new owner is not in channel', async () => {
+    it("should throw error when new owner is not in channel", async () => {
       mockMembers.get = jest.fn().mockReturnValue(undefined);
 
       await expect(
-        manager.transferOwnership('channel-id', 'old-owner-id', 'new-owner-id')
-      ).rejects.toThrow('New owner is not in the channel');
+        manager.transferOwnership("channel-id", "old-owner-id", "new-owner-id"),
+      ).rejects.toThrow("New owner is not in the channel");
     });
   });
 
-  describe('Custom name tracking', () => {
-    it('should mark channel as having custom name', () => {
-      manager.setCustomChannelName('channel-id', 'Custom Name');
+  describe("Custom name tracking", () => {
+    it("should mark channel as having custom name", () => {
+      manager.setCustomChannelName("channel-id", "Custom Name");
 
-      expect(manager.hasCustomName('channel-id')).toBe(true);
-      expect(manager.getCustomChannelName('channel-id')).toBe('Custom Name');
+      expect(manager.hasCustomName("channel-id")).toBe(true);
+      expect(manager.getCustomChannelName("channel-id")).toBe("Custom Name");
     });
 
-    it('should return false for channel without custom name', () => {
-      expect(manager.hasCustomName('non-existent-id')).toBe(false);
-      expect(manager.getCustomChannelName('non-existent-id')).toBeUndefined();
+    it("should return false for channel without custom name", () => {
+      expect(manager.hasCustomName("non-existent-id")).toBe(false);
+      expect(manager.getCustomChannelName("non-existent-id")).toBeUndefined();
     });
   });
 });

--- a/__tests__/services/voice-channel-manager.test.ts
+++ b/__tests__/services/voice-channel-manager.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect } from "@jest/globals";
 
-describe('VoiceChannelManager', () => {
-  it('placeholder test', () => {
+describe("VoiceChannelManager", () => {
+  it("placeholder test", () => {
     expect(true).toBe(true);
   });
 });

--- a/__tests__/services/voice-channel-tracker.test.ts
+++ b/__tests__/services/voice-channel-tracker.test.ts
@@ -1,14 +1,19 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import type { Client, VoiceState, GuildMember, VoiceChannel } from 'discord.js';
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import type { Client, VoiceState, GuildMember, VoiceChannel } from "discord.js";
 
 // Do NOT override the global mongoose mock from setup.ts — rely on it for stable jest.fn() instances.
 // The global mock's model() returns a shared object so its methods can be reconfigured per-test.
 
-jest.mock('../../src/utils/logger.js', () => ({
-  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+jest.mock("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
 }));
 
-jest.mock('../../src/services/achievements-service.js', () => ({
+jest.mock("../../src/services/achievements-service.js", () => ({
   AchievementsService: {
     getInstance: jest.fn(() => ({
       checkAndAwardAccolades: jest.fn().mockResolvedValue([]),
@@ -19,28 +24,28 @@ jest.mock('../../src/services/achievements-service.js', () => ({
 }));
 
 // Static imports — mocks are registered before these load (jest.mock is hoisted)
-import { VoiceChannelTracker } from '../../src/services/voice-channel-tracker.js';
-import { VoiceChannelTracking } from '../../src/models/voice-channel-tracking.js';
+import { VoiceChannelTracker } from "../../src/services/voice-channel-tracker.js";
+import { VoiceChannelTracking } from "../../src/models/voice-channel-tracking.js";
 
 // Helper to create a configured tracker with injected mock config service
 function createTracker(mockClient: Partial<Client>) {
   const tracker = VoiceChannelTracker.getInstance(mockClient as Client);
 
   const mockConfigService = {
-    getString: jest.fn().mockResolvedValue('mongodb://localhost/test'),
+    getString: jest.fn().mockResolvedValue("mongodb://localhost/test"),
     getBoolean: jest.fn().mockResolvedValue(false),
     get: jest.fn().mockResolvedValue(null),
     getNumber: jest.fn().mockResolvedValue(0),
     triggerReload: jest.fn().mockResolvedValue(undefined),
   };
   // Inject mock config service and mark as connected (established pattern from codebase)
-  (tracker as never)['configService'] = mockConfigService;
-  (tracker as never)['isConnected'] = true;
+  (tracker as never)["configService"] = mockConfigService;
+  (tracker as never)["isConnected"] = true;
 
   return { tracker, mockConfigService };
 }
 
-describe('VoiceChannelTracker', () => {
+describe("VoiceChannelTracker", () => {
   let mockClient: Partial<Client>;
 
   beforeEach(() => {
@@ -57,30 +62,33 @@ describe('VoiceChannelTracker', () => {
     };
 
     // Reset singleton between tests
-    (VoiceChannelTracker as unknown as { instance: unknown }).instance = undefined;
+    (VoiceChannelTracker as unknown as { instance: unknown }).instance =
+      undefined;
   });
 
-  describe('singleton pattern', () => {
-    it('should create a singleton instance', () => {
+  describe("singleton pattern", () => {
+    it("should create a singleton instance", () => {
       const instance1 = VoiceChannelTracker.getInstance(mockClient as Client);
       const instance2 = VoiceChannelTracker.getInstance(mockClient as Client);
       expect(instance1).toBe(instance2);
     });
 
-    it('should create an instance with a client', () => {
-      expect(VoiceChannelTracker.getInstance(mockClient as Client)).toBeDefined();
+    it("should create an instance with a client", () => {
+      expect(
+        VoiceChannelTracker.getInstance(mockClient as Client),
+      ).toBeDefined();
     });
   });
 
-  describe('getActiveSession', () => {
-    it('should return null for unknown user', () => {
+  describe("getActiveSession", () => {
+    it("should return null for unknown user", () => {
       const { tracker } = createTracker(mockClient);
-      expect(tracker.getActiveSession('unknown-user')).toBeNull();
+      expect(tracker.getActiveSession("unknown-user")).toBeNull();
     });
   });
 
-  describe('handleVoiceStateUpdate', () => {
-    it('should return early when voice tracking is disabled', async () => {
+  describe("handleVoiceStateUpdate", () => {
+    it("should return early when voice tracking is disabled", async () => {
       const { tracker, mockConfigService } = createTracker(mockClient);
       mockConfigService.getBoolean.mockResolvedValue(false);
 
@@ -91,7 +99,7 @@ describe('VoiceChannelTracker', () => {
       expect(VoiceChannelTracking.findOne).not.toHaveBeenCalled();
     });
 
-    it('should handle missing member gracefully when tracking enabled', async () => {
+    it("should handle missing member gracefully when tracking enabled", async () => {
       const { tracker, mockConfigService } = createTracker(mockClient);
       mockConfigService.getBoolean.mockResolvedValue(true);
 
@@ -99,93 +107,115 @@ describe('VoiceChannelTracker', () => {
         tracker.handleVoiceStateUpdate(
           { member: null, channel: null } as unknown as VoiceState,
           { member: null, channel: null } as unknown as VoiceState,
-        )
+        ),
       ).resolves.not.toThrow();
     });
 
-    it('should handle user joining a channel (tracking enabled)', async () => {
+    it("should handle user joining a channel (tracking enabled)", async () => {
       const { tracker, mockConfigService } = createTracker(mockClient);
       mockConfigService.getBoolean.mockResolvedValue(true);
       mockConfigService.get.mockResolvedValue(null);
 
       const mockMember = {
-        id: 'user123',
-        displayName: 'TestUser',
-        guild: { channels: { cache: { get: jest.fn().mockReturnValue(null) } } },
+        id: "user123",
+        displayName: "TestUser",
+        guild: {
+          channels: { cache: { get: jest.fn().mockReturnValue(null) } },
+        },
       } as unknown as GuildMember;
-      const mockChannel = { id: 'channel123', name: 'TestChannel' } as unknown as VoiceChannel;
+      const mockChannel = {
+        id: "channel123",
+        name: "TestChannel",
+      } as unknown as VoiceChannel;
 
       await tracker.handleVoiceStateUpdate(
         { member: mockMember, channel: null } as unknown as VoiceState,
         { member: mockMember, channel: mockChannel } as unknown as VoiceState,
       );
 
-      const session = tracker.getActiveSession('user123');
+      const session = tracker.getActiveSession("user123");
       expect(session).not.toBeNull();
-      expect(session?.channelName).toBe('TestChannel');
+      expect(session?.channelName).toBe("TestChannel");
     });
 
-    it('should handle user leaving a channel (tracking enabled)', async () => {
+    it("should handle user leaving a channel (tracking enabled)", async () => {
       const { tracker, mockConfigService } = createTracker(mockClient);
       mockConfigService.getBoolean.mockResolvedValue(true);
       mockConfigService.get.mockResolvedValue(null);
 
       const mockMember = {
-        id: 'user123',
-        displayName: 'TestUser',
-        guild: { channels: { cache: { get: jest.fn().mockReturnValue(null) } } },
+        id: "user123",
+        displayName: "TestUser",
+        guild: {
+          channels: { cache: { get: jest.fn().mockReturnValue(null) } },
+        },
       } as unknown as GuildMember;
-      const mockChannel = { id: 'channel123', name: 'TestChannel' } as unknown as VoiceChannel;
+      const mockChannel = {
+        id: "channel123",
+        name: "TestChannel",
+      } as unknown as VoiceChannel;
 
       await tracker.handleVoiceStateUpdate(
         { member: mockMember, channel: null } as unknown as VoiceState,
         { member: mockMember, channel: mockChannel } as unknown as VoiceState,
       );
-      expect(tracker.getActiveSession('user123')).not.toBeNull();
+      expect(tracker.getActiveSession("user123")).not.toBeNull();
 
-      (mockClient.users as any).fetch = jest.fn().mockResolvedValue({ username: 'TestUser', id: 'user123' });
+      (mockClient.users as any).fetch = jest
+        .fn()
+        .mockResolvedValue({ username: "TestUser", id: "user123" });
       await tracker.handleVoiceStateUpdate(
         { member: mockMember, channel: mockChannel } as unknown as VoiceState,
         { member: mockMember, channel: null } as unknown as VoiceState,
       );
-      expect(tracker.getActiveSession('user123')).toBeNull();
+      expect(tracker.getActiveSession("user123")).toBeNull();
     });
 
-    it('should handle user switching channels', async () => {
+    it("should handle user switching channels", async () => {
       const { tracker, mockConfigService } = createTracker(mockClient);
       mockConfigService.getBoolean.mockResolvedValue(true);
       mockConfigService.get.mockResolvedValue(null);
 
       const mockMember = {
-        id: 'user123',
-        displayName: 'TestUser',
-        guild: { channels: { cache: { get: jest.fn().mockReturnValue(null) } } },
+        id: "user123",
+        displayName: "TestUser",
+        guild: {
+          channels: { cache: { get: jest.fn().mockReturnValue(null) } },
+        },
       } as unknown as GuildMember;
-      const mockChannel1 = { id: 'channel1', name: 'Channel1' } as unknown as VoiceChannel;
-      const mockChannel2 = { id: 'channel2', name: 'Channel2' } as unknown as VoiceChannel;
-      (mockClient.users as any).fetch = jest.fn().mockResolvedValue({ username: 'TestUser', id: 'user123' });
+      const mockChannel1 = {
+        id: "channel1",
+        name: "Channel1",
+      } as unknown as VoiceChannel;
+      const mockChannel2 = {
+        id: "channel2",
+        name: "Channel2",
+      } as unknown as VoiceChannel;
+      (mockClient.users as any).fetch = jest
+        .fn()
+        .mockResolvedValue({ username: "TestUser", id: "user123" });
 
       await tracker.handleVoiceStateUpdate(
         { member: mockMember, channel: mockChannel1 } as unknown as VoiceState,
         { member: mockMember, channel: mockChannel2 } as unknown as VoiceState,
       );
-      expect(tracker.getActiveSession('user123')?.channelName).toBe('Channel2');
+      expect(tracker.getActiveSession("user123")?.channelName).toBe("Channel2");
     });
 
-    it('should handle errors in voice state update gracefully', async () => {
+    it("should handle errors in voice state update gracefully", async () => {
       const { tracker, mockConfigService } = createTracker(mockClient);
-      mockConfigService.getBoolean.mockRejectedValue(new Error('Config error'));
+      mockConfigService.getBoolean.mockRejectedValue(new Error("Config error"));
 
       await expect(
         tracker.handleVoiceStateUpdate(
           { member: null, channel: null } as unknown as VoiceState,
           { member: null, channel: null } as unknown as VoiceState,
-        )
+        ),
       ).resolves.not.toThrow();
     });
   });
 
-  describe('companion overlap & voice firsts (#570)', () => {
+  describe("companion overlap & voice firsts (#570)", () => {
     // Builds a member whose guild channel cache returns a channel populated
     // with `presentIds` so startTracking can snapshot co-present users.
     function memberInChannel(
@@ -199,15 +229,17 @@ describe('VoiceChannelTracker', () => {
       return {
         id,
         displayName: id,
-        guild: { channels: { cache: { get: jest.fn().mockReturnValue(channel) } } },
+        guild: {
+          channels: { cache: { get: jest.fn().mockReturnValue(channel) } },
+        },
       } as unknown as GuildMember;
     }
 
     function gate(companionsEnabled: boolean) {
       return (key: string) =>
         Promise.resolve(
-          key === 'voicetracking.enabled' ||
-            (companionsEnabled && key === 'voicetracking.companions.enabled'),
+          key === "voicetracking.enabled" ||
+            (companionsEnabled && key === "voicetracking.companions.enabled"),
         );
     }
 
@@ -217,7 +249,10 @@ describe('VoiceChannelTracker', () => {
       channelId: string,
       channelName: string,
     ) {
-      const channelState = { id: channelId, name: channelName } as unknown as VoiceChannel;
+      const channelState = {
+        id: channelId,
+        name: channelName,
+      } as unknown as VoiceChannel;
       // The global findOneAndUpdate mock accumulates calls across tests; clear
       // it so the assertion can read this scenario's session as calls[0].
       (VoiceChannelTracking.findOneAndUpdate as jest.Mock).mockClear();
@@ -231,18 +266,18 @@ describe('VoiceChannelTracker', () => {
       );
     }
 
-    it('omits companion/firsts fields when the feature is disabled', async () => {
+    it("omits companion/firsts fields when the feature is disabled", async () => {
       const { tracker, mockConfigService } = createTracker(mockClient);
       mockConfigService.getBoolean.mockImplementation(gate(false));
       (mockClient.users as any).fetch = jest
         .fn()
-        .mockResolvedValue({ username: 'u1', id: 'u1' });
+        .mockResolvedValue({ username: "u1", id: "u1" });
 
       await joinThenLeave(
         tracker,
-        memberInChannel('u1', 'c1', 'C1', ['other1']),
-        'c1',
-        'C1',
+        memberInChannel("u1", "c1", "C1", ["other1"]),
+        "c1",
+        "C1",
       );
 
       const pushed = (VoiceChannelTracking.findOneAndUpdate as jest.Mock).mock
@@ -251,44 +286,44 @@ describe('VoiceChannelTracker', () => {
       expect(pushed.wasFirst).toBeUndefined();
       expect(pushed.joinedExisting).toBeUndefined();
       // The legacy union set is still captured.
-      expect(pushed.otherUsers).toEqual(['other1']);
+      expect(pushed.otherUsers).toEqual(["other1"]);
     });
 
-    it('captures companions, joinedExisting, and wasFirst=false when present at join', async () => {
+    it("captures companions, joinedExisting, and wasFirst=false when present at join", async () => {
       const { tracker, mockConfigService } = createTracker(mockClient);
       mockConfigService.getBoolean.mockImplementation(gate(true));
       (mockClient.users as any).fetch = jest
         .fn()
-        .mockResolvedValue({ username: 'u1', id: 'u1' });
+        .mockResolvedValue({ username: "u1", id: "u1" });
 
       await joinThenLeave(
         tracker,
-        memberInChannel('u1', 'c1', 'C1', ['other1']),
-        'c1',
-        'C1',
+        memberInChannel("u1", "c1", "C1", ["other1"]),
+        "c1",
+        "C1",
       );
 
       const pushed = (VoiceChannelTracking.findOneAndUpdate as jest.Mock).mock
         .calls[0][1].$push.sessions;
       expect(pushed.wasFirst).toBe(false);
-      expect(pushed.joinedExisting).toEqual(['other1']);
+      expect(pushed.joinedExisting).toEqual(["other1"]);
       expect(pushed.companions).toEqual([
-        { userId: 'other1', seconds: expect.any(Number) },
+        { userId: "other1", seconds: expect.any(Number) },
       ]);
     });
 
-    it('marks wasFirst=true when the channel was empty at join', async () => {
+    it("marks wasFirst=true when the channel was empty at join", async () => {
       const { tracker, mockConfigService } = createTracker(mockClient);
       mockConfigService.getBoolean.mockImplementation(gate(true));
       (mockClient.users as any).fetch = jest
         .fn()
-        .mockResolvedValue({ username: 'u1', id: 'u1' });
+        .mockResolvedValue({ username: "u1", id: "u1" });
 
       await joinThenLeave(
         tracker,
-        memberInChannel('u1', 'c1', 'C1', []),
-        'c1',
-        'C1',
+        memberInChannel("u1", "c1", "C1", []),
+        "c1",
+        "C1",
       );
 
       const pushed = (VoiceChannelTracking.findOneAndUpdate as jest.Mock).mock
@@ -299,110 +334,147 @@ describe('VoiceChannelTracker', () => {
     });
   });
 
-  describe('getUserStats', () => {
-    it('should return null when user not found', async () => {
+  describe("getUserStats", () => {
+    it("should return null when user not found", async () => {
       const { tracker } = createTracker(mockClient);
       (VoiceChannelTracking.findOne as jest.Mock).mockResolvedValue(null);
-      expect(await tracker.getUserStats('unknown-user')).toBeNull();
+      expect(await tracker.getUserStats("unknown-user")).toBeNull();
     });
 
-    it('should return user stats for alltime period', async () => {
+    it("should return user stats for alltime period", async () => {
       const { tracker } = createTracker(mockClient);
       (VoiceChannelTracking.findOne as jest.Mock).mockResolvedValue({
-        userId: 'user123', username: 'TestUser', totalTime: 7200, lastSeen: new Date(), sessions: [],
+        userId: "user123",
+        username: "TestUser",
+        totalTime: 7200,
+        lastSeen: new Date(),
+        sessions: [],
       });
 
-      const result = await tracker.getUserStats('user123', 'alltime');
+      const result = await tracker.getUserStats("user123", "alltime");
       expect(result).not.toBeNull();
-      expect(result?.userId).toBe('user123');
+      expect(result?.userId).toBe("user123");
       expect(result?.totalTime).toBe(7200);
     });
 
-    it('should return filtered stats for weekly period', async () => {
+    it("should return filtered stats for weekly period", async () => {
       const { tracker } = createTracker(mockClient);
       const recentDate = new Date();
       (VoiceChannelTracking.findOne as jest.Mock).mockResolvedValue({
-        userId: 'user123', username: 'TestUser', totalTime: 7200, lastSeen: new Date(),
-        sessions: [{ startTime: recentDate, endTime: recentDate, duration: 3600, channelId: 'ch1', channelName: 'Test' }],
+        userId: "user123",
+        username: "TestUser",
+        totalTime: 7200,
+        lastSeen: new Date(),
+        sessions: [
+          {
+            startTime: recentDate,
+            endTime: recentDate,
+            duration: 3600,
+            channelId: "ch1",
+            channelName: "Test",
+          },
+        ],
       });
 
-      const result = await tracker.getUserStats('user123', 'week');
-      expect(result?.userId).toBe('user123');
+      const result = await tracker.getUserStats("user123", "week");
+      expect(result?.userId).toBe("user123");
     });
 
-    it('should return filtered stats for monthly period', async () => {
+    it("should return filtered stats for monthly period", async () => {
       const { tracker } = createTracker(mockClient);
       const recentDate = new Date();
       (VoiceChannelTracking.findOne as jest.Mock).mockResolvedValue({
-        userId: 'user123', username: 'TestUser', totalTime: 7200, lastSeen: new Date(),
-        sessions: [{ startTime: recentDate, endTime: recentDate, duration: 3600, channelId: 'ch1', channelName: 'Test' }],
+        userId: "user123",
+        username: "TestUser",
+        totalTime: 7200,
+        lastSeen: new Date(),
+        sessions: [
+          {
+            startTime: recentDate,
+            endTime: recentDate,
+            duration: 3600,
+            channelId: "ch1",
+            channelName: "Test",
+          },
+        ],
       });
 
-      expect((await tracker.getUserStats('user123', 'month'))?.userId).toBe('user123');
+      expect((await tracker.getUserStats("user123", "month"))?.userId).toBe(
+        "user123",
+      );
     });
 
-    it('should handle database errors gracefully', async () => {
+    it("should handle database errors gracefully", async () => {
       const { tracker } = createTracker(mockClient);
-      (VoiceChannelTracking.findOne as jest.Mock).mockRejectedValue(new Error('DB error'));
-      expect(await tracker.getUserStats('user123')).toBeNull();
+      (VoiceChannelTracking.findOne as jest.Mock).mockRejectedValue(
+        new Error("DB error"),
+      );
+      expect(await tracker.getUserStats("user123")).toBeNull();
     });
   });
 
-  describe('getTopUsers', () => {
-    it('should return top users for alltime period', async () => {
+  describe("getTopUsers", () => {
+    it("should return top users for alltime period", async () => {
       const { tracker } = createTracker(mockClient);
       (VoiceChannelTracking.aggregate as jest.Mock).mockResolvedValue([
-        { _id: 'user1', username: 'User1', totalTime: 10000 },
-        { _id: 'user2', username: 'User2', totalTime: 8000 },
+        { _id: "user1", username: "User1", totalTime: 10000 },
+        { _id: "user2", username: "User2", totalTime: 8000 },
       ]);
 
-      const result = await tracker.getTopUsers(10, 'alltime');
+      const result = await tracker.getTopUsers(10, "alltime");
       expect(result).toHaveLength(2);
-      expect(result[0].userId).toBe('user1');
+      expect(result[0].userId).toBe("user1");
       expect(result[0].totalTime).toBe(10000);
     });
 
-    it('should return top users for weekly period', async () => {
+    it("should return top users for weekly period", async () => {
       const { tracker } = createTracker(mockClient);
-      (VoiceChannelTracking.aggregate as jest.Mock).mockResolvedValue([{ _id: 'user1', username: 'User1', totalTime: 5000 }]);
-      expect(await tracker.getTopUsers(10, 'week')).toHaveLength(1);
+      (VoiceChannelTracking.aggregate as jest.Mock).mockResolvedValue([
+        { _id: "user1", username: "User1", totalTime: 5000 },
+      ]);
+      expect(await tracker.getTopUsers(10, "week")).toHaveLength(1);
     });
 
-    it('should return top users for monthly period', async () => {
+    it("should return top users for monthly period", async () => {
       const { tracker } = createTracker(mockClient);
-      (VoiceChannelTracking.aggregate as jest.Mock).mockResolvedValue([{ _id: 'user1', username: 'User1', totalTime: 5000 }]);
-      expect(await tracker.getTopUsers(10, 'month')).toHaveLength(1);
+      (VoiceChannelTracking.aggregate as jest.Mock).mockResolvedValue([
+        { _id: "user1", username: "User1", totalTime: 5000 },
+      ]);
+      expect(await tracker.getTopUsers(10, "month")).toHaveLength(1);
     });
 
-    it('should handle database errors and return empty array', async () => {
+    it("should handle database errors and return empty array", async () => {
       const { tracker } = createTracker(mockClient);
-      (VoiceChannelTracking.aggregate as jest.Mock).mockRejectedValue(new Error('DB error'));
+      (VoiceChannelTracking.aggregate as jest.Mock).mockRejectedValue(
+        new Error("DB error"),
+      );
       expect(await tracker.getTopUsers()).toEqual([]);
     });
 
-    it('reads the cap from the leaderboard_max_results config key', async () => {
+    it("reads the cap from the leaderboard_max_results config key", async () => {
       const { tracker, mockConfigService } = createTracker(mockClient);
       (VoiceChannelTracking.aggregate as jest.Mock).mockResolvedValue([]);
 
-      await tracker.getTopUsers(10, 'alltime');
+      await tracker.getTopUsers(10, "alltime");
 
       expect(mockConfigService.getNumber).toHaveBeenCalledWith(
-        'voicetracking.stats.leaderboard_max_results',
+        "voicetracking.stats.leaderboard_max_results",
         50,
       );
     });
 
-    it('clamps a large requested limit to the configurable cap', async () => {
+    it("clamps a large requested limit to the configurable cap", async () => {
       const { tracker, mockConfigService } = createTracker(mockClient);
       mockConfigService.getNumber.mockResolvedValue(5);
       (VoiceChannelTracking.aggregate as jest.Mock).mockClear();
       (VoiceChannelTracking.aggregate as jest.Mock).mockResolvedValue([]);
 
-      await tracker.getTopUsers(1000, 'alltime');
+      await tracker.getTopUsers(1000, "alltime");
 
-      const pipeline = (VoiceChannelTracking.aggregate as jest.Mock).mock.calls[0][0];
+      const pipeline = (VoiceChannelTracking.aggregate as jest.Mock).mock
+        .calls[0][0];
       const limitStage = pipeline.find(
-        (stage: Record<string, unknown>) => '$limit' in stage,
+        (stage: Record<string, unknown>) => "$limit" in stage,
       );
       expect(limitStage).toEqual({ $limit: 5 });
     });
@@ -413,41 +485,46 @@ describe('VoiceChannelTracker', () => {
       (VoiceChannelTracking.aggregate as jest.Mock).mockClear();
       (VoiceChannelTracking.aggregate as jest.Mock).mockResolvedValue([]);
 
-      await tracker.getTopUsers(0, 'week');
+      await tracker.getTopUsers(0, "week");
 
-      const pipeline = (VoiceChannelTracking.aggregate as jest.Mock).mock.calls[0][0];
+      const pipeline = (VoiceChannelTracking.aggregate as jest.Mock).mock
+        .calls[0][0];
       const limitStage = pipeline.find(
-        (stage: Record<string, unknown>) => '$limit' in stage,
+        (stage: Record<string, unknown>) => "$limit" in stage,
       );
       expect(limitStage).toBeUndefined();
     });
   });
 
-  describe('getUserLastSeen', () => {
-    it('should return null when user not found', async () => {
+  describe("getUserLastSeen", () => {
+    it("should return null when user not found", async () => {
       const { tracker } = createTracker(mockClient);
       (VoiceChannelTracking.findOne as jest.Mock).mockResolvedValue(null);
-      expect(await tracker.getUserLastSeen('unknown-user')).toBeNull();
+      expect(await tracker.getUserLastSeen("unknown-user")).toBeNull();
     });
 
-    it('should return lastSeen date when user found', async () => {
+    it("should return lastSeen date when user found", async () => {
       const { tracker } = createTracker(mockClient);
-      const lastSeenDate = new Date('2024-01-01');
-      (VoiceChannelTracking.findOne as jest.Mock).mockResolvedValue({ lastSeen: lastSeenDate });
-      expect(await tracker.getUserLastSeen('user123')).toEqual(lastSeenDate);
+      const lastSeenDate = new Date("2024-01-01");
+      (VoiceChannelTracking.findOne as jest.Mock).mockResolvedValue({
+        lastSeen: lastSeenDate,
+      });
+      expect(await tracker.getUserLastSeen("user123")).toEqual(lastSeenDate);
     });
 
-    it('should handle database errors gracefully', async () => {
+    it("should handle database errors gracefully", async () => {
       const { tracker } = createTracker(mockClient);
-      (VoiceChannelTracking.findOne as jest.Mock).mockRejectedValue(new Error('DB error'));
-      expect(await tracker.getUserLastSeen('user123')).toBeNull();
+      (VoiceChannelTracking.findOne as jest.Mock).mockRejectedValue(
+        new Error("DB error"),
+      );
+      expect(await tracker.getUserLastSeen("user123")).toBeNull();
     });
   });
 
-  describe('initialize', () => {
-    it('should expose an initialize method', () => {
+  describe("initialize", () => {
+    it("should expose an initialize method", () => {
       const { tracker } = createTracker(mockClient);
-      expect(typeof tracker.initialize).toBe('function');
+      expect(typeof tracker.initialize).toBe("function");
     });
   });
 });

--- a/__tests__/services/voice-channel-truncation-methods.test.ts
+++ b/__tests__/services/voice-channel-truncation-methods.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import type { Client } from 'discord.js';
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import type { Client } from "discord.js";
 
 // Mock dependencies
-jest.mock('../../src/services/config-service.js');
-jest.mock('../../src/utils/logger.js');
-jest.mock('../../src/models/voice-channel-tracking.js', () => ({
+jest.mock("../../src/services/config-service.js");
+jest.mock("../../src/utils/logger.js");
+jest.mock("../../src/models/voice-channel-tracking.js", () => ({
   VoiceChannelTracking: {
     find: jest.fn().mockResolvedValue([]),
     findOne: jest.fn().mockResolvedValue(null),
@@ -12,9 +12,9 @@ jest.mock('../../src/models/voice-channel-tracking.js', () => ({
   },
 }));
 
-import { VoiceChannelTracking } from '../../src/models/voice-channel-tracking.js';
+import { VoiceChannelTracking } from "../../src/models/voice-channel-tracking.js";
 
-describe('VoiceChannelTruncationService Methods', () => {
+describe("VoiceChannelTruncationService Methods", () => {
   let mockClient: Partial<Client>;
 
   beforeEach(() => {
@@ -27,40 +27,55 @@ describe('VoiceChannelTruncationService Methods', () => {
     } as Client;
   });
 
-  it('should have getInstance method', async () => {
-    const { VoiceChannelTruncationService } = await import('../../src/services/voice-channel-truncation.js');
-    
-    expect(typeof VoiceChannelTruncationService.getInstance).toBe('function');
+  it("should have getInstance method", async () => {
+    const { VoiceChannelTruncationService } =
+      await import("../../src/services/voice-channel-truncation.js");
+
+    expect(typeof VoiceChannelTruncationService.getInstance).toBe("function");
   });
 
-  it('should return singleton instance', async () => {
-    const { VoiceChannelTruncationService } = await import('../../src/services/voice-channel-truncation.js');
-    
-    const instance1 = VoiceChannelTruncationService.getInstance(mockClient as Client);
-    const instance2 = VoiceChannelTruncationService.getInstance(mockClient as Client);
+  it("should return singleton instance", async () => {
+    const { VoiceChannelTruncationService } =
+      await import("../../src/services/voice-channel-truncation.js");
+
+    const instance1 = VoiceChannelTruncationService.getInstance(
+      mockClient as Client,
+    );
+    const instance2 = VoiceChannelTruncationService.getInstance(
+      mockClient as Client,
+    );
 
     expect(instance1).toBe(instance2);
   });
 
-  it('should have runCleanup method', async () => {
-    const { VoiceChannelTruncationService } = await import('../../src/services/voice-channel-truncation.js');
-    
-    const instance = VoiceChannelTruncationService.getInstance(mockClient as Client);
+  it("should have runCleanup method", async () => {
+    const { VoiceChannelTruncationService } =
+      await import("../../src/services/voice-channel-truncation.js");
 
-    expect(typeof instance.runCleanup).toBe('function');
+    const instance = VoiceChannelTruncationService.getInstance(
+      mockClient as Client,
+    );
+
+    expect(typeof instance.runCleanup).toBe("function");
   });
 
-  it('should have getStatus method', async () => {
-    const { VoiceChannelTruncationService } = await import('../../src/services/voice-channel-truncation.js');
+  it("should have getStatus method", async () => {
+    const { VoiceChannelTruncationService } =
+      await import("../../src/services/voice-channel-truncation.js");
 
-    const instance = VoiceChannelTruncationService.getInstance(mockClient as Client);
+    const instance = VoiceChannelTruncationService.getInstance(
+      mockClient as Client,
+    );
 
-    expect(typeof instance.getStatus).toBe('function');
+    expect(typeof instance.getStatus).toBe("function");
   });
 
-  it('streams the tracking collection via a cursor, not an unbounded find', async () => {
-    const { VoiceChannelTruncationService } = await import('../../src/services/voice-channel-truncation.js');
-    const instance = VoiceChannelTruncationService.getInstance(mockClient as Client);
+  it("streams the tracking collection via a cursor, not an unbounded find", async () => {
+    const { VoiceChannelTruncationService } =
+      await import("../../src/services/voice-channel-truncation.js");
+    const instance = VoiceChannelTruncationService.getInstance(
+      mockClient as Client,
+    );
 
     const cursor = jest.fn(() => ({
       async *[Symbol.asyncIterator]() {},
@@ -70,11 +85,13 @@ describe('VoiceChannelTruncationService Methods', () => {
     find.mockReturnValue({ lean });
 
     // performCleanup is the private worker that the cron tick invokes.
-    await (instance as unknown as { performCleanup: () => Promise<unknown> }).performCleanup();
+    await (
+      instance as unknown as { performCleanup: () => Promise<unknown> }
+    ).performCleanup();
 
     expect(find).toHaveBeenCalledTimes(1);
     expect(cursor).toHaveBeenCalledTimes(1);
     // The unbounded materialisation path (.exec()) must never be used.
-    expect(find.mock.results[0].value).not.toHaveProperty('exec');
+    expect(find.mock.results[0].value).not.toHaveProperty("exec");
   });
 });

--- a/__tests__/services/voice-channel-truncation.test.ts
+++ b/__tests__/services/voice-channel-truncation.test.ts
@@ -1,50 +1,50 @@
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
-import { VoiceChannelTruncationService } from '../../src/services/voice-channel-truncation.js';
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import { VoiceChannelTruncationService } from "../../src/services/voice-channel-truncation.js";
 
 // Mock dependencies
-jest.mock('../../src/services/config-service.js');
-jest.mock('../../src/utils/logger.js');
-jest.mock('../../src/models/voice-channel-tracking.js');
+jest.mock("../../src/services/config-service.js");
+jest.mock("../../src/utils/logger.js");
+jest.mock("../../src/models/voice-channel-tracking.js");
 
-describe('VoiceChannelTruncationService', () => {
+describe("VoiceChannelTruncationService", () => {
   let service: VoiceChannelTruncationService;
   let mockClient: any;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockClient = { 
-      user: { id: '123' },
+    mockClient = {
+      user: { id: "123" },
     };
     service = VoiceChannelTruncationService.getInstance(mockClient);
   });
 
-  describe('singleton pattern', () => {
-    it('should create a singleton instance', () => {
+  describe("singleton pattern", () => {
+    it("should create a singleton instance", () => {
       const instance1 = VoiceChannelTruncationService.getInstance(mockClient);
       const instance2 = VoiceChannelTruncationService.getInstance(mockClient);
-      
+
       expect(instance1).toBe(instance2);
     });
   });
 
-  describe('initialization', () => {
-    it('should create an instance with a client', () => {
+  describe("initialization", () => {
+    it("should create an instance with a client", () => {
       expect(service).toBeDefined();
       expect(service).toBeInstanceOf(VoiceChannelTruncationService);
     });
   });
 
-  describe('public methods', () => {
-    it('should have initialize method', () => {
-      expect(typeof service.initialize).toBe('function');
+  describe("public methods", () => {
+    it("should have initialize method", () => {
+      expect(typeof service.initialize).toBe("function");
     });
 
-    it('should have runCleanup method', () => {
-      expect(typeof service.runCleanup).toBe('function');
+    it("should have runCleanup method", () => {
+      expect(typeof service.runCleanup).toBe("function");
     });
 
-    it('should have getStatus method', () => {
-      expect(typeof service.getStatus).toBe('function');
+    it("should have getStatus method", () => {
+      expect(typeof service.getStatus).toBe("function");
     });
   });
 });

--- a/__tests__/services/web-session-service.test.ts
+++ b/__tests__/services/web-session-service.test.ts
@@ -176,7 +176,9 @@ describe("WebSessionService", () => {
     };
     const newExpiresAt = update.$set.expiresAt.getTime();
     const defaultLifetimeMs = 24 * 60 * 60 * 1000;
-    expect(newExpiresAt).toBeGreaterThanOrEqual(before + defaultLifetimeMs - 1000);
+    expect(newExpiresAt).toBeGreaterThanOrEqual(
+      before + defaultLifetimeMs - 1000,
+    );
     expect(newExpiresAt).toBeLessThanOrEqual(after + defaultLifetimeMs + 1000);
   });
 

--- a/__tests__/services/wizard-service.test.ts
+++ b/__tests__/services/wizard-service.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
-import { WizardService } from '../../src/services/wizard-service.js';
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import { WizardService } from "../../src/services/wizard-service.js";
 
 // Mock dependencies
-jest.mock('../../src/services/config-service.js');
-jest.mock('../../src/utils/logger.js');
+jest.mock("../../src/services/config-service.js");
+jest.mock("../../src/utils/logger.js");
 
-describe('WizardService', () => {
+describe("WizardService", () => {
   let service: WizardService;
 
   beforeEach(() => {
@@ -13,63 +13,63 @@ describe('WizardService', () => {
     service = WizardService.getInstance();
   });
 
-  describe('singleton pattern', () => {
-    it('should create a singleton instance', () => {
+  describe("singleton pattern", () => {
+    it("should create a singleton instance", () => {
       const instance1 = WizardService.getInstance();
       const instance2 = WizardService.getInstance();
-      
+
       expect(instance1).toBe(instance2);
     });
   });
 
-  describe('initialization', () => {
-    it('should create an instance', () => {
+  describe("initialization", () => {
+    it("should create an instance", () => {
       expect(service).toBeDefined();
       expect(service).toBeInstanceOf(WizardService);
     });
   });
 
-  describe('public methods', () => {
-    it('should have createSession method', () => {
-      expect(typeof service.createSession).toBe('function');
+  describe("public methods", () => {
+    it("should have createSession method", () => {
+      expect(typeof service.createSession).toBe("function");
     });
 
-    it('should have getSession method', () => {
-      expect(typeof service.getSession).toBe('function');
+    it("should have getSession method", () => {
+      expect(typeof service.getSession).toBe("function");
     });
 
-    it('should have updateSession method', () => {
-      expect(typeof service.updateSession).toBe('function');
+    it("should have updateSession method", () => {
+      expect(typeof service.updateSession).toBe("function");
     });
 
-    it('should have endSession method', () => {
-      expect(typeof service.endSession).toBe('function');
+    it("should have endSession method", () => {
+      expect(typeof service.endSession).toBe("function");
     });
 
-    it('should have addConfiguration method', () => {
-      expect(typeof service.addConfiguration).toBe('function');
+    it("should have addConfiguration method", () => {
+      expect(typeof service.addConfiguration).toBe("function");
     });
 
-    it('should have nextStep method', () => {
-      expect(typeof service.nextStep).toBe('function');
+    it("should have nextStep method", () => {
+      expect(typeof service.nextStep).toBe("function");
     });
 
-    it('should have previousStep method', () => {
-      expect(typeof service.previousStep).toBe('function');
+    it("should have previousStep method", () => {
+      expect(typeof service.previousStep).toBe("function");
     });
 
-    it('should have shutdown method', () => {
-      expect(typeof service.shutdown).toBe('function');
+    it("should have shutdown method", () => {
+      expect(typeof service.shutdown).toBe("function");
     });
   });
 
-  describe('session management', () => {
-    const mockUserId = 'user-123';
-    const mockGuildId = 'guild-456';
+  describe("session management", () => {
+    const mockUserId = "user-123";
+    const mockGuildId = "guild-456";
 
-    it('should create a new session', () => {
+    it("should create a new session", () => {
       const state = service.createSession(mockUserId, mockGuildId);
-      
+
       expect(state).toBeDefined();
       expect(state.userId).toBe(mockUserId);
       expect(state.guildId).toBe(mockGuildId);
@@ -78,103 +78,108 @@ describe('WizardService', () => {
       expect(state.startTime).toBeInstanceOf(Date);
     });
 
-    it('should retrieve an existing session', () => {
+    it("should retrieve an existing session", () => {
       service.createSession(mockUserId, mockGuildId);
       const state = service.getSession(mockUserId, mockGuildId);
-      
+
       expect(state).toBeDefined();
       expect(state?.userId).toBe(mockUserId);
     });
 
-    it('should return null for non-existent session', () => {
-      const state = service.getSession('non-existent', 'non-existent');
-      
+    it("should return null for non-existent session", () => {
+      const state = service.getSession("non-existent", "non-existent");
+
       expect(state).toBeNull();
     });
 
-    it('should update an existing session', () => {
+    it("should update an existing session", () => {
       service.createSession(mockUserId, mockGuildId);
       const updated = service.updateSession(mockUserId, mockGuildId, {
         currentStep: 2,
       });
-      
+
       expect(updated).toBe(true);
       const state = service.getSession(mockUserId, mockGuildId);
       expect(state?.currentStep).toBe(2);
     });
 
-    it('should return false when updating non-existent session', () => {
-      const updated = service.updateSession('non-existent', 'non-existent', {
+    it("should return false when updating non-existent session", () => {
+      const updated = service.updateSession("non-existent", "non-existent", {
         currentStep: 2,
       });
-      
+
       expect(updated).toBe(false);
     });
 
-    it('should end a session', () => {
+    it("should end a session", () => {
       service.createSession(mockUserId, mockGuildId);
       const result = service.endSession(mockUserId, mockGuildId);
-      
+
       expect(result).toBe(true);
       const state = service.getSession(mockUserId, mockGuildId);
       expect(state).toBeNull();
     });
 
-    it('should return false when ending non-existent session', () => {
-      const result = service.endSession('non-existent', 'non-existent');
-      
+    it("should return false when ending non-existent session", () => {
+      const result = service.endSession("non-existent", "non-existent");
+
       expect(result).toBe(false);
     });
 
-    it('should add configuration to session', () => {
+    it("should add configuration to session", () => {
       service.createSession(mockUserId, mockGuildId);
-      service.addConfiguration(mockUserId, mockGuildId, 'test.key', 'test-value');
+      service.addConfiguration(
+        mockUserId,
+        mockGuildId,
+        "test.key",
+        "test-value",
+      );
       const state = service.getSession(mockUserId, mockGuildId);
-      
-      expect(state?.configuration['test.key']).toBe('test-value');
+
+      expect(state?.configuration["test.key"]).toBe("test-value");
     });
 
-    it('should navigate to next step', () => {
+    it("should navigate to next step", () => {
       service.createSession(mockUserId, mockGuildId);
       const result = service.nextStep(mockUserId, mockGuildId);
-      
+
       expect(result).toBe(true);
       const state = service.getSession(mockUserId, mockGuildId);
       expect(state?.currentStep).toBe(1);
     });
 
-    it('should navigate to previous step', () => {
+    it("should navigate to previous step", () => {
       service.createSession(mockUserId, mockGuildId);
       service.nextStep(mockUserId, mockGuildId);
       const result = service.previousStep(mockUserId, mockGuildId);
-      
+
       expect(result).toBe(true);
       const state = service.getSession(mockUserId, mockGuildId);
       expect(state?.currentStep).toBe(0);
     });
 
-    it('should initialize channelPage to 0 when creating session', () => {
+    it("should initialize channelPage to 0 when creating session", () => {
       const state = service.createSession(mockUserId, mockGuildId);
-      
+
       expect(state.channelPage).toBe(0);
     });
 
-    it('should update channelPage in session', () => {
+    it("should update channelPage in session", () => {
       service.createSession(mockUserId, mockGuildId);
       const updated = service.updateSession(mockUserId, mockGuildId, {
         channelPage: 2,
       });
-      
+
       expect(updated).toBe(true);
       const state = service.getSession(mockUserId, mockGuildId);
       expect(state?.channelPage).toBe(2);
     });
   });
 
-  describe('shutdown', () => {
-    it('should shutdown without errors', () => {
+  describe("shutdown", () => {
+    it("should shutdown without errors", () => {
       service.shutdown();
-      
+
       // Method should execute without errors
       expect(true).toBe(true);
     });

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -1,10 +1,10 @@
-import { jest } from '@jest/globals';
+import { jest } from "@jest/globals";
 
 // Mock ConfigService globally to prevent MongoDB connections and hangs
-jest.mock('../src/services/config-service.js', () => ({
+jest.mock("../src/services/config-service.js", () => ({
   ConfigService: {
     getInstance: jest.fn(() => ({
-      getString: jest.fn().mockResolvedValue('test-value'),
+      getString: jest.fn().mockResolvedValue("test-value"),
       getNumber: jest.fn().mockResolvedValue(123),
       getBoolean: jest.fn().mockResolvedValue(true),
       getConfig: jest.fn().mockResolvedValue(new Map()),
@@ -21,8 +21,8 @@ class MockSchema {
     return this;
   }
   static Types = {
-    Mixed: 'Mixed',
-    ObjectId: 'ObjectId',
+    Mixed: "Mixed",
+    ObjectId: "ObjectId",
     String: String,
     Number: Number,
     Boolean: Boolean,
@@ -34,7 +34,7 @@ class MockSchema {
 }
 
 // Mock mongoose globally to prevent DB connections
-jest.mock('mongoose', () => ({
+jest.mock("mongoose", () => ({
   default: {
     connect: jest.fn().mockResolvedValue(undefined),
     connection: {

--- a/__tests__/test-utils.ts
+++ b/__tests__/test-utils.ts
@@ -3,7 +3,7 @@
  */
 export function createMockCollection<K, V>(entries: [K, V][] = []): any {
   const map = new Map(entries);
-  
+
   return {
     get: (key: K): V | undefined => map.get(key),
     set: (key: K, value: V): Map<K, V> => map.set(key, value),
@@ -11,8 +11,11 @@ export function createMockCollection<K, V>(entries: [K, V][] = []): any {
     delete: (key: K): boolean => map.delete(key),
     clear: (): void => map.clear(),
     forEach: (fn: (value: V, key: K) => void): void => map.forEach(fn),
-    map: <T>(fn: (value: V, key: K) => T): T[] => Array.from(map.values()).map((v, i) => fn(v, Array.from(map.keys())[i])),
-    filter: (fn: (value: V, key: K) => boolean): ReturnType<typeof createMockCollection<K, V>> => {
+    map: <T>(fn: (value: V, key: K) => T): T[] =>
+      Array.from(map.values()).map((v, i) => fn(v, Array.from(map.keys())[i])),
+    filter: (
+      fn: (value: V, key: K) => boolean,
+    ): ReturnType<typeof createMockCollection<K, V>> => {
       const filtered = Array.from(map.entries()).filter(([k, v]) => fn(v, k));
       return createMockCollection(filtered);
     },

--- a/__tests__/utils/channel-detector.test.ts
+++ b/__tests__/utils/channel-detector.test.ts
@@ -1,9 +1,16 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import { ChannelDetector } from '../../src/utils/channel-detector.js';
-import { ChannelType, type Guild, type CategoryChannel, type VoiceChannel, type TextChannel, type GuildBasedChannel } from 'discord.js';
-import { createMockCollection } from '../test-utils.js';
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { ChannelDetector } from "../../src/utils/channel-detector.js";
+import {
+  ChannelType,
+  type Guild,
+  type CategoryChannel,
+  type VoiceChannel,
+  type TextChannel,
+  type GuildBasedChannel,
+} from "discord.js";
+import { createMockCollection } from "../test-utils.js";
 
-describe('ChannelDetector', () => {
+describe("ChannelDetector", () => {
   let mockGuild: Partial<Guild>;
   let mockChannels: any;
 
@@ -19,17 +26,17 @@ describe('ChannelDetector', () => {
     };
   });
 
-  describe('detectChannels', () => {
-    it('should detect voice categories', async () => {
-      mockChannels.set('cat1', {
-        id: 'cat1',
-        name: 'Voice Channels',
+  describe("detectChannels", () => {
+    it("should detect voice categories", async () => {
+      mockChannels.set("cat1", {
+        id: "cat1",
+        name: "Voice Channels",
         type: ChannelType.GuildCategory,
       } as CategoryChannel);
 
-      mockChannels.set('cat2', {
-        id: 'cat2',
-        name: 'VC Lobby',
+      mockChannels.set("cat2", {
+        id: "cat2",
+        name: "VC Lobby",
         type: ChannelType.GuildCategory,
       } as CategoryChannel);
 
@@ -40,16 +47,16 @@ describe('ChannelDetector', () => {
       expect(result.textChannels).toHaveLength(0);
     });
 
-    it('should detect lobby voice channels', async () => {
-      mockChannels.set('vc1', {
-        id: 'vc1',
-        name: 'Lobby',
+    it("should detect lobby voice channels", async () => {
+      mockChannels.set("vc1", {
+        id: "vc1",
+        name: "Lobby",
         type: ChannelType.GuildVoice,
       } as VoiceChannel);
 
-      mockChannels.set('vc2', {
-        id: 'vc2',
-        name: 'Waiting Lounge',
+      mockChannels.set("vc2", {
+        id: "vc2",
+        name: "Waiting Lounge",
         type: ChannelType.GuildVoice,
       } as VoiceChannel);
 
@@ -60,16 +67,16 @@ describe('ChannelDetector', () => {
       expect(result.textChannels).toHaveLength(0);
     });
 
-    it('should detect text channels', async () => {
-      mockChannels.set('txt1', {
-        id: 'txt1',
-        name: 'general',
+    it("should detect text channels", async () => {
+      mockChannels.set("txt1", {
+        id: "txt1",
+        name: "general",
         type: ChannelType.GuildText,
       } as TextChannel);
 
-      mockChannels.set('txt2', {
-        id: 'txt2',
-        name: 'announcements',
+      mockChannels.set("txt2", {
+        id: "txt2",
+        name: "announcements",
         type: ChannelType.GuildText,
       } as TextChannel);
 
@@ -80,22 +87,22 @@ describe('ChannelDetector', () => {
       expect(result.lobbyChannels).toHaveLength(0);
     });
 
-    it('should detect all channel types together', async () => {
-      mockChannels.set('cat1', {
-        id: 'cat1',
-        name: 'Voice Chat',
+    it("should detect all channel types together", async () => {
+      mockChannels.set("cat1", {
+        id: "cat1",
+        name: "Voice Chat",
         type: ChannelType.GuildCategory,
       } as CategoryChannel);
 
-      mockChannels.set('vc1', {
-        id: 'vc1',
-        name: 'Join Lobby',
+      mockChannels.set("vc1", {
+        id: "vc1",
+        name: "Join Lobby",
         type: ChannelType.GuildVoice,
       } as VoiceChannel);
 
-      mockChannels.set('txt1', {
-        id: 'txt1',
-        name: 'general',
+      mockChannels.set("txt1", {
+        id: "txt1",
+        name: "general",
         type: ChannelType.GuildText,
       } as TextChannel);
 
@@ -106,11 +113,11 @@ describe('ChannelDetector', () => {
       expect(result.textChannels).toHaveLength(1);
     });
 
-    it('should ignore null channels', async () => {
-      mockChannels.set('null1', null as any);
-      mockChannels.set('txt1', {
-        id: 'txt1',
-        name: 'general',
+    it("should ignore null channels", async () => {
+      mockChannels.set("null1", null as any);
+      mockChannels.set("txt1", {
+        id: "txt1",
+        name: "general",
         type: ChannelType.GuildText,
       } as TextChannel);
 
@@ -120,9 +127,9 @@ describe('ChannelDetector', () => {
     });
 
     it('should detect categories with "talk" in name', async () => {
-      mockChannels.set('cat1', {
-        id: 'cat1',
-        name: 'Talk Channels',
+      mockChannels.set("cat1", {
+        id: "cat1",
+        name: "Talk Channels",
         type: ChannelType.GuildCategory,
       } as CategoryChannel);
 
@@ -132,9 +139,9 @@ describe('ChannelDetector', () => {
     });
 
     it('should detect categories with "chat" in name', async () => {
-      mockChannels.set('cat1', {
-        id: 'cat1',
-        name: 'Chat Rooms',
+      mockChannels.set("cat1", {
+        id: "cat1",
+        name: "Chat Rooms",
         type: ChannelType.GuildCategory,
       } as CategoryChannel);
 
@@ -143,22 +150,26 @@ describe('ChannelDetector', () => {
       expect(result.voiceCategories).toHaveLength(1);
     });
 
-    it('should handle errors gracefully', async () => {
-      mockGuild.channels!.fetch = jest.fn().mockRejectedValue(new Error('Test error'));
+    it("should handle errors gracefully", async () => {
+      mockGuild.channels!.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error("Test error"));
 
-      await expect(ChannelDetector.detectChannels(mockGuild as Guild)).rejects.toThrow('Test error');
+      await expect(
+        ChannelDetector.detectChannels(mockGuild as Guild),
+      ).rejects.toThrow("Test error");
     });
 
-    it('should be case-insensitive when detecting channels', async () => {
-      mockChannels.set('cat1', {
-        id: 'cat1',
-        name: 'VOICE CHANNELS',
+    it("should be case-insensitive when detecting channels", async () => {
+      mockChannels.set("cat1", {
+        id: "cat1",
+        name: "VOICE CHANNELS",
         type: ChannelType.GuildCategory,
       } as CategoryChannel);
 
-      mockChannels.set('vc1', {
-        id: 'vc1',
-        name: 'LOBBY',
+      mockChannels.set("vc1", {
+        id: "vc1",
+        name: "LOBBY",
         type: ChannelType.GuildVoice,
       } as VoiceChannel);
 
@@ -169,223 +180,302 @@ describe('ChannelDetector', () => {
     });
   });
 
-  describe('findCategoryByName', () => {
-    it('should find category by exact name', async () => {
+  describe("findCategoryByName", () => {
+    it("should find category by exact name", async () => {
       const mockCategory = {
-        id: 'cat1',
-        name: 'Voice Channels',
+        id: "cat1",
+        name: "Voice Channels",
         type: ChannelType.GuildCategory,
       } as CategoryChannel;
 
-      mockChannels.set('cat1', mockCategory);
+      mockChannels.set("cat1", mockCategory);
 
-      const result = await ChannelDetector.findCategoryByName(mockGuild as Guild, 'Voice Channels');
+      const result = await ChannelDetector.findCategoryByName(
+        mockGuild as Guild,
+        "Voice Channels",
+      );
 
       expect(result).toBeDefined();
       expect(result).toBe(mockCategory);
     });
 
-    it('should be case-insensitive', async () => {
+    it("should be case-insensitive", async () => {
       const mockCategory = {
-        id: 'cat1',
-        name: 'Voice Channels',
+        id: "cat1",
+        name: "Voice Channels",
         type: ChannelType.GuildCategory,
       } as CategoryChannel;
 
-      mockChannels.set('cat1', mockCategory);
+      mockChannels.set("cat1", mockCategory);
 
-      const result = await ChannelDetector.findCategoryByName(mockGuild as Guild, 'voice channels');
+      const result = await ChannelDetector.findCategoryByName(
+        mockGuild as Guild,
+        "voice channels",
+      );
 
       expect(result).toBeDefined();
       expect(result).toBe(mockCategory);
     });
 
-    it('should return null if category not found', async () => {
-      const result = await ChannelDetector.findCategoryByName(mockGuild as Guild, 'NonExistent');
+    it("should return null if category not found", async () => {
+      const result = await ChannelDetector.findCategoryByName(
+        mockGuild as Guild,
+        "NonExistent",
+      );
 
       expect(result).toBeNull();
     });
 
-    it('should handle errors gracefully', async () => {
-      mockGuild.channels!.fetch = jest.fn().mockRejectedValue(new Error('Test error'));
+    it("should handle errors gracefully", async () => {
+      mockGuild.channels!.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error("Test error"));
 
-      const result = await ChannelDetector.findCategoryByName(mockGuild as Guild, 'Test');
+      const result = await ChannelDetector.findCategoryByName(
+        mockGuild as Guild,
+        "Test",
+      );
 
       expect(result).toBeNull();
     });
 
-    it('should ignore non-category channels', async () => {
-      mockChannels.set('txt1', {
-        id: 'txt1',
-        name: 'Voice Channels',
+    it("should ignore non-category channels", async () => {
+      mockChannels.set("txt1", {
+        id: "txt1",
+        name: "Voice Channels",
         type: ChannelType.GuildText,
       } as TextChannel);
 
-      const result = await ChannelDetector.findCategoryByName(mockGuild as Guild, 'Voice Channels');
+      const result = await ChannelDetector.findCategoryByName(
+        mockGuild as Guild,
+        "Voice Channels",
+      );
 
       expect(result).toBeNull();
     });
   });
 
-  describe('findVoiceChannelByName', () => {
-    it('should find voice channel by exact name', async () => {
+  describe("findVoiceChannelByName", () => {
+    it("should find voice channel by exact name", async () => {
       const mockVoice = {
-        id: 'vc1',
-        name: 'Lobby',
+        id: "vc1",
+        name: "Lobby",
         type: ChannelType.GuildVoice,
       } as VoiceChannel;
 
-      mockChannels.set('vc1', mockVoice);
+      mockChannels.set("vc1", mockVoice);
 
-      const result = await ChannelDetector.findVoiceChannelByName(mockGuild as Guild, 'Lobby');
+      const result = await ChannelDetector.findVoiceChannelByName(
+        mockGuild as Guild,
+        "Lobby",
+      );
 
       expect(result).toBeDefined();
       expect(result).toBe(mockVoice);
     });
 
-    it('should be case-insensitive', async () => {
+    it("should be case-insensitive", async () => {
       const mockVoice = {
-        id: 'vc1',
-        name: 'Lobby',
+        id: "vc1",
+        name: "Lobby",
         type: ChannelType.GuildVoice,
       } as VoiceChannel;
 
-      mockChannels.set('vc1', mockVoice);
+      mockChannels.set("vc1", mockVoice);
 
-      const result = await ChannelDetector.findVoiceChannelByName(mockGuild as Guild, 'lobby');
+      const result = await ChannelDetector.findVoiceChannelByName(
+        mockGuild as Guild,
+        "lobby",
+      );
 
       expect(result).toBeDefined();
       expect(result).toBe(mockVoice);
     });
 
-    it('should return null if voice channel not found', async () => {
-      const result = await ChannelDetector.findVoiceChannelByName(mockGuild as Guild, 'NonExistent');
+    it("should return null if voice channel not found", async () => {
+      const result = await ChannelDetector.findVoiceChannelByName(
+        mockGuild as Guild,
+        "NonExistent",
+      );
 
       expect(result).toBeNull();
     });
 
-    it('should handle errors gracefully', async () => {
-      mockGuild.channels!.fetch = jest.fn().mockRejectedValue(new Error('Test error'));
+    it("should handle errors gracefully", async () => {
+      mockGuild.channels!.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error("Test error"));
 
-      const result = await ChannelDetector.findVoiceChannelByName(mockGuild as Guild, 'Test');
-
-      expect(result).toBeNull();
-    });
-  });
-
-  describe('findTextChannelByName', () => {
-    it('should find text channel by exact name', async () => {
-      const mockText = {
-        id: 'txt1',
-        name: 'general',
-        type: ChannelType.GuildText,
-      } as TextChannel;
-
-      mockChannels.set('txt1', mockText);
-
-      const result = await ChannelDetector.findTextChannelByName(mockGuild as Guild, 'general');
-
-      expect(result).toBeDefined();
-      expect(result).toBe(mockText);
-    });
-
-    it('should be case-insensitive', async () => {
-      const mockText = {
-        id: 'txt1',
-        name: 'General',
-        type: ChannelType.GuildText,
-      } as TextChannel;
-
-      mockChannels.set('txt1', mockText);
-
-      const result = await ChannelDetector.findTextChannelByName(mockGuild as Guild, 'GENERAL');
-
-      expect(result).toBeDefined();
-      expect(result).toBe(mockText);
-    });
-
-    it('should return null if text channel not found', async () => {
-      const result = await ChannelDetector.findTextChannelByName(mockGuild as Guild, 'NonExistent');
-
-      expect(result).toBeNull();
-    });
-
-    it('should handle errors gracefully', async () => {
-      mockGuild.channels!.fetch = jest.fn().mockRejectedValue(new Error('Test error'));
-
-      const result = await ChannelDetector.findTextChannelByName(mockGuild as Guild, 'Test');
+      const result = await ChannelDetector.findVoiceChannelByName(
+        mockGuild as Guild,
+        "Test",
+      );
 
       expect(result).toBeNull();
     });
   });
 
-  describe('resourceExists', () => {
+  describe("findTextChannelByName", () => {
+    it("should find text channel by exact name", async () => {
+      const mockText = {
+        id: "txt1",
+        name: "general",
+        type: ChannelType.GuildText,
+      } as TextChannel;
+
+      mockChannels.set("txt1", mockText);
+
+      const result = await ChannelDetector.findTextChannelByName(
+        mockGuild as Guild,
+        "general",
+      );
+
+      expect(result).toBeDefined();
+      expect(result).toBe(mockText);
+    });
+
+    it("should be case-insensitive", async () => {
+      const mockText = {
+        id: "txt1",
+        name: "General",
+        type: ChannelType.GuildText,
+      } as TextChannel;
+
+      mockChannels.set("txt1", mockText);
+
+      const result = await ChannelDetector.findTextChannelByName(
+        mockGuild as Guild,
+        "GENERAL",
+      );
+
+      expect(result).toBeDefined();
+      expect(result).toBe(mockText);
+    });
+
+    it("should return null if text channel not found", async () => {
+      const result = await ChannelDetector.findTextChannelByName(
+        mockGuild as Guild,
+        "NonExistent",
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should handle errors gracefully", async () => {
+      mockGuild.channels!.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error("Test error"));
+
+      const result = await ChannelDetector.findTextChannelByName(
+        mockGuild as Guild,
+        "Test",
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("resourceExists", () => {
     beforeEach(() => {
-      mockChannels.set('cat1', {
-        id: 'cat1',
-        name: 'Voice',
+      mockChannels.set("cat1", {
+        id: "cat1",
+        name: "Voice",
         type: ChannelType.GuildCategory,
       } as CategoryChannel);
 
-      mockChannels.set('vc1', {
-        id: 'vc1',
-        name: 'Lobby',
+      mockChannels.set("vc1", {
+        id: "vc1",
+        name: "Lobby",
         type: ChannelType.GuildVoice,
       } as VoiceChannel);
 
-      mockChannels.set('txt1', {
-        id: 'txt1',
-        name: 'general',
+      mockChannels.set("txt1", {
+        id: "txt1",
+        name: "general",
         type: ChannelType.GuildText,
       } as TextChannel);
     });
 
-    it('should return true for existing category', async () => {
-      const result = await ChannelDetector.resourceExists(mockGuild as Guild, 'category', 'Voice');
+    it("should return true for existing category", async () => {
+      const result = await ChannelDetector.resourceExists(
+        mockGuild as Guild,
+        "category",
+        "Voice",
+      );
 
       expect(result).toBe(true);
     });
 
-    it('should return true for existing voice channel', async () => {
-      const result = await ChannelDetector.resourceExists(mockGuild as Guild, 'voice', 'Lobby');
+    it("should return true for existing voice channel", async () => {
+      const result = await ChannelDetector.resourceExists(
+        mockGuild as Guild,
+        "voice",
+        "Lobby",
+      );
 
       expect(result).toBe(true);
     });
 
-    it('should return true for existing text channel', async () => {
-      const result = await ChannelDetector.resourceExists(mockGuild as Guild, 'text', 'general');
+    it("should return true for existing text channel", async () => {
+      const result = await ChannelDetector.resourceExists(
+        mockGuild as Guild,
+        "text",
+        "general",
+      );
 
       expect(result).toBe(true);
     });
 
-    it('should return false for non-existing category', async () => {
-      const result = await ChannelDetector.resourceExists(mockGuild as Guild, 'category', 'NonExistent');
+    it("should return false for non-existing category", async () => {
+      const result = await ChannelDetector.resourceExists(
+        mockGuild as Guild,
+        "category",
+        "NonExistent",
+      );
 
       expect(result).toBe(false);
     });
 
-    it('should return false for non-existing voice channel', async () => {
-      const result = await ChannelDetector.resourceExists(mockGuild as Guild, 'voice', 'NonExistent');
+    it("should return false for non-existing voice channel", async () => {
+      const result = await ChannelDetector.resourceExists(
+        mockGuild as Guild,
+        "voice",
+        "NonExistent",
+      );
 
       expect(result).toBe(false);
     });
 
-    it('should return false for non-existing text channel', async () => {
-      const result = await ChannelDetector.resourceExists(mockGuild as Guild, 'text', 'NonExistent');
+    it("should return false for non-existing text channel", async () => {
+      const result = await ChannelDetector.resourceExists(
+        mockGuild as Guild,
+        "text",
+        "NonExistent",
+      );
 
       expect(result).toBe(false);
     });
 
-    it('should handle errors gracefully', async () => {
-      mockGuild.channels!.fetch = jest.fn().mockRejectedValue(new Error('Test error'));
+    it("should handle errors gracefully", async () => {
+      mockGuild.channels!.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error("Test error"));
 
-      const result = await ChannelDetector.resourceExists(mockGuild as Guild, 'text', 'general');
+      const result = await ChannelDetector.resourceExists(
+        mockGuild as Guild,
+        "text",
+        "general",
+      );
 
       expect(result).toBe(false);
     });
 
-    it('should return false for invalid type', async () => {
-      const result = await ChannelDetector.resourceExists(mockGuild as Guild, 'invalid' as any, 'Test');
+    it("should return false for invalid type", async () => {
+      const result = await ChannelDetector.resourceExists(
+        mockGuild as Guild,
+        "invalid" as any,
+        "Test",
+      );
 
       expect(result).toBe(false);
     });

--- a/__tests__/utils/logger-methods.test.ts
+++ b/__tests__/utils/logger-methods.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, afterEach } from '@jest/globals';
+import { describe, it, expect, afterEach } from "@jest/globals";
 
-describe('Logger Utility', () => {
+describe("Logger Utility", () => {
   const originalDebug = process.env.DEBUG;
 
   afterEach(() => {
-    if (typeof originalDebug === 'undefined') {
+    if (typeof originalDebug === "undefined") {
       delete process.env.DEBUG;
       return;
     }
@@ -12,43 +12,43 @@ describe('Logger Utility', () => {
     process.env.DEBUG = originalDebug;
   });
 
-  it('should export logger object', async () => {
-    const logger = await import('../../src/utils/logger.js');
-    
+  it("should export logger object", async () => {
+    const logger = await import("../../src/utils/logger.js");
+
     expect(logger.default).toBeDefined();
   });
 
-  it('should have logging methods', async () => {
-    const { default: logger } = await import('../../src/utils/logger.js');
-    
-    expect(typeof logger.info).toBe('function');
-    expect(typeof logger.error).toBe('function');
-    expect(typeof logger.warn).toBe('function');
-    expect(typeof logger.debug).toBe('function');
+  it("should have logging methods", async () => {
+    const { default: logger } = await import("../../src/utils/logger.js");
+
+    expect(typeof logger.info).toBe("function");
+    expect(typeof logger.error).toBe("function");
+    expect(typeof logger.warn).toBe("function");
+    expect(typeof logger.debug).toBe("function");
   });
 
-  it('should not throw when calling logger methods', async () => {
-    const { default: logger } = await import('../../src/utils/logger.js');
-    
-    expect(() => logger.info('test')).not.toThrow();
-    expect(() => logger.error('test')).not.toThrow();
-    expect(() => logger.warn('test')).not.toThrow();
-    expect(() => logger.debug('test')).not.toThrow();
+  it("should not throw when calling logger methods", async () => {
+    const { default: logger } = await import("../../src/utils/logger.js");
+
+    expect(() => logger.info("test")).not.toThrow();
+    expect(() => logger.error("test")).not.toThrow();
+    expect(() => logger.warn("test")).not.toThrow();
+    expect(() => logger.debug("test")).not.toThrow();
   });
 
-  it('should evaluate debug mode from process.env.DEBUG', async () => {
-    const { isDebugMode } = await import('../../src/utils/logger.js');
+  it("should evaluate debug mode from process.env.DEBUG", async () => {
+    const { isDebugMode } = await import("../../src/utils/logger.js");
 
-    process.env.DEBUG = 'true';
+    process.env.DEBUG = "true";
     expect(isDebugMode()).toBe(true);
 
-    process.env.DEBUG = 'false';
+    process.env.DEBUG = "false";
     expect(isDebugMode()).toBe(false);
 
-    process.env.DEBUG = '';
+    process.env.DEBUG = "";
     expect(isDebugMode()).toBe(false);
 
-    process.env.DEBUG = '1';
+    process.env.DEBUG = "1";
     expect(isDebugMode()).toBe(false);
 
     delete process.env.DEBUG;

--- a/__tests__/utils/logger.test.ts
+++ b/__tests__/utils/logger.test.ts
@@ -1,31 +1,34 @@
-import { describe, it, expect } from '@jest/globals';
-import winston from 'winston';
-import logger from '../../src/utils/logger.js';
+import { describe, it, expect } from "@jest/globals";
+import winston from "winston";
+import logger from "../../src/utils/logger.js";
 
-describe('Logger Error Handling', () => {
-  describe('Logger Configuration', () => {
-    it('should create logger with error serialization format', () => {
+describe("Logger Error Handling", () => {
+  describe("Logger Configuration", () => {
+    it("should create logger with error serialization format", () => {
       const testLogger = winston.createLogger({
-        level: 'info',
+        level: "info",
         format: winston.format.combine(
           winston.format.timestamp(),
           winston.format.errors({ stack: true }),
-          winston.format.printf(({ timestamp, level, message, stack, ...meta }) => {
-            let log = `${timestamp} [${level.toUpperCase()}]: ${message}`;
+          winston.format.printf(
+            ({ timestamp, level, message, stack, ...meta }) => {
+              let log = `${timestamp} [${level.toUpperCase()}]: ${message}`;
 
-            if (stack) {
-              log += `\n${stack}`;
-            }
+              if (stack) {
+                log += `\n${stack}`;
+              }
 
-            const metaKeys = Object.keys(meta).filter(
-              (key) => !['timestamp', 'level', 'message', 'stack'].includes(key),
-            );
-            if (metaKeys.length > 0) {
-              log += `\n${JSON.stringify(meta, null, 2)}`;
-            }
+              const metaKeys = Object.keys(meta).filter(
+                (key) =>
+                  !["timestamp", "level", "message", "stack"].includes(key),
+              );
+              if (metaKeys.length > 0) {
+                log += `\n${JSON.stringify(meta, null, 2)}`;
+              }
 
-            return log;
-          }),
+              return log;
+            },
+          ),
         ),
         transports: [
           new winston.transports.Console({
@@ -35,12 +38,12 @@ describe('Logger Error Handling', () => {
       });
 
       expect(testLogger).toBeDefined();
-      expect(testLogger.level).toBe('info');
+      expect(testLogger.level).toBe("info");
     });
 
-    it('should handle Error objects without crashing', () => {
+    it("should handle Error objects without crashing", () => {
       const testLogger = winston.createLogger({
-        level: 'info',
+        level: "info",
         format: winston.format.combine(
           winston.format.timestamp(),
           winston.format.errors({ stack: true }),
@@ -59,17 +62,17 @@ describe('Logger Error Handling', () => {
         ],
       });
 
-      const testError = new Error('Test error message');
-      
+      const testError = new Error("Test error message");
+
       // Should not throw when logging error objects
       expect(() => {
-        testLogger.error('Uncaught exception:', testError);
+        testLogger.error("Uncaught exception:", testError);
       }).not.toThrow();
     });
 
-    it('should handle TypeError objects without crashing', () => {
+    it("should handle TypeError objects without crashing", () => {
       const testLogger = winston.createLogger({
-        level: 'info',
+        level: "info",
         format: winston.format.combine(
           winston.format.timestamp(),
           winston.format.errors({ stack: true }),
@@ -88,16 +91,16 @@ describe('Logger Error Handling', () => {
         ],
       });
 
-      const typeError = new TypeError('Invalid type');
-      
+      const typeError = new TypeError("Invalid type");
+
       expect(() => {
-        testLogger.error('Type error occurred:', typeError);
+        testLogger.error("Type error occurred:", typeError);
       }).not.toThrow();
     });
 
-    it('should handle ReferenceError objects without crashing', () => {
+    it("should handle ReferenceError objects without crashing", () => {
       const testLogger = winston.createLogger({
-        level: 'info',
+        level: "info",
         format: winston.format.combine(
           winston.format.timestamp(),
           winston.format.errors({ stack: true }),
@@ -116,16 +119,16 @@ describe('Logger Error Handling', () => {
         ],
       });
 
-      const refError = new ReferenceError('Variable not defined');
-      
+      const refError = new ReferenceError("Variable not defined");
+
       expect(() => {
-        testLogger.error('Reference error:', refError);
+        testLogger.error("Reference error:", refError);
       }).not.toThrow();
     });
 
-    it('should handle custom error objects without crashing', () => {
+    it("should handle custom error objects without crashing", () => {
       const testLogger = winston.createLogger({
-        level: 'info',
+        level: "info",
         format: winston.format.combine(
           winston.format.timestamp(),
           winston.format.errors({ stack: true }),
@@ -144,32 +147,35 @@ describe('Logger Error Handling', () => {
         ],
       });
 
-      const customError = { message: 'Custom error object' };
-      
+      const customError = { message: "Custom error object" };
+
       expect(() => {
-        testLogger.error('Custom error:', customError);
+        testLogger.error("Custom error:", customError);
       }).not.toThrow();
     });
 
-    it('should handle metadata without crashing', () => {
+    it("should handle metadata without crashing", () => {
       const testLogger = winston.createLogger({
-        level: 'info',
+        level: "info",
         format: winston.format.combine(
           winston.format.timestamp(),
           winston.format.errors({ stack: true }),
-          winston.format.printf(({ timestamp, level, message, stack, ...meta }) => {
-            let log = `${timestamp} [${level.toUpperCase()}]: ${message}`;
-            if (stack) {
-              log += `\n${stack}`;
-            }
-            const metaKeys = Object.keys(meta).filter(
-              (key) => !['timestamp', 'level', 'message', 'stack'].includes(key),
-            );
-            if (metaKeys.length > 0) {
-              log += `\n${JSON.stringify(meta, null, 2)}`;
-            }
-            return log;
-          }),
+          winston.format.printf(
+            ({ timestamp, level, message, stack, ...meta }) => {
+              let log = `${timestamp} [${level.toUpperCase()}]: ${message}`;
+              if (stack) {
+                log += `\n${stack}`;
+              }
+              const metaKeys = Object.keys(meta).filter(
+                (key) =>
+                  !["timestamp", "level", "message", "stack"].includes(key),
+              );
+              if (metaKeys.length > 0) {
+                log += `\n${JSON.stringify(meta, null, 2)}`;
+              }
+              return log;
+            },
+          ),
         ),
         transports: [
           new winston.transports.Console({
@@ -179,42 +185,45 @@ describe('Logger Error Handling', () => {
       });
 
       expect(() => {
-        testLogger.error('Error with metadata', { userId: '123', action: 'login' });
+        testLogger.error("Error with metadata", {
+          userId: "123",
+          action: "login",
+        });
       }).not.toThrow();
     });
   });
 
-  describe('Actual Logger Instance', () => {
-    it('should export a valid logger instance', () => {
+  describe("Actual Logger Instance", () => {
+    it("should export a valid logger instance", () => {
       expect(logger).toBeDefined();
-      expect(typeof logger.info).toBe('function');
-      expect(typeof logger.error).toBe('function');
-      expect(typeof logger.debug).toBe('function');
-      expect(typeof logger.warn).toBe('function');
+      expect(typeof logger.info).toBe("function");
+      expect(typeof logger.error).toBe("function");
+      expect(typeof logger.debug).toBe("function");
+      expect(typeof logger.warn).toBe("function");
     });
 
-    it('should log info messages', () => {
+    it("should log info messages", () => {
       expect(() => {
-        logger.info('Test info message');
+        logger.info("Test info message");
       }).not.toThrow();
     });
 
-    it('should log error messages', () => {
+    it("should log error messages", () => {
       expect(() => {
-        logger.error('Test error message');
+        logger.error("Test error message");
       }).not.toThrow();
     });
 
-    it('should log with metadata', () => {
+    it("should log with metadata", () => {
       expect(() => {
-        logger.info('Test with metadata', { key: 'value' });
+        logger.info("Test with metadata", { key: "value" });
       }).not.toThrow();
     });
 
-    it('should log errors with stack traces', () => {
-      const error = new Error('Test error');
+    it("should log errors with stack traces", () => {
+      const error = new Error("Test error");
       expect(() => {
-        logger.error('Error occurred:', error);
+        logger.error("Error occurred:", error);
       }).not.toThrow();
     });
   });

--- a/__tests__/utils/record-command-audit.test.ts
+++ b/__tests__/utils/record-command-audit.test.ts
@@ -1,16 +1,16 @@
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 
 const createMock = jest.fn<() => Promise<unknown>>();
 const errorMock = jest.fn();
 
 jest.unstable_mockModule(
-  '../../src/models/discord-command-audit-log.js',
+  "../../src/models/discord-command-audit-log.js",
   () => ({
     DiscordCommandAuditLog: { create: createMock },
   }),
 );
 
-jest.unstable_mockModule('../../src/utils/logger.js', () => ({
+jest.unstable_mockModule("../../src/utils/logger.js", () => ({
   default: {
     error: errorMock,
     warn: jest.fn(),
@@ -19,47 +19,46 @@ jest.unstable_mockModule('../../src/utils/logger.js', () => ({
   },
 }));
 
-const { recordCommandAudit } = await import(
-  '../../src/utils/record-command-audit.js'
-);
+const { recordCommandAudit } =
+  await import("../../src/utils/record-command-audit.js");
 
-describe('recordCommandAudit', () => {
+describe("recordCommandAudit", () => {
   beforeEach(() => {
     createMock.mockClear();
     errorMock.mockClear();
     createMock.mockResolvedValue({});
   });
 
-  it('persists every supplied field', async () => {
+  it("persists every supplied field", async () => {
     await recordCommandAudit({
-      guildId: 'g1',
-      discordUserId: 'u1',
-      commandName: 'quote',
-      subcommand: 'add',
-      channelId: 'c1',
-      result: 'success',
+      guildId: "g1",
+      discordUserId: "u1",
+      commandName: "quote",
+      subcommand: "add",
+      channelId: "c1",
+      result: "success",
       errorMessage: null,
       durationMs: 42,
     });
     expect(createMock).toHaveBeenCalledTimes(1);
     expect(createMock).toHaveBeenCalledWith({
-      guildId: 'g1',
-      discordUserId: 'u1',
-      commandName: 'quote',
-      subcommand: 'add',
-      channelId: 'c1',
-      result: 'success',
+      guildId: "g1",
+      discordUserId: "u1",
+      commandName: "quote",
+      subcommand: "add",
+      channelId: "c1",
+      result: "success",
       errorMessage: null,
       durationMs: 42,
     });
   });
 
-  it('coerces missing optional fields to null', async () => {
+  it("coerces missing optional fields to null", async () => {
     await recordCommandAudit({
-      guildId: 'g1',
-      discordUserId: 'u1',
-      commandName: 'ping',
-      result: 'error',
+      guildId: "g1",
+      discordUserId: "u1",
+      commandName: "ping",
+      result: "error",
       durationMs: 5,
     });
     const arg = createMock.mock.calls[0]?.[0] as Record<string, unknown>;
@@ -68,19 +67,19 @@ describe('recordCommandAudit', () => {
     expect(arg.errorMessage).toBeNull();
   });
 
-  it('swallows DB errors so the user-facing command is unaffected', async () => {
-    createMock.mockRejectedValueOnce(new Error('mongo down'));
+  it("swallows DB errors so the user-facing command is unaffected", async () => {
+    createMock.mockRejectedValueOnce(new Error("mongo down"));
     await expect(
       recordCommandAudit({
-        guildId: 'g1',
-        discordUserId: 'u1',
-        commandName: 'ping',
-        result: 'success',
+        guildId: "g1",
+        discordUserId: "u1",
+        commandName: "ping",
+        result: "success",
         durationMs: 1,
       }),
     ).resolves.toBeUndefined();
     expect(errorMock).toHaveBeenCalledWith(
-      'Failed to record Discord command audit entry',
+      "Failed to record Discord command audit entry",
       expect.any(Error),
     );
   });

--- a/__tests__/utils/time-edge-cases.test.ts
+++ b/__tests__/utils/time-edge-cases.test.ts
@@ -1,57 +1,57 @@
-import { describe, it, expect } from '@jest/globals';
-import { formatDuration } from '../../src/utils/time.js';
+import { describe, it, expect } from "@jest/globals";
+import { formatDuration } from "../../src/utils/time.js";
 
-describe('Time Utilities - Edge Cases', () => {
-  describe('formatDuration - additional edge cases', () => {
-    it('should format exact 1 minute', () => {
+describe("Time Utilities - Edge Cases", () => {
+  describe("formatDuration - additional edge cases", () => {
+    it("should format exact 1 minute", () => {
       const result = formatDuration(60000);
-      expect(result).toBe('1 minute');
+      expect(result).toBe("1 minute");
     });
 
-    it('should format exact 1 hour', () => {
+    it("should format exact 1 hour", () => {
       const result = formatDuration(3600000);
-      expect(result).toBe('1 hour');
+      expect(result).toBe("1 hour");
     });
 
-    it('should format exact 1 day', () => {
+    it("should format exact 1 day", () => {
       const result = formatDuration(86400000);
-      expect(result).toBe('1 day');
+      expect(result).toBe("1 day");
     });
 
-    it('should format hours with no minutes', () => {
+    it("should format hours with no minutes", () => {
       const result = formatDuration(7200000); // 2 hours exactly
-      expect(result).toBe('2 hours');
+      expect(result).toBe("2 hours");
     });
 
-    it('should format days with hours and minutes', () => {
+    it("should format days with hours and minutes", () => {
       const result = formatDuration(90060000); // 1 day, 1 hour, 1 minute
-      expect(result).toBe('1 day, 1 hour, 1 minute');
+      expect(result).toBe("1 day, 1 hour, 1 minute");
     });
 
-    it('should format large duration correctly', () => {
+    it("should format large duration correctly", () => {
       const result = formatDuration(345600000); // 4 days exactly
-      expect(result).toBe('4 days');
+      expect(result).toBe("4 days");
     });
 
-    it('should format duration with all components', () => {
+    it("should format duration with all components", () => {
       const result = formatDuration(183780000); // 2 days, 3 hours, 3 minutes
-      expect(result).toBe('2 days, 3 hours, 3 minutes');
+      expect(result).toBe("2 days, 3 hours, 3 minutes");
     });
 
-    it('should not show seconds when there are larger units', () => {
+    it("should not show seconds when there are larger units", () => {
       const result = formatDuration(125000); // 2 minutes 5 seconds
-      expect(result).toBe('2 minutes');
-      expect(result).not.toContain('second');
+      expect(result).toBe("2 minutes");
+      expect(result).not.toContain("second");
     });
 
-    it('should show seconds only when it is the only unit', () => {
+    it("should show seconds only when it is the only unit", () => {
       const result = formatDuration(30000); // 30 seconds
-      expect(result).toBe('30 seconds');
+      expect(result).toBe("30 seconds");
     });
 
-    it('should handle very large durations', () => {
+    it("should handle very large durations", () => {
       const result = formatDuration(31536000000); // 365 days
-      expect(result).toContain('days');
+      expect(result).toContain("days");
     });
   });
 });

--- a/__tests__/utils/time-utility.test.ts
+++ b/__tests__/utils/time-utility.test.ts
@@ -1,37 +1,37 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect } from "@jest/globals";
 
-describe('Time Utility', () => {
-  it('should export formatDuration function', async () => {
-    const time = await import('../../src/utils/time.js');
-    
+describe("Time Utility", () => {
+  it("should export formatDuration function", async () => {
+    const time = await import("../../src/utils/time.js");
+
     expect(time.formatDuration).toBeDefined();
-    expect(typeof time.formatDuration).toBe('function');
+    expect(typeof time.formatDuration).toBe("function");
   });
 
-  it('should format duration correctly', async () => {
-    const { formatDuration } = await import('../../src/utils/time.js');
-    
+  it("should format duration correctly", async () => {
+    const { formatDuration } = await import("../../src/utils/time.js");
+
     const result = formatDuration(3665);
-    
+
     expect(result).toBeTruthy();
-    expect(typeof result).toBe('string');
+    expect(typeof result).toBe("string");
   });
 
-  it('should handle zero duration', async () => {
-    const { formatDuration } = await import('../../src/utils/time.js');
-    
+  it("should handle zero duration", async () => {
+    const { formatDuration } = await import("../../src/utils/time.js");
+
     const result = formatDuration(0);
-    
-    expect(result).toBe('');
-    expect(typeof result).toBe('string');
+
+    expect(result).toBe("");
+    expect(typeof result).toBe("string");
   });
 
-  it('should handle large durations', async () => {
-    const { formatDuration } = await import('../../src/utils/time.js');
-    
+  it("should handle large durations", async () => {
+    const { formatDuration } = await import("../../src/utils/time.js");
+
     const result = formatDuration(86400); // 1 day in seconds
-    
+
     expect(result).toBeTruthy();
-    expect(typeof result).toBe('string');
+    expect(typeof result).toBe("string");
   });
 });

--- a/__tests__/utils/time.test.ts
+++ b/__tests__/utils/time.test.ts
@@ -1,121 +1,125 @@
-import { describe, it, expect } from '@jest/globals';
-import { formatDuration, formatTimeAgo, formatDateInTimezone } from '../../src/utils/time.js';
+import { describe, it, expect } from "@jest/globals";
+import {
+  formatDuration,
+  formatTimeAgo,
+  formatDateInTimezone,
+} from "../../src/utils/time.js";
 
-describe('Time Utilities', () => {
-  describe('formatDuration', () => {
-    it('should format seconds only', () => {
+describe("Time Utilities", () => {
+  describe("formatDuration", () => {
+    it("should format seconds only", () => {
       const result = formatDuration(5000); // 5 seconds
-      expect(result).toBe('5 seconds');
+      expect(result).toBe("5 seconds");
     });
 
-    it('should format single second', () => {
+    it("should format single second", () => {
       const result = formatDuration(1000); // 1 second
-      expect(result).toBe('1 second');
+      expect(result).toBe("1 second");
     });
 
-    it('should format minutes and seconds', () => {
+    it("should format minutes and seconds", () => {
       const result = formatDuration(90000); // 1 minute 30 seconds
-      expect(result).toBe('1 minute');
+      expect(result).toBe("1 minute");
     });
 
-    it('should format hours and minutes', () => {
+    it("should format hours and minutes", () => {
       const result = formatDuration(3660000); // 1 hour 1 minute
-      expect(result).toBe('1 hour, 1 minute');
+      expect(result).toBe("1 hour, 1 minute");
     });
 
-    it('should format days, hours, and minutes', () => {
+    it("should format days, hours, and minutes", () => {
       const result = formatDuration(90000000); // 1 day 1 hour
-      expect(result).toBe('1 day, 1 hour');
+      expect(result).toBe("1 day, 1 hour");
     });
 
-    it('should handle multiple days', () => {
+    it("should handle multiple days", () => {
       const result = formatDuration(172800000); // 2 days
-      expect(result).toBe('2 days');
+      expect(result).toBe("2 days");
     });
 
-    it('should handle multiple hours', () => {
+    it("should handle multiple hours", () => {
       const result = formatDuration(7200000); // 2 hours
-      expect(result).toBe('2 hours');
+      expect(result).toBe("2 hours");
     });
 
-    it('should handle multiple minutes', () => {
+    it("should handle multiple minutes", () => {
       const result = formatDuration(120000); // 2 minutes
-      expect(result).toBe('2 minutes');
+      expect(result).toBe("2 minutes");
     });
 
-    it('should handle zero milliseconds', () => {
+    it("should handle zero milliseconds", () => {
       const result = formatDuration(0);
-      expect(result).toBe(''); // Returns empty string when no parts
+      expect(result).toBe(""); // Returns empty string when no parts
     });
 
-    it('should handle less than 1 second', () => {
+    it("should handle less than 1 second", () => {
       const result = formatDuration(500); // 0.5 seconds
-      expect(result).toBe(''); // Returns empty string for sub-second durations
+      expect(result).toBe(""); // Returns empty string for sub-second durations
     });
 
-    it('should format complex duration', () => {
+    it("should format complex duration", () => {
       const result = formatDuration(93784000); // 1 day, 2 hours, 3 minutes, 4 seconds
-      expect(result).toBe('1 day, 2 hours, 3 minutes');
+      expect(result).toBe("1 day, 2 hours, 3 minutes");
     });
   });
 
-  describe('formatTimeAgo', () => {
-    it('should format recent time', () => {
+  describe("formatTimeAgo", () => {
+    it("should format recent time", () => {
       const date = new Date(Date.now() - 5000); // 5 seconds ago
       const result = formatTimeAgo(date);
       // date-fns may say "less than a minute ago" for very recent times
-      expect(result).toContain('ago');
+      expect(result).toContain("ago");
     });
 
-    it('should format minutes ago', () => {
+    it("should format minutes ago", () => {
       const date = new Date(Date.now() - 120000); // 2 minutes ago
       const result = formatTimeAgo(date);
-      expect(result).toContain('minute');
-      expect(result).toContain('ago');
+      expect(result).toContain("minute");
+      expect(result).toContain("ago");
     });
 
-    it('should format hours ago', () => {
+    it("should format hours ago", () => {
       const date = new Date(Date.now() - 3600000); // 1 hour ago
       const result = formatTimeAgo(date);
-      expect(result).toContain('hour');
-      expect(result).toContain('ago');
+      expect(result).toContain("hour");
+      expect(result).toContain("ago");
     });
 
-    it('should format days ago', () => {
+    it("should format days ago", () => {
       const date = new Date(Date.now() - 86400000); // 1 day ago
       const result = formatTimeAgo(date);
-      expect(result).toContain('day');
-      expect(result).toContain('ago');
+      expect(result).toContain("day");
+      expect(result).toContain("ago");
     });
 
-    it('should handle invalid date gracefully', () => {
-      const result = formatTimeAgo(new Date('invalid'));
-      expect(result).toBe('unknown time');
+    it("should handle invalid date gracefully", () => {
+      const result = formatTimeAgo(new Date("invalid"));
+      expect(result).toBe("unknown time");
     });
   });
 
-  describe('formatDateInTimezone', () => {
-    it('should format date in UTC', () => {
-      const date = new Date('2024-01-15T10:30:00Z');
-      const result = formatDateInTimezone(date, 'UTC');
-      expect(result).toBe('2024-01-15 10:30:00');
+  describe("formatDateInTimezone", () => {
+    it("should format date in UTC", () => {
+      const date = new Date("2024-01-15T10:30:00Z");
+      const result = formatDateInTimezone(date, "UTC");
+      expect(result).toBe("2024-01-15 10:30:00");
     });
 
-    it('should format date in America/New_York', () => {
-      const date = new Date('2024-01-15T15:30:00Z');
-      const result = formatDateInTimezone(date, 'America/New_York');
+    it("should format date in America/New_York", () => {
+      const date = new Date("2024-01-15T15:30:00Z");
+      const result = formatDateInTimezone(date, "America/New_York");
       expect(result).toMatch(/2024-01-15 \d{2}:\d{2}:\d{2}/);
     });
 
-    it('should handle invalid timezone by falling back to UTC format', () => {
-      const date = new Date('2024-01-15T10:30:00Z');
-      const result = formatDateInTimezone(date, 'Invalid/Timezone');
+    it("should handle invalid timezone by falling back to UTC format", () => {
+      const date = new Date("2024-01-15T10:30:00Z");
+      const result = formatDateInTimezone(date, "Invalid/Timezone");
       expect(result).toMatch(/2024-01-15 \d{2}:\d{2}:\d{2}/);
     });
 
-    it('should format date in Europe/London', () => {
-      const date = new Date('2024-01-15T12:00:00Z');
-      const result = formatDateInTimezone(date, 'Europe/London');
+    it("should format date in Europe/London", () => {
+      const date = new Date("2024-01-15T12:00:00Z");
+      const result = formatDateInTimezone(date, "Europe/London");
       expect(result).toMatch(/2024-01-15 \d{2}:\d{2}:\d{2}/);
     });
   });

--- a/__tests__/utils/timezone.test.ts
+++ b/__tests__/utils/timezone.test.ts
@@ -65,7 +65,9 @@ describe("timezone utils", () => {
   describe("formatInZone", () => {
     it("formats a UTC instant in the requested zone", () => {
       const d = new Date("2026-06-12T12:00:00Z");
-      expect(formatInZone(d, "UTC", "yyyy-MM-dd HH:mm")).toBe("2026-06-12 12:00");
+      expect(formatInZone(d, "UTC", "yyyy-MM-dd HH:mm")).toBe(
+        "2026-06-12 12:00",
+      );
       // 12:00 UTC is 08:00 in New York (EDT, UTC-4) in June.
       expect(formatInZone(d, "America/New_York", "yyyy-MM-dd HH:mm")).toBe(
         "2026-06-12 08:00",

--- a/__tests__/web/session-ping.test.ts
+++ b/__tests__/web/session-ping.test.ts
@@ -119,11 +119,7 @@ describe("createSessionPingHandler", () => {
     const req = makeReq(cookie);
     const res = makeRes();
     const next = jest.fn();
-    await createSessionPingHandler()(
-      req as never,
-      res as never,
-      next as never,
-    );
+    await createSessionPingHandler()(req as never, res as never, next as never);
 
     expect(res.statusCode).toBe(200);
     expect(next).not.toHaveBeenCalled();

--- a/__tests__/web/write-routes.test.ts
+++ b/__tests__/web/write-routes.test.ts
@@ -377,13 +377,15 @@ describe("coerceConfigValue", () => {
     });
 
     it("leaves a name value with no shortcode unchanged", () => {
-      expect(
-        coerceConfigValue("voicechannels.lobby.name", "Lobby"),
-      ).toEqual({ ok: true, value: "Lobby" });
+      expect(coerceConfigValue("voicechannels.lobby.name", "Lobby")).toEqual({
+        ok: true,
+        value: "Lobby",
+      });
       // Raw Unicode the admin pasted directly must survive verbatim.
-      expect(
-        coerceConfigValue("voicechannels.channel.prefix", "🎮"),
-      ).toEqual({ ok: true, value: "🎮" });
+      expect(coerceConfigValue("voicechannels.channel.prefix", "🎮")).toEqual({
+        ok: true,
+        value: "🎮",
+      });
     });
 
     it("does not resolve shortcodes for non-name string keys", () => {
@@ -395,10 +397,7 @@ describe("coerceConfigValue", () => {
       );
       expect(nameResult.ok && nameResult.value).toBe("🟢");
       // A non-name string key is left as-typed.
-      const r = coerceConfigValue(
-        "leaderboard_roles.tiers",
-        ":green_circle:",
-      );
+      const r = coerceConfigValue("leaderboard_roles.tiers", ":green_circle:");
       expect(r).toEqual({ ok: true, value: ":green_circle:" });
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -495,6 +495,9 @@ async function gracefulShutdown(signal: string): Promise<void> {
         digestService.destroy();
         rewindNudgeService.destroy();
         WizardService.getInstance().shutdown();
+        // Persist any metrics still buffered in memory before the DB
+        // connection closes below, then stop the flush/logging timers.
+        await MonitoringService.getInstance().flushMetrics();
         MonitoringService.getInstance().destroy();
         await botStatusService.shutdown();
       },

--- a/src/models/command-metrics.ts
+++ b/src/models/command-metrics.ts
@@ -1,0 +1,71 @@
+import mongoose, { Document, Schema } from "mongoose";
+
+/**
+ * Persisted, per-command daily metric bucket (issue #648).
+ *
+ * `MonitoringService` keeps rich per-command counters in memory, but those
+ * are wiped on every restart and never surfaced outside the logs. This model
+ * gives them a durable home: one document per `{command, date, guildId}`
+ * (a UTC day bucket), upserted in batches by `MonitoringService.flushMetrics`.
+ *
+ * Daily bucketing (rather than one cumulative doc per command) yields natural
+ * time-series data for the Admin → Command Metrics dashboard and makes
+ * retention a simple matter of dropping old buckets.
+ *
+ * Retention is handled by a TTL index on `expiresAt`. Each write stamps
+ * `expiresAt = lastUsedAt + monitoring.metrics_retention_days`, so the window
+ * is operator-configurable at write time even though a TTL index's
+ * `expireAfterSeconds` is otherwise fixed — Mongo simply removes a doc once
+ * its own `expiresAt` passes.
+ */
+export interface ICommandMetrics extends Document {
+  /** Slash-command name (no leading slash, no subcommand). */
+  command: string;
+  /** UTC day bucket key, formatted "YYYY-MM-DD". */
+  date: string;
+  guildId: string;
+  /** Successful + failed invocations recorded in this bucket. */
+  usageCount: number;
+  /** Subset of `usageCount` that ended in an error. */
+  errorCount: number;
+  /** Summed response time (ms) across `usageCount` invocations. */
+  totalResponseMs: number;
+  firstUsedAt: Date;
+  lastUsedAt: Date;
+  /** TTL anchor — the doc is pruned once this timestamp passes. */
+  expiresAt: Date;
+}
+
+const CommandMetricsSchema = new Schema<ICommandMetrics>(
+  {
+    command: { type: String, required: true },
+    date: { type: String, required: true },
+    guildId: { type: String, required: true },
+    usageCount: { type: Number, default: 0 },
+    errorCount: { type: Number, default: 0 },
+    totalResponseMs: { type: Number, default: 0 },
+    firstUsedAt: { type: Date, required: true, default: Date.now },
+    lastUsedAt: { type: Date, required: true, default: Date.now },
+    expiresAt: { type: Date, required: true },
+  },
+  { timestamps: false },
+);
+
+// One bucket per command per guild per day — the upsert key.
+CommandMetricsSchema.index(
+  { command: 1, date: 1, guildId: 1 },
+  { unique: true },
+);
+
+// Backs the dashboard's "last N days for this guild" range scans.
+CommandMetricsSchema.index({ guildId: 1, date: 1 });
+
+// TTL: remove a bucket once its per-document `expiresAt` passes. The
+// `expireAfterSeconds: 0` form defers entirely to each doc's own anchor,
+// which is what lets the retention window stay config-driven.
+CommandMetricsSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+export const CommandMetrics = mongoose.model<ICommandMetrics>(
+  "CommandMetrics",
+  CommandMetricsSchema,
+);

--- a/src/services/command-manager.ts
+++ b/src/services/command-manager.ts
@@ -554,6 +554,7 @@ export class CommandManager {
         trackingId,
         startTime,
         true,
+        interaction.guildId,
       );
       recordCommandInvocation(commandName, "ok");
       await recordAudit("success", null);
@@ -563,6 +564,7 @@ export class CommandManager {
         trackingId,
         startTime,
         false,
+        interaction.guildId,
       );
       monitoringService.trackError(commandName, error as Error);
       recordCommandInvocation(commandName, "error");

--- a/src/services/command-metrics-query.ts
+++ b/src/services/command-metrics-query.ts
@@ -1,0 +1,132 @@
+import { CommandMetrics } from "../models/command-metrics.js";
+
+/**
+ * Aggregated, per-command rollup of the persisted daily metric buckets over a
+ * trailing window (issue #648). Powers the Admin → Command Metrics dashboard.
+ */
+export interface CommandMetricSummaryRow {
+  command: string;
+  usageCount: number;
+  errorCount: number;
+  /** errorCount / usageCount, in the range 0..1 (0 when usageCount is 0). */
+  errorRate: number;
+  /** totalResponseMs / usageCount (0 when usageCount is 0). */
+  avgResponseMs: number;
+  totalResponseMs: number;
+  lastUsedAt: string | null;
+}
+
+/** Per-day totals across all commands, for the usage-trend chart. */
+export interface CommandMetricsDailyTotal {
+  date: string;
+  usageCount: number;
+  errorCount: number;
+}
+
+export interface CommandMetricsSummary {
+  windowDays: number;
+  /** Inclusive lower bound of the window, as a "YYYY-MM-DD" key. */
+  fromDate: string;
+  /** Per-command rows, sorted by usage descending. */
+  rows: CommandMetricSummaryRow[];
+  /** Per-day totals, sorted by date ascending. */
+  dailyTotals: CommandMetricsDailyTotal[];
+  totalUsage: number;
+  totalErrors: number;
+}
+
+interface RawCommandGroup {
+  _id: string;
+  usageCount: number;
+  errorCount: number;
+  totalResponseMs: number;
+  lastUsedAt: Date | string | null;
+}
+
+interface RawDailyGroup {
+  _id: string;
+  usageCount: number;
+  errorCount: number;
+}
+
+/** "YYYY-MM-DD" key for `daysAgo` days before `now` (UTC). */
+export function dayKeyDaysAgo(daysAgo: number, now: Date = new Date()): string {
+  const d = new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Roll up the persisted command-metric buckets for a guild over the trailing
+ * `windowDays` days into per-command and per-day summaries. Kept free of any
+ * Discord/HTTP concerns so the route stays thin and this is unit-testable by
+ * stubbing the model's `aggregate`.
+ */
+export async function getCommandMetricsSummary(
+  guildId: string,
+  windowDays: number,
+): Promise<CommandMetricsSummary> {
+  // Window is inclusive of today, so a 7-day window covers today plus the
+  // previous 6 days.
+  const fromDate = dayKeyDaysAgo(Math.max(0, windowDays - 1));
+  const match = { guildId, date: { $gte: fromDate } };
+
+  const [byCommand, byDay] = await Promise.all([
+    CommandMetrics.aggregate<RawCommandGroup>([
+      { $match: match },
+      {
+        $group: {
+          _id: "$command",
+          usageCount: { $sum: "$usageCount" },
+          errorCount: { $sum: "$errorCount" },
+          totalResponseMs: { $sum: "$totalResponseMs" },
+          lastUsedAt: { $max: "$lastUsedAt" },
+        },
+      },
+      { $sort: { usageCount: -1, _id: 1 } },
+    ]),
+    CommandMetrics.aggregate<RawDailyGroup>([
+      { $match: match },
+      {
+        $group: {
+          _id: "$date",
+          usageCount: { $sum: "$usageCount" },
+          errorCount: { $sum: "$errorCount" },
+        },
+      },
+      { $sort: { _id: 1 } },
+    ]),
+  ]);
+
+  const rows: CommandMetricSummaryRow[] = byCommand.map((g) => {
+    const usageCount = g.usageCount ?? 0;
+    const errorCount = g.errorCount ?? 0;
+    const totalResponseMs = g.totalResponseMs ?? 0;
+    return {
+      command: g._id,
+      usageCount,
+      errorCount,
+      errorRate: usageCount > 0 ? errorCount / usageCount : 0,
+      avgResponseMs: usageCount > 0 ? totalResponseMs / usageCount : 0,
+      totalResponseMs,
+      lastUsedAt: g.lastUsedAt ? new Date(g.lastUsedAt).toISOString() : null,
+    };
+  });
+
+  const dailyTotals: CommandMetricsDailyTotal[] = byDay.map((g) => ({
+    date: g._id,
+    usageCount: g.usageCount ?? 0,
+    errorCount: g.errorCount ?? 0,
+  }));
+
+  const totalUsage = rows.reduce((sum, r) => sum + r.usageCount, 0);
+  const totalErrors = rows.reduce((sum, r) => sum + r.errorCount, 0);
+
+  return {
+    windowDays,
+    fromDate,
+    rows,
+    dailyTotals,
+    totalUsage,
+    totalErrors,
+  };
+}

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -107,6 +107,10 @@ export interface ConfigSchema {
   // Discord slash-command audit log (issue #459)
   "core.command_audit.enabled": boolean;
   "core.command_audit.retention_days": number;
+
+  // Persisted command metrics (issue #648)
+  "monitoring.metrics_persistence.enabled": boolean;
+  "monitoring.metrics_retention_days": number;
 }
 
 /**
@@ -269,6 +273,12 @@ export const defaultConfig: ConfigSchema = {
   // matches the proposal in the issue (90 days).
   "core.command_audit.enabled": true,
   "core.command_audit.retention_days": 90,
+
+  // Persisted command metrics defaults (#648). On by default so fresh
+  // installs get historical command analytics in the Admin → Command
+  // Metrics dashboard out of the box; 30-day window matches the issue.
+  "monitoring.metrics_persistence.enabled": true,
+  "monitoring.metrics_retention_days": 30,
 };
 
 /**
@@ -1001,6 +1011,20 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
     label: "Slash-command audit retention (days)",
     description:
       "Days to keep slash-command audit rows before the cleanup job prunes them.",
+    category: "core",
+    type: "number",
+  },
+  "monitoring.metrics_persistence.enabled": {
+    label: "Persist command metrics",
+    description:
+      "Store per-command daily usage/error/latency buckets in MongoDB so command analytics survive restarts and feed the Admin → Command Metrics dashboard. When off, metrics remain in-memory only.",
+    category: "core",
+    type: "boolean",
+  },
+  "monitoring.metrics_retention_days": {
+    label: "Command-metrics retention (days)",
+    description:
+      "Days to keep persisted command-metric buckets before MongoDB's TTL index prunes them.",
     category: "core",
     type: "number",
   },

--- a/src/services/monitoring-service.ts
+++ b/src/services/monitoring-service.ts
@@ -1,5 +1,8 @@
 import { Collection } from "discord.js";
+import mongoose from "mongoose";
 import logger from "../utils/logger.js";
+import { CommandMetrics as CommandMetricsModel } from "../models/command-metrics.js";
+import { ConfigService } from "./config-service.js";
 
 interface CommandMetrics {
   name: string;
@@ -9,6 +12,37 @@ interface CommandMetrics {
   errorCount: number;
   lastUsed: Date;
   firstUsed: Date;
+}
+
+/**
+ * Accumulated counters for a single `{guildId, command, date}` bucket,
+ * waiting to be flushed to MongoDB. Batching these in memory keeps the DB
+ * write off the per-invocation hot path (issue #648).
+ */
+interface PendingBucket {
+  command: string;
+  guildId: string;
+  /** UTC "YYYY-MM-DD" day key. */
+  date: string;
+  usageCount: number;
+  errorCount: number;
+  totalResponseMs: number;
+  firstUsedAt: Date;
+  lastUsedAt: Date;
+}
+
+/**
+ * How often the pending buckets are flushed to MongoDB. Comfortably under
+ * the "at least once per hour" bar from the issue, while still batching so
+ * a busy guild doesn't trigger a write per command.
+ */
+const FLUSH_INTERVAL_MS = 5 * 60 * 1000;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function pendingKey(guildId: string, command: string, date: string): string {
+  // NUL separator can't appear in a command name or snowflake.
+  return `${guildId}\u0000${command}\u0000${date}`;
 }
 
 interface PerformanceMetrics {
@@ -31,10 +65,15 @@ export class MonitoringService {
   private totalCommands: number = 0;
   private totalErrors: number = 0;
   private periodicLoggingInterval: ReturnType<typeof setInterval> | null = null;
+  // Per-bucket counters awaiting a batched DB flush (issue #648).
+  private pendingBuckets: Map<string, PendingBucket> = new Map();
+  private flushInterval: ReturnType<typeof setInterval> | null = null;
 
   private constructor() {
     // Start periodic memory usage logging
     this.startPeriodicLogging();
+    // Periodically persist accumulated command metrics to MongoDB.
+    this.startPeriodicFlush();
   }
 
   public static getInstance(): MonitoringService {
@@ -74,13 +113,20 @@ export class MonitoringService {
   }
 
   /**
-   * Track command execution completion
+   * Track command execution completion.
+   *
+   * When a `guildId` is supplied, the invocation is also accumulated into a
+   * pending daily bucket for batched persistence to MongoDB (issue #648).
+   * Callers that represent a blocked attempt rather than a real execution
+   * (permission denied, rate limited) intentionally omit the `guildId` so
+   * those don't pollute the historical usage/error counts.
    */
   public trackCommandEnd(
     commandName: string,
     trackingId: string,
     startTime: number,
     success: boolean = true,
+    guildId?: string | null,
   ): void {
     const endTime = Date.now();
     const responseTime = endTime - startTime;
@@ -97,9 +143,117 @@ export class MonitoringService {
       }
     }
 
+    if (guildId) {
+      const now = new Date();
+      this.addPending({
+        command: commandName,
+        guildId,
+        date: this.dayKey(now),
+        usageCount: 1,
+        errorCount: success ? 0 : 1,
+        totalResponseMs: responseTime,
+        firstUsedAt: now,
+        lastUsedAt: now,
+      });
+    }
+
     logger.debug(
       `Command completed: ${commandName} (ID: ${trackingId}) - ${responseTime}ms - ${success ? "SUCCESS" : "ERROR"}`,
     );
+  }
+
+  /** UTC day-bucket key ("YYYY-MM-DD") for a timestamp. */
+  private dayKey(when: Date): string {
+    return when.toISOString().slice(0, 10);
+  }
+
+  /**
+   * Fold a bucket's counters into the pending map, merging with any counters
+   * already accumulated for the same `{guildId, command, date}` key. Used both
+   * by the live track path and by `flushMetrics` when re-queuing a batch that
+   * failed to write.
+   */
+  private addPending(bucket: PendingBucket): void {
+    const key = pendingKey(bucket.guildId, bucket.command, bucket.date);
+    const existing = this.pendingBuckets.get(key);
+    if (!existing) {
+      this.pendingBuckets.set(key, bucket);
+      return;
+    }
+    existing.usageCount += bucket.usageCount;
+    existing.errorCount += bucket.errorCount;
+    existing.totalResponseMs += bucket.totalResponseMs;
+    if (bucket.firstUsedAt < existing.firstUsedAt) {
+      existing.firstUsedAt = bucket.firstUsedAt;
+    }
+    if (bucket.lastUsedAt > existing.lastUsedAt) {
+      existing.lastUsedAt = bucket.lastUsedAt;
+    }
+  }
+
+  /**
+   * Persist accumulated command-metric buckets to MongoDB as a single batch
+   * of upserts (issue #648). Each bucket increments the matching daily doc's
+   * counters and bumps its TTL anchor based on the configured retention.
+   *
+   * No-op (counters kept for the next tick) when the DB isn't connected, and
+   * a guard skips the whole pass when persistence is disabled. Per-bucket
+   * write failures are logged and the bucket is re-queued so a transient blip
+   * doesn't lose counts. Never throws — safe to call from a timer.
+   */
+  public async flushMetrics(): Promise<void> {
+    if (this.pendingBuckets.size === 0) return;
+    if (mongoose.connection.readyState !== 1) return;
+
+    const config = ConfigService.getInstance();
+    const enabled = await config
+      .getBoolean("monitoring.metrics_persistence.enabled", true)
+      .catch(() => true);
+    if (!enabled) {
+      // Persistence is off — drop the buffer so it can't grow unbounded.
+      this.pendingBuckets.clear();
+      return;
+    }
+    const retentionDays = await config
+      .getNumber("monitoring.metrics_retention_days", 30)
+      .catch(() => 30);
+
+    // Snapshot and clear up front so concurrent tracking accumulates into a
+    // fresh batch rather than racing the writes below.
+    const batch = Array.from(this.pendingBuckets.values());
+    this.pendingBuckets.clear();
+
+    for (const bucket of batch) {
+      try {
+        const expiresAt = new Date(
+          bucket.lastUsedAt.getTime() + retentionDays * DAY_MS,
+        );
+        await CommandMetricsModel.findOneAndUpdate(
+          {
+            command: bucket.command,
+            date: bucket.date,
+            guildId: bucket.guildId,
+          },
+          {
+            $inc: {
+              usageCount: bucket.usageCount,
+              totalResponseMs: bucket.totalResponseMs,
+              errorCount: bucket.errorCount,
+            },
+            $min: { firstUsedAt: bucket.firstUsedAt },
+            $max: { lastUsedAt: bucket.lastUsedAt, expiresAt },
+          },
+          { upsert: true },
+        );
+      } catch (error) {
+        logger.error(
+          `Failed to flush command metrics for ${bucket.command}:`,
+          error,
+        );
+        // Re-queue so the counts survive a transient DB failure.
+        this.addPending(bucket);
+      }
+    }
   }
 
   /**
@@ -219,6 +373,17 @@ export class MonitoringService {
   }
 
   /**
+   * Start the periodic batched flush of command metrics to MongoDB.
+   */
+  private startPeriodicFlush(): void {
+    this.flushInterval = setInterval(() => {
+      this.flushMetrics().catch((error) => {
+        logger.error("Periodic command-metrics flush failed:", error);
+      });
+    }, FLUSH_INTERVAL_MS);
+  }
+
+  /**
    * Format uptime for display
    */
   public formatUptime(): string {
@@ -239,12 +404,21 @@ export class MonitoringService {
   }
 
   /**
-   * Stop periodic logging and clear the interval handle.
+   * Stop periodic logging/flush timers and clear the interval handles.
+   *
+   * Any metrics still pending are NOT flushed here (destroy is synchronous
+   * and runs during shutdown right before the DB connection closes). The
+   * shutdown path awaits `flushMetrics()` explicitly before calling this so
+   * the final batch isn't lost.
    */
   public destroy(): void {
     if (this.periodicLoggingInterval) {
       clearInterval(this.periodicLoggingInterval);
       this.periodicLoggingInterval = null;
+    }
+    if (this.flushInterval) {
+      clearInterval(this.flushInterval);
+      this.flushInterval = null;
     }
   }
 }

--- a/src/services/monitoring-service.ts
+++ b/src/services/monitoring-service.ts
@@ -40,6 +40,18 @@ const FLUSH_INTERVAL_MS = 5 * 60 * 1000;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * Hard cap on the number of distinct pending buckets held in memory. A
+ * prolonged DB outage makes `flushMetrics` keep (rather than drain) the
+ * buffer, so without a cap a busy multi-guild bot could accumulate buckets
+ * without bound and OOM during the very incident that caused the outage.
+ * At the cap, new buckets are dropped (with a one-shot warning) while
+ * already-tracked buckets keep merging. Buckets are tiny, so this still
+ * allows tens of thousands — far beyond any legitimate
+ * commands x guilds x days working set — before shedding load.
+ */
+export const MAX_PENDING_BUCKETS = 50_000;
+
 function pendingKey(guildId: string, command: string, date: string): string {
   // NUL separator can't appear in a command name or snowflake.
   return `${guildId}\u0000${command}\u0000${date}`;
@@ -68,6 +80,10 @@ export class MonitoringService {
   // Per-bucket counters awaiting a batched DB flush (issue #648).
   private pendingBuckets: Map<string, PendingBucket> = new Map();
   private flushInterval: ReturnType<typeof setInterval> | null = null;
+  // Latches true once the buffer hits MAX_PENDING_BUCKETS so the cap warning
+  // fires once per episode rather than on every dropped bucket. Cleared when
+  // the buffer next drains via a successful flush.
+  private droppingPending = false;
 
   private constructor() {
     // Start periodic memory usage logging
@@ -176,30 +192,43 @@ export class MonitoringService {
   private addPending(bucket: PendingBucket): void {
     const key = pendingKey(bucket.guildId, bucket.command, bucket.date);
     const existing = this.pendingBuckets.get(key);
-    if (!existing) {
-      this.pendingBuckets.set(key, bucket);
+    if (existing) {
+      existing.usageCount += bucket.usageCount;
+      existing.errorCount += bucket.errorCount;
+      existing.totalResponseMs += bucket.totalResponseMs;
+      if (bucket.firstUsedAt < existing.firstUsedAt) {
+        existing.firstUsedAt = bucket.firstUsedAt;
+      }
+      if (bucket.lastUsedAt > existing.lastUsedAt) {
+        existing.lastUsedAt = bucket.lastUsedAt;
+      }
       return;
     }
-    existing.usageCount += bucket.usageCount;
-    existing.errorCount += bucket.errorCount;
-    existing.totalResponseMs += bucket.totalResponseMs;
-    if (bucket.firstUsedAt < existing.firstUsedAt) {
-      existing.firstUsedAt = bucket.firstUsedAt;
+    // Merging above never adds a key; only a brand-new bucket grows the map.
+    // Shed those once at the cap so a DB outage can't drive unbounded growth.
+    if (this.pendingBuckets.size >= MAX_PENDING_BUCKETS) {
+      if (!this.droppingPending) {
+        this.droppingPending = true;
+        logger.warn(
+          `Command-metrics buffer reached its ${MAX_PENDING_BUCKETS}-bucket cap; ` +
+            "dropping new buckets until it drains (is MongoDB reachable?).",
+        );
+      }
+      return;
     }
-    if (bucket.lastUsedAt > existing.lastUsedAt) {
-      existing.lastUsedAt = bucket.lastUsedAt;
-    }
+    this.pendingBuckets.set(key, bucket);
   }
 
   /**
-   * Persist accumulated command-metric buckets to MongoDB as a single batch
-   * of upserts (issue #648). Each bucket increments the matching daily doc's
-   * counters and bumps its TTL anchor based on the configured retention.
+   * Persist accumulated command-metric buckets to MongoDB in a single
+   * `bulkWrite` of upserts (issue #648). Each op increments the matching
+   * daily doc's counters and bumps its TTL anchor based on the configured
+   * retention.
    *
    * No-op (counters kept for the next tick) when the DB isn't connected, and
-   * a guard skips the whole pass when persistence is disabled. Per-bucket
-   * write failures are logged and the bucket is re-queued so a transient blip
-   * doesn't lose counts. Never throws — safe to call from a timer.
+   * a guard skips the whole pass when persistence is disabled. A failed write
+   * re-queues the whole batch so a transient blip doesn't lose counts. Never
+   * throws — safe to call from a timer.
    */
   public async flushMetrics(): Promise<void> {
     if (this.pendingBuckets.size === 0) return;
@@ -212,6 +241,7 @@ export class MonitoringService {
     if (!enabled) {
       // Persistence is off — drop the buffer so it can't grow unbounded.
       this.pendingBuckets.clear();
+      this.droppingPending = false;
       return;
     }
     const retentionDays = await config
@@ -219,22 +249,22 @@ export class MonitoringService {
       .catch(() => 30);
 
     // Snapshot and clear up front so concurrent tracking accumulates into a
-    // fresh batch rather than racing the writes below.
+    // fresh batch rather than racing the write below.
     const batch = Array.from(this.pendingBuckets.values());
     this.pendingBuckets.clear();
 
-    for (const bucket of batch) {
-      try {
-        const expiresAt = new Date(
-          bucket.lastUsedAt.getTime() + retentionDays * DAY_MS,
-        );
-        await CommandMetricsModel.findOneAndUpdate(
-          {
+    const ops = batch.map((bucket) => {
+      const expiresAt = new Date(
+        bucket.lastUsedAt.getTime() + retentionDays * DAY_MS,
+      );
+      return {
+        updateOne: {
+          filter: {
             command: bucket.command,
             date: bucket.date,
             guildId: bucket.guildId,
           },
-          {
+          update: {
             $inc: {
               usageCount: bucket.usageCount,
               totalResponseMs: bucket.totalResponseMs,
@@ -243,14 +273,20 @@ export class MonitoringService {
             $min: { firstUsedAt: bucket.firstUsedAt },
             $max: { lastUsedAt: bucket.lastUsedAt, expiresAt },
           },
-          { upsert: true },
-        );
-      } catch (error) {
-        logger.error(
-          `Failed to flush command metrics for ${bucket.command}:`,
-          error,
-        );
-        // Re-queue so the counts survive a transient DB failure.
+          upsert: true,
+        },
+      };
+    });
+
+    try {
+      // `ordered: false` so one bad op can't block the rest of the batch.
+      await CommandMetricsModel.bulkWrite(ops, { ordered: false });
+      // A clean flush drained the buffer — clear the cap-warning latch.
+      this.droppingPending = false;
+    } catch (error) {
+      logger.error("Failed to flush command metrics batch:", error);
+      // Re-queue the whole batch so the counts survive a transient DB failure.
+      for (const bucket of batch) {
         this.addPending(bucket);
       }
     }

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -99,6 +99,7 @@ export const NAV_ITEMS: NavItem[] = [
   { href: "/admin/bot-status", label: "Bot Status", group: "Info" },
   { href: "/admin/database", label: "Database", group: "Info" },
   { href: "/admin/audit/commands", label: "Command Audit", group: "Info" },
+  { href: "/admin/metrics", label: "Command Metrics", group: "Info" },
   { href: "/admin/bootstrap", label: "Bootstrap", group: "Info" },
   // Settings — configuration & setup surfaces.
   { href: "/admin/settings", label: "Settings", group: "Settings" },

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -2404,3 +2404,188 @@ export function renderCommandAuditPage(props: CommandAuditProps): string {
     navFeatureStatus: props.navFeatureStatus,
   });
 }
+
+// ---------- Command Metrics (issue #648) ----------
+
+export interface CommandMetricsRow {
+  command: string;
+  usageCount: number;
+  errorCount: number;
+  /** errorCount / usageCount, in the range 0..1. */
+  errorRate: number;
+  avgResponseMs: number;
+  lastUsedAt: string | null;
+}
+
+export interface CommandMetricsDailyView {
+  date: string;
+  usageCount: number;
+  errorCount: number;
+}
+
+export interface CommandMetricsProps extends CommonProps {
+  enabled: boolean;
+  retentionDays: number;
+  /** Selected trailing window in days (7 or 30). */
+  windowDays: number;
+  totalUsage: number;
+  totalErrors: number;
+  /** Per-command rollup, sorted by usage descending. */
+  rows: CommandMetricsRow[];
+  /** Per-day totals over the window, sorted by date ascending. */
+  dailyTotals: CommandMetricsDailyView[];
+}
+
+/** Error rate (as a fraction) at or above which a command is "spotlit". */
+const METRICS_ERROR_SPOTLIGHT = 0.1;
+
+function formatMs(ms: number): string {
+  return `${Math.round(ms)}ms`;
+}
+
+function formatPct(fraction: number): string {
+  return `${(fraction * 100).toFixed(1)}%`;
+}
+
+function errorRateTag(rate: number): string {
+  if (rate >= METRICS_ERROR_SPOTLIGHT) {
+    return `<span class="tag tag-off">${formatPct(rate)}</span>`;
+  }
+  if (rate > 0) {
+    return `<span class="tag tag-warn">${formatPct(rate)}</span>`;
+  }
+  return `<span class="tag tag-on">0%</span>`;
+}
+
+export function renderCommandMetricsPage(props: CommandMetricsProps): string {
+  const windowToggle = [7, 30]
+    .map((w) => {
+      const active = w === props.windowDays;
+      const cls = active ? "btn btn-sm btn-primary" : "btn btn-sm";
+      return `<a class="${cls}" href="/admin/metrics?window=${w}">${w}d</a>`;
+    })
+    .join(" ");
+
+  const usageRowsHtml =
+    props.rows.length === 0
+      ? `<div class="empty">No command metrics recorded in the last ${props.windowDays} days.</div>`
+      : `<table>
+<thead><tr>
+<th>Command</th><th>Invocations</th><th>Error rate</th><th>Avg response</th><th>Last used</th>
+</tr></thead>
+<tbody>${props.rows
+          .map(
+            (r) => `<tr>
+<td class="mono">/${escapeHtml(r.command)}</td>
+<td>${r.usageCount}</td>
+<td>${errorRateTag(r.errorRate)} <span class="muted">(${r.errorCount})</span></td>
+<td class="muted">${formatMs(r.avgResponseMs)}</td>
+<td class="muted mono">${r.lastUsedAt ? escapeHtml(r.lastUsedAt) : "—"}</td>
+</tr>`,
+          )
+          .join("")}</tbody></table>`;
+
+  const spotlight = props.rows.filter(
+    (r) => r.errorRate >= METRICS_ERROR_SPOTLIGHT,
+  );
+  const spotlightHtml =
+    spotlight.length === 0
+      ? `<p class="muted">No command exceeded a ${formatPct(METRICS_ERROR_SPOTLIGHT)} error rate. 🎉</p>`
+      : `<table>
+<thead><tr><th>Command</th><th>Error rate</th><th>Errors</th><th>Invocations</th></tr></thead>
+<tbody>${spotlight
+          .map(
+            (r) => `<tr>
+<td class="mono">/${escapeHtml(r.command)}</td>
+<td>${errorRateTag(r.errorRate)}</td>
+<td>${r.errorCount}</td>
+<td class="muted">${r.usageCount}</td>
+</tr>`,
+          )
+          .join("")}</tbody></table>`;
+
+  const slowest = [...props.rows]
+    .filter((r) => r.usageCount > 0)
+    .sort((a, b) => b.avgResponseMs - a.avgResponseMs)
+    .slice(0, 10);
+  const slowestHtml =
+    slowest.length === 0
+      ? `<div class="empty">No data yet.</div>`
+      : `<table>
+<thead><tr><th>Command</th><th>Avg response</th><th>Invocations</th></tr></thead>
+<tbody>${slowest
+          .map(
+            (r) => `<tr>
+<td class="mono">/${escapeHtml(r.command)}</td>
+<td>${formatMs(r.avgResponseMs)}</td>
+<td class="muted">${r.usageCount}</td>
+</tr>`,
+          )
+          .join("")}</tbody></table>`;
+
+  const maxDaily = props.dailyTotals.reduce(
+    (max, d) => Math.max(max, d.usageCount),
+    0,
+  );
+  const trendHtml =
+    props.dailyTotals.length === 0
+      ? `<div class="empty">No data yet.</div>`
+      : props.dailyTotals
+          .map((d) => {
+            const pct = maxDaily > 0 ? (d.usageCount / maxDaily) * 100 : 0;
+            return `<div class="field-row" style="align-items:center;gap:.75rem">
+<span class="muted mono" style="min-width:6rem">${escapeHtml(d.date)}</span>
+<span style="flex:1;background:#1e293b;border-radius:4px;overflow:hidden">
+  <span style="display:block;height:1rem;width:${pct.toFixed(1)}%;background:#3b82f6"></span>
+</span>
+<span class="mono" style="min-width:3rem;text-align:right">${d.usageCount}</span>
+</div>`;
+          })
+          .join("");
+
+  const body = `
+<h1>Command metrics</h1>
+<p class="subtitle">Historical per-command usage, error rate, and latency persisted to MongoDB. Complements the live in-memory view and the Prometheus <code>/metrics</code> endpoint.</p>
+
+<div class="card">
+  <h2>Overview</h2>
+  <dl class="kv">
+    <dt>Persistence</dt><dd>${props.enabled ? '<span class="tag tag-on">enabled</span>' : '<span class="tag tag-off">disabled</span>'}</dd>
+    <dt>Retention</dt><dd>${props.retentionDays} days</dd>
+    <dt>Window</dt><dd>${props.windowDays} days &nbsp; ${windowToggle}</dd>
+    <dt>Total invocations</dt><dd>${props.totalUsage}</dd>
+    <dt>Total errors</dt><dd>${props.totalErrors}</dd>
+  </dl>
+  ${props.enabled ? "" : '<p class="muted">Enable <code>monitoring.metrics_persistence.enabled</code> in Settings to start recording. Counts already shown were captured before it was disabled.</p>'}
+</div>
+
+<div class="card">
+  <h2>Commands by usage</h2>
+  ${usageRowsHtml}
+</div>
+
+<div class="card">
+  <h2>Error spotlight</h2>
+  <p class="subtitle">Commands with an error rate at or above ${formatPct(METRICS_ERROR_SPOTLIGHT)} over the window.</p>
+  ${spotlightHtml}
+</div>
+
+<div class="card">
+  <h2>Slowest commands</h2>
+  ${slowestHtml}
+</div>
+
+<div class="card">
+  <h2>Usage trend</h2>
+  ${trendHtml}
+</div>
+`;
+  return renderAdminPage({
+    title: "Command metrics",
+    active: "/admin/metrics",
+    body,
+    csrfToken: props.csrfToken,
+    remainingMs: props.remainingMs,
+    navFeatureStatus: props.navFeatureStatus,
+  });
+}

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -41,6 +41,7 @@ import {
 } from "../services/voice-channel-manager.js";
 import { WebAuditLog } from "../models/web-audit-log.js";
 import { DiscordCommandAuditLog } from "../models/discord-command-audit-log.js";
+import { getCommandMetricsSummary } from "../services/command-metrics-query.js";
 import { BOOTSTRAP_VARS } from "./bootstrap-vars.js";
 import { getEnv } from "../config/env.js";
 import {
@@ -58,6 +59,7 @@ import {
   renderBootstrapPage,
   renderBotStatusPage,
   renderCommandAuditPage,
+  renderCommandMetricsPage,
   renderDashboardPage,
   renderDatabasePage,
   renderNoticesPage,
@@ -967,6 +969,57 @@ export function createReadOnlyRouter(
           channels,
           categoryFound,
           flash: readFlash(req),
+        }),
+      );
+    }),
+  );
+
+  // ---------- Command Metrics (#648) ----------
+  router.get(
+    "/metrics",
+    asyncHandler(async (req, res) => {
+      const common = await commonFromReq(req);
+      const config = ConfigService.getInstance();
+
+      // Only the two documented windows are accepted; anything else falls
+      // back to 30 so a hand-edited query string can't request an
+      // unbounded scan.
+      const windowRaw = Number.parseInt(String(req.query.window ?? "30"), 10);
+      const windowDays = windowRaw === 7 ? 7 : 30;
+
+      const [enabled, retentionDays, summary] = await Promise.all([
+        config.getBoolean("monitoring.metrics_persistence.enabled", true),
+        config.getNumber("monitoring.metrics_retention_days", 30),
+        getCommandMetricsSummary(common.guildId, windowDays).catch((err) => {
+          logger.debug("command metrics aggregation failed", err);
+          return {
+            windowDays,
+            fromDate: "",
+            rows: [],
+            dailyTotals: [],
+            totalUsage: 0,
+            totalErrors: 0,
+          };
+        }),
+      ]);
+
+      res.type("text/html").send(
+        renderCommandMetricsPage({
+          ...common,
+          enabled,
+          retentionDays,
+          windowDays,
+          totalUsage: summary.totalUsage,
+          totalErrors: summary.totalErrors,
+          rows: summary.rows.map((r) => ({
+            command: r.command,
+            usageCount: r.usageCount,
+            errorCount: r.errorCount,
+            errorRate: r.errorRate,
+            avgResponseMs: r.avgResponseMs,
+            lastUsedAt: r.lastUsedAt,
+          })),
+          dailyTotals: summary.dailyTotals,
         }),
       );
     }),


### PR DESCRIPTION
## Summary

`MonitoringService` collected rich per-command metrics (usage, error count, response time) but stored them **entirely in memory** — every restart wiped them, and they were never surfaced outside the logs. This PR persists them to MongoDB and adds an admin Web UI dashboard, with no change to the Discord-facing feature set. Closes #648.

## What changed

### 1. Persistence layer — `models/command-metrics.ts`
Daily-bucket schema, one document per `{command, date, guildId}`:
- **Unique compound index** on `{command, date, guildId}` (the upsert key)
- A `{guildId, date}` index backing the dashboard's range scans
- A **TTL index** on a per-document `expiresAt` anchor (`expireAfterSeconds: 0`). Each write stamps `expiresAt = lastUsedAt + retention_days`, so the retention window stays operator-configurable even though a TTL index's seconds are otherwise fixed.

### 2. Batched flush in `MonitoringService`
- Accumulates per-bucket counters in memory and flushes them in a single batch of upserts (`$inc` / `$min` / `$max`) **every 5 minutes** — never per-invocation — plus a final flush on graceful shutdown before the DB connection closes.
- No-ops while the DB is disconnected or persistence is disabled, and **re-queues a batch on transient write failure** so counts aren't lost.
- `CommandManager` threads `guildId` through on the real execution paths only; blocked attempts (permission denied / rate limited) are intentionally **not** persisted, so they don't pollute usage/error counts.

### 3. Admin dashboard — `/admin/metrics`
New read-only page behind the existing admin auth middleware, with a 7d / 30d window toggle:
- **Commands by usage** — table with invocations, error-rate badge, avg response time
- **Error spotlight** — commands at or above a 10% error rate
- **Slowest commands** — by average response time
- **Usage trend** — per-day totals bar chart

Aggregation lives in a thin, testable `command-metrics-query.ts` helper. A "Command Metrics" nav item is added to the Info group.

### 4. Retention / config
- `monitoring.metrics_persistence.enabled` (bool, default **true**)
- `monitoring.metrics_retention_days` (number, default **30**)

## Tests
- `monitoring-service-flush.test.ts` — batched flush: single upsert per bucket with correct `$inc`/`$min`/`$max` and TTL anchor, guildId gating, disconnected/disabled no-ops, and failure re-queue.
- `command-metrics-query.test.ts` — aggregation match/range, derived error-rate & avg-response, divide-by-zero guard.
- `command-metrics.test.ts` — model load + canonical shape.
- Updated the existing `destroy()` idempotency test (two intervals now) and the `*enabled` config-schema drift audit.

## Docs
`SETTINGS.md` (new config keys) and `WEBUI.md` (new dashboard page) updated.

## Verification
`npm run build`, `npm run lint`, `npm run format:check`, `npx markdownlint`, and `npm run test:ci` (1225 passing, coverage thresholds met) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138qtexYsSweCY8pTybwoTf

---
_Generated by [Claude Code](https://claude.ai/code/session_0138qtexYsSweCY8pTybwoTf)_