### PR TITLE
feat: declare feature dependencies via dependsOn in SettingMetadata

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -878,6 +878,27 @@ keys that may be missing from this summary include the `help.*` toggle,
 `leaderboard_roles.*` family (covered in [its own section](#-leaderboard-role-rewards)
 above).
 
+#### Feature dependencies (`dependsOn` metadata)
+
+Some features only work when another feature is enabled. These hard
+dependencies are declared once in the `dependsOn` field of each key's
+`SettingMetadata` in `src/services/config-schema.ts` (read via the
+`getDependencies(key)` accessor), so the Settings page, setup wizard, and
+write-time validation can all share one source of truth. A key declares
+`dependsOn` only when it is genuinely broken/empty without the target —
+graceful aggregators like Rewind, which render only the sections that are
+tracked, are intentionally **not** listed and are never blocked on enable.
+
+Current hard dependencies:
+
+| Setting | Requires |
+| --- | --- |
+| `leaderboard_roles.enabled` | `voicetracking.enabled` |
+| `digest.enabled` | `voicetracking.enabled` |
+| `digest.include_achievements` | `achievements.enabled` |
+| `achievements.enabled` | `voicetracking.enabled` |
+| `voicetracking.announcements.enabled` | `voicetracking.enabled` |
+
 #### Commands
 
 - `ping.enabled` (bool, default: false)

--- a/__tests__/services/config-schema.test.ts
+++ b/__tests__/services/config-schema.test.ts
@@ -174,13 +174,16 @@ describe("Config Schema", () => {
     // truth consumed by write-time enforcement (#663) and the Settings
     // "requires X" hint (#666). Rewind is deliberately absent — it is a
     // graceful aggregator that must never be blocked on enable.
-    const EXPECTED_DEPENDENCIES: Record<string, (keyof ConfigSchema)[]> = {
+    // `satisfies` checks every key/value against `keyof ConfigSchema` at
+    // compile time, so a typo in a config key fails the build instead of
+    // being hidden by a runtime cast.
+    const EXPECTED_DEPENDENCIES = {
       "leaderboard_roles.enabled": ["voicetracking.enabled"],
       "digest.enabled": ["voicetracking.enabled"],
       "digest.include_achievements": ["achievements.enabled"],
       "achievements.enabled": ["voicetracking.enabled"],
       "voicetracking.announcements.enabled": ["voicetracking.enabled"],
-    };
+    } satisfies Partial<Record<keyof ConfigSchema, (keyof ConfigSchema)[]>>;
 
     it("declares exactly the #659 hard-dependency table", () => {
       const declared: Record<string, (keyof ConfigSchema)[]> = {};

--- a/__tests__/services/config-schema.test.ts
+++ b/__tests__/services/config-schema.test.ts
@@ -3,7 +3,9 @@ import {
   defaultConfig,
   settingsMetadata,
   categoryMetadata,
+  getDependencies,
   REWIND_RETENTION_MIN_DAYS,
+  type ConfigSchema,
 } from "../../src/services/config-schema.js";
 
 describe("Config Schema", () => {
@@ -163,6 +165,63 @@ describe("Config Schema", () => {
         (k) => !(k in defaultConfig),
       );
       expect(orphans).toEqual([]);
+    });
+  });
+
+  describe("feature dependencies (dependsOn / #662)", () => {
+    // The hard-dependency table from #659: each key may only be enabled
+    // when every listed key is also enabled. This is the single source of
+    // truth consumed by write-time enforcement (#663) and the Settings
+    // "requires X" hint (#666). Rewind is deliberately absent — it is a
+    // graceful aggregator that must never be blocked on enable.
+    const EXPECTED_DEPENDENCIES: Record<string, (keyof ConfigSchema)[]> = {
+      "leaderboard_roles.enabled": ["voicetracking.enabled"],
+      "digest.enabled": ["voicetracking.enabled"],
+      "digest.include_achievements": ["achievements.enabled"],
+      "achievements.enabled": ["voicetracking.enabled"],
+      "voicetracking.announcements.enabled": ["voicetracking.enabled"],
+    };
+
+    it("declares exactly the #659 hard-dependency table", () => {
+      const declared: Record<string, (keyof ConfigSchema)[]> = {};
+      for (const [key, meta] of Object.entries(settingsMetadata)) {
+        if (meta.dependsOn && meta.dependsOn.length > 0) {
+          declared[key] = meta.dependsOn;
+        }
+      }
+      expect(declared).toEqual(EXPECTED_DEPENDENCIES);
+    });
+
+    it("exposes each key's dependencies through getDependencies()", () => {
+      for (const [key, deps] of Object.entries(EXPECTED_DEPENDENCIES)) {
+        expect(getDependencies(key as keyof ConfigSchema)).toEqual(deps);
+      }
+    });
+
+    it("returns an empty array for keys with no declared dependencies", () => {
+      expect(getDependencies("voicetracking.enabled")).toEqual([]);
+      expect(getDependencies("quotes.enabled")).toEqual([]);
+    });
+
+    it("does NOT declare dependsOn on any rewind key (graceful aggregator)", () => {
+      const rewindKeys = Object.keys(settingsMetadata).filter((k) =>
+        k.startsWith("rewind."),
+      );
+      // Sanity check that rewind keys actually exist in the schema.
+      expect(rewindKeys.length).toBeGreaterThan(0);
+      for (const key of rewindKeys) {
+        expect(getDependencies(key as keyof ConfigSchema)).toEqual([]);
+      }
+    });
+
+    it("only points dependencies at real, enableable config keys", () => {
+      for (const deps of Object.values(EXPECTED_DEPENDENCIES)) {
+        for (const dep of deps) {
+          expect(dep in defaultConfig).toBe(true);
+          // Hard dependencies are always on an `*.enabled` gate.
+          expect(dep.endsWith(".enabled")).toBe(true);
+        }
+      }
     });
   });
 

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -400,7 +400,9 @@ export interface SettingMetadata {
 export function getDependencies(
   key: keyof ConfigSchema,
 ): (keyof ConfigSchema)[] {
-  return settingsMetadata[key]?.dependsOn ?? [];
+  // Return a fresh copy so callers can't mutate the array stored in
+  // settingsMetadata and silently corrupt the shared dependency graph.
+  return [...(settingsMetadata[key]?.dependsOn ?? [])];
 }
 
 /**

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -376,6 +376,31 @@ export interface SettingMetadata {
    * Ignored for non-channel types.
    */
   channelKind?: "text" | "voice";
+  /**
+   * Hard dependencies: this key may only be enabled when every listed key
+   * is also enabled (truthy). Used by write-time validation and the Settings
+   * UI to block/grey a toggle until its requirements are met. Only declare
+   * *hard* data dependencies here — features that are broken/empty without
+   * the target. Optional/graceful readers (e.g. rewind's per-section sources)
+   * are intentionally NOT listed: rewind is a graceful aggregator that renders
+   * only the sections that are tracked, so it must never be blocked on enable.
+   * Sub-feature/parent gates may also be declared when it helps the UI.
+   */
+  dependsOn?: (keyof ConfigSchema)[];
+}
+
+/**
+ * Read the hard dependencies declared for a config key. Returns the keys that
+ * must also be enabled before `key` may be turned on, or an empty array when
+ * the key declares none. Typed against `ConfigSchema` so callers
+ * (write-time validation #663, the Settings "requires X" hint #666) get a
+ * checked list. The single source of truth is each key's `dependsOn` in
+ * `settingsMetadata`.
+ */
+export function getDependencies(
+  key: keyof ConfigSchema,
+): (keyof ConfigSchema)[] {
+  return settingsMetadata[key]?.dependsOn ?? [];
 }
 
 /**
@@ -599,6 +624,7 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
     description: "Enable scheduled voice-stats announcements.",
     category: "voicetracking",
     type: "boolean",
+    dependsOn: ["voicetracking.enabled"],
   },
   "voicetracking.announcements.schedule": {
     label: "Announcement schedule (cron)",
@@ -801,6 +827,7 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
     description: "Enable the achievements / accolades system.",
     category: "achievements",
     type: "boolean",
+    dependsOn: ["voicetracking.enabled"],
   },
   "achievements.announcements.enabled": {
     label: "Channel announcements for earned achievements",
@@ -822,6 +849,7 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
       "Send a personalised weekly DM summarising each eligible user's voice activity, rank, streak, and new achievements.",
     category: "digest",
     type: "boolean",
+    dependsOn: ["voicetracking.enabled"],
   },
   "digest.cron": {
     label: "Digest schedule (cron)",
@@ -850,6 +878,7 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
       "Embed the achievements earned during the past week alongside the activity summary.",
     category: "digest",
     type: "boolean",
+    dependsOn: ["achievements.enabled"],
   },
 
   // Rewind year-in-review (#484, #608)
@@ -964,6 +993,7 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
       "Auto-assign Discord roles to users based on their voice-leaderboard position.",
     category: "leaderboard_roles",
     type: "boolean",
+    dependsOn: ["voicetracking.enabled"],
   },
   "leaderboard_roles.period": {
     label: "Period",


### PR DESCRIPTION
## Summary

Adds a single machine-readable source of truth for the feature dependency graph mapped in #659. The dependency relationships previously lived only implicitly in service code and prose schema comments; this PR declares them once so every surface — Settings page, setup wizard, `/config`, write-time validation, and docs — can read the same data.

This is the **foundation** for the rest of the #659 follow-ups: write-time enforcement (#663) and the UI "requires X" hint (#666) both consume the declaration added here. Enforcement and UI wiring are intentionally **out of scope** so each can land independently.

## Changes

- **`SettingMetadata.dependsOn?: (keyof ConfigSchema)[]`** added and documented in `config-schema.ts`.
- **`getDependencies(key)`** accessor — returns a key's hard dependencies (typed against `ConfigSchema`), or `[]` when none are declared.
- Populated the five hard-dependency keys from the #659 table:

  | Key | `dependsOn` |
  | --- | --- |
  | `leaderboard_roles.enabled` | `["voicetracking.enabled"]` |
  | `digest.enabled` | `["voicetracking.enabled"]` |
  | `digest.include_achievements` | `["achievements.enabled"]` |
  | `achievements.enabled` | `["voicetracking.enabled"]` |
  | `voicetracking.announcements.enabled` | `["voicetracking.enabled"]` |

- **Rewind keys deliberately excluded** — Rewind is a graceful aggregator that renders only the sections that are tracked and must never be blocked on enable.
- Unit tests asserting the declared graph matches the #659 table, that `getDependencies()` exposes it, and that no `rewind.*` key declares a dependency.
- `SETTINGS.md` documents the new metadata field and lists the current hard dependencies.

## Acceptance criteria

- [x] `SettingMetadata.dependsOn?: (keyof ConfigSchema)[]` added and documented
- [x] The five hard-dependency keys declare their `dependsOn`; rewind keys do not
- [x] Accessor (`getDependencies`) exists, typed against `ConfigSchema`
- [x] Unit test asserts the declared graph matches the #659 table and rewind is absent
- [x] `SETTINGS.md` notes the new metadata field

## Verification

- `npm run build` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `markdownlint SETTINGS.md` ✅
- `config-schema.test.ts` — 25 passed ✅

Closes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JsagLX3VxyqpjZj4nuzv7c)_