### PR TITLE
feat(voice): apply user name pattern and add /me/voice preset management

### DIFF
--- a/WEBUI.md
+++ b/WEBUI.md
@@ -804,6 +804,7 @@ counters.
 | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Overview** (`/me/`)                   | Index for your own settings — links to the available per-user pages.                                                                                       |
 | **Notifications** (`/me/notifications`) | Opt in or out of DM nudges from Koolbot (achievements, weekly digest, Rewind nudge). Each toggle records a `WebAuditLog` row.                              |
+| **Voice** (`/me/voice`)                 | Manage your channel name pattern and saved voice-channel presets (rename, edit, set-default, delete). Gated by `voicechannels.presets.enabled`.            |
 | **Rewind** (`/me/rewind`)               | Personal year-in-review: voice time, top voice companions, peak day, longest session, streak, badges, annual rank, weekly-rank journey, and text activity. |
 
 Notification preferences are scoped per `(userId, guildId)`. The page
@@ -815,6 +816,23 @@ The whole feature is gated by `rewind.enabled` (`#608`). When it is off
 the route returns a 404 "feature disabled" state and the nav link is
 suppressed on every `/me/*` page; the end-of-year DM nudge is a separate
 toggle (`rewind.nudge.enabled`).
+
+The **Voice** page (`/me/voice`, `#656`) lets a member manage the
+per-user voice preferences that back the Discord control panel's
+**Presets** button. It exposes two things: a **channel name pattern**
+(applied to every channel you spawn from the lobby — use `{username}` as a
+placeholder for your display name; leave blank for the server default
+naming) and your **saved presets**. Presets themselves are still *created*
+in Discord by snapshotting a live channel (control panel → Presets → Save
+current as preset); the web page lets you **edit** a preset's name, channel
+name, user limit, and bitrate, **set-default** (the default auto-applies on
+your next lobby spawn), and **delete**. Every write goes through the same
+`UserVoicePrefsService` validation as the Discord modal — so the
+max-per-user cap, name/limit/bitrate bounds, and name-pattern length are
+identical on both surfaces — and records a `WebAuditLog` row
+(`user.voice.namepattern.set`, `user.voice.preset.edit|default|delete`).
+The whole page is gated by `voicechannels.presets.enabled`: when off it
+returns a 404 "feature disabled" state and its nav link is suppressed.
 
 The bare **Rewind** page (`/me/rewind`) lands on the most recent year you
 actually have data for, so visiting right after the year rolls over shows

--- a/__tests__/services/user-voice-prefs-service.test.ts
+++ b/__tests__/services/user-voice-prefs-service.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import {
+  applyNamePattern,
+  UserVoicePrefsService,
+  VoicePrefsValidationError,
+} from "../../src/services/user-voice-prefs-service.js";
+import { UserVoicePreferences } from "../../src/models/user-voice-preferences.js";
+
+jest.mock("../../src/models/user-voice-preferences.js");
+jest.mock("../../src/utils/logger.js");
+
+const mockModel = UserVoicePreferences as unknown as {
+  findOne: jest.Mock;
+  create: jest.Mock;
+};
+
+interface FakeDoc {
+  userId: string;
+  namePattern?: string;
+  presets: Array<{
+    name: string;
+    channelName?: string;
+    userLimit?: number;
+    bitrate?: number;
+    isDefault?: boolean;
+  }>;
+  save: jest.Mock;
+  markModified: jest.Mock;
+}
+
+function makeDoc(overrides: Partial<FakeDoc> = {}): FakeDoc {
+  return {
+    userId: "u1",
+    presets: [],
+    save: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    markModified: jest.fn(),
+    ...overrides,
+  };
+}
+
+// getPrefs awaits findOne() directly; point it at our fake doc so the
+// lazy-create branch is never taken.
+function stubGetPrefs(doc: FakeDoc): void {
+  mockModel.findOne.mockResolvedValue(doc as never);
+}
+
+describe("applyNamePattern", () => {
+  it("substitutes {username} (case-insensitive) with the display name", () => {
+    expect(applyNamePattern("{username}'s Room", "Ada")).toBe("Ada's Room");
+    expect(applyNamePattern("🎮 {USERNAME}", "Ada")).toBe("🎮 Ada");
+    expect(applyNamePattern("{displayName} HQ", "Ada")).toBe("Ada HQ");
+  });
+
+  it("trims and clamps to 100 characters", () => {
+    expect(applyNamePattern("  spaced  ", "Ada")).toBe("spaced");
+    const long = applyNamePattern("{username}".padEnd(200, "x"), "Ada");
+    expect(long).not.toBeNull();
+    expect(long!.length).toBe(100);
+  });
+
+  it("returns null when the result is empty", () => {
+    expect(applyNamePattern("   ", "Ada")).toBeNull();
+  });
+});
+
+describe("UserVoicePrefsService validation", () => {
+  let service: UserVoicePrefsService;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = UserVoicePrefsService.getInstance();
+  });
+
+  it("setNamePattern clears on empty input", async () => {
+    const doc = makeDoc({ namePattern: "old" });
+    stubGetPrefs(doc);
+    const result = await service.setNamePattern("u1", "  ");
+    expect(result).toBeNull();
+    expect(doc.namePattern).toBeUndefined();
+    expect(doc.save).toHaveBeenCalled();
+  });
+
+  it("setNamePattern rejects an over-long pattern", async () => {
+    const doc = makeDoc();
+    stubGetPrefs(doc);
+    await expect(
+      service.setNamePattern("u1", "x".repeat(101)),
+    ).rejects.toBeInstanceOf(VoicePrefsValidationError);
+    expect(doc.save).not.toHaveBeenCalled();
+  });
+
+  it("setNamePattern stores a trimmed pattern", async () => {
+    const doc = makeDoc();
+    stubGetPrefs(doc);
+    const result = await service.setNamePattern("u1", "  {username} HQ ");
+    expect(result).toBe("{username} HQ");
+    expect(doc.namePattern).toBe("{username} HQ");
+  });
+});
+
+describe("UserVoicePrefsService preset CRUD", () => {
+  let service: UserVoicePrefsService;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = UserVoicePrefsService.getInstance();
+  });
+
+  it("savePreset creates a new preset", async () => {
+    const doc = makeDoc();
+    stubGetPrefs(doc);
+    const out = await service.savePreset(
+      "u1",
+      "Squad night",
+      { channelName: "Squad", userLimit: 5, bitrate: 96 },
+      3,
+    );
+    expect(out).toEqual({ updated: false, name: "Squad night" });
+    expect(doc.presets).toHaveLength(1);
+    expect(doc.presets[0]).toMatchObject({
+      name: "Squad night",
+      channelName: "Squad",
+      userLimit: 5,
+      bitrate: 96,
+      isDefault: false,
+    });
+  });
+
+  it("savePreset updates an existing preset by case-insensitive name and preserves isDefault", async () => {
+    const doc = makeDoc({
+      presets: [{ name: "Squad", channelName: "Old", isDefault: true }],
+    });
+    stubGetPrefs(doc);
+    const out = await service.savePreset(
+      "u1",
+      "squad",
+      { channelName: "New", userLimit: 2, bitrate: 64 },
+      3,
+    );
+    expect(out.updated).toBe(true);
+    expect(doc.presets).toHaveLength(1);
+    expect(doc.presets[0]).toMatchObject({
+      name: "squad",
+      channelName: "New",
+      isDefault: true,
+    });
+  });
+
+  it("savePreset rejects when the max is reached for a new preset", async () => {
+    const doc = makeDoc({
+      presets: [{ name: "a" }, { name: "b" }, { name: "c" }],
+    });
+    stubGetPrefs(doc);
+    await expect(
+      service.savePreset("u1", "d", {}, 3),
+    ).rejects.toBeInstanceOf(VoicePrefsValidationError);
+    expect(doc.save).not.toHaveBeenCalled();
+  });
+
+  it("savePreset rejects an empty name", async () => {
+    const doc = makeDoc();
+    stubGetPrefs(doc);
+    await expect(
+      service.savePreset("u1", "   ", {}, 3),
+    ).rejects.toBeInstanceOf(VoicePrefsValidationError);
+  });
+
+  it("editPreset validates bounds and updates fields", async () => {
+    const doc = makeDoc({ presets: [{ name: "Squad", isDefault: true }] });
+    stubGetPrefs(doc);
+    await service.editPreset(
+      "u1",
+      0,
+      { name: "Squad+", channelName: "Room", userLimit: 10, bitrate: 128 },
+      "Squad",
+    );
+    expect(doc.presets[0]).toMatchObject({
+      name: "Squad+",
+      channelName: "Room",
+      userLimit: 10,
+      bitrate: 128,
+      isDefault: true,
+    });
+  });
+
+  it("editPreset rejects an out-of-range bitrate", async () => {
+    const doc = makeDoc({ presets: [{ name: "Squad" }] });
+    stubGetPrefs(doc);
+    await expect(
+      service.editPreset("u1", 0, { name: "Squad", bitrate: 999 }),
+    ).rejects.toBeInstanceOf(VoicePrefsValidationError);
+  });
+
+  it("editPreset rejects a name collision with another preset", async () => {
+    const doc = makeDoc({ presets: [{ name: "A" }, { name: "B" }] });
+    stubGetPrefs(doc);
+    await expect(
+      service.editPreset("u1", 1, { name: "a" }),
+    ).rejects.toBeInstanceOf(VoicePrefsValidationError);
+  });
+
+  it("renamePreset rejects when expectedName no longer matches", async () => {
+    const doc = makeDoc({ presets: [{ name: "Renamed" }] });
+    stubGetPrefs(doc);
+    await expect(
+      service.renamePreset("u1", 0, "New", "Stale"),
+    ).rejects.toBeInstanceOf(VoicePrefsValidationError);
+  });
+
+  it("deletePreset removes the row and reports remaining count", async () => {
+    const doc = makeDoc({ presets: [{ name: "A" }, { name: "B" }] });
+    stubGetPrefs(doc);
+    const out = await service.deletePreset("u1", 0, "A");
+    expect(out).toEqual({ name: "A", remaining: 1 });
+    expect(doc.presets).toEqual([{ name: "B" }]);
+  });
+
+  it("setDefault toggles the default and clears the others", async () => {
+    const doc = makeDoc({
+      presets: [
+        { name: "A", isDefault: true },
+        { name: "B", isDefault: false },
+      ],
+    });
+    stubGetPrefs(doc);
+    const out = await service.setDefault("u1", 1, "B");
+    expect(out).toEqual({ name: "B", isDefault: true });
+    expect(doc.presets[0].isDefault).toBe(false);
+    expect(doc.presets[1].isDefault).toBe(true);
+  });
+
+  it("setDefault unsets when the target was already default", async () => {
+    const doc = makeDoc({ presets: [{ name: "A", isDefault: true }] });
+    stubGetPrefs(doc);
+    const out = await service.setDefault("u1", 0, "A");
+    expect(out.isDefault).toBe(false);
+    expect(doc.presets[0].isDefault).toBe(false);
+  });
+});

--- a/__tests__/services/user-voice-prefs-service.test.ts
+++ b/__tests__/services/user-voice-prefs-service.test.ts
@@ -11,6 +11,7 @@ jest.mock("../../src/utils/logger.js");
 
 const mockModel = UserVoicePreferences as unknown as {
   findOne: jest.Mock;
+  findOneAndUpdate: jest.Mock;
   create: jest.Mock;
 };
 
@@ -38,10 +39,10 @@ function makeDoc(overrides: Partial<FakeDoc> = {}): FakeDoc {
   };
 }
 
-// getPrefs awaits findOne() directly; point it at our fake doc so the
-// lazy-create branch is never taken.
+// getPrefs uses an atomic upsert (findOneAndUpdate); point it at our fake
+// doc so each call resolves to the same in-memory preferences row.
 function stubGetPrefs(doc: FakeDoc): void {
-  mockModel.findOne.mockResolvedValue(doc as never);
+  mockModel.findOneAndUpdate.mockResolvedValue(doc as never);
 }
 
 describe("applyNamePattern", () => {

--- a/__tests__/web/user-routes.test.ts
+++ b/__tests__/web/user-routes.test.ts
@@ -881,6 +881,323 @@ describe("/me/rewind", () => {
   });
 });
 
+describe("/me/voice (#656)", () => {
+  beforeEach(() => {
+    process.env.WEBUI_SESSION_SECRET = SECRET;
+    process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES = "30";
+    (WebSessionService as unknown as { instance: unknown }).instance = null;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  async function dispatch(opts: {
+    method: "GET" | "POST";
+    url?: string; // path under /me, e.g. "/voice/preset/default"
+    body?: Record<string, unknown>;
+    csrfHeader?: string;
+    presetsEnabled?: boolean;
+    prefs?: { namePattern?: string; presets: unknown[] };
+    serviceImpl?: Record<string, unknown>;
+  }): Promise<{
+    statusCode: number;
+    body: string;
+    redirectedTo?: string;
+    audit?: Record<string, unknown>;
+  }> {
+    const now = Date.now();
+    const payload: CookiePayload = {
+      sid: "session-id",
+      uid: "user-1",
+      gid: "guild-1",
+      rol: "user",
+      iat: now - 60_000,
+      act: now - 60_000,
+    };
+    const cookie = `koolbot_session=${buildCookie(payload)}; koolbot_csrf=csrf-1`;
+
+    const svc = WebSessionService.getInstance();
+    jest.spyOn(svc, "findById").mockResolvedValue({
+      discordUserId: "user-1",
+      guildId: "guild-1",
+      role: "user",
+      scopes: [],
+      revokedAt: null,
+      expiresAt: new Date(now + 60 * 60 * 1000),
+    } as never);
+
+    const { PermissionsService } =
+      await import("../../src/services/permissions-service.js");
+    jest.spyOn(PermissionsService, "getInstance").mockReturnValue({
+      checkCommandPermission: async () => true,
+    } as never);
+
+    const presetsEnabled = opts.presetsEnabled ?? true;
+    const { ConfigService } =
+      await import("../../src/services/config-service.js");
+    jest.spyOn(ConfigService, "getInstance").mockReturnValue({
+      getBoolean: async (key: string) =>
+        key === "voicechannels.presets.enabled" ? presetsEnabled : false,
+      getNumber: async () => 3,
+    } as never);
+
+    const { UserVoicePrefsService } =
+      await import("../../src/services/user-voice-prefs-service.js");
+    const defaults = {
+      getPrefs: async () =>
+        opts.prefs ?? { namePattern: undefined, presets: [] },
+      setNamePattern: jest
+        .fn<(u: string, raw: string) => Promise<string | null>>()
+        .mockImplementation(async (_u, raw) => (raw.trim() === "" ? null : raw.trim())),
+      setDefault: jest
+        .fn()
+        .mockResolvedValue({ name: "Squad", isDefault: true } as never),
+      deletePreset: jest
+        .fn()
+        .mockResolvedValue({ name: "Squad", remaining: 0 } as never),
+      editPreset: jest.fn().mockResolvedValue({ name: "Squad" } as never),
+    };
+    const serviceImpl = { ...defaults, ...(opts.serviceImpl ?? {}) };
+    jest
+      .spyOn(UserVoicePrefsService, "getInstance")
+      .mockReturnValue(serviceImpl as never);
+
+    const { WebAuditLog } = await import("../../src/models/web-audit-log.js");
+    const createSpy = jest
+      .spyOn(WebAuditLog, "create")
+      .mockResolvedValue({} as never);
+
+    const mockClient = {} as never;
+    const { createSessionMiddleware } =
+      await import("../../src/web/session.js");
+    const requireSession = createSessionMiddleware(mockClient);
+    const router = createUserRouter(mockClient, requireSession);
+
+    const headers: Record<string, unknown> = { cookie };
+    if (opts.method === "POST" && opts.csrfHeader) {
+      headers["x-csrf-token"] = opts.csrfHeader;
+    }
+
+    const url = opts.url ?? "/voice";
+    const captured: {
+      statusCode: number;
+      body: string;
+      redirectedTo?: string;
+    } = { statusCode: 200, body: "" };
+    const res = makeRes() as ReturnType<typeof makeRes> & {
+      redirect: jest.Mock;
+      header: jest.Mock;
+    };
+    res.status.mockImplementation((code: number) => {
+      captured.statusCode = code;
+      res.statusCode = code;
+      return res;
+    });
+    res.send.mockImplementation((body: unknown) => {
+      captured.body = typeof body === "string" ? body : String(body);
+      res.body = captured.body;
+      return res;
+    });
+    res.redirect = jest.fn((code: unknown, target?: unknown) => {
+      if (typeof code === "number") {
+        captured.statusCode = code;
+        captured.redirectedTo = String(target);
+      } else {
+        captured.statusCode = 302;
+        captured.redirectedTo = String(code);
+      }
+      return res;
+    });
+    res.header = jest.fn(() => res);
+
+    const req = {
+      method: opts.method,
+      url,
+      originalUrl: `/me${url}`,
+      path: url,
+      baseUrl: "/me",
+      headers,
+      body: opts.body ?? {},
+      query: {},
+      csrfToken: "csrf-1",
+      header: (name: string) => headers[name.toLowerCase()],
+    } as never as Parameters<typeof router>[0];
+
+    await new Promise<void>((resolve) => {
+      router(req as never, res as never, (() => resolve()) as never);
+      setTimeout(resolve, 0);
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const auditCall = createSpy.mock.calls.at(-1)?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    return { ...captured, audit: auditCall };
+  }
+
+  it("renders the voice page with the name pattern and presets", async () => {
+    const out = await dispatch({
+      method: "GET",
+      prefs: {
+        namePattern: "{username}'s Room",
+        presets: [
+          {
+            name: "Squad",
+            channelName: "Squad HQ",
+            userLimit: 5,
+            bitrate: 96,
+            isDefault: true,
+          },
+        ],
+      },
+    });
+    expect(out.statusCode).toBe(200);
+    expect(out.body).toContain("Voice preferences");
+    expect(out.body).toContain('action="/me/voice/name-pattern"');
+    expect(out.body).toContain("{username}&#39;s Room");
+    expect(out.body).toContain("Squad");
+    // The preview substitutes the (fallback) display name.
+    expect(out.body).toContain("Preview:");
+  });
+
+  it("returns a 404 disabled state when presets are off, and hides the nav link", async () => {
+    const out = await dispatch({ method: "GET", presetsEnabled: false });
+    expect(out.statusCode).toBe(404);
+    expect(out.body).toContain("voice presets are currently disabled");
+    expect(out.body).not.toContain('href="/me/voice"');
+  });
+
+  it("saves the name pattern and audits it", async () => {
+    const out = await dispatch({
+      method: "POST",
+      url: "/voice/name-pattern",
+      body: { _csrf: "csrf-1", namePattern: "🎮 {username}" },
+      csrfHeader: "csrf-1",
+    });
+    expect(out.statusCode).toBe(303);
+    expect(out.redirectedTo).toMatch(/^\/me\/voice\?/);
+    expect(out.audit).toMatchObject({
+      action: "user.voice.namepattern.set",
+      result: "success",
+    });
+  });
+
+  it("rejects a name-pattern POST without CSRF", async () => {
+    const out = await dispatch({
+      method: "POST",
+      url: "/voice/name-pattern",
+      body: { namePattern: "x" },
+    });
+    expect(out.statusCode).toBe(403);
+  });
+
+  it("sets a preset as default through the service", async () => {
+    const setDefault = jest
+      .fn()
+      .mockResolvedValue({ name: "Squad", isDefault: true } as never);
+    const out = await dispatch({
+      method: "POST",
+      url: "/voice/preset/default",
+      body: { _csrf: "csrf-1", index: "0", expectedName: "Squad" },
+      csrfHeader: "csrf-1",
+      serviceImpl: { setDefault },
+    });
+    expect(out.statusCode).toBe(303);
+    expect(setDefault).toHaveBeenCalledWith("user-1", 0, "Squad");
+    expect(out.audit).toMatchObject({
+      action: "user.voice.preset.default",
+      result: "success",
+    });
+  });
+
+  it("deletes a preset through the service", async () => {
+    const deletePreset = jest
+      .fn()
+      .mockResolvedValue({ name: "Squad", remaining: 0 } as never);
+    const out = await dispatch({
+      method: "POST",
+      url: "/voice/preset/delete",
+      body: { _csrf: "csrf-1", index: "0", expectedName: "Squad" },
+      csrfHeader: "csrf-1",
+      serviceImpl: { deletePreset },
+    });
+    expect(out.statusCode).toBe(303);
+    expect(deletePreset).toHaveBeenCalledWith("user-1", 0, "Squad");
+  });
+
+  it("edits a preset's fields through the service", async () => {
+    const editPreset = jest
+      .fn()
+      .mockResolvedValue({ name: "Squad+" } as never);
+    const out = await dispatch({
+      method: "POST",
+      url: "/voice/preset/edit",
+      body: {
+        _csrf: "csrf-1",
+        index: "0",
+        expectedName: "Squad",
+        name: "Squad+",
+        channelName: "Room",
+        userLimit: "10",
+        bitrate: "128",
+      },
+      csrfHeader: "csrf-1",
+      serviceImpl: { editPreset },
+    });
+    expect(out.statusCode).toBe(303);
+    expect(editPreset).toHaveBeenCalledWith(
+      "user-1",
+      0,
+      { name: "Squad+", channelName: "Room", userLimit: 10, bitrate: 128 },
+      "Squad",
+    );
+  });
+
+  it("surfaces a validation error as a warn flash without throwing", async () => {
+    const { VoicePrefsValidationError } =
+      await import("../../src/services/user-voice-prefs-service.js");
+    const editPreset = jest
+      .fn()
+      .mockRejectedValue(
+        new VoicePrefsValidationError("Bitrate must be a whole number"),
+      );
+    const out = await dispatch({
+      method: "POST",
+      url: "/voice/preset/edit",
+      body: {
+        _csrf: "csrf-1",
+        index: "0",
+        expectedName: "Squad",
+        name: "Squad",
+        bitrate: "999",
+      },
+      csrfHeader: "csrf-1",
+      serviceImpl: { editPreset },
+    });
+    expect(out.statusCode).toBe(303);
+    expect(out.redirectedTo).toContain("flash=warn");
+    expect(out.audit).toMatchObject({
+      action: "user.voice.preset.edit",
+      result: "failure",
+    });
+  });
+
+  it("rejects an edit with a missing preset index", async () => {
+    const editPreset = jest.fn();
+    const out = await dispatch({
+      method: "POST",
+      url: "/voice/preset/edit",
+      body: { _csrf: "csrf-1", name: "Squad" },
+      csrfHeader: "csrf-1",
+      serviceImpl: { editPreset },
+    });
+    expect(out.statusCode).toBe(303);
+    expect(out.redirectedTo).toContain("flash=err");
+    expect(editPreset).not.toHaveBeenCalled();
+  });
+});
+
 describe("/me/timezone (#524)", () => {
   beforeEach(() => {
     process.env.WEBUI_SESSION_SECRET = SECRET;

--- a/src/handlers/vc-modal-handler.ts
+++ b/src/handlers/vc-modal-handler.ts
@@ -2,7 +2,10 @@ import { ModalSubmitInteraction, ChannelType } from "discord.js";
 import logger from "../utils/logger.js";
 import { VoiceChannelManager } from "../services/voice-channel-manager.js";
 import { ConfigService } from "../services/config-service.js";
-import { UserVoicePreferences } from "../models/user-voice-preferences.js";
+import {
+  UserVoicePrefsService,
+  VoicePrefsValidationError,
+} from "../services/user-voice-prefs-service.js";
 
 const configService = ConfigService.getInstance();
 
@@ -157,14 +160,7 @@ async function handleSavePresetModal(
     return;
   }
 
-  const presetName = interaction.fields.getTextInputValue("name").trim();
-  if (presetName.length === 0 || presetName.length > 50) {
-    await interaction.reply({
-      content: "❌ Preset name must be 1–50 characters.",
-      ephemeral: true,
-    });
-    return;
-  }
+  const presetName = interaction.fields.getTextInputValue("name");
 
   const channel = await interaction.guild?.channels.fetch(channelId);
   if (!channel || channel.type !== ChannelType.GuildVoice) {
@@ -179,50 +175,40 @@ async function handleSavePresetModal(
     "voicechannels.presets.max_per_user",
     3,
   );
-  const prefs =
-    (await UserVoicePreferences.findOne({ userId })) ??
-    (await UserVoicePreferences.create({ userId, presets: [] }));
 
-  const existingIndex = prefs.presets.findIndex(
-    (p) => p.name.toLowerCase() === presetName.toLowerCase(),
-  );
+  try {
+    const { updated, name } =
+      await UserVoicePrefsService.getInstance().savePreset(
+        userId,
+        presetName,
+        {
+          channelName: channel.name,
+          userLimit: channel.userLimit ?? 0,
+          bitrate: Math.round((channel.bitrate ?? 64000) / 1000),
+        },
+        max,
+      );
 
-  if (existingIndex === -1 && prefs.presets.length >= max) {
+    logger.info(
+      `User ${userId} saved preset "${name}" from channel ${channelId}`,
+    );
+
     await interaction.reply({
-      content: `❌ You already have ${max} presets (the configured maximum). Delete one first or rename an existing preset.`,
+      content: updated
+        ? `✅ Preset **${name}** updated from this channel's settings.`
+        : `✅ Preset **${name}** saved.`,
       ephemeral: true,
     });
-    return;
+  } catch (error) {
+    if (error instanceof VoicePrefsValidationError) {
+      await interaction.reply({
+        content: `❌ ${error.message}`,
+        ephemeral: true,
+      });
+      return;
+    }
+    throw error;
   }
-
-  const snapshot = {
-    name: presetName,
-    channelName: channel.name,
-    userLimit: channel.userLimit ?? 0,
-    bitrate: Math.round((channel.bitrate ?? 64000) / 1000),
-    isDefault:
-      existingIndex !== -1 ? !!prefs.presets[existingIndex].isDefault : false,
-  };
-
-  if (existingIndex !== -1) {
-    prefs.presets[existingIndex] = snapshot;
-  } else {
-    prefs.presets.push(snapshot);
-  }
-  prefs.markModified("presets");
-  await prefs.save();
-
-  logger.info(
-    `User ${userId} saved preset "${presetName}" from channel ${channelId}`,
-  );
-
-  await interaction.reply({
-    content:
-      existingIndex !== -1
-        ? `✅ Preset **${presetName}** updated from this channel's settings.`
-        : `✅ Preset **${presetName}** saved.`,
-    ephemeral: true,
-  });
 }
 
 async function handleRenamePresetModal(
@@ -242,44 +228,28 @@ async function handleRenamePresetModal(
     return;
   }
 
-  const newName = interaction.fields.getTextInputValue("name").trim();
-  if (newName.length === 0 || newName.length > 50) {
+  const newName = interaction.fields.getTextInputValue("name");
+
+  try {
+    const { oldName, newName: savedName } =
+      await UserVoicePrefsService.getInstance().renamePreset(
+        userId,
+        presetIndex,
+        newName,
+      );
+
     await interaction.reply({
-      content: "❌ Preset name must be 1–50 characters.",
+      content: `✏️ Preset **${oldName}** renamed to **${savedName}**.`,
       ephemeral: true,
     });
-    return;
+  } catch (error) {
+    if (error instanceof VoicePrefsValidationError) {
+      await interaction.reply({
+        content: `❌ ${error.message}`,
+        ephemeral: true,
+      });
+      return;
+    }
+    throw error;
   }
-
-  const prefs = await UserVoicePreferences.findOne({ userId });
-  const preset = prefs?.presets?.[presetIndex];
-  if (!prefs || !preset) {
-    await interaction.reply({
-      content: "❌ Preset no longer exists.",
-      ephemeral: true,
-    });
-    return;
-  }
-
-  const collision = prefs.presets.findIndex(
-    (p, i) =>
-      i !== presetIndex && p.name.toLowerCase() === newName.toLowerCase(),
-  );
-  if (collision !== -1) {
-    await interaction.reply({
-      content: `❌ You already have a preset named **${newName}**.`,
-      ephemeral: true,
-    });
-    return;
-  }
-
-  const oldName = preset.name;
-  preset.name = newName;
-  prefs.markModified("presets");
-  await prefs.save();
-
-  await interaction.reply({
-    content: `✏️ Preset **${oldName}** renamed to **${newName}**.`,
-    ephemeral: true,
-  });
 }

--- a/src/handlers/vc-preset-handler.ts
+++ b/src/handlers/vc-preset-handler.ts
@@ -20,6 +20,7 @@ import {
   IChannelPreset,
   IUserVoicePreferences,
 } from "../models/user-voice-preferences.js";
+import { UserVoicePrefsService } from "../services/user-voice-prefs-service.js";
 
 const configService = ConfigService.getInstance();
 
@@ -481,9 +482,13 @@ async function toggleDefault(
   parsed: ParsedId,
 ): Promise<void> {
   if (parsed.presetIndex === null) return;
-  const prefs = await loadPrefs(parsed.ownerId);
-  const target = prefs.presets[parsed.presetIndex];
-  if (!target) {
+  let result: { name: string; isDefault: boolean };
+  try {
+    result = await UserVoicePrefsService.getInstance().setDefault(
+      parsed.ownerId,
+      parsed.presetIndex,
+    );
+  } catch {
     await interaction.reply({
       content: "❌ Preset no longer exists.",
       flags: MessageFlags.Ephemeral,
@@ -491,19 +496,11 @@ async function toggleDefault(
     return;
   }
 
-  const wasDefault = !!target.isDefault;
-  prefs.presets.forEach((p) => {
-    p.isDefault = false;
-  });
-  if (!wasDefault) target.isDefault = true;
-  prefs.markModified("presets");
-  await prefs.save();
-
   await switchToManage(interaction, parsed, parsed.presetIndex);
   await interaction.followUp({
-    content: wasDefault
-      ? `⭐ **${target.name}** is no longer the default.`
-      : `⭐ **${target.name}** will auto-apply on your next channel.`,
+    content: result.isDefault
+      ? `⭐ **${result.name}** will auto-apply on your next channel.`
+      : `⭐ **${result.name}** is no longer the default.`,
     flags: MessageFlags.Ephemeral,
   });
 }
@@ -513,9 +510,13 @@ async function deletePreset(
   parsed: ParsedId,
 ): Promise<void> {
   if (parsed.presetIndex === null) return;
-  const prefs = await loadPrefs(parsed.ownerId);
-  const target = prefs.presets[parsed.presetIndex];
-  if (!target) {
+  let removed: { name: string; remaining: number };
+  try {
+    removed = await UserVoicePrefsService.getInstance().deletePreset(
+      parsed.ownerId,
+      parsed.presetIndex,
+    );
+  } catch {
     await interaction.reply({
       content: "❌ Preset no longer exists.",
       flags: MessageFlags.Ephemeral,
@@ -523,18 +524,13 @@ async function deletePreset(
     return;
   }
 
-  const removedName = target.name;
-  prefs.presets.splice(parsed.presetIndex, 1);
-  prefs.markModified("presets");
-  await prefs.save();
-
-  if (prefs.presets.length === 0) {
+  if (removed.remaining === 0) {
     await switchToApply(interaction, parsed);
   } else {
     await switchToManage(interaction, parsed, null);
   }
   await interaction.followUp({
-    content: `🗑️ Deleted preset **${removedName}**.`,
+    content: `🗑️ Deleted preset **${removed.name}**.`,
     flags: MessageFlags.Ephemeral,
   });
 }

--- a/src/handlers/vc-preset-handler.ts
+++ b/src/handlers/vc-preset-handler.ts
@@ -20,7 +20,10 @@ import {
   IChannelPreset,
   IUserVoicePreferences,
 } from "../models/user-voice-preferences.js";
-import { UserVoicePrefsService } from "../services/user-voice-prefs-service.js";
+import {
+  UserVoicePrefsService,
+  VoicePrefsValidationError,
+} from "../services/user-voice-prefs-service.js";
 
 const configService = ConfigService.getInstance();
 
@@ -488,12 +491,18 @@ async function toggleDefault(
       parsed.ownerId,
       parsed.presetIndex,
     );
-  } catch {
-    await interaction.reply({
-      content: "❌ Preset no longer exists.",
-      flags: MessageFlags.Ephemeral,
-    });
-    return;
+  } catch (error) {
+    // Only the known "missing preset" validation case becomes a friendly
+    // reply here; unexpected errors (DB/Discord) propagate to the outer
+    // handler so they're logged and surfaced generically.
+    if (error instanceof VoicePrefsValidationError) {
+      await interaction.reply({
+        content: `❌ ${error.message}`,
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+    throw error;
   }
 
   await switchToManage(interaction, parsed, parsed.presetIndex);
@@ -516,12 +525,17 @@ async function deletePreset(
       parsed.ownerId,
       parsed.presetIndex,
     );
-  } catch {
-    await interaction.reply({
-      content: "❌ Preset no longer exists.",
-      flags: MessageFlags.Ephemeral,
-    });
-    return;
+  } catch (error) {
+    // As in toggleDefault: translate only the known validation/missing case;
+    // rethrow unexpected errors for the outer handler to log and report.
+    if (error instanceof VoicePrefsValidationError) {
+      await interaction.reply({
+        content: `❌ ${error.message}`,
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+    throw error;
   }
 
   if (removed.remaining === 0) {

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -534,9 +534,9 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
     type: "boolean",
   },
   "voicechannels.presets.enabled": {
-    label: "Per-user channel presets enabled",
+    label: "Per-user voice preferences enabled",
     description:
-      "Enable per-user channel presets (saved channel name + privacy).",
+      "Enable per-user voice preferences: a channel name pattern and saved presets (channel name, user limit, bitrate), managed from the Discord control panel and the /me/voice web page.",
     category: "voicechannels",
     type: "boolean",
   },

--- a/src/services/user-voice-prefs-service.ts
+++ b/src/services/user-voice-prefs-service.ts
@@ -1,0 +1,360 @@
+/**
+ * Single source of truth for per-user voice-channel preferences (#656).
+ *
+ * Both the Discord modal/button handlers (`vc-modal-handler`,
+ * `vc-preset-handler`) and the `/me/voice` web surface go through this
+ * service so the validation rules — name bounds, max-per-user, user-limit
+ * and bitrate bounds, name-pattern length — can never diverge between the
+ * two surfaces. The service is pure data + validation; anything that
+ * touches a live Discord channel (applying a preset, naming a freshly
+ * spawned channel) stays in the caller.
+ *
+ * Preferences are keyed by Discord `userId` only (presets are global to a
+ * user, not per-guild — see `models/user-voice-preferences.ts`).
+ */
+
+import {
+  UserVoicePreferences,
+  IChannelPreset,
+  IUserVoicePreferences,
+} from "../models/user-voice-preferences.js";
+
+// Bounds shared by every write path. Kept in sync with the Mongoose schema
+// in `models/user-voice-preferences.ts`.
+export const PRESET_NAME_MAX = 50;
+export const CHANNEL_NAME_MAX = 100;
+export const USER_LIMIT_MIN = 0;
+export const USER_LIMIT_MAX = 99;
+export const BITRATE_MIN = 8;
+export const BITRATE_MAX = 384;
+export const NAME_PATTERN_MAX = 100;
+
+/**
+ * Thrown by validating writes with a user-facing message. Callers surface
+ * `.message` directly (Discord reply / web flash) — keep messages friendly.
+ */
+export class VoicePrefsValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "VoicePrefsValidationError";
+  }
+}
+
+export interface PresetSnapshot {
+  channelName?: string;
+  userLimit?: number;
+  bitrate?: number;
+}
+
+export interface PresetEdit {
+  name: string;
+  channelName?: string;
+  userLimit?: number;
+  bitrate?: number;
+}
+
+/**
+ * Apply a user's naming pattern to produce a channel name.
+ *
+ * Substitutes `{username}` / `{displayName}` (case-insensitive) with the
+ * member's display name, trims, and clamps to Discord's 100-char channel
+ * name limit. Returns `null` when the result is empty so the caller can
+ * fall back to the default naming scheme.
+ */
+export function applyNamePattern(
+  pattern: string,
+  displayName: string,
+): string | null {
+  const substituted = pattern
+    .replace(/\{username\}/gi, displayName)
+    .replace(/\{displayname\}/gi, displayName)
+    .trim();
+  if (substituted.length === 0) return null;
+  return substituted.slice(0, CHANNEL_NAME_MAX);
+}
+
+export class UserVoicePrefsService {
+  private static instance: UserVoicePrefsService | null = null;
+
+  static getInstance(): UserVoicePrefsService {
+    if (!UserVoicePrefsService.instance) {
+      UserVoicePrefsService.instance = new UserVoicePrefsService();
+    }
+    return UserVoicePrefsService.instance;
+  }
+
+  /** Load (or lazily create) the preferences document for a user. */
+  async getPrefs(userId: string): Promise<IUserVoicePreferences> {
+    return (
+      (await UserVoicePreferences.findOne({ userId })) ??
+      (await UserVoicePreferences.create({ userId, presets: [] }))
+    );
+  }
+
+  // ---------- Validation helpers ----------
+
+  validatePresetName(raw: string): string {
+    const name = raw.trim();
+    if (name.length === 0 || name.length > PRESET_NAME_MAX) {
+      throw new VoicePrefsValidationError(
+        `Preset name must be 1–${PRESET_NAME_MAX} characters.`,
+      );
+    }
+    return name;
+  }
+
+  /**
+   * Normalise a name pattern: trims, treats empty as "cleared" (`null`),
+   * and enforces the length cap. Returns the value to store.
+   */
+  validateNamePattern(raw: string | null): string | null {
+    if (raw === null) return null;
+    const pattern = raw.trim();
+    if (pattern.length === 0) return null;
+    if (pattern.length > NAME_PATTERN_MAX) {
+      throw new VoicePrefsValidationError(
+        `Name pattern must be ${NAME_PATTERN_MAX} characters or less.`,
+      );
+    }
+    return pattern;
+  }
+
+  /** Validate an optional channel-name override (preset field). */
+  validateChannelName(raw: string | undefined): string | undefined {
+    if (raw === undefined) return undefined;
+    const name = raw.trim();
+    if (name.length === 0) return undefined;
+    if (name.length > CHANNEL_NAME_MAX) {
+      throw new VoicePrefsValidationError(
+        `Channel name must be ${CHANNEL_NAME_MAX} characters or less.`,
+      );
+    }
+    return name;
+  }
+
+  /** Validate an optional user limit (0 = unlimited). */
+  validateUserLimit(raw: number | undefined): number | undefined {
+    if (raw === undefined) return undefined;
+    if (
+      !Number.isInteger(raw) ||
+      raw < USER_LIMIT_MIN ||
+      raw > USER_LIMIT_MAX
+    ) {
+      throw new VoicePrefsValidationError(
+        `User limit must be a whole number between ${USER_LIMIT_MIN} and ${USER_LIMIT_MAX} (0 = unlimited).`,
+      );
+    }
+    return raw;
+  }
+
+  /** Validate an optional bitrate in kbps. */
+  validateBitrate(raw: number | undefined): number | undefined {
+    if (raw === undefined) return undefined;
+    if (!Number.isInteger(raw) || raw < BITRATE_MIN || raw > BITRATE_MAX) {
+      throw new VoicePrefsValidationError(
+        `Bitrate must be a whole number between ${BITRATE_MIN} and ${BITRATE_MAX} kbps.`,
+      );
+    }
+    return raw;
+  }
+
+  // ---------- Name pattern ----------
+
+  async getNamePattern(userId: string): Promise<string | null> {
+    const prefs = await UserVoicePreferences.findOne({ userId }).lean();
+    return prefs?.namePattern ?? null;
+  }
+
+  /**
+   * Persist a name pattern (or clear it with `null`/empty). Returns the
+   * stored value so callers can report the normalised result.
+   */
+  async setNamePattern(
+    userId: string,
+    raw: string | null,
+  ): Promise<string | null> {
+    const value = this.validateNamePattern(raw);
+    const prefs = await this.getPrefs(userId);
+    prefs.namePattern = value ?? undefined;
+    await prefs.save();
+    return value;
+  }
+
+  // ---------- Preset writes ----------
+
+  /**
+   * Save a snapshot of the current channel as a named preset, or update an
+   * existing preset of the same name (case-insensitive). Enforces the
+   * max-per-user cap for genuinely new presets.
+   *
+   * Returns whether an existing preset was updated (vs. created) so the
+   * caller can word its confirmation.
+   */
+  async savePreset(
+    userId: string,
+    rawName: string,
+    snapshot: PresetSnapshot,
+    maxPerUser: number,
+  ): Promise<{ updated: boolean; name: string }> {
+    const name = this.validatePresetName(rawName);
+    const prefs = await this.getPrefs(userId);
+
+    const existingIndex = prefs.presets.findIndex(
+      (p) => p.name.toLowerCase() === name.toLowerCase(),
+    );
+
+    if (existingIndex === -1 && prefs.presets.length >= maxPerUser) {
+      throw new VoicePrefsValidationError(
+        `You already have ${maxPerUser} presets (the configured maximum). Delete one first or rename an existing preset.`,
+      );
+    }
+
+    const preset: IChannelPreset = {
+      name,
+      channelName: this.validateChannelName(snapshot.channelName),
+      userLimit: this.validateUserLimit(snapshot.userLimit),
+      bitrate: this.validateBitrate(snapshot.bitrate),
+      isDefault:
+        existingIndex !== -1 ? !!prefs.presets[existingIndex].isDefault : false,
+    };
+
+    if (existingIndex !== -1) {
+      prefs.presets[existingIndex] = preset;
+    } else {
+      prefs.presets.push(preset);
+    }
+    prefs.markModified("presets");
+    await prefs.save();
+    return { updated: existingIndex !== -1, name };
+  }
+
+  /**
+   * Rename a preset by index. `expectedName`, when supplied, guards against
+   * a stale web form acting on the wrong row after the list shifted.
+   */
+  async renamePreset(
+    userId: string,
+    index: number,
+    rawNewName: string,
+    expectedName?: string,
+  ): Promise<{ oldName: string; newName: string }> {
+    const newName = this.validatePresetName(rawNewName);
+    const prefs = await this.getPrefs(userId);
+    const preset = prefs.presets[index];
+    if (
+      !preset ||
+      (expectedName !== undefined && preset.name !== expectedName)
+    ) {
+      throw new VoicePrefsValidationError("Preset no longer exists.");
+    }
+
+    const collision = prefs.presets.findIndex(
+      (p, i) => i !== index && p.name.toLowerCase() === newName.toLowerCase(),
+    );
+    if (collision !== -1) {
+      throw new VoicePrefsValidationError(
+        `You already have a preset named "${newName}".`,
+      );
+    }
+
+    const oldName = preset.name;
+    preset.name = newName;
+    prefs.markModified("presets");
+    await prefs.save();
+    return { oldName, newName };
+  }
+
+  /**
+   * Edit a preset's full field set (name + channelName + userLimit +
+   * bitrate) in one write. Used by the web surface where all fields are
+   * editable at once. `isDefault` is preserved.
+   */
+  async editPreset(
+    userId: string,
+    index: number,
+    edit: PresetEdit,
+    expectedName?: string,
+  ): Promise<{ name: string }> {
+    const name = this.validatePresetName(edit.name);
+    const channelName = this.validateChannelName(edit.channelName);
+    const userLimit = this.validateUserLimit(edit.userLimit);
+    const bitrate = this.validateBitrate(edit.bitrate);
+
+    const prefs = await this.getPrefs(userId);
+    const preset = prefs.presets[index];
+    if (
+      !preset ||
+      (expectedName !== undefined && preset.name !== expectedName)
+    ) {
+      throw new VoicePrefsValidationError("Preset no longer exists.");
+    }
+
+    const collision = prefs.presets.findIndex(
+      (p, i) => i !== index && p.name.toLowerCase() === name.toLowerCase(),
+    );
+    if (collision !== -1) {
+      throw new VoicePrefsValidationError(
+        `You already have a preset named "${name}".`,
+      );
+    }
+
+    preset.name = name;
+    preset.channelName = channelName;
+    preset.userLimit = userLimit;
+    preset.bitrate = bitrate;
+    prefs.markModified("presets");
+    await prefs.save();
+    return { name };
+  }
+
+  /** Delete a preset by index, returning the removed name and remaining count. */
+  async deletePreset(
+    userId: string,
+    index: number,
+    expectedName?: string,
+  ): Promise<{ name: string; remaining: number }> {
+    const prefs = await this.getPrefs(userId);
+    const preset = prefs.presets[index];
+    if (
+      !preset ||
+      (expectedName !== undefined && preset.name !== expectedName)
+    ) {
+      throw new VoicePrefsValidationError("Preset no longer exists.");
+    }
+
+    const name = preset.name;
+    prefs.presets.splice(index, 1);
+    prefs.markModified("presets");
+    await prefs.save();
+    return { name, remaining: prefs.presets.length };
+  }
+
+  /**
+   * Toggle (or set) which preset auto-applies on the next channel spawn.
+   * Only one preset can be the default; setting one clears the others.
+   * Returns the new default state of the targeted preset.
+   */
+  async setDefault(
+    userId: string,
+    index: number,
+    expectedName?: string,
+  ): Promise<{ name: string; isDefault: boolean }> {
+    const prefs = await this.getPrefs(userId);
+    const target = prefs.presets[index];
+    if (
+      !target ||
+      (expectedName !== undefined && target.name !== expectedName)
+    ) {
+      throw new VoicePrefsValidationError("Preset no longer exists.");
+    }
+
+    const wasDefault = !!target.isDefault;
+    prefs.presets.forEach((p) => {
+      p.isDefault = false;
+    });
+    if (!wasDefault) target.isDefault = true;
+    prefs.markModified("presets");
+    await prefs.save();
+    return { name: target.name, isDefault: !wasDefault };
+  }
+}

--- a/src/services/user-voice-prefs-service.ts
+++ b/src/services/user-voice-prefs-service.ts
@@ -83,12 +83,20 @@ export class UserVoicePrefsService {
     return UserVoicePrefsService.instance;
   }
 
-  /** Load (or lazily create) the preferences document for a user. */
+  /**
+   * Load (or lazily create) the preferences document for a user. Uses an
+   * atomic upsert so two concurrent first-time requests can't race a
+   * `findOne() ?? create()` into a duplicate-key error on the unique
+   * `userId` index — both resolve to the same row.
+   */
   async getPrefs(userId: string): Promise<IUserVoicePreferences> {
-    return (
-      (await UserVoicePreferences.findOne({ userId })) ??
-      (await UserVoicePreferences.create({ userId, presets: [] }))
+    // `upsert: true, new: true` always resolves to a document (never null).
+    const prefs = await UserVoicePreferences.findOneAndUpdate(
+      { userId },
+      { $setOnInsert: { userId, presets: [] } },
+      { upsert: true, new: true, setDefaultsOnInsert: true },
     );
+    return prefs as IUserVoicePreferences;
   }
 
   // ---------- Validation helpers ----------

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -1504,11 +1504,37 @@ export class VoiceChannelManager {
 
       const member = await guild.members.fetch(userId);
 
-      // Determine channel name
-      let finalChannelName: string;
+      // Determine channel name. Precedence: explicit name argument →
+      // the owner's saved name pattern (a "my channels are always X"
+      // preference, #656) → the server's default prefix/suffix scheme.
+      // The name pattern only applies while per-user presets are enabled,
+      // the same feature gate that exposes its management UI.
+      let finalChannelName: string | null = null;
       if (channelName) {
         finalChannelName = channelName;
       } else {
+        const presetsEnabledForNaming = await configService.getBoolean(
+          "voicechannels.presets.enabled",
+          false,
+        );
+        if (presetsEnabledForNaming && member) {
+          try {
+            const { applyNamePattern, UserVoicePrefsService } =
+              await import("./user-voice-prefs-service.js");
+            const namePattern =
+              await UserVoicePrefsService.getInstance().getNamePattern(userId);
+            if (namePattern) {
+              finalChannelName = applyNamePattern(
+                namePattern,
+                member.displayName,
+              );
+            }
+          } catch (error) {
+            logger.error("Error applying user name pattern:", error);
+          }
+        }
+      }
+      if (!finalChannelName) {
         // Use default naming
         const channelPrefix = await configService.getString(
           "voicechannels.channel.prefix",

--- a/src/web/user-layout.ts
+++ b/src/web/user-layout.ts
@@ -22,7 +22,7 @@ interface UserNavItem {
    * (#608): a disabled feature drops out of the nav but the URL stays
    * reachable by direct navigation (the route itself enforces the gate).
    */
-  feature?: "rewind";
+  feature?: "rewind" | "voice";
 }
 
 /**
@@ -35,6 +35,7 @@ export const USER_NAV_ITEMS: UserNavItem[] = [
   { href: "/me/", label: "Overview" },
   { href: "/me/notifications", label: "Notifications" },
   { href: "/me/timezone", label: "Timezone" },
+  { href: "/me/voice", label: "Voice", feature: "voice" },
   { href: "/me/rewind", label: "Rewind", feature: "rewind" },
 ];
 
@@ -69,6 +70,12 @@ export interface UserPageOptions {
    * unchanged.
    */
   rewindEnabled?: boolean;
+  /**
+   * Enabled-state of the feature-gated Voice-preferences page (#656). When
+   * `false`, the Voice nav link is suppressed. Omitted/`undefined` keeps the
+   * link visible, mirroring `rewindEnabled`.
+   */
+  presetsEnabled?: boolean;
 }
 
 const STYLE = [
@@ -115,6 +122,15 @@ const STYLE = [
   ".tz-preview .now{font-weight:600;color:#e4e6eb}",
   ".btn{background:#2563eb;color:#fff;border:0;padding:.45rem .9rem;border-radius:4px;cursor:pointer;font-weight:600;font-size:.9rem}",
   ".btn:hover{background:#1d4ed8}",
+  ".btn-secondary{background:#374151;color:#e4e6eb;border:0;padding:.45rem .9rem;border-radius:4px;cursor:pointer;font-weight:600;font-size:.9rem}",
+  ".btn-secondary:hover{background:#4b5563}",
+  ".btn-danger{background:#dc2626;color:#fff;border:0;padding:.45rem .9rem;border-radius:4px;cursor:pointer;font-weight:600;font-size:.9rem}",
+  ".btn-danger:hover{background:#b91c1c}",
+  ".preset-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:.75rem;margin:.5rem 0}",
+  ".preset-grid label{display:flex;flex-direction:column;gap:.25rem;font-size:.8rem;color:#94a3b8}",
+  ".preset-grid input{background:#0f1115;color:#e4e6eb;border:1px solid #2d3748;border-radius:4px;padding:.4rem .5rem;font-size:.9rem}",
+  ".preset-actions{display:flex;gap:.5rem;margin-top:.5rem}",
+  ".preset-actions form{display:inline;margin:0}",
   ".form-actions{margin-top:1rem;display:flex;gap:.5rem;align-items:center}",
   ".feature-list{list-style:none;padding:0;margin:0;display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:.75rem}",
   ".feature-list li{background:#0f1115;border:1px solid #2d3748;border-radius:6px;padding:.75rem 1rem}",
@@ -217,19 +233,25 @@ export function renderUserPage(opts: UserPageOptions): string {
     '<button type="submit">Finish</button>',
     "</form></div></div>",
     '<div class="shell">',
-    `<main>${renderPageNav(opts.active, opts.rewindEnabled)}${renderFlash(opts.flash)}${opts.body}</main></div>`,
+    `<main>${renderPageNav(opts.active, opts.rewindEnabled, opts.presetsEnabled)}${renderFlash(opts.flash)}${opts.body}</main></div>`,
     `<script>${SCRIPT}</script>`,
     "</body></html>",
   ].join("");
 }
 
-function renderPageNav(active: string, rewindEnabled?: boolean): string {
-  const items = USER_NAV_ITEMS.filter(
+function renderPageNav(
+  active: string,
+  rewindEnabled?: boolean,
+  presetsEnabled?: boolean,
+): string {
+  const items = USER_NAV_ITEMS.filter((item) => {
     // A feature-gated item only shows while its feature is enabled.
     // `undefined` is treated as enabled so non-gating callers are
-    // unaffected (#608).
-    (item) => item.feature !== "rewind" || rewindEnabled !== false,
-  )
+    // unaffected (#608/#656).
+    if (item.feature === "rewind") return rewindEnabled !== false;
+    if (item.feature === "voice") return presetsEnabled !== false;
+    return true;
+  })
     .map((item) => {
       const isActive =
         item.href === active ||
@@ -260,6 +282,9 @@ export function renderUserIndexBody(opts: {
   // Whether the feature-gated Rewind page is enabled (#608). When false,
   // its card is omitted so the overview never links to a disabled page.
   rewindEnabled?: boolean;
+  // Whether the feature-gated Voice page is enabled (#656). When false,
+  // its card is omitted so the overview never links to a disabled page.
+  presetsEnabled?: boolean;
 }): string {
   const greeting = opts.isAdmin
     ? `<p class="subtitle">Signed in as an administrator viewing your own preferences. Use the <em>Back to admin panel</em> link above to manage the server.</p>`
@@ -269,6 +294,11 @@ export function renderUserIndexBody(opts: {
       ? ""
       : '<li><span class="feature-name"><a href="/me/rewind">Rewind</a></span>' +
         '<span class="feature-desc">Your personal year-in-review of voice activity, top voice companions, peak day, and badges earned.</span></li>';
+  const voiceCard =
+    opts.presetsEnabled === false
+      ? ""
+      : '<li><span class="feature-name"><a href="/me/voice">Voice</a></span>' +
+        '<span class="feature-desc">Manage your channel name pattern and saved voice-channel presets.</span></li>';
   return [
     "<h1>My preferences</h1>",
     greeting,
@@ -280,6 +310,7 @@ export function renderUserIndexBody(opts: {
       '<span class="feature-desc">Opt in or out of DM nudges from Koolbot.</span></li>',
     '<li><span class="feature-name"><a href="/me/timezone">Timezone</a></span>' +
       '<span class="feature-desc">Choose the timezone Koolbot uses when it shows you times in digests, Rewind, and voicestats.</span></li>',
+    voiceCard,
     rewindCard,
     "</ul>",
     "</div>",
@@ -721,5 +752,118 @@ export function renderUserNotificationsBody(
     "</div>",
     "</div>",
     "</form>",
+  ].join("");
+}
+
+// --------------------------------------------------------------------
+// Voice preferences page (#656)
+// --------------------------------------------------------------------
+
+export interface VoicePresetView {
+  /** Stable index into the user's preset array (the form's row key). */
+  index: number;
+  name: string;
+  channelName: string | null;
+  /** null = inherit Discord's default (unlimited); 0 = explicitly unlimited. */
+  userLimit: number | null;
+  bitrate: number | null;
+  isDefault: boolean;
+}
+
+export interface VoicePageBodyOptions {
+  csrfToken: string;
+  /** Current name pattern, or null when unset. */
+  namePattern: string | null;
+  /** Member display name, used to preview the pattern. */
+  displayName: string;
+  presets: VoicePresetView[];
+  /** Configured max presets per user (shown as guidance). */
+  maxPerUser: number;
+}
+
+function renderPresetRow(p: VoicePresetView, csrfToken: string): string {
+  const bits: string[] = [];
+  if (p.channelName) bits.push(`name "${escapeHtml(p.channelName)}"`);
+  if (p.userLimit !== null)
+    bits.push(p.userLimit === 0 ? "no limit" : `limit ${p.userLimit}`);
+  if (p.bitrate !== null) bits.push(`${p.bitrate}kbps`);
+  const summary = bits.length ? bits.join(" · ") : "(empty)";
+
+  const csrf = `<input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">`;
+  // The hidden `index`/`expectedName` pair lets the server reject a stale
+  // form whose row shifted (e.g. another tab deleted a preset first).
+  const idFields =
+    `<input type="hidden" name="index" value="${p.index}">` +
+    `<input type="hidden" name="expectedName" value="${escapeHtml(p.name)}">`;
+
+  return [
+    '<div class="card">',
+    `<h2>${escapeHtml(p.name)} ${p.isDefault ? "⭐" : ""}</h2>`,
+    `<p class="muted">${summary}</p>`,
+    // Edit form (name + channel name + limit + bitrate in one save).
+    '<form method="POST" action="/me/voice/preset/edit">',
+    csrf,
+    idFields,
+    '<div class="preset-grid">',
+    `<label>Preset name<input type="text" name="name" value="${escapeHtml(p.name)}" maxlength="50" required></label>`,
+    `<label>Channel name<input type="text" name="channelName" value="${escapeHtml(p.channelName ?? "")}" maxlength="100" placeholder="(unchanged)"></label>`,
+    `<label>User limit<input type="number" name="userLimit" value="${p.userLimit ?? ""}" min="0" max="99" placeholder="(default)"></label>`,
+    `<label>Bitrate (kbps)<input type="number" name="bitrate" value="${p.bitrate ?? ""}" min="8" max="384" placeholder="(default)"></label>`,
+    "</div>",
+    '<div class="form-actions"><button class="btn" type="submit">Save changes</button></div>',
+    "</form>",
+    // Default + delete as separate small forms so each is a single POST.
+    '<div class="preset-actions">',
+    '<form method="POST" action="/me/voice/preset/default">',
+    csrf,
+    idFields,
+    `<button class="btn-secondary" type="submit">${p.isDefault ? "Unset default" : "Set as default"}</button>`,
+    "</form>",
+    '<form method="POST" action="/me/voice/preset/delete">',
+    csrf,
+    idFields,
+    '<button class="btn-danger" type="submit">Delete</button>',
+    "</form>",
+    "</div>",
+    "</div>",
+  ].join("");
+}
+
+/**
+ * Inner HTML for `GET /me/voice` (#656). One form to edit the name
+ * pattern, then a card per saved preset (edit / set-default / delete).
+ * Presets themselves are created in Discord by snapshotting a live
+ * channel — the web surface manages the ones you already have.
+ */
+export function renderUserVoiceBody(opts: VoicePageBodyOptions): string {
+  const presetCards =
+    opts.presets.length === 0
+      ? '<div class="card"><div class="empty">No saved presets yet. Open a voice channel\'s control panel in Discord and choose <strong>Presets → Save current as preset</strong> to create one.</div></div>'
+      : opts.presets.map((p) => renderPresetRow(p, opts.csrfToken)).join("");
+
+  return [
+    "<h1>Voice preferences</h1>",
+    '<p class="subtitle">Manage how your dynamic voice channels are named and the presets you can apply to them.</p>',
+    // ---- Name pattern ----
+    '<form method="POST" action="/me/voice/name-pattern">',
+    `<input type="hidden" name="_csrf" value="${escapeHtml(opts.csrfToken)}">`,
+    '<div class="card">',
+    "<h2>Channel name pattern</h2>",
+    '<p class="muted">Applied to every new channel you spawn from the lobby. Use <code>{username}</code> as a placeholder for your display name. Leave blank to use the server default naming.</p>',
+    `<div style="margin-top:.5rem"><input type="text" name="namePattern" class="tz-select" maxlength="100" value="${escapeHtml(opts.namePattern ?? "")}" placeholder="e.g. {username}'s Room"></div>`,
+    `<p class="muted" style="margin-top:.5rem">Preview: <span class="mono">${escapeHtml(
+      opts.namePattern
+        ? opts.namePattern
+            .replace(/\{username\}/gi, opts.displayName)
+            .replace(/\{displayname\}/gi, opts.displayName)
+        : "(server default)",
+    )}</span></p>`,
+    '<div class="form-actions"><button class="btn" type="submit">Save name pattern</button>',
+    '<span class="muted">Save an empty value to clear it.</span></div>',
+    "</div>",
+    "</form>",
+    // ---- Presets ----
+    `<h2>Saved presets <span class="muted" style="font-size:.85rem">(max ${opts.maxPerUser})</span></h2>`,
+    presetCards,
   ].join("");
 }

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -233,13 +233,17 @@ async function resolveDisplayName(
   }
 }
 
-/** Parse an optional numeric form field, treating blank as "unset". */
+/**
+ * Parse an optional integer form field, treating blank as "unset". A
+ * non-integer (e.g. "1.9", "abc") yields `NaN` so callers reject it rather
+ * than silently truncating — the service's bounds are integer-only.
+ */
 function parseOptionalInt(raw: unknown): number | undefined {
   if (typeof raw !== "string") return undefined;
   const trimmed = raw.trim();
   if (trimmed.length === 0) return undefined;
   const n = Number(trimmed);
-  return Number.isFinite(n) ? Math.trunc(n) : NaN;
+  return Number.isInteger(n) ? n : NaN;
 }
 
 function toPresetViews(
@@ -720,11 +724,11 @@ export function createUserRouter(
 
   // Helper shared by every voice route: 404 with a friendly disabled
   // state when the feature is off (mirrors the Rewind gate, #608).
-  const renderVoiceDisabled = (
+  const renderVoiceDisabled = async (
     req: AuthenticatedRequest,
     res: Response,
     session: WebSessionContext,
-  ): void => {
+  ): Promise<void> => {
     res
       .status(404)
       .type("text/html")
@@ -738,6 +742,7 @@ export function createUserRouter(
           csrfToken: getCsrfToken(req),
           remainingMs: getDisplayedRemainingMs(session),
           isAdmin: session.role === "admin",
+          rewindEnabled: await isRewindFeatureEnabled(),
           presetsEnabled: false,
         }),
       );
@@ -752,7 +757,7 @@ export function createUserRouter(
         return;
       }
       if (!(await isVoicePresetsEnabled())) {
-        renderVoiceDisabled(req, res, session);
+        await renderVoiceDisabled(req, res, session);
         return;
       }
       const { userId } = assertSelfScope(session, {
@@ -805,7 +810,7 @@ export function createUserRouter(
         return;
       }
       if (!(await isVoicePresetsEnabled())) {
-        renderVoiceDisabled(req, res, session);
+        await renderVoiceDisabled(req, res, session);
         return;
       }
       const { userId } = assertSelfScope(session, {
@@ -878,7 +883,7 @@ export function createUserRouter(
         return;
       }
       if (!(await isVoicePresetsEnabled())) {
-        renderVoiceDisabled(req, res, session);
+        await renderVoiceDisabled(req, res, session);
         return;
       }
       const { userId } = assertSelfScope(session, {

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -39,8 +39,14 @@ import {
   renderUserPage,
   renderUserRewindBody,
   renderUserTimezoneBody,
+  renderUserVoiceBody,
   type UserFlashMessage,
+  type VoicePresetView,
 } from "./user-layout.js";
+import {
+  UserVoicePrefsService,
+  VoicePrefsValidationError,
+} from "../services/user-voice-prefs-service.js";
 import {
   getServerTimezone,
   listSupportedTimezones,
@@ -194,6 +200,67 @@ async function isRewindFeatureEnabled(): Promise<boolean> {
   return ConfigService.getInstance().getBoolean("rewind.enabled", false);
 }
 
+/**
+ * Whether the per-user voice-preferences feature (`/me/voice` + its nav
+ * entry) is enabled (#656). Shares the `voicechannels.presets.enabled`
+ * gate with the Discord modal surface so both turn on together. Defaults
+ * to `false`, following the repo's opt-in feature-gate convention.
+ */
+async function isVoicePresetsEnabled(): Promise<boolean> {
+  return ConfigService.getInstance().getBoolean(
+    "voicechannels.presets.enabled",
+    false,
+  );
+}
+
+/**
+ * Resolve the session user's display name for the name-pattern preview.
+ * Best-effort: falls back to the raw user id when the member can't be
+ * fetched (e.g. left the guild), so the page still renders.
+ */
+async function resolveDisplayName(
+  client: Client,
+  guildId: string,
+  userId: string,
+): Promise<string> {
+  try {
+    const guild =
+      client.guilds.cache.get(guildId) ?? (await client.guilds.fetch(guildId));
+    const member = await guild.members.fetch(userId);
+    return member.displayName;
+  } catch {
+    return userId;
+  }
+}
+
+/** Parse an optional numeric form field, treating blank as "unset". */
+function parseOptionalInt(raw: unknown): number | undefined {
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? Math.trunc(n) : NaN;
+}
+
+function toPresetViews(
+  presets: {
+    name: string;
+    channelName?: string;
+    userLimit?: number;
+    bitrate?: number;
+    isDefault?: boolean;
+  }[],
+): VoicePresetView[] {
+  return presets.map((p, index) => ({
+    index,
+    name: p.name,
+    channelName: p.channelName ?? null,
+    userLimit: typeof p.userLimit === "number" ? p.userLimit : null,
+    bitrate: typeof p.bitrate === "number" ? p.bitrate : null,
+    isDefault: !!p.isDefault,
+  }));
+}
+
 function parseYearParam(raw: unknown, fallback: number): number {
   if (typeof raw !== "string" || raw.length === 0) return fallback;
   const n = Number.parseInt(raw, 10);
@@ -233,6 +300,7 @@ export function createUserRouter(
         return;
       }
       const rewindEnabled = await isRewindFeatureEnabled();
+      const presetsEnabled = await isVoicePresetsEnabled();
       res.type("text/html").send(
         renderUserPage({
           title: "Overview",
@@ -242,11 +310,13 @@ export function createUserRouter(
             guildId: session.guildId,
             isAdmin: session.role === "admin",
             rewindEnabled,
+            presetsEnabled,
           }),
           csrfToken: getCsrfToken(req),
           remainingMs: getDisplayedRemainingMs(session),
           isAdmin: session.role === "admin",
           rewindEnabled,
+          presetsEnabled,
         }),
       );
     }),
@@ -283,6 +353,7 @@ export function createUserRouter(
           isAdmin: session.role === "admin",
           flash,
           rewindEnabled: await isRewindFeatureEnabled(),
+          presetsEnabled: await isVoicePresetsEnabled(),
         }),
       );
     }),
@@ -404,6 +475,7 @@ export function createUserRouter(
           isAdmin: session.role === "admin",
           flash,
           rewindEnabled: await isRewindFeatureEnabled(),
+          presetsEnabled: await isVoicePresetsEnabled(),
         }),
       );
     }),
@@ -494,6 +566,7 @@ export function createUserRouter(
       userId: session.discordUserId,
       guildId: session.guildId,
     });
+    const presetsEnabled = await isVoicePresetsEnabled();
 
     // Feature gate (#608): when Rewind is disabled the page is not served
     // (and the nav link is already suppressed). Return a friendly disabled
@@ -514,6 +587,7 @@ export function createUserRouter(
             remainingMs: getDisplayedRemainingMs(session),
             isAdmin: session.role === "admin",
             rewindEnabled: false,
+            presetsEnabled,
           }),
         );
       return;
@@ -561,6 +635,7 @@ export function createUserRouter(
             remainingMs: getDisplayedRemainingMs(session),
             isAdmin: session.role === "admin",
             rewindEnabled: true,
+            presetsEnabled,
           }),
         );
       return;
@@ -628,11 +703,316 @@ export function createUserRouter(
         remainingMs: getDisplayedRemainingMs(session),
         isAdmin: session.role === "admin",
         rewindEnabled: true,
+        presetsEnabled,
       }),
     );
   });
   router.get("/rewind", rewindHandler);
   router.get("/rewind/:year", rewindHandler);
+
+  // ---------- Voice preferences (#656) ----------
+  // `/me/voice` manages the per-user name pattern + saved presets. It
+  // shares the `voicechannels.presets.enabled` gate with the Discord
+  // modal surface and reuses `UserVoicePrefsService` so the validation
+  // rules never diverge between the two surfaces. Presets are created in
+  // Discord (snapshot of a live channel); the web surface edits, sets the
+  // default, and deletes the ones you already have.
+
+  // Helper shared by every voice route: 404 with a friendly disabled
+  // state when the feature is off (mirrors the Rewind gate, #608).
+  const renderVoiceDisabled = (
+    req: AuthenticatedRequest,
+    res: Response,
+    session: WebSessionContext,
+  ): void => {
+    res
+      .status(404)
+      .type("text/html")
+      .send(
+        renderUserPage({
+          title: "Voice preferences",
+          active: "/me/voice",
+          body:
+            "<h1>Voice preferences</h1>" +
+            '<div class="notice info">Per-user voice presets are currently disabled on this server.</div>',
+          csrfToken: getCsrfToken(req),
+          remainingMs: getDisplayedRemainingMs(session),
+          isAdmin: session.role === "admin",
+          presetsEnabled: false,
+        }),
+      );
+  };
+
+  router.get(
+    "/voice",
+    asyncHandler(async (req, res) => {
+      const session = req.webSession;
+      if (!session) {
+        res.status(500).type("text/plain").send("session missing");
+        return;
+      }
+      if (!(await isVoicePresetsEnabled())) {
+        renderVoiceDisabled(req, res, session);
+        return;
+      }
+      const { userId } = assertSelfScope(session, {
+        userId: session.discordUserId,
+        guildId: session.guildId,
+      });
+
+      const service = UserVoicePrefsService.getInstance();
+      const prefs = await service.getPrefs(userId);
+      const displayName = await resolveDisplayName(
+        client,
+        session.guildId,
+        userId,
+      );
+      const maxPerUser = await ConfigService.getInstance().getNumber(
+        "voicechannels.presets.max_per_user",
+        3,
+      );
+      const flash = readFlashFromQuery(req);
+
+      res.type("text/html").send(
+        renderUserPage({
+          title: "Voice preferences",
+          active: "/me/voice",
+          body: renderUserVoiceBody({
+            csrfToken: getCsrfToken(req),
+            namePattern: prefs.namePattern ?? null,
+            displayName,
+            presets: toPresetViews(prefs.presets),
+            maxPerUser,
+          }),
+          csrfToken: getCsrfToken(req),
+          remainingMs: getDisplayedRemainingMs(session),
+          isAdmin: session.role === "admin",
+          flash,
+          rewindEnabled: await isRewindFeatureEnabled(),
+          presetsEnabled: true,
+        }),
+      );
+    }),
+  );
+
+  router.post(
+    "/voice/name-pattern",
+    requireCsrf,
+    asyncHandler(async (req, res) => {
+      const session = req.webSession;
+      if (!session) {
+        res.status(500).type("text/plain").send("session missing");
+        return;
+      }
+      if (!(await isVoicePresetsEnabled())) {
+        renderVoiceDisabled(req, res, session);
+        return;
+      }
+      const { userId } = assertSelfScope(session, {
+        userId: session.discordUserId,
+        guildId: session.guildId,
+      });
+
+      const body = (req.body as Record<string, unknown> | undefined) ?? {};
+      const raw =
+        typeof body.namePattern === "string"
+          ? body.namePattern.replace(/[\r\n]+/g, "")
+          : "";
+
+      let result: "success" | "failure" = "success";
+      let errorMessage: string | null = null;
+      let stored: string | null = null;
+      try {
+        stored = await UserVoicePrefsService.getInstance().setNamePattern(
+          userId,
+          raw,
+        );
+      } catch (err) {
+        result = "failure";
+        errorMessage = err instanceof Error ? err.message : String(err);
+      }
+
+      await recordAudit(session, {
+        action: "user.voice.namepattern.set",
+        targetId: userId,
+        details:
+          result === "success"
+            ? { pattern: stored }
+            : { attempted: sanitizeForLog(raw) },
+        result,
+        errorMessage,
+      });
+
+      const flash: UserFlashMessage =
+        result === "failure"
+          ? {
+              type: "err",
+              text: `Could not save your name pattern: ${errorMessage ?? "unknown error"}.`,
+            }
+          : stored === null
+            ? { type: "ok", text: "Cleared your name pattern." }
+            : { type: "ok", text: `Saved your name pattern as "${stored}".` };
+      res.redirect(303, flashUrl("/me/voice", flash));
+    }),
+  );
+
+  // Shared body for the three preset-mutation routes: validates the
+  // `index`/`expectedName` pair, runs `op`, and PRG-redirects with a flash.
+  const presetMutation = (
+    action: string,
+    op: (args: {
+      service: UserVoicePrefsService;
+      userId: string;
+      index: number;
+      expectedName: string;
+      body: Record<string, unknown>;
+    }) => Promise<{
+      flash: UserFlashMessage;
+      details: Record<string, unknown>;
+    }>,
+  ): RequestHandler =>
+    asyncHandler(async (req, res) => {
+      const session = req.webSession;
+      if (!session) {
+        res.status(500).type("text/plain").send("session missing");
+        return;
+      }
+      if (!(await isVoicePresetsEnabled())) {
+        renderVoiceDisabled(req, res, session);
+        return;
+      }
+      const { userId } = assertSelfScope(session, {
+        userId: session.discordUserId,
+        guildId: session.guildId,
+      });
+
+      const body = (req.body as Record<string, unknown> | undefined) ?? {};
+      const index = parseOptionalInt(body.index);
+      const expectedName =
+        typeof body.expectedName === "string" ? body.expectedName : "";
+
+      let result: "success" | "failure" = "success";
+      let errorMessage: string | null = null;
+      let flash: UserFlashMessage;
+      let details: Record<string, unknown> = {};
+
+      if (index === undefined || index === null || Number.isNaN(index)) {
+        result = "failure";
+        errorMessage = "Invalid preset reference.";
+        flash = {
+          type: "err",
+          text: "Could not find that preset — reload the page and try again.",
+        };
+      } else {
+        try {
+          const out = await op({
+            service: UserVoicePrefsService.getInstance(),
+            userId,
+            index,
+            expectedName,
+            body,
+          });
+          flash = out.flash;
+          details = out.details;
+        } catch (err) {
+          result = "failure";
+          errorMessage = err instanceof Error ? err.message : String(err);
+          flash = {
+            type: err instanceof VoicePrefsValidationError ? "warn" : "err",
+            text:
+              err instanceof VoicePrefsValidationError
+                ? errorMessage
+                : `Could not update the preset: ${errorMessage}.`,
+          };
+        }
+      }
+
+      await recordAudit(session, {
+        action,
+        targetId: userId,
+        details: { ...details, index, expectedName },
+        result,
+        errorMessage,
+      });
+
+      res.redirect(303, flashUrl("/me/voice", flash));
+    });
+
+  router.post(
+    "/voice/preset/edit",
+    requireCsrf,
+    presetMutation(
+      "user.voice.preset.edit",
+      async ({ service, userId, index, expectedName, body }) => {
+        const name = typeof body.name === "string" ? body.name : "";
+        const channelName =
+          typeof body.channelName === "string" ? body.channelName : undefined;
+        const userLimit = parseOptionalInt(body.userLimit);
+        const bitrate = parseOptionalInt(body.bitrate);
+        // NaN means "present but not a number" — surface a friendly error
+        // rather than passing it to the validator as a bound check.
+        if (Number.isNaN(userLimit)) {
+          throw new VoicePrefsValidationError("User limit must be a number.");
+        }
+        if (Number.isNaN(bitrate)) {
+          throw new VoicePrefsValidationError("Bitrate must be a number.");
+        }
+        const saved = await service.editPreset(
+          userId,
+          index,
+          { name, channelName, userLimit, bitrate },
+          expectedName,
+        );
+        return {
+          flash: { type: "ok", text: `Saved changes to "${saved.name}".` },
+          details: { name: saved.name },
+        };
+      },
+    ),
+  );
+
+  router.post(
+    "/voice/preset/default",
+    requireCsrf,
+    presetMutation(
+      "user.voice.preset.default",
+      async ({ service, userId, index, expectedName }) => {
+        const { name, isDefault } = await service.setDefault(
+          userId,
+          index,
+          expectedName,
+        );
+        return {
+          flash: {
+            type: "ok",
+            text: isDefault
+              ? `"${name}" will auto-apply on your next channel.`
+              : `"${name}" is no longer the default.`,
+          },
+          details: { name, isDefault },
+        };
+      },
+    ),
+  );
+
+  router.post(
+    "/voice/preset/delete",
+    requireCsrf,
+    presetMutation(
+      "user.voice.preset.delete",
+      async ({ service, userId, index, expectedName }) => {
+        const { name } = await service.deletePreset(
+          userId,
+          index,
+          expectedName,
+        );
+        return {
+          flash: { type: "ok", text: `Deleted preset "${name}".` },
+          details: { name },
+        };
+      },
+    ),
+  );
 
   // ---------- Finish (sign out) ----------
   // CSRF-checked, same pattern as `/admin/finish`. The session row is


### PR DESCRIPTION
## Summary

Closes the remaining gaps in per-user voice-channel presets (#656). The feature was largely built; this PR wires up the two halves that were dead and adds web management, rather than rebuilding anything.

### 1. `namePattern` is now applied (was a dead field)

`IUserVoicePreferences.namePattern` is wired into the channel-naming path in `voice-channel-manager.ts`. When a member spawns a channel from the lobby, naming precedence is:

1. an explicit name argument, then
2. the owner's saved **name pattern** (`{username}` / `{displayName}` substitution, e.g. `🎮 {username}`), then
3. the server's default prefix/suffix scheme.

The pattern only applies while `voicechannels.presets.enabled` is on (the same gate that exposes its management UI), and a default preset with its own `channelName` still wins (auto-apply runs after creation, unchanged).

### 2. New `/me/voice` web page

A member-facing page under `/me/` to manage their name pattern and saved presets — **view / edit (name, channel name, user limit, bitrate) / set-default / delete**. Presets are still _created_ in Discord by snapshotting a live channel; the web page manages the ones you already have. Gated behind `voicechannels.presets.enabled` (404 + suppressed nav link when off, mirroring the Rewind gate), audited via `WebAuditLog` (`user.voice.namepattern.set`, `user.voice.preset.edit|default|delete`), CSRF-protected, and self-scoped.

### 3. Single source of truth for validation

Extracted `UserVoicePrefsService` to own all preset/name-pattern validation (max-per-user, name/limit/bitrate bounds, name-pattern length) and CRUD. **Both** the Discord modal/button handlers (`vc-modal-handler`, `vc-preset-handler`) and the new web routes now go through it, so the rules can't diverge between the two surfaces. Web preset rows carry an `index`/`expectedName` guard so a stale tab can't mutate the wrong row.

## Acceptance criteria

- [x] `namePattern` applied to newly-created channels with `{username}` substitution.
- [x] `/me/voice` manages `namePattern` + presets (view / edit / set-default / delete), gated behind `voicechannels.presets.enabled`, audited via `WebAuditLog`.
- [x] Web writes reuse the existing preset validation — no divergent rules between modal and web.
- [x] `WEBUI.md` documents the new page; no new config keys (SETTINGS.md unchanged; stale "privacy" wording in the schema description corrected).
- [x] Unit tests for `namePattern` application and the web preset CRUD path.

## Testing

- `npm run build` ✅ · `npm run lint` ✅ · `npm run format:check` ✅ · `markdownlint WEBUI.md` ✅
- `npm run test:ci` ✅ — 1238 passing, coverage thresholds met. New tests: `__tests__/services/user-voice-prefs-service.test.ts` (17) and a `/me/voice` block in `__tests__/web/user-routes.test.ts`.

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wf87q7FQS54yy2EWt6QFKy)_