### PR TITLE
feat: make time-of-day and day-of-week accolades timezone-aware

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -294,8 +294,9 @@ Total Achievements: 0
 **Notes on time-based accolades:**
 
 - Night Owl / Early Bird evaluate their hour windows in **your configured
-  timezone** (set it via `/config`). If you haven't set one, they fall back
-  to **UTC**.
+  timezone** (set it on your personal Web UI page: `/config` → **My
+  preferences** → **Timezone**, i.e. `/me/timezone`). If you haven't set one,
+  they fall back to **UTC**.
 - Weekend Warrior / Weekday Warrior bucket day-of-week in your configured
   timezone too (UTC when unset).
 - The consistency streaks (On a Roll / Dedicated AF / No-Lifer) count

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -276,8 +276,8 @@ Total Achievements: 0
 - 🦸 **Ultra Marathoner** — 8+ hour session
 - 🦋 **Social Butterfly** — 10+ unique users
 - 🤝 **Connector** — 25+ unique users
-- 🦉 **Night Owl** — 50+ late-night hours (10 PM - 6 AM UTC)
-- 🐦 **Early Bird** — 50+ early-morning hours (6 AM - 10 AM UTC)
+- 🦉 **Night Owl** — 50+ late-night hours (10 PM - 6 AM, your timezone)
+- 🐦 **Early Bird** — 50+ early-morning hours (6 AM - 10 AM, your timezone)
 - 🎮 **Weekend Warrior** — 100+ weekend hours
 - 💼 **Weekday Warrior** — 100+ weekday hours
 - 🔥 **On a Roll** — 7 consecutive days (5+ min/day)
@@ -293,8 +293,13 @@ Total Achievements: 0
 
 **Notes on time-based accolades:**
 
-- Night Owl / Early Bird use **UTC**, not your local timezone
-- Weekend Warrior / Weekday Warrior use UTC day-of-week
+- Night Owl / Early Bird evaluate their hour windows in **your configured
+  timezone** (set it via `/config`). If you haven't set one, they fall back
+  to **UTC**.
+- Weekend Warrior / Weekday Warrior bucket day-of-week in your configured
+  timezone too (UTC when unset).
+- The consistency streaks (On a Roll / Dedicated AF / No-Lifer) count
+  consecutive days using your timezone's local midnight (UTC when unset).
 
 **Notifications:**
 

--- a/__tests__/services/achievements-timezone.test.ts
+++ b/__tests__/services/achievements-timezone.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import type { Client } from 'discord.js';
+
+// Rely on the global mongoose mock from setup.ts.
+jest.mock('../../src/utils/logger.js', () => ({
+  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('../../src/services/quote-service.js', () => ({
+  quoteService: {
+    getQuotesAuthoredByUser: jest.fn().mockResolvedValue(0),
+    getQuotesAddedByUser: jest.fn().mockResolvedValue(0),
+    getMostLikedQuoteByAuthor: jest.fn().mockResolvedValue(null),
+  },
+}));
+
+import { AchievementsService } from '../../src/services/achievements-service.js';
+import { UserNotificationPrefsService } from '../../src/services/user-notification-prefs-service.js';
+import type { IVoiceChannelTracking } from '../../src/models/voice-channel-tracking.js';
+
+// Closure shapes — the accolade logic now takes a trailing `timeZone` arg (#658).
+type CheckFn = (
+  userId: string,
+  userData: IVoiceChannelTracking | null,
+  timeZone: string,
+) => Promise<boolean>;
+type MetaFn = (
+  userId: string,
+  userData: IVoiceChannelTracking | null,
+  timeZone: string,
+) => Promise<{ value?: number }>;
+
+function makeService(): {
+  service: AchievementsService;
+  mockConfigService: { getString: jest.Mock };
+} {
+  const mockClient = { users: { fetch: jest.fn() } } as unknown as Client;
+  const service = AchievementsService.getInstance(mockClient);
+  const mockConfigService = {
+    getString: jest.fn().mockResolvedValue('guild-1'),
+    getBoolean: jest.fn().mockResolvedValue(true),
+    getNumber: jest.fn().mockResolvedValue(0),
+  };
+  (service as never)['configService'] = mockConfigService;
+  (service as never)['isConnected'] = true;
+  return { service, mockConfigService };
+}
+
+function trackingWith(
+  sessions: Array<{ startTime: Date; endTime?: Date; duration?: number }>,
+): IVoiceChannelTracking {
+  return {
+    userId: 'user123',
+    username: 'TestUser',
+    totalTime: 0,
+    sessions,
+  } as unknown as IVoiceChannelTracking;
+}
+
+function accoladeLogic(
+  service: AchievementsService,
+): Record<string, { checkFunction: CheckFn; metadataFunction?: MetaFn }> {
+  return (service as never)['accoladeLogic'];
+}
+
+describe('AchievementsService timezone-aware accolades (#658)', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    (AchievementsService as unknown as { instance: unknown }).instance = undefined;
+    (UserNotificationPrefsService as unknown as { instance: unknown }).instance = null;
+  });
+
+  describe('time-of-day windows (Night Owl / Early Bird)', () => {
+    // 12:00–16:00 UTC: daytime in UTC, but 00:00–04:00 in Auckland (+12),
+    // which lands entirely in the late-night window (22:00–06:00).
+    const session = {
+      startTime: new Date('2026-06-22T12:00:00Z'),
+      endTime: new Date('2026-06-22T16:00:00Z'),
+      duration: 4 * 3600,
+    };
+
+    it('counts no late-night hours under the UTC default', async () => {
+      const { service } = makeService();
+      const meta = await accoladeLogic(service).night_owl.metadataFunction!(
+        'user123',
+        trackingWith([session]),
+        'UTC',
+      );
+      expect(meta.value).toBe(0);
+    });
+
+    it('counts the session as late-night in the user timezone', async () => {
+      const { service } = makeService();
+      const meta = await accoladeLogic(service).night_owl.metadataFunction!(
+        'user123',
+        trackingWith([session]),
+        'Pacific/Auckland',
+      );
+      expect(meta.value).toBe(4);
+    });
+
+    it('buckets early-morning hours in the user timezone', async () => {
+      const { service } = makeService();
+      // 18:00–22:00 UTC → 06:00–10:00 in Auckland (early-morning window).
+      const early = {
+        startTime: new Date('2026-06-22T18:00:00Z'),
+        endTime: new Date('2026-06-22T22:00:00Z'),
+        duration: 4 * 3600,
+      };
+      const utc = await accoladeLogic(service).early_bird.metadataFunction!(
+        'user123',
+        trackingWith([early]),
+        'UTC',
+      );
+      const akl = await accoladeLogic(service).early_bird.metadataFunction!(
+        'user123',
+        trackingWith([early]),
+        'Pacific/Auckland',
+      );
+      expect(utc.value).toBe(0);
+      expect(akl.value).toBe(4);
+    });
+  });
+
+  describe('day-of-week (Weekend / Weekday Warrior)', () => {
+    // Friday 23:00 UTC is still Friday in UTC, but Saturday in Auckland (+12).
+    const session = {
+      startTime: new Date('2026-06-19T23:00:00Z'),
+      duration: 3600,
+    };
+
+    it('treats the session as a weekday under the UTC default', async () => {
+      const { service } = makeService();
+      const weekend = await accoladeLogic(service).weekend_warrior.metadataFunction!(
+        'user123',
+        trackingWith([session]),
+        'UTC',
+      );
+      const weekday = await accoladeLogic(service).weekday_warrior.metadataFunction!(
+        'user123',
+        trackingWith([session]),
+        'UTC',
+      );
+      expect(weekend.value).toBe(0);
+      expect(weekday.value).toBe(1);
+    });
+
+    it('treats the session as a weekend day in the user timezone', async () => {
+      const { service } = makeService();
+      const weekend = await accoladeLogic(service).weekend_warrior.metadataFunction!(
+        'user123',
+        trackingWith([session]),
+        'Pacific/Auckland',
+      );
+      const weekday = await accoladeLogic(service).weekday_warrior.metadataFunction!(
+        'user123',
+        trackingWith([session]),
+        'Pacific/Auckland',
+      );
+      expect(weekend.value).toBe(1);
+      expect(weekday.value).toBe(0);
+    });
+  });
+
+  describe('consistency streaks', () => {
+    // Two sessions on the same UTC calendar day, but split across two
+    // consecutive days in Los Angeles (UTC-7): 18:00 on the 21st and
+    // 06:00 on the 22nd.
+    const sessions = [
+      { startTime: new Date('2026-06-22T01:00:00Z'), duration: 600 },
+      { startTime: new Date('2026-06-22T13:00:00Z'), duration: 600 },
+    ];
+
+    it('buckets both sessions into one day under the UTC default', async () => {
+      const { service } = makeService();
+      const meta = await accoladeLogic(service).consistent_week.metadataFunction!(
+        'user123',
+        trackingWith(sessions),
+        'UTC',
+      );
+      expect(meta.value).toBe(1);
+    });
+
+    it('splits the sessions across two local days, forming a 2-day streak', async () => {
+      const { service } = makeService();
+      const meta = await accoladeLogic(service).consistent_week.metadataFunction!(
+        'user123',
+        trackingWith(sessions),
+        'America/Los_Angeles',
+      );
+      expect(meta.value).toBe(2);
+    });
+  });
+
+  describe('resolveUserTimezone', () => {
+    const resolve = (service: AchievementsService): ((userId: string) => Promise<string>) =>
+      (service as never)['resolveUserTimezone'].bind(service);
+
+    it('returns the stored valid timezone when set', async () => {
+      const { service } = makeService();
+      jest
+        .spyOn(UserNotificationPrefsService.prototype, 'getTimezone')
+        .mockResolvedValue('Pacific/Auckland');
+      expect(await resolve(service)('user123')).toBe('Pacific/Auckland');
+    });
+
+    it('falls back to UTC when no timezone is set', async () => {
+      const { service } = makeService();
+      jest
+        .spyOn(UserNotificationPrefsService.prototype, 'getTimezone')
+        .mockResolvedValue(null);
+      expect(await resolve(service)('user123')).toBe('UTC');
+    });
+
+    it('falls back to UTC when an invalid timezone is stored', async () => {
+      const { service } = makeService();
+      jest
+        .spyOn(UserNotificationPrefsService.prototype, 'getTimezone')
+        .mockResolvedValue('Not/AZone');
+      expect(await resolve(service)('user123')).toBe('UTC');
+    });
+
+    it('falls back to UTC when no guild id is configured', async () => {
+      const { service, mockConfigService } = makeService();
+      mockConfigService.getString.mockResolvedValue('');
+      const spy = jest
+        .spyOn(UserNotificationPrefsService.prototype, 'getTimezone')
+        .mockResolvedValue('Pacific/Auckland');
+      expect(await resolve(service)('user123')).toBe('UTC');
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/content/README.md
+++ b/src/content/README.md
@@ -53,8 +53,10 @@ Two-step change, both verified by the type checker:
 
    ```ts
    my_new_accolade: {
-     checkFunction: async (userId, userData) => { /* ... */ },
-     metadataFunction: async (userId, userData) => { /* ... */ },
+     // `timeZone` is the user's accolade-bucketing zone ("UTC" when unset);
+     // time-of-day / day-of-week / streak checks use it, others omit it.
+     checkFunction: async (userId, userData, timeZone) => { /* ... */ },
+     metadataFunction: async (userId, userData, timeZone) => { /* ... */ },
    },
    ```
 

--- a/src/services/achievements-service.ts
+++ b/src/services/achievements-service.ts
@@ -876,8 +876,15 @@ export class AchievementsService {
     let currentStreak = 1;
     const today = new Date();
     const todayKey = isoDateInZone(today, timeZone);
-    const yesterday = new Date(today.getTime() - 86400000);
-    const yesterdayKey = isoDateInZone(yesterday, timeZone);
+    // Derive "yesterday" from the calendar-day key, not by subtracting 24h
+    // of wall-clock time: around DST transitions a local day is 23/25 hours,
+    // so a fixed 86,400,000ms step can skip or repeat a calendar day and
+    // wrongly break an active streak. Anchoring at the date string's UTC
+    // midnight makes the minus-one-day arithmetic DST-safe.
+    const yesterdayKey = isoDateInZone(
+      new Date(new Date(`${todayKey}T00:00:00Z`).getTime() - 86400000),
+      "UTC",
+    );
 
     for (let i = 1; i < qualifyingDays.length; i++) {
       const prevDate = new Date(qualifyingDays[i - 1] + "T00:00:00Z");

--- a/src/services/achievements-service.ts
+++ b/src/services/achievements-service.ts
@@ -10,6 +10,13 @@ import {
 } from "../models/voice-channel-tracking.js";
 import { ConfigService } from "./config-service.js";
 import { UserNotificationPrefsService } from "./user-notification-prefs-service.js";
+import {
+  dayOfWeekInZone,
+  hourInZone,
+  isoDateInZone,
+  isValidTimezone,
+  secondsIntoHourInZone,
+} from "../utils/timezone.js";
 import logger from "../utils/logger.js";
 import mongoose from "mongoose";
 import { quoteService } from "./quote-service.js";
@@ -22,13 +29,19 @@ import {
 export type { AccoladeType, AchievementType };
 
 interface BadgeLogic {
+  // `timeZone` is the IANA zone the time-sensitive accolades bucket in
+  // (#658) — the acting user's `UserNotificationPrefs.timezone`, or "UTC"
+  // when unset. Hour/day-agnostic checks (total hours, social, quote)
+  // simply omit the parameter.
   checkFunction: (
     userId: string,
     userData: IVoiceChannelTracking | null,
+    timeZone: string,
   ) => Promise<boolean>;
   metadataFunction?: (
     userId: string,
     userData: IVoiceChannelTracking | null,
+    timeZone: string,
   ) => Promise<{ value?: number; description?: string; unit?: string }>;
 }
 
@@ -276,6 +289,7 @@ export class AchievementsService {
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
+        timeZone: string,
       ) => {
         const user =
           userData || (await VoiceChannelTracking.findOne({ userId }));
@@ -286,6 +300,7 @@ export class AchievementsService {
             lateNightSeconds += this.calculateLateNightDuration(
               session.startTime,
               session.endTime,
+              timeZone,
             );
           }
         }
@@ -294,6 +309,7 @@ export class AchievementsService {
       metadataFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
+        timeZone: string,
       ) => {
         const user =
           userData || (await VoiceChannelTracking.findOne({ userId }));
@@ -304,6 +320,7 @@ export class AchievementsService {
               lateNightSeconds += this.calculateLateNightDuration(
                 session.startTime,
                 session.endTime,
+                timeZone,
               );
             }
           }
@@ -319,6 +336,7 @@ export class AchievementsService {
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
+        timeZone: string,
       ) => {
         const user =
           userData || (await VoiceChannelTracking.findOne({ userId }));
@@ -329,6 +347,7 @@ export class AchievementsService {
             earlyMorningSeconds += this.calculateEarlyMorningDuration(
               session.startTime,
               session.endTime,
+              timeZone,
             );
           }
         }
@@ -337,6 +356,7 @@ export class AchievementsService {
       metadataFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
+        timeZone: string,
       ) => {
         const user =
           userData || (await VoiceChannelTracking.findOne({ userId }));
@@ -347,6 +367,7 @@ export class AchievementsService {
               earlyMorningSeconds += this.calculateEarlyMorningDuration(
                 session.startTime,
                 session.endTime,
+                timeZone,
               );
             }
           }
@@ -362,6 +383,7 @@ export class AchievementsService {
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
+        timeZone: string,
       ) => {
         const user =
           userData || (await VoiceChannelTracking.findOne({ userId }));
@@ -369,7 +391,7 @@ export class AchievementsService {
         let weekendSeconds = 0;
         for (const session of user.sessions) {
           if (session.startTime && session.duration) {
-            const day = session.startTime.getDay();
+            const day = dayOfWeekInZone(session.startTime, timeZone);
             if (day === 0 || day === 6) {
               weekendSeconds += session.duration;
             }
@@ -380,6 +402,7 @@ export class AchievementsService {
       metadataFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
+        timeZone: string,
       ) => {
         const user =
           userData || (await VoiceChannelTracking.findOne({ userId }));
@@ -387,7 +410,7 @@ export class AchievementsService {
         if (user) {
           for (const session of user.sessions) {
             if (session.startTime && session.duration) {
-              const day = session.startTime.getDay();
+              const day = dayOfWeekInZone(session.startTime, timeZone);
               if (day === 0 || day === 6) {
                 weekendSeconds += session.duration;
               }
@@ -405,6 +428,7 @@ export class AchievementsService {
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
+        timeZone: string,
       ) => {
         const user =
           userData || (await VoiceChannelTracking.findOne({ userId }));
@@ -412,7 +436,7 @@ export class AchievementsService {
         let weekdaySeconds = 0;
         for (const session of user.sessions) {
           if (session.startTime && session.duration) {
-            const day = session.startTime.getDay();
+            const day = dayOfWeekInZone(session.startTime, timeZone);
             if (day >= 1 && day <= 5) {
               weekdaySeconds += session.duration;
             }
@@ -423,6 +447,7 @@ export class AchievementsService {
       metadataFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
+        timeZone: string,
       ) => {
         const user =
           userData || (await VoiceChannelTracking.findOne({ userId }));
@@ -430,7 +455,7 @@ export class AchievementsService {
         if (user) {
           for (const session of user.sessions) {
             if (session.startTime && session.duration) {
-              const day = session.startTime.getDay();
+              const day = dayOfWeekInZone(session.startTime, timeZone);
               if (day >= 1 && day <= 5) {
                 weekdaySeconds += session.duration;
               }
@@ -448,12 +473,14 @@ export class AchievementsService {
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
+        timeZone: string,
       ) => {
         const user =
           userData || (await VoiceChannelTracking.findOne({ userId }));
         if (!user) return false;
         const { longestStreak } = this.calculateConsecutiveDays(
           user.sessions,
+          timeZone,
           AchievementsService.MIN_DAILY_DURATION_SECONDS,
         );
         return longestStreak >= 7;
@@ -461,6 +488,7 @@ export class AchievementsService {
       metadataFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
+        timeZone: string,
       ) => {
         const user =
           userData || (await VoiceChannelTracking.findOne({ userId }));
@@ -473,6 +501,7 @@ export class AchievementsService {
         }
         const { longestStreak } = this.calculateConsecutiveDays(
           user.sessions,
+          timeZone,
           AchievementsService.MIN_DAILY_DURATION_SECONDS,
         );
         return {
@@ -486,12 +515,14 @@ export class AchievementsService {
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
+        timeZone: string,
       ) => {
         const user =
           userData || (await VoiceChannelTracking.findOne({ userId }));
         if (!user) return false;
         const { longestStreak } = this.calculateConsecutiveDays(
           user.sessions,
+          timeZone,
           AchievementsService.MIN_DAILY_DURATION_SECONDS,
         );
         return longestStreak >= 14;
@@ -499,6 +530,7 @@ export class AchievementsService {
       metadataFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
+        timeZone: string,
       ) => {
         const user =
           userData || (await VoiceChannelTracking.findOne({ userId }));
@@ -511,6 +543,7 @@ export class AchievementsService {
         }
         const { longestStreak } = this.calculateConsecutiveDays(
           user.sessions,
+          timeZone,
           AchievementsService.MIN_DAILY_DURATION_SECONDS,
         );
         return {
@@ -524,12 +557,14 @@ export class AchievementsService {
       checkFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
+        timeZone: string,
       ) => {
         const user =
           userData || (await VoiceChannelTracking.findOne({ userId }));
         if (!user) return false;
         const { longestStreak } = this.calculateConsecutiveDays(
           user.sessions,
+          timeZone,
           AchievementsService.MIN_DAILY_DURATION_SECONDS,
         );
         return longestStreak >= 30;
@@ -537,6 +572,7 @@ export class AchievementsService {
       metadataFunction: async (
         userId: string,
         userData: IVoiceChannelTracking | null,
+        timeZone: string,
       ) => {
         const user =
           userData || (await VoiceChannelTracking.findOne({ userId }));
@@ -549,6 +585,7 @@ export class AchievementsService {
         }
         const { longestStreak } = this.calculateConsecutiveDays(
           user.sessions,
+          timeZone,
           AchievementsService.MIN_DAILY_DURATION_SECONDS,
         );
         return {
@@ -722,69 +759,70 @@ export class AchievementsService {
   }
 
   /**
-   * Calculate how much of a session occurred during late night hours (10 PM - 6 AM)
+   * Sum the seconds of `[startTime, endTime)` whose wall-clock hour (in the
+   * given IANA `timeZone`) satisfies `inWindow`. The walk aligns each
+   * segment to the local-hour boundary in that zone, so it stays correct
+   * for zones with sub-hour offsets and honours the user's timezone (#658).
+   * Callers pass "UTC" for users with no timezone preference.
    */
-  private calculateLateNightDuration(startTime: Date, endTime: Date): number {
+  private calculateHourWindowSeconds(
+    startTime: Date,
+    endTime: Date,
+    timeZone: string,
+    inWindow: (hour: number) => boolean,
+  ): number {
     let totalSeconds = 0;
-    const current = new Date(startTime);
-    const end = new Date(endTime);
+    let current = startTime.getTime();
+    const end = endTime.getTime();
 
     while (current < end) {
-      const hour = current.getHours();
-      const isLateNight = hour >= 22 || hour < 6;
+      const at = new Date(current);
+      const hour = hourInZone(at, timeZone);
+      const secondsToBoundary = 3600 - secondsIntoHourInZone(at, timeZone);
+      const segmentEnd = Math.min(current + secondsToBoundary * 1000, end);
 
-      if (isLateNight) {
-        const nextHour = new Date(current);
-        nextHour.setHours(current.getHours() + 1, 0, 0, 0);
-        const segmentEnd = nextHour < end ? nextHour : end;
-        totalSeconds += Math.floor(
-          (segmentEnd.getTime() - current.getTime()) / 1000,
-        );
-        current.setTime(segmentEnd.getTime());
-      } else {
-        current.setHours(current.getHours() + 1, 0, 0, 0);
+      if (inWindow(hour)) {
+        totalSeconds += Math.floor((segmentEnd - current) / 1000);
       }
+
+      current = segmentEnd;
     }
 
     return totalSeconds;
   }
 
   /**
-   * Calculate how much of a session occurred during early morning (6 AM - 10 AM)
+   * Calculate how much of a session occurred during late night hours
+   * (10 PM - 6 AM in the user's timezone, UTC when unset).
+   */
+  private calculateLateNightDuration(
+    startTime: Date,
+    endTime: Date,
+    timeZone: string,
+  ): number {
+    return this.calculateHourWindowSeconds(
+      startTime,
+      endTime,
+      timeZone,
+      (hour) => hour >= 22 || hour < 6,
+    );
+  }
+
+  /**
+   * Calculate how much of a session occurred during early morning
+   * (6 AM - 10 AM in the user's timezone, UTC when unset).
    */
   private calculateEarlyMorningDuration(
     startTime: Date,
     endTime: Date,
+    timeZone: string,
   ): number {
-    let totalSeconds = 0;
-    const current = new Date(startTime);
-    const end = new Date(endTime);
-
-    while (current < end) {
-      const hour = current.getHours();
-      const isEarlyMorning = hour >= 6 && hour < 10;
-
-      if (isEarlyMorning) {
-        const nextHour = new Date(current);
-        nextHour.setHours(current.getHours() + 1, 0, 0, 0);
-        const segmentEnd = nextHour < end ? nextHour : end;
-        totalSeconds += Math.floor(
-          (segmentEnd.getTime() - current.getTime()) / 1000,
-        );
-        current.setTime(segmentEnd.getTime());
-      } else {
-        current.setHours(current.getHours() + 1, 0, 0, 0);
-      }
-    }
-
-    return totalSeconds;
-  }
-
-  /**
-   * Format a date as YYYY-MM-DD string using UTC
-   */
-  private formatDateKeyUTC(date: Date): string {
-    return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`;
+    return this.calculateHourWindowSeconds(
+      startTime,
+      endTime,
+      timeZone,
+      (hour) => hour >= 6 && hour < 10,
+    );
   }
 
   /**
@@ -797,24 +835,27 @@ export class AchievementsService {
    * - For longer streaks: Increase retention accordingly
    *
    * @param sessions Array of user sessions
+   * @param timeZone IANA zone to bucket days in ("UTC" when the user has no
+   *   timezone preference) so streaks reflect the user's local midnight (#658)
    * @param minDuration Minimum duration in seconds per day (default: MIN_DAILY_DURATION_SECONDS)
    * @returns Object with currentStreak and longestStreak
    */
   private calculateConsecutiveDays(
     sessions: Array<{ startTime: Date; duration?: number }>,
+    timeZone: string,
     minDuration: number = AchievementsService.MIN_DAILY_DURATION_SECONDS,
   ): { currentStreak: number; longestStreak: number } {
     if (!sessions || sessions.length === 0) {
       return { currentStreak: 0, longestStreak: 0 };
     }
 
-    // Group sessions by day (using UTC date)
+    // Group sessions by day, bucketed in the user's timezone (UTC default).
     const dayTotals = new Map<string, number>();
 
     for (const session of sessions) {
       if (session.startTime && session.duration) {
         const date = new Date(session.startTime);
-        const dayKey = this.formatDateKeyUTC(date);
+        const dayKey = isoDateInZone(date, timeZone);
         const currentTotal = dayTotals.get(dayKey) || 0;
         dayTotals.set(dayKey, currentTotal + session.duration);
       }
@@ -834,9 +875,9 @@ export class AchievementsService {
     let longestStreak = 1;
     let currentStreak = 1;
     const today = new Date();
-    const todayKey = this.formatDateKeyUTC(today);
+    const todayKey = isoDateInZone(today, timeZone);
     const yesterday = new Date(today.getTime() - 86400000);
-    const yesterdayKey = this.formatDateKeyUTC(yesterday);
+    const yesterdayKey = isoDateInZone(yesterday, timeZone);
 
     for (let i = 1; i < qualifyingDays.length; i++) {
       const prevDate = new Date(qualifyingDays[i - 1] + "T00:00:00Z");
@@ -935,6 +976,33 @@ export class AchievementsService {
   }
 
   /**
+   * Resolve the acting user's accolade-bucketing timezone (#658), mirroring
+   * Rewind's default semantics: the stored `UserNotificationPrefs.timezone`
+   * when set and valid, otherwise "UTC" (so unconfigured members keep their
+   * existing progress). The guild id comes from bootstrap `GUILD_ID` config,
+   * matching `notifyUserOfAccolades`; when it's unset we can't look up prefs,
+   * so we fall back to UTC. Any error degrades to UTC rather than failing the
+   * whole accolade check.
+   */
+  private async resolveUserTimezone(userId: string): Promise<string> {
+    try {
+      const guildId = await this.configService.getString("GUILD_ID", "");
+      if (!guildId) return "UTC";
+      const tz = await UserNotificationPrefsService.getInstance().getTimezone(
+        userId,
+        guildId,
+      );
+      return tz && isValidTimezone(tz) ? tz : "UTC";
+    } catch (error) {
+      logger.warn(
+        `Failed to resolve timezone for ${userId}; defaulting to UTC:`,
+        error,
+      );
+      return "UTC";
+    }
+  }
+
+  /**
    * Check and award accolades (persistent badges) to a user
    * Returns newly earned accolades
    */
@@ -973,6 +1041,13 @@ export class AchievementsService {
       // Fetch user tracking data once to avoid multiple DB queries
       const userTrackingData = await VoiceChannelTracking.findOne({ userId });
 
+      // Resolve the acting user's timezone once per evaluation (#658): the
+      // time-of-day / day-of-week / streak accolades bucket sessions in it,
+      // falling back to UTC when unset or invalid so unconfigured members'
+      // progress doesn't shift. Kept out of the per-accolade loop — and well
+      // out of the per-session inner loops — so it costs at most one lookup.
+      const timeZone = await this.resolveUserTimezone(userId);
+
       // Check each accolade type
       for (const type of Object.keys(ACCOLADE_METADATA) as AccoladeType[]) {
         if (existingAccoladeTypes.has(type)) {
@@ -980,10 +1055,14 @@ export class AchievementsService {
         }
 
         const logic = this.accoladeLogic[type];
-        const earned = await logic.checkFunction(userId, userTrackingData);
+        const earned = await logic.checkFunction(
+          userId,
+          userTrackingData,
+          timeZone,
+        );
         if (earned) {
           const metadata = logic.metadataFunction
-            ? await logic.metadataFunction(userId, userTrackingData)
+            ? await logic.metadataFunction(userId, userTrackingData, timeZone)
             : {};
 
           const accolade: IAccolade = {
@@ -1069,10 +1148,13 @@ export class AchievementsService {
         const logic = this.achievementLogic[type];
         if (!logic) continue;
 
-        const earned = await logic.checkFunction(userId, null);
+        // Weekly achievements are time-window aggregates evaluated in UTC
+        // (out of scope for #658); the timezone arg is accepted for a
+        // uniform BadgeLogic signature but unused by these checks.
+        const earned = await logic.checkFunction(userId, null, "UTC");
         if (earned) {
           const metadata = logic.metadataFunction
-            ? await logic.metadataFunction(userId, null)
+            ? await logic.metadataFunction(userId, null, "UTC")
             : undefined;
 
           const achievement: IAchievement = {

--- a/src/utils/timezone.ts
+++ b/src/utils/timezone.ts
@@ -92,6 +92,38 @@ export function isoDateInZone(date: Date, tz: string): string {
 }
 
 /**
+ * Wall-clock hour (0–23) for `date` in an explicit IANA zone. Used by the
+ * time-of-day accolades (Night Owl / Early Bird) so their hour windows are
+ * evaluated in the user's local time rather than UTC (#658). Callers pass
+ * `"UTC"` for users with no timezone preference.
+ */
+export function hourInZone(date: Date, tz: string): number {
+  return Number(formatInTimeZone(date, tz, "H"));
+}
+
+/**
+ * Day of week for `date` in an explicit IANA zone, using JS
+ * `Date.getDay()` numbering (0 = Sunday … 6 = Saturday) so it drops in for
+ * the previous `getUTCDay()` calls in the day-of-week accolades (#658).
+ */
+export function dayOfWeekInZone(date: Date, tz: string): number {
+  // date-fns "i" is ISO day-of-week (1 = Mon … 7 = Sun); map Sunday → 0.
+  return Number(formatInTimeZone(date, tz, "i")) % 7;
+}
+
+/**
+ * Seconds elapsed since the start of the current wall-clock hour in `tz`.
+ * Lets the hour-window accolade walk align its segments to local-hour
+ * boundaries even in zones with sub-hour offsets (#658).
+ */
+export function secondsIntoHourInZone(date: Date, tz: string): number {
+  const [minute, second] = formatInTimeZone(date, tz, "m:s")
+    .split(":")
+    .map(Number);
+  return minute * 60 + second;
+}
+
+/**
  * Render a date+time plus the resolved zone name, e.g.
  * `2026-06-12 14:30 (Europe/London)`. Used where a bare timestamp would
  * otherwise be ambiguous (e.g. `/voicestats user`).


### PR DESCRIPTION
## Summary

Brings the **accolade** system in line with Rewind (#524) by bucketing the time-sensitive badges in the user's configured timezone instead of the server clock. Resolves #658.

Previously Night Owl / Early Bird, Weekend / Weekday Warrior, and the consistency streaks (On a Roll / Dedicated AF / No-Lifer) bucketed sessions using the server clock (`getHours()` / `getDay()` / UTC date keys), so the badges felt arbitrary for non-UTC members.

## Changes

- **`utils/timezone.ts`** — add `hourInZone`, `dayOfWeekInZone` (0 = Sun … 6 = Sat, matching `getDay()`), and `secondsIntoHourInZone`, alongside the existing `isoDateInZone`.
- **`services/achievements-service.ts`**
  - Resolve the acting user's `UserNotificationPrefs.timezone` once per evaluation via a new `resolveUserTimezone` helper (guild id from bootstrap `GUILD_ID`, same as `notifyUserOfAccolades`), falling back to **UTC** when unset/invalid or when no guild id is configured — same default semantics as Rewind's `dayKey`.
  - Thread the resolved zone through the accolade check/metadata closures and the late-night / early-morning / consecutive-days helpers. The new hour-window walk aligns segments to local-hour boundaries so it stays correct in sub-hour-offset zones.
  - The timezone lookup is kept out of the per-accolade loop and the per-session inner loops (one lookup per evaluation), per the issue's perf note.
  - Weekly achievements stay UTC (out of scope) and pass `"UTC"` explicitly.
- **Docs** — update the `COMMANDS.md` accolade notes and the `src/content` authoring README to reflect the new `timeZone` closure argument.

## Behaviour

- Timezone set → hour windows, day-of-week, and streak days evaluate in the user's local time.
- Timezone unset → UTC, so existing members' progress doesn't silently shift.

## Tests

New `__tests__/services/achievements-timezone.test.ts` proves a session lands in the correct local window/day under a non-UTC zone and the UTC fallback for:

- time-of-day (Night Owl + Early Bird),
- day-of-week (Weekend + Weekday Warrior),
- the consistency streak (two same-UTC-day sessions splitting into a 2-day local streak),
- plus `resolveUserTimezone`'s fallbacks.

Full suite green (`npm run test:ci`: 1210 passed), `npm run build` / `lint` / `format:check` / markdownlint all clean.

## Acceptance criteria

- [x] Night Owl / Early Bird evaluate hour windows in the user's timezone when set.
- [x] Weekend / Weekday Warrior evaluate day-of-week in the user's timezone when set.
- [x] Consistency streaks bucket days in the user's timezone when set.
- [x] Users with no timezone set keep UTC behaviour (no regression).
- [x] `COMMANDS.md` accolade notes updated.
- [x] Unit tests cover a non-UTC zone and the UTC fallback for a time-of-day, a day-of-week, and the streak check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019dHbQuDRJJZwvtXCcKPf5P)_