### PR TITLE
feat(digest): add Web UI digest preview and send-now page

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -474,6 +474,10 @@ the user's **/me/notifications** page (no slash command).
   every run.
 - Delta + streak math uses a per-user `DigestState` row that is updated
   after each successful delivery.
+- Admins can **preview** the digest (a dry run that sends nothing) or
+  **Send now** from the Web UI **Weekly Digest** page (`/admin/digest`)
+  — see [WEBUI.md](WEBUI.md#what-the-web-ui-lets-you-do). There is no
+  `/digest` slash command.
 
 ---
 

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -753,6 +753,7 @@ No dashboard JSON ships with the bot — wire these up to taste:
 | **Notices**        | `/notice add`, `edit`, `delete`, `sync`                                                             |
 | **Bot Status**     | (new — edit the "Watching …" presence message pools)                                                |
 | **Voice Channels** | `/vc force-reload` (single **Force VC cleanup** button)                                             |
+| **Weekly Digest**  | (new — **Preview** the weekly digest dry-run, plus a **Send now** button)                           |
 | **Database**       | `/dbtrunk status`, `/dbtrunk run`                                                                   |
 | **Command Audit**  | (new — read-only Discord slash-command audit log)                                                   |
 | **Command Metrics**| (new — historical per-command usage / error-rate / latency dashboard)                               |
@@ -797,6 +798,22 @@ how long buckets are kept before the TTL index prunes them. This is
 complementary to the Prometheus `/metrics` endpoint, which exposes
 process-level gauges (uptime, memory) rather than historical per-command
 counters.
+
+The **Weekly Digest** page (`/admin/digest`) lets an admin **preview** the
+weekly voice digest before it sends (#539). **Preview** is a read-only dry run:
+it reuses the exact qualifying-users query and embed builder the cron job uses
+and renders an HTML approximation of the embeds for the most recent complete
+week, plus a summary line (how many members qualify, how many opted in vs.
+opted out, and whether a digest has already gone out this week) — **without
+sending any DMs or writing anything**. It's GET-driven, so it's safe to refresh.
+Users who have DMs closed can't be detected without actually sending, so those
+skips only surface on a real run. The page is gated by `digest.enabled`
+(the #610 disabled-feature pattern), and the digest thresholds/schedule
+themselves live under **Settings** (`digest.*`). A **Send now** button force-fires the
+digest immediately — the same path the cron runs, including DM delivery and
+streak/state updates; concurrent runs coalesce, so clicking it during a
+scheduled tick can't double-deliver. There is intentionally **no `/digest`
+slash command** — the Web UI is the admin surface.
 
 ### User self-service (`/me/*`, both admin and user roles)
 

--- a/__tests__/services/digest-service.test.ts
+++ b/__tests__/services/digest-service.test.ts
@@ -375,5 +375,40 @@ describe("DigestService", () => {
 
       expect(preview.alreadySentAt).toBeNull();
     });
+
+    it("clamps an out-of-range limit to the documented maximum", async () => {
+      mockDigestState({});
+      mockGetTopUsers.mockResolvedValue([]);
+
+      const svc: ServiceInstance = DigestService.getInstance(makeClient());
+      const tooBig = await svc.previewDigest(1000);
+      expect(tooBig.limit).toBe(25);
+
+      const tooSmall = await svc.previewDigest(0);
+      expect(tooSmall.limit).toBe(1);
+    });
+
+    it("reports the real achievements setting on the unconfigured early return", async () => {
+      // Feature on, but GUILD_ID unset → early return. include_achievements
+      // must reflect config, not a hard-coded false.
+      mockConfigGetBoolean.mockImplementation(async (key: unknown) => {
+        const k = key as string;
+        if (k === "digest.enabled") return true;
+        if (k === "digest.include_achievements") return true;
+        return false;
+      });
+      mockConfigGetString.mockImplementation(async (key: unknown) => {
+        if (key === "GUILD_ID") return "";
+        return "";
+      });
+
+      const svc: ServiceInstance = DigestService.getInstance(makeClient());
+      const preview = await svc.previewDigest();
+
+      expect(preview.enabled).toBe(true);
+      expect(preview.includeAchievements).toBe(true);
+      expect(preview.entries).toHaveLength(0);
+      expect(mockGetTopUsers).not.toHaveBeenCalled();
+    });
   });
 });

--- a/__tests__/services/digest-service.test.ts
+++ b/__tests__/services/digest-service.test.ts
@@ -269,4 +269,111 @@ describe("DigestService", () => {
       expect(mockGetPrefsWithTimezone).toHaveBeenCalledWith("u1", "guild-1");
     });
   });
+
+  describe("previewDigest (#539)", () => {
+    // previewDigest issues two distinct findOne shapes: the guild-level
+    // "already sent this week?" query (chained `.sort()`) and the per-user
+    // previousState lookup (direct await). Route both through one mock.
+    function mockDigestState(opts: {
+      alreadySent?: Date | null;
+      previous?: Record<string, unknown> | null;
+    }): void {
+      mockDigestStateFindOne.mockImplementation((query: unknown) => {
+        const q = query as Record<string, unknown>;
+        if (q && "lastSentAt" in q) {
+          const doc =
+            opts.alreadySent != null ? { lastSentAt: opts.alreadySent } : null;
+          return { sort: jest.fn().mockResolvedValue(doc) };
+        }
+        return Promise.resolve(opts.previous ?? null);
+      });
+    }
+
+    it("returns a disabled, empty preview when the feature is off", async () => {
+      mockConfigGetBoolean.mockResolvedValue(false);
+      const svc: ServiceInstance = DigestService.getInstance(makeClient());
+      const preview = await svc.previewDigest();
+
+      expect(preview.enabled).toBe(false);
+      expect(preview.qualifying).toBe(0);
+      expect(preview.entries).toHaveLength(0);
+      expect(mockGetTopUsers).not.toHaveBeenCalled();
+    });
+
+    it("reports zero qualifying when nobody clears the threshold", async () => {
+      mockDigestState({});
+      mockGetTopUsers.mockResolvedValue([
+        { userId: "u1", username: "u1", totalTime: 60 * 5 }, // 5 min - below 30
+      ]);
+
+      const svc: ServiceInstance = DigestService.getInstance(makeClient());
+      const preview = await svc.previewDigest();
+
+      expect(preview.enabled).toBe(true);
+      expect(preview.qualifying).toBe(0);
+      expect(preview.optedIn).toBe(0);
+      expect(preview.skippedOptOut).toBe(0);
+      expect(preview.entries).toHaveLength(0);
+      // Read-only: no DM and no state write as a side effect.
+      expect(mockUserSend).not.toHaveBeenCalled();
+      expect(mockDigestStateFindOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it("counts opted-out users separately and only renders opted-in ones", async () => {
+      mockDigestState({});
+      mockGetTopUsers.mockResolvedValue([
+        { userId: "u1", username: "u1", totalTime: 60 * 60 },
+        { userId: "u2", username: "u2", totalTime: 60 * 45 },
+      ]);
+      mockGetPrefsWithTimezone.mockImplementation(async (userId: unknown) => ({
+        prefs: {
+          achievements: true,
+          digest: userId !== "u2", // u2 opted out
+          rewind: true,
+        },
+        timezone: null,
+      }));
+
+      const svc: ServiceInstance = DigestService.getInstance(makeClient());
+      const preview = await svc.previewDigest();
+
+      expect(preview.qualifying).toBe(2);
+      expect(preview.optedIn).toBe(1);
+      expect(preview.skippedOptOut).toBe(1);
+      expect(preview.entries).toHaveLength(1);
+      expect(preview.entries[0]).toMatchObject({ username: "u1", rank: 1 });
+      // The rendered entry carries the real embed structure (reused builder).
+      expect(preview.entries[0].title).toContain("weekly voice digest");
+      expect(preview.entries[0].fields.length).toBeGreaterThan(0);
+      // Still no side effects.
+      expect(mockUserSend).not.toHaveBeenCalled();
+      expect(mockDigestStateFindOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it("surfaces alreadySentAt when a delivery landed this week", async () => {
+      const sentAt = new Date("2026-06-22T09:00:00Z");
+      mockDigestState({ alreadySent: sentAt });
+      mockGetTopUsers.mockResolvedValue([
+        { userId: "u1", username: "u1", totalTime: 60 * 60 },
+      ]);
+
+      const svc: ServiceInstance = DigestService.getInstance(makeClient());
+      const preview = await svc.previewDigest();
+
+      expect(preview.alreadySentAt).toEqual(sentAt);
+      expect(preview.optedIn).toBe(1);
+    });
+
+    it("reports no prior delivery when none landed this week", async () => {
+      mockDigestState({ alreadySent: null });
+      mockGetTopUsers.mockResolvedValue([
+        { userId: "u1", username: "u1", totalTime: 60 * 60 },
+      ]);
+
+      const svc: ServiceInstance = DigestService.getInstance(makeClient());
+      const preview = await svc.previewDigest();
+
+      expect(preview.alreadySentAt).toBeNull();
+    });
+  });
 });

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -7,6 +7,7 @@ import {
   renderCommandAuditPage,
   renderDashboardPage,
   renderDatabasePage,
+  renderDigestPage,
   renderImportDiffPage,
   renderNoticesPage,
   renderPermissionsPage,
@@ -1358,6 +1359,106 @@ describe("renderVoiceChannelsPage", () => {
       /<button[^>]*type="submit"[^>]*disabled[^>]*>Force VC cleanup<\/button>/,
     );
     expect(html).not.toContain("Clean up empty channels");
+  });
+});
+
+describe("renderDigestPage", () => {
+  const DIGEST_CONFIG = {
+    enabled: true,
+    cron: "0 9 * * 1",
+    minActiveMinutes: 30,
+    streakMinMinutes: 30,
+    includeAchievements: true,
+  };
+
+  it("renders the feature-disabled banner and disables actions when off", () => {
+    const html = renderDigestPage({
+      ...COMMON,
+      ...DIGEST_CONFIG,
+      enabled: false,
+      preview: null,
+    });
+    expect(html).toContain("feature-disabled");
+    expect(html).toMatch(
+      /<button[^>]*name="preview"[^>]*disabled[^>]*>Preview digest<\/button>/,
+    );
+    expect(html).toMatch(
+      /<button[^>]*type="submit"[^>]*disabled[^>]*>Send now<\/button>/,
+    );
+  });
+
+  it("exposes the preview (GET) and send-now (POST) actions when enabled", () => {
+    const html = renderDigestPage({
+      ...COMMON,
+      ...DIGEST_CONFIG,
+      preview: null,
+    });
+    expect(html).toContain('method="GET" action="/admin/digest"');
+    expect(html).toContain('action="/admin/digest/send-now"');
+    // No preview requested → no rendered embed card (the CSS in <style> stays).
+    expect(html).not.toContain('<div class="digest-embed">');
+  });
+
+  it("renders the summary line and embed cards for a preview", () => {
+    const html = renderDigestPage({
+      ...COMMON,
+      ...DIGEST_CONFIG,
+      preview: {
+        generatedAt: "2026-06-22T09:00:00.000Z",
+        weekRange: "Jun 15 – Jun 22",
+        qualifying: 3,
+        optedIn: 2,
+        skippedOptOut: 1,
+        alreadySentAt: null,
+        includeAchievements: true,
+        limit: 25,
+        entries: [
+          {
+            username: "alice",
+            rank: 1,
+            title: "📊 Your weekly voice digest",
+            description: "Here's a snapshot, alice.",
+            fields: [
+              { name: "This week", value: "5h\n▲ 1h vs last week", inline: true },
+              { name: "Rank", value: "#1", inline: true },
+            ],
+            footer: "Keep it up!\nDon't want these? Run /config.",
+          },
+        ],
+      },
+    });
+    expect(html).toContain("members qualify");
+    expect(html).toContain("opted in");
+    expect(html).toContain("opted out");
+    expect(html).toContain("digest has not been sent yet this week");
+    expect(html).toContain('<div class="digest-embed">');
+    expect(html).toContain("alice");
+    // Newlines in field values become <br> in the HTML approximation.
+    expect(html).toContain("▲ 1h vs last week");
+  });
+
+  it("shows the already-sent state when a delivery landed this week", () => {
+    const html = renderDigestPage({
+      ...COMMON,
+      ...DIGEST_CONFIG,
+      preview: {
+        generatedAt: "2026-06-22T09:00:00.000Z",
+        weekRange: "Jun 15 – Jun 22",
+        qualifying: 1,
+        optedIn: 1,
+        skippedOptOut: 0,
+        alreadySentAt: "2026-06-22T09:00:00.000Z",
+        includeAchievements: false,
+        limit: 25,
+        entries: [],
+      },
+    });
+    expect(html).toContain("already sent at");
+    // Achievements-off note surfaces.
+    expect(html).toContain("digest.include_achievements");
+    expect(html).toContain(
+      "No opted-in members qualify for the digest this week",
+    );
   });
 });
 

--- a/src/services/digest-service.ts
+++ b/src/services/digest-service.ts
@@ -28,6 +28,52 @@ export interface DigestRunSummary {
   failed: number;
 }
 
+/** One rendered digest entry in a preview (no DM sent). */
+export interface DigestPreviewEntry {
+  userId: string;
+  username: string;
+  rank: number;
+  totalTime: number; // seconds
+  streakWeeks: number;
+  /** Embed title, e.g. "📊 Your weekly voice digest". */
+  title: string;
+  /** Embed description (week range + greeting), rendered in the user's zone. */
+  description: string;
+  /** The embed fields exactly as they would appear in the DM'd embed. */
+  fields: Array<{ name: string; value: string; inline: boolean }>;
+  /** Embed footer text (motivational line + opt-out hint). */
+  footer: string;
+}
+
+/**
+ * Result of a dry-run digest preview (#539). Reuses the same qualifying-users
+ * query and embed builder as the real cron run but sends no DMs and writes
+ * nothing to `DigestState`.
+ */
+export interface DigestPreview {
+  enabled: boolean;
+  generatedAt: Date;
+  /** Week window label in the server timezone, e.g. "Jun 15 – Jun 22". */
+  weekRange: string;
+  /** Total users clearing the min-active threshold this week. */
+  qualifying: number;
+  /** Of the qualifying users, how many have opted in to the digest DM. */
+  optedIn: number;
+  /** Of the qualifying users, how many opted out (would be skipped). */
+  skippedOptOut: number;
+  /**
+   * Whether the digest has already gone out this week, and when. Derived
+   * from the most recent `DigestState.lastSentAt` inside the current 7-day
+   * window — null when no delivery has landed this week yet.
+   */
+  alreadySentAt: Date | null;
+  includeAchievements: boolean;
+  /** Max entries rendered (the rest are counted but not built). */
+  limit: number;
+  /** Rendered embeds for the opted-in qualifying users, up to `limit`. */
+  entries: DigestPreviewEntry[];
+}
+
 const DEFAULT_CRON = "0 9 * * 1";
 const SECONDS_PER_MINUTE = 60;
 const SECONDS_PER_WEEK = 7 * 24 * 60 * 60;
@@ -257,22 +303,13 @@ export class DigestService {
       const streakMinSeconds =
         Math.max(0, streakMinMinutes) * SECONDS_PER_MINUTE;
 
-      const tracker = VoiceChannelTracker.getInstance(this.client);
       const prefsService = UserNotificationPrefsService.getInstance();
       // Ensure the singleton is alive so a guild that flips this on
       // without ever having earned an accolade still has the service
       // ready when we look up weekly rows below.
       AchievementsService.getInstance(this.client);
 
-      const ranked = await tracker.getTopUsers(0, "week");
-      const qualifying: QualifyingUser[] = ranked
-        .map((user, index) => ({
-          userId: user.userId,
-          username: user.username,
-          totalTime: user.totalTime,
-          rank: index + 1,
-        }))
-        .filter((user) => user.totalTime >= minActiveSeconds);
+      const qualifying = await this.getQualifyingUsers(minActiveSeconds);
 
       const summary: DigestRunSummary = {
         ranAt: new Date(),
@@ -373,6 +410,175 @@ export class DigestService {
     } finally {
       this.isRunning = false;
     }
+  }
+
+  /**
+   * Rank this week's voice activity and keep everyone who clears the
+   * minimum-active threshold. Shared by the cron run and the dry-run
+   * preview (#539) so both see an identical qualifying set.
+   */
+  private async getQualifyingUsers(
+    minActiveSeconds: number,
+  ): Promise<QualifyingUser[]> {
+    const tracker = VoiceChannelTracker.getInstance(this.client);
+    const ranked = await tracker.getTopUsers(0, "week");
+    return ranked
+      .map((user, index) => ({
+        userId: user.userId,
+        username: user.username,
+        totalTime: user.totalTime,
+        rank: index + 1,
+      }))
+      .filter((user) => user.totalTime >= minActiveSeconds);
+  }
+
+  /**
+   * Dry-run the weekly digest (#539). Reuses the exact qualifying-users
+   * query and embed builder the cron run uses, but **sends no DMs and
+   * writes nothing to `DigestState`** — safe to call repeatedly from the
+   * admin Web UI to preview the output for the current week's window.
+   *
+   * Only opted-in qualifying users get a rendered embed (capped at
+   * `limit`); opt-outs are counted but not built. DMs-closed skips are
+   * *not* determined here — that can only be known by actually sending —
+   * so the preview reports qualifying/opted-in/opted-out and leaves
+   * delivery failures to the real run.
+   */
+  public async previewDigest(limit = 25): Promise<DigestPreview> {
+    const generatedAt = new Date();
+    const enabled = await this.configService.getBoolean(
+      "digest.enabled",
+      false,
+    );
+    const guildId = await this.configService.getString("GUILD_ID", "");
+
+    const weekStart = new Date(generatedAt.getTime() - SECONDS_PER_WEEK * 1000);
+    const weekRange = `${formatInZone(weekStart, null, "MMM d")} – ${formatInZone(generatedAt, null, "MMM d")}`;
+
+    const empty: DigestPreview = {
+      enabled,
+      generatedAt,
+      weekRange,
+      qualifying: 0,
+      optedIn: 0,
+      skippedOptOut: 0,
+      alreadySentAt: null,
+      includeAchievements: false,
+      limit,
+      entries: [],
+    };
+
+    if (!enabled || !guildId) {
+      return empty;
+    }
+
+    const minActiveMinutes = await this.configService.getNumber(
+      "digest.min_active_minutes",
+      30,
+    );
+    const streakMinMinutes = await this.configService.getNumber(
+      "digest.streak_min_minutes",
+      30,
+    );
+    const includeAchievements = await this.configService.getBoolean(
+      "digest.include_achievements",
+      true,
+    );
+    const minActiveSeconds = Math.max(0, minActiveMinutes) * SECONDS_PER_MINUTE;
+    const streakMinSeconds = Math.max(0, streakMinMinutes) * SECONDS_PER_MINUTE;
+
+    const prefsService = UserNotificationPrefsService.getInstance();
+    const qualifying = await this.getQualifyingUsers(minActiveSeconds);
+
+    // "Already sent this week?" — the most recent delivery anywhere in the
+    // guild that landed inside the current 7-day window.
+    const recent = await DigestState.findOne({
+      guildId,
+      lastSentAt: { $gte: weekStart },
+    }).sort({ lastSentAt: -1 });
+    const alreadySentAt = recent?.lastSentAt ?? null;
+
+    let skippedOptOut = 0;
+    const entries: DigestPreviewEntry[] = [];
+
+    for (const user of qualifying) {
+      const { prefs, timezone } = await prefsService.getPrefsWithTimezone(
+        user.userId,
+        guildId,
+      );
+      if (!prefs.digest) {
+        skippedOptOut += 1;
+        continue;
+      }
+      // Cap rendered embeds but keep counting opt-outs beyond the cap so
+      // the summary line stays accurate for large guilds.
+      if (entries.length >= limit) continue;
+
+      const previousState = await DigestState.findOne({
+        userId: user.userId,
+        guildId,
+      });
+
+      const streakWeeks = this.computeStreak(
+        user.totalTime,
+        streakMinSeconds,
+        previousState?.lastSentAt ?? null,
+        previousState?.streakWeeks ?? 0,
+        generatedAt,
+      );
+
+      let weeklyAchievements: Array<{
+        emoji: string;
+        name: string;
+        description: string;
+      }> = [];
+      if (includeAchievements) {
+        weeklyAchievements = await this.collectWeeklyAchievements(
+          user.userId,
+          generatedAt,
+        );
+      }
+
+      const embed = this.buildEmbed({
+        user,
+        previousState,
+        streakWeeks,
+        includeAchievements,
+        weeklyAchievements,
+        ranAt: generatedAt,
+        timezone,
+      });
+      const data = embed.data;
+
+      entries.push({
+        userId: user.userId,
+        username: user.username,
+        rank: user.rank,
+        totalTime: user.totalTime,
+        streakWeeks,
+        title: data.title ?? "",
+        description: data.description ?? "",
+        fields: (data.fields ?? []).map((f) => ({
+          name: f.name,
+          value: f.value,
+          inline: f.inline ?? false,
+        })),
+        footer: data.footer?.text ?? "",
+      });
+    }
+
+    return {
+      enabled,
+      generatedAt,
+      weekRange,
+      qualifying: qualifying.length,
+      optedIn: qualifying.length - skippedOptOut,
+      skippedOptOut,
+      alreadySentAt,
+      includeAchievements,
+      limit,
+      entries,
+    };
   }
 
   /**

--- a/src/services/digest-service.ts
+++ b/src/services/digest-service.ts
@@ -445,12 +445,21 @@ export class DigestService {
    * delivery failures to the real run.
    */
   public async previewDigest(limit = 25): Promise<DigestPreview> {
+    // Clamp to a sane window so a hand-crafted call can't materialise an
+    // unbounded set of embeds; the Web UI always uses the default.
+    const cappedLimit = Math.min(Math.max(1, Math.floor(limit)), 25);
     const generatedAt = new Date();
     const enabled = await this.configService.getBoolean(
       "digest.enabled",
       false,
     );
     const guildId = await this.configService.getString("GUILD_ID", "");
+    // Read up-front so the early-return (unconfigured) preview reports the
+    // real achievements setting rather than a hard-coded false.
+    const includeAchievements = await this.configService.getBoolean(
+      "digest.include_achievements",
+      true,
+    );
 
     const weekStart = new Date(generatedAt.getTime() - SECONDS_PER_WEEK * 1000);
     const weekRange = `${formatInZone(weekStart, null, "MMM d")} – ${formatInZone(generatedAt, null, "MMM d")}`;
@@ -463,8 +472,8 @@ export class DigestService {
       optedIn: 0,
       skippedOptOut: 0,
       alreadySentAt: null,
-      includeAchievements: false,
-      limit,
+      includeAchievements,
+      limit: cappedLimit,
       entries: [],
     };
 
@@ -479,10 +488,6 @@ export class DigestService {
     const streakMinMinutes = await this.configService.getNumber(
       "digest.streak_min_minutes",
       30,
-    );
-    const includeAchievements = await this.configService.getBoolean(
-      "digest.include_achievements",
-      true,
     );
     const minActiveSeconds = Math.max(0, minActiveMinutes) * SECONDS_PER_MINUTE;
     const streakMinSeconds = Math.max(0, streakMinMinutes) * SECONDS_PER_MINUTE;
@@ -512,7 +517,7 @@ export class DigestService {
       }
       // Cap rendered embeds but keep counting opt-outs beyond the cap so
       // the summary line stays accurate for large guilds.
-      if (entries.length >= limit) continue;
+      if (entries.length >= cappedLimit) continue;
 
       const previousState = await DigestState.findOne({
         userId: user.userId,
@@ -576,7 +581,7 @@ export class DigestService {
       skippedOptOut,
       alreadySentAt,
       includeAchievements,
-      limit,
+      limit: cappedLimit,
       entries,
     };
   }

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -136,6 +136,12 @@ export const NAV_ITEMS: NavItem[] = [
     group: "Features",
     featureKey: "voicechannels.enabled",
   },
+  {
+    href: "/admin/digest",
+    label: "Weekly Digest",
+    group: "Features",
+    featureKey: "digest.enabled",
+  },
 ];
 
 /**

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -2257,6 +2257,162 @@ ${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Voice Channels",
   });
 }
 
+// ---------- Digest (#539) ----------
+
+export interface DigestPreviewEntryView {
+  username: string;
+  rank: number;
+  title: string;
+  description: string;
+  fields: Array<{ name: string; value: string; inline: boolean }>;
+  footer: string;
+}
+
+export interface DigestPreviewView {
+  generatedAt: string;
+  weekRange: string;
+  qualifying: number;
+  optedIn: number;
+  skippedOptOut: number;
+  alreadySentAt: string | null;
+  includeAchievements: boolean;
+  limit: number;
+  entries: DigestPreviewEntryView[];
+}
+
+export interface DigestProps extends CommonProps {
+  enabled: boolean;
+  cron: string;
+  minActiveMinutes: number;
+  streakMinMinutes: number;
+  includeAchievements: boolean;
+  /** Populated only when a preview was requested (`?preview=1`). */
+  preview: DigestPreviewView | null;
+  flash?: FlashMessage | null;
+}
+
+/**
+ * Render one dry-run digest embed as an HTML approximation of the Discord
+ * embed the user would be DM'd. We mirror the embed's structure (title,
+ * description, inline/full-width fields, footer) so an admin previewing
+ * sees the real output, not just counts.
+ */
+function renderDigestEmbedCard(entry: DigestPreviewEntryView): string {
+  const fieldsHtml = entry.fields
+    .map(
+      (f) => `<div class="digest-field${f.inline ? " inline" : ""}">
+  <div class="digest-field-name">${escapeHtml(f.name)}</div>
+  <div class="digest-field-value">${escapeHtml(f.value).replace(/\n/g, "<br>")}</div>
+</div>`,
+    )
+    .join("");
+
+  return `<div class="digest-embed">
+  <div class="digest-embed-head">
+    <span class="tag tag-info">#${entry.rank}</span>
+    <strong>${escapeHtml(entry.username)}</strong>
+  </div>
+  <div class="digest-embed-title">${escapeHtml(entry.title)}</div>
+  <div class="digest-embed-desc">${escapeHtml(entry.description)}</div>
+  <div class="digest-fields">${fieldsHtml}</div>
+  <div class="digest-embed-footer">${escapeHtml(entry.footer).replace(/\n/g, "<br>")}</div>
+</div>`;
+}
+
+export function renderDigestPage(props: DigestProps): string {
+  const csrfInput = `<input type="hidden" name="_csrf" value="${escapeHtml(props.csrfToken)}">`;
+
+  const sendDisabled = !props.enabled;
+  const sendHint = !props.enabled
+    ? "Enable <code>digest.enabled</code> first."
+    : "Fires the digest immediately — the same path the cron runs, including DM delivery. Concurrent runs coalesce, so this is safe to click during a scheduled tick.";
+
+  let previewHtml = "";
+  if (props.preview) {
+    const p = props.preview;
+    const sentLabel = p.alreadySentAt
+      ? `already sent at ${escapeHtml(p.alreadySentAt)}`
+      : "digest has not been sent yet this week";
+    const summary = `<strong>${p.qualifying}</strong> member${p.qualifying === 1 ? "" : "s"} qualify · <strong>${p.optedIn}</strong> opted in · <strong>${p.skippedOptOut}</strong> opted out (would be skipped) · ${sentLabel}`;
+
+    const achievementsNote = p.includeAchievements
+      ? ""
+      : `<p class="muted">Achievements are excluded from the digest (<code>digest.include_achievements</code> is off).</p>`;
+
+    const dmsNote = `<p class="muted">Users with DMs closed can't be detected without sending — those skips only show up on a real run.</p>`;
+
+    const capNote =
+      p.optedIn > p.entries.length
+        ? `<p class="muted">Showing the top ${p.entries.length} of ${p.optedIn} opted-in members (capped at ${p.limit}).</p>`
+        : "";
+
+    const embeds =
+      p.entries.length === 0
+        ? `<div class="empty">No opted-in members qualify for the digest this week.</div>`
+        : p.entries.map(renderDigestEmbedCard).join("");
+
+    previewHtml = `<div class="card">
+  <h2>Preview <span class="muted">(week of ${escapeHtml(p.weekRange)})</span></h2>
+  <div class="notice">${summary}</div>
+  ${achievementsNote}
+  ${dmsNote}
+  ${capNote}
+  ${embeds}
+  <p class="muted">Generated ${escapeHtml(p.generatedAt)}. No DMs were sent and nothing was written.</p>
+</div>`;
+  }
+
+  const body = `
+<style>
+.digest-embed{border-left:4px solid #5865f2;background:#1f2430;border-radius:4px;padding:.75rem 1rem;margin:.75rem 0}
+.digest-embed-head{display:flex;gap:.5rem;align-items:center;margin-bottom:.35rem;font-size:.9rem}
+.digest-embed-title{font-weight:600;margin-bottom:.25rem}
+.digest-embed-desc{color:#cbd5e1;margin-bottom:.6rem}
+.digest-fields{display:flex;flex-wrap:wrap;gap:.75rem 1.5rem}
+.digest-field{flex:1 1 100%}
+.digest-field.inline{flex:1 1 28%;min-width:120px}
+.digest-field-name{font-size:.75rem;text-transform:uppercase;letter-spacing:.04em;color:#94a3b8}
+.digest-field-value{color:#e2e8f0}
+.digest-embed-footer{margin-top:.75rem;padding-top:.5rem;border-top:1px solid #2d3748;font-size:.78rem;color:#94a3b8}
+</style>
+<h1>Weekly Digest</h1>
+<p class="subtitle">Preview the weekly voice digest before it sends — a dry run of the same query and embeds the cron job DMs to qualifying members, with no DMs sent. Configure the thresholds and schedule under <a href="/admin/settings">Settings</a>.</p>
+${renderFlash(props.flash)}
+${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Weekly Digest", featureKey: "digest.enabled", returnTo: "/admin/digest", csrfToken: props.csrfToken })}
+<div class="card">
+  <h2>Configuration</h2>
+  <dl class="kv">
+    <dt>Feature</dt><dd>${tagOnOff(props.enabled, "enabled", "disabled")}</dd>
+    <dt>Schedule</dt><dd class="mono">${escapeHtml(props.cron || "(unset)")}</dd>
+    <dt>Minimum active time to qualify</dt><dd>${props.minActiveMinutes} min/week</dd>
+    <dt>Minimum time counting toward a streak</dt><dd>${props.streakMinMinutes} min/week</dd>
+    <dt>Include achievements</dt><dd>${tagOnOff(props.includeAchievements, "yes", "no")}</dd>
+  </dl>
+</div>
+<div class="card">
+  <h2>Actions</h2>
+  <form method="GET" action="/admin/digest" class="inline-form">
+    <button type="submit" name="preview" value="1" class="btn btn-primary"${props.enabled ? "" : " disabled"}>Preview digest</button>
+    <span class="muted">Renders the digest for the most recent complete week without sending anything.</span>
+  </form>
+  <form method="POST" action="/admin/digest/send-now" class="inline-form" style="margin-top:.75rem" onsubmit="return confirm('Send the weekly digest to all qualifying members right now?');">
+    ${csrfInput}
+    <button type="submit" class="btn btn-danger"${sendDisabled ? " disabled" : ""}>Send now</button>
+    <span class="muted">${sendHint}</span>
+  </form>
+</div>
+${previewHtml}
+`;
+  return renderAdminPage({
+    title: "Weekly Digest",
+    active: "/admin/digest",
+    body,
+    csrfToken: props.csrfToken,
+    remainingMs: props.remainingMs,
+    navFeatureStatus: props.navFeatureStatus,
+  });
+}
+
 // ---------- Command Audit Log ----------
 
 export interface CommandAuditRow {

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -35,6 +35,7 @@ import {
   STATUS_TEXT_MAX,
 } from "../content/statuses.js";
 import { VoiceChannelTruncationService } from "../services/voice-channel-truncation.js";
+import { DigestService } from "../services/digest-service.js";
 import {
   VoiceChannelManager,
   resolveManagedCategory,
@@ -62,6 +63,7 @@ import {
   renderCommandMetricsPage,
   renderDashboardPage,
   renderDatabasePage,
+  renderDigestPage,
   renderNoticesPage,
   renderPermissionsPage,
   renderPollsPage,
@@ -71,6 +73,7 @@ import {
   type ChannelOption,
   type CommandAuditRow,
   type DbTrunkHistoryRow,
+  type DigestPreviewView,
   type FlashMessage,
   type NoticeCategoryOption,
   type ReactionRoleRow,
@@ -968,6 +971,75 @@ export function createReadOnlyRouter(
           totalEmpty,
           channels,
           categoryFound,
+          flash: readFlash(req),
+        }),
+      );
+    }),
+  );
+
+  // ---------- Weekly Digest (#539) ----------
+  router.get(
+    "/digest",
+    asyncHandler(async (req, res) => {
+      const common = await commonFromReq(req);
+      const config = ConfigService.getInstance();
+
+      const [
+        enabled,
+        cron,
+        minActiveMinutes,
+        streakMinMinutes,
+        includeAchievements,
+      ] = await Promise.all([
+        config.getBoolean("digest.enabled", false),
+        config.getString("digest.cron", "0 9 * * 1"),
+        config.getNumber("digest.min_active_minutes", 30),
+        config.getNumber("digest.streak_min_minutes", 30),
+        config.getBoolean("digest.include_achievements", true),
+      ]);
+
+      // Preview is a read-only dry run, so it's GET-driven: the "Preview"
+      // button submits `?preview=1` and we render the embeds inline. Nothing
+      // is sent or written, so it's safe to refresh/bookmark.
+      let preview: DigestPreviewView | null = null;
+      if (req.query.preview === "1" && enabled) {
+        try {
+          const result =
+            await DigestService.getInstance(client).previewDigest();
+          preview = {
+            generatedAt: result.generatedAt.toISOString(),
+            weekRange: result.weekRange,
+            qualifying: result.qualifying,
+            optedIn: result.optedIn,
+            skippedOptOut: result.skippedOptOut,
+            alreadySentAt: result.alreadySentAt
+              ? result.alreadySentAt.toISOString()
+              : null,
+            includeAchievements: result.includeAchievements,
+            limit: result.limit,
+            entries: result.entries.map((e) => ({
+              username: e.username,
+              rank: e.rank,
+              title: e.title,
+              description: e.description,
+              fields: e.fields,
+              footer: e.footer,
+            })),
+          };
+        } catch (err) {
+          logger.error("digest preview failed", err);
+        }
+      }
+
+      res.type("text/html").send(
+        renderDigestPage({
+          ...common,
+          enabled,
+          cron,
+          minActiveMinutes,
+          streakMinMinutes,
+          includeAchievements,
+          preview,
           flash: readFlash(req),
         }),
       );

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -3240,16 +3240,17 @@ export function createWriteRouter(
       try {
         const summary = await service.runNow();
         if (!summary) {
-          // runNow returns null when the feature is disabled, GUILD_ID is
-          // unset, or another run is already in flight.
+          // runNow returns null only when the feature is disabled or
+          // GUILD_ID is unset. Concurrent invocations don't return null —
+          // they coalesce onto the in-flight run via `inFlight`.
           await recordAudit(session, {
             action: "digest.send-now",
             result: "failure",
-            errorMessage: "digest disabled, unconfigured, or already running",
+            errorMessage: "digest disabled or GUILD_ID unset",
           });
           flashRedirect(res, "/admin/digest", {
             type: "warn",
-            text: "Digest did not run — it is disabled, missing GUILD_ID, or a run is already in progress.",
+            text: "Digest did not run — it is disabled or GUILD_ID is not configured.",
           });
           return;
         }

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -24,6 +24,7 @@ import { ReactionRoleService } from "../services/reaction-role-service.js";
 import { NoticesChannelManager } from "../services/notices-channel-manager.js";
 import { VoiceChannelTruncationService } from "../services/voice-channel-truncation.js";
 import { VoiceChannelManager } from "../services/voice-channel-manager.js";
+import { DigestService } from "../services/digest-service.js";
 import { ConfigService } from "../services/config-service.js";
 import { PermissionsService } from "../services/permissions-service.js";
 import { WizardService } from "../services/wizard-service.js";
@@ -3222,6 +3223,64 @@ export function createWriteRouter(
         flashRedirect(res, "/admin/voice-channels", {
           type: "err",
           text: `Force cleanup failed: ${text}`,
+        });
+      }
+    }),
+  );
+
+  // ============================================================
+  // Weekly Digest — send now (issue #539)
+  // ============================================================
+
+  router.post(
+    "/digest/send-now",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const service = DigestService.getInstance(client);
+      try {
+        const summary = await service.runNow();
+        if (!summary) {
+          // runNow returns null when the feature is disabled, GUILD_ID is
+          // unset, or another run is already in flight.
+          await recordAudit(session, {
+            action: "digest.send-now",
+            result: "failure",
+            errorMessage: "digest disabled, unconfigured, or already running",
+          });
+          flashRedirect(res, "/admin/digest", {
+            type: "warn",
+            text: "Digest did not run — it is disabled, missing GUILD_ID, or a run is already in progress.",
+          });
+          return;
+        }
+        await recordAudit(session, {
+          action: "digest.send-now",
+          details: {
+            qualifying: summary.qualifying,
+            sent: summary.sent,
+            skippedOptOut: summary.skippedOptOut,
+            skippedDmsClosed: summary.skippedDmsClosed,
+            failed: summary.failed,
+          },
+          result: summary.failed > 0 ? "failure" : "success",
+          errorMessage:
+            summary.failed > 0 ? `${summary.failed} delivery error(s)` : null,
+        });
+        flashRedirect(res, "/admin/digest", {
+          type: summary.failed > 0 ? "warn" : "ok",
+          text: `Digest sent. ${summary.sent} delivered · ${summary.skippedOptOut} opted out · ${summary.skippedDmsClosed} DMs closed · ${summary.failed} failed.`,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("digest send-now failed", err);
+        await recordAudit(session, {
+          action: "digest.send-now",
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/digest", {
+          type: "err",
+          text: `Digest send failed: ${text}`,
         });
       }
     }),


### PR DESCRIPTION
## Summary

Implements #539, reimagined per the discussion comment: instead of a `/digest preview` slash command, this adds a **Weekly Digest admin page** to the Web UI. Per `WEBUI.md`, the Web UI is the only admin surface from v1.0 onward (every former admin slash command already migrated), so a new `/digest` command would cut against the architecture and add another command to remember. This is a button on the Web UI, not a slash command.

The page lets an admin **preview** the weekly voice digest before it sends (a read-only dry run) and optionally **Send now**.

## What changed

**Service (`src/services/digest-service.ts`)**
- New `previewDigest()` — reuses the exact qualifying-users query and `buildEmbed()` the cron run uses, but **sends no DMs and writes nothing to `DigestState`**. Returns summary counts (qualifying / opted-in / opted-out), whether a digest already landed this week (from `DigestState`), and the rendered embed data for the top-N opted-in users (capped at 25).
- Extracted a shared `getQualifyingUsers()` helper, now used by both `runOnce()` and `previewDigest()` (no duplicated ranking/filter logic).

**Web UI**
- `GET /admin/digest` (`read-only-routes.ts`) renders the config summary and, when `?preview=1`, an inline HTML approximation of the embeds. Preview is **GET-driven** because it's read-only and idempotent — safe to refresh/bookmark.
- `POST /admin/digest/send-now` (`write-routes.ts`) calls `DigestService.runNow()` behind a confirm dialog and records a `digest.send-now` `WebAuditLog` row (mirrors the `dbtrunk.run` / `voicechannels.force-reload` pattern). `runNow()` already coalesces concurrent runs, so clicking during a cron tick can't double-deliver.
- New **Weekly Digest** sidebar entry, gated by `digest.enabled` (the #610 disabled-feature pattern: greyed link + enable banner; actions disabled while off).
- `renderDigestPage` + an embed-card renderer in `admin-views.ts`.

**Notes on the one subtlety**: users with DMs closed can't be detected without actually sending, so the preview reports qualifying / opted-in / opted-out precisely and documents on the page that DMs-closed skips only surface on a real run.

## Tests
- `previewDigest()`: no qualifying users, partial opt-out (counts opt-outs separately, renders only opted-in, asserts no DM/no state write), already-sent week, and disabled feature.
- `renderDigestPage`: disabled banner + disabled actions, enabled actions wiring, preview summary + embed cards, already-sent state.
- Docs: `WEBUI.md` table + paragraph and `SETTINGS.md` updated.

`npm run check:all` passes (build, lint, format, 110 suites / 1221 tests). markdownlint clean.

## Acceptance criteria
- [x] Digest page at `/admin/digest`, sidebar-linked, gated by `digest.enabled` (#610 pattern)
- [x] Preview renders embeds + summary (qualifying, opted-out, already-sent), no DMs, no writes
- [x] Send now fires `runNow()` behind a confirm, records an audit row
- [x] Admin-only (`/admin/*` gating)
- [x] Unit tests for `previewDigest()` (no qualifiers / partial opt-out / already-sent)
- [x] `WEBUI.md` + `SETTINGS.md` updated

Closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013e77ciaL7CzyK5GGFAgyq9)_