### PR TITLE
feat(birthdays): celebrate member birthdays in their own timezone

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -526,6 +526,41 @@ expose the page.
 
 ---
 
+## 🎂 Birthdays
+
+Celebrate members' birthdays with a message in a configured channel on
+the day — evaluated in **each member's own timezone** — optionally
+granting a temporary "birthday" role that is removed automatically.
+Members set their birthday on the **`/me/birthday`** page (the year is
+optional for privacy); there is no slash command.
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `birthdays.enabled` | `false` | Master switch — enables the recurring check and announcements |
+| `birthdays.cron` | `"0 * * * *"` | Cron schedule for the check. Hourly by default so the post lands on each member's local day across timezones; a once-daily schedule can miss members far ahead of or behind the host |
+| `birthdays.channel_id` | `""` | Channel where birthday messages are posted (required) |
+| `birthdays.message` | `"🎂 Happy birthday, {user}! 🎉"` | Message template. Placeholders: `{user}` (mention), `{username}` (display name, no ping), `{age}` (blank when no birth year is on file) |
+| `birthdays.mention` | `true` | When on, the `{user}` placeholder pings the member; when off, the name shows without a notification |
+| `birthdays.role_id` | `""` | Optional role granted on the birthday and auto-removed later. Leave empty to skip the role |
+| `birthdays.role_duration_hours` | `24` | How long the temporary birthday role is held before the sweep removes it |
+
+**Notes:**
+
+- The date is evaluated in the member's `/me/timezone` preference
+  (falling back to the server timezone when unset, #524), so a birthday
+  fires on the member's local day rather than the host's.
+- A per-row `lastAnnouncedYear` (keyed to the member's local year) makes
+  the announcement idempotent across restarts, DST edges, and the
+  sub-daily cron cadence — each member is celebrated once per year.
+- Feb 29 birthdays are celebrated on Mar 1 in non-leap years.
+- The temporary role's grant time is persisted, so the daily sweep can
+  revoke it after the configured duration even across a restart.
+- A summary row (announced / roles granted / roles removed / failed) is
+  posted to the configured cron log channel after a run that did
+  anything (empty hourly ticks are silent).
+
+---
+
 ### Cron schedule format
 
 ```text
@@ -990,6 +1025,16 @@ Current hard dependencies:
 - `rewind.nudge.enabled` (bool, default: false)
 - `rewind.cron` (string, default: `"0 10 30 12 *"`)
 - `rewind.min_minutes` (number, default: 60)
+
+#### Birthdays
+
+- `birthdays.enabled` (bool, default: false)
+- `birthdays.cron` (string, default: `"0 * * * *"`)
+- `birthdays.channel_id` (string, default: "")
+- `birthdays.message` (string, default: `"🎂 Happy birthday, {user}! 🎉"`)
+- `birthdays.mention` (bool, default: true)
+- `birthdays.role_id` (string, default: "")
+- `birthdays.role_duration_hours` (number, default: 24)
 
 #### Cleanup
 

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -822,12 +822,25 @@ slash command** — the Web UI is the admin surface.
 | **Overview** (`/me/`)                   | Index for your own settings — links to the available per-user pages.                                                                                       |
 | **Notifications** (`/me/notifications`) | Opt in or out of DM nudges from Koolbot (achievements, weekly digest, Rewind nudge). Each toggle records a `WebAuditLog` row.                              |
 | **Voice** (`/me/voice`)                 | Manage your channel name pattern and saved voice-channel presets (rename, edit, set-default, delete). Gated by `voicechannels.presets.enabled`.            |
+| **Timezone** (`/me/timezone`)           | Pick the IANA timezone Koolbot renders your times in (digest, Rewind, voicestats) and uses to evaluate your birthday. Saving records a `WebAuditLog` row.  |
+| **Birthday** (`/me/birthday`)           | Set your birthday (month/day, optional year) so Koolbot can celebrate it on the day in your own timezone. Saving or removing records a `WebAuditLog` row.  |
 | **Rewind** (`/me/rewind`)               | Personal year-in-review: voice time, top voice companions, peak day, longest session, streak, badges, annual rank, weekly-rank journey, and text activity. |
 
 Notification preferences are scoped per `(userId, guildId)`. The page
 lists every notification type with the current state and a checkbox;
 toggling one row is a single POST that records the diff in the audit
 log and PRG-redirects back to the page.
+
+The **Birthday** page (`#657`) stores a month/day and an optional year
+per `(userId, guildId)`. The year is optional by design — many people
+share the date but not the age — and when omitted no age is computed or
+shown. The page stays reachable even when `birthdays.enabled` is off so a
+member can pre-set their date (it shows an informational notice that
+nothing will be posted until an admin enables the feature), mirroring how
+the Notifications page exposes toggles for not-yet-active paths. A
+"Remove my birthday" button clears the stored date. The daily birthday
+announcement itself is evaluated in the member's `/me/timezone`
+preference so it fires on their local day (`#524`).
 
 The whole feature is gated by `rewind.enabled` (`#608`). When it is off
 the route returns a 404 "feature disabled" state and the nav link is

--- a/__tests__/services/birthday-service.test.ts
+++ b/__tests__/services/birthday-service.test.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import type { Client } from "discord.js";
+
+const mockRegisterReloadCallback = jest.fn();
+const mockConfigGetBoolean = jest.fn();
+const mockConfigGetString = jest.fn();
+const mockConfigGetNumber = jest.fn();
+
+const mockGetTimezone = jest.fn();
+const mockPrefsGetInstance = jest.fn(() => ({
+  getTimezone: mockGetTimezone,
+}));
+
+const mockLoggerIsReady = jest.fn(() => false);
+const mockLogCronSuccess = jest.fn();
+const mockDiscordLoggerGetInstance = jest.fn(() => ({
+  isReady: mockLoggerIsReady,
+  logCronSuccess: mockLogCronSuccess,
+}));
+
+const mockBirthdayFindOne = jest.fn();
+const mockBirthdayFindOneAndUpdate = jest.fn();
+const mockBirthdayDeleteOne = jest.fn();
+const mockBirthdayFind = jest.fn();
+
+jest.unstable_mockModule("../../src/services/config-service.js", () => ({
+  ConfigService: {
+    getInstance: jest.fn(() => ({
+      registerReloadCallback: mockRegisterReloadCallback,
+      getBoolean: mockConfigGetBoolean,
+      getString: mockConfigGetString,
+      getNumber: mockConfigGetNumber,
+    })),
+  },
+}));
+
+jest.unstable_mockModule(
+  "../../src/services/user-notification-prefs-service.js",
+  () => ({
+    UserNotificationPrefsService: { getInstance: mockPrefsGetInstance },
+  }),
+);
+
+jest.unstable_mockModule("../../src/services/discord-logger.js", () => ({
+  DiscordLogger: { getInstance: mockDiscordLoggerGetInstance },
+}));
+
+jest.unstable_mockModule("../../src/models/user-birthday.js", () => ({
+  UserBirthday: {
+    findOne: mockBirthdayFindOne,
+    findOneAndUpdate: mockBirthdayFindOneAndUpdate,
+    deleteOne: mockBirthdayDeleteOne,
+    find: mockBirthdayFind,
+  },
+}));
+
+jest.unstable_mockModule("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const {
+  BirthdayService,
+  isLeapYear,
+  isValidMonthDay,
+  isBirthdayToday,
+  shouldAnnounceBirthday,
+  localYmdInZone,
+  renderBirthdayMessage,
+} = await import("../../src/services/birthday-service.js");
+
+type ServiceInstance = InstanceType<typeof BirthdayService>;
+
+function resetSingleton(): void {
+  (BirthdayService as unknown as { instance: unknown }).instance = undefined;
+}
+
+function makeClient(): Client {
+  return {
+    guilds: { fetch: jest.fn() },
+  } as unknown as Client;
+}
+
+describe("birthday pure helpers", () => {
+  describe("isLeapYear", () => {
+    it("classifies common leap and non-leap years", () => {
+      expect(isLeapYear(2024)).toBe(true);
+      expect(isLeapYear(2023)).toBe(false);
+      expect(isLeapYear(2000)).toBe(true); // divisible by 400
+      expect(isLeapYear(1900)).toBe(false); // divisible by 100 but not 400
+    });
+  });
+
+  describe("isValidMonthDay", () => {
+    it("accepts valid calendar dates including Feb 29", () => {
+      expect(isValidMonthDay(1, 1)).toBe(true);
+      expect(isValidMonthDay(2, 29)).toBe(true);
+      expect(isValidMonthDay(12, 31)).toBe(true);
+    });
+    it("rejects out-of-range months and days", () => {
+      expect(isValidMonthDay(0, 1)).toBe(false);
+      expect(isValidMonthDay(13, 1)).toBe(false);
+      expect(isValidMonthDay(1, 0)).toBe(false);
+      expect(isValidMonthDay(1, 32)).toBe(false);
+      expect(isValidMonthDay(4, 31)).toBe(false); // April has 30 days
+      expect(isValidMonthDay(2, 30)).toBe(false);
+    });
+    it("rejects non-integers", () => {
+      expect(isValidMonthDay(1.5, 10)).toBe(false);
+      expect(isValidMonthDay(1, 10.2)).toBe(false);
+    });
+  });
+
+  describe("localYmdInZone — 'is it today' across timezones (#524)", () => {
+    it("resolves the local calendar day in the member's zone", () => {
+      // 2026-06-15 23:30 UTC is already 2026-06-16 in Tokyo (UTC+9) but
+      // still 2026-06-15 in New York (UTC-4).
+      const instant = new Date("2026-06-15T23:30:00Z");
+      expect(localYmdInZone(instant, "Asia/Tokyo")).toEqual({
+        year: 2026,
+        month: 6,
+        day: 16,
+      });
+      expect(localYmdInZone(instant, "America/New_York")).toEqual({
+        year: 2026,
+        month: 6,
+        day: 15,
+      });
+      expect(localYmdInZone(instant, "UTC")).toEqual({
+        year: 2026,
+        month: 6,
+        day: 15,
+      });
+    });
+
+    it("a birthday fires on the member's local day, not the host's", () => {
+      const instant = new Date("2026-06-15T23:30:00Z");
+      const birthday = { month: 6, day: 16 };
+      // Today in Tokyo it IS June 16 → announce.
+      expect(
+        isBirthdayToday(birthday, localYmdInZone(instant, "Asia/Tokyo")),
+      ).toBe(true);
+      // In New York it's still June 15 → not yet.
+      expect(
+        isBirthdayToday(birthday, localYmdInZone(instant, "America/New_York")),
+      ).toBe(false);
+    });
+  });
+
+  describe("isBirthdayToday", () => {
+    it("matches the exact month/day", () => {
+      expect(isBirthdayToday({ month: 3, day: 14 }, { year: 2026, month: 3, day: 14 })).toBe(true);
+      expect(isBirthdayToday({ month: 3, day: 14 }, { year: 2026, month: 3, day: 15 })).toBe(false);
+    });
+    it("celebrates a Feb 29 birthday on Mar 1 in non-leap years", () => {
+      // 2026 is not a leap year.
+      expect(isBirthdayToday({ month: 2, day: 29 }, { year: 2026, month: 3, day: 1 })).toBe(true);
+      expect(isBirthdayToday({ month: 2, day: 29 }, { year: 2026, month: 2, day: 28 })).toBe(false);
+    });
+    it("celebrates a Feb 29 birthday on Feb 29 in leap years (not Mar 1)", () => {
+      // 2028 is a leap year.
+      expect(isBirthdayToday({ month: 2, day: 29 }, { year: 2028, month: 2, day: 29 })).toBe(true);
+      expect(isBirthdayToday({ month: 2, day: 29 }, { year: 2028, month: 3, day: 1 })).toBe(false);
+    });
+  });
+
+  describe("shouldAnnounceBirthday — double-announce guard", () => {
+    const local = { year: 2026, month: 5, day: 10 };
+    it("announces when it's the birthday and not yet announced this year", () => {
+      expect(shouldAnnounceBirthday({ month: 5, day: 10 }, local)).toBe(true);
+      expect(
+        shouldAnnounceBirthday({ month: 5, day: 10, lastAnnouncedYear: 2025 }, local),
+      ).toBe(true);
+    });
+    it("suppresses a second announcement in the same local year", () => {
+      expect(
+        shouldAnnounceBirthday({ month: 5, day: 10, lastAnnouncedYear: 2026 }, local),
+      ).toBe(false);
+    });
+    it("does not announce when it isn't the birthday regardless of guard", () => {
+      expect(
+        shouldAnnounceBirthday({ month: 5, day: 11, lastAnnouncedYear: 2025 }, local),
+      ).toBe(false);
+    });
+  });
+
+  describe("renderBirthdayMessage", () => {
+    it("renders the user mention and age", () => {
+      expect(
+        renderBirthdayMessage("🎂 {user} turns {age} today!", {
+          userId: "123",
+          displayName: "Sam",
+          age: 30,
+        }),
+      ).toBe("🎂 <@123> turns 30 today!");
+    });
+    it("uses the display name for {username} without a ping", () => {
+      expect(
+        renderBirthdayMessage("Happy birthday {username}!", {
+          userId: "123",
+          displayName: "Sam",
+          age: null,
+        }),
+      ).toBe("Happy birthday Sam!");
+    });
+    it("collapses the gap left by {age} when no year is on file", () => {
+      expect(
+        renderBirthdayMessage("{user} turns {age} today", {
+          userId: "9",
+          displayName: "X",
+          age: null,
+        }),
+      ).toBe("<@9> turns today");
+    });
+  });
+});
+
+describe("BirthdayService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetSingleton();
+    mockConfigGetBoolean.mockImplementation(async (key: unknown) => {
+      const k = key as string;
+      if (k === "birthdays.enabled") return true;
+      if (k === "birthdays.mention") return true;
+      return false;
+    });
+    mockConfigGetString.mockImplementation(async (key: unknown, def: unknown) => {
+      const k = key as string;
+      if (k === "GUILD_ID") return "guild-1";
+      if (k === "birthdays.cron") return "0 * * * *";
+      return (def as string) ?? "";
+    });
+    mockConfigGetNumber.mockImplementation(async (key: unknown, def: unknown) => {
+      return (def as number) ?? 0;
+    });
+    mockGetTimezone.mockResolvedValue(null);
+  });
+
+  describe("singleton + lifecycle", () => {
+    it("returns the same instance for the same client", () => {
+      const client = makeClient();
+      expect(BirthdayService.getInstance(client)).toBe(
+        BirthdayService.getInstance(client),
+      );
+    });
+
+    it("registers a reload callback on construction", () => {
+      BirthdayService.getInstance(makeClient());
+      expect(mockRegisterReloadCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws if constructed with a different client", () => {
+      BirthdayService.getInstance(makeClient());
+      expect(() => BirthdayService.getInstance(makeClient())).toThrow(
+        /different client/,
+      );
+    });
+  });
+
+  describe("runNow guards", () => {
+    it("returns null when the feature is disabled", async () => {
+      mockConfigGetBoolean.mockResolvedValue(false);
+      const svc: ServiceInstance = BirthdayService.getInstance(makeClient());
+      expect(await svc.runNow()).toBeNull();
+      expect(mockBirthdayFind).not.toHaveBeenCalled();
+    });
+
+    it("returns null when no announcement channel is configured", async () => {
+      // GUILD_ID present, channel id empty.
+      const svc: ServiceInstance = BirthdayService.getInstance(makeClient());
+      expect(await svc.runNow()).toBeNull();
+      expect(mockBirthdayFind).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getBirthday / setBirthday storage", () => {
+    it("returns null when no row exists", async () => {
+      mockBirthdayFindOne.mockResolvedValue(null);
+      const svc: ServiceInstance = BirthdayService.getInstance(makeClient());
+      expect(await svc.getBirthday("u1", "g1")).toBeNull();
+    });
+
+    it("maps a stored row to a plain birthday (year null when absent)", async () => {
+      mockBirthdayFindOne.mockResolvedValue({ month: 4, day: 2 });
+      const svc: ServiceInstance = BirthdayService.getInstance(makeClient());
+      expect(await svc.getBirthday("u1", "g1")).toEqual({
+        month: 4,
+        day: 2,
+        year: null,
+      });
+    });
+
+    it("degrades to null on a read error", async () => {
+      mockBirthdayFindOne.mockRejectedValue(new Error("db down"));
+      const svc: ServiceInstance = BirthdayService.getInstance(makeClient());
+      expect(await svc.getBirthday("u1", "g1")).toBeNull();
+    });
+
+    it("clears the birthday when input is null", async () => {
+      mockBirthdayDeleteOne.mockResolvedValue({ deletedCount: 1 });
+      const svc: ServiceInstance = BirthdayService.getInstance(makeClient());
+      expect(await svc.setBirthday("u1", "g1", null)).toBeNull();
+      expect(mockBirthdayDeleteOne).toHaveBeenCalledWith({
+        userId: "u1",
+        guildId: "g1",
+      });
+    });
+
+    it("upserts a valid birthday and resets lastAnnouncedYear", async () => {
+      mockBirthdayFindOneAndUpdate.mockResolvedValue({
+        month: 6,
+        day: 16,
+        year: 1990,
+      });
+      const svc: ServiceInstance = BirthdayService.getInstance(makeClient());
+      const result = await svc.setBirthday("u1", "g1", {
+        month: 6,
+        day: 16,
+        year: 1990,
+      });
+      expect(result).toEqual({ month: 6, day: 16, year: 1990 });
+      const [, update] = mockBirthdayFindOneAndUpdate.mock.calls[0] as [
+        unknown,
+        { $set: Record<string, unknown>; $unset: Record<string, unknown> },
+      ];
+      expect(update.$set).toMatchObject({ month: 6, day: 16, year: 1990 });
+      expect(update.$unset).toHaveProperty("lastAnnouncedYear");
+    });
+
+    it("$unsets the year when omitted (privacy: date without age)", async () => {
+      mockBirthdayFindOneAndUpdate.mockResolvedValue({ month: 6, day: 16 });
+      const svc: ServiceInstance = BirthdayService.getInstance(makeClient());
+      await svc.setBirthday("u1", "g1", { month: 6, day: 16, year: null });
+      const [, update] = mockBirthdayFindOneAndUpdate.mock.calls[0] as [
+        unknown,
+        { $set: Record<string, unknown>; $unset: Record<string, unknown> },
+      ];
+      expect(update.$set).not.toHaveProperty("year");
+      expect(update.$unset).toHaveProperty("year");
+    });
+
+    it("rejects an invalid month/day before writing", async () => {
+      const svc: ServiceInstance = BirthdayService.getInstance(makeClient());
+      await expect(
+        svc.setBirthday("u1", "g1", { month: 2, day: 30 }),
+      ).rejects.toThrow(/valid month\/day/);
+      expect(mockBirthdayFindOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it("rejects a future or implausible birth year", async () => {
+      const svc: ServiceInstance = BirthdayService.getInstance(makeClient());
+      const nextYear = new Date().getUTCFullYear() + 1;
+      await expect(
+        svc.setBirthday("u1", "g1", { month: 6, day: 16, year: nextYear }),
+      ).rejects.toThrow(/valid birth year/);
+      await expect(
+        svc.setBirthday("u1", "g1", { month: 6, day: 16, year: 1800 }),
+      ).rejects.toThrow(/valid birth year/);
+      expect(mockBirthdayFindOneAndUpdate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/services/config-schema.test.ts
+++ b/__tests__/services/config-schema.test.ts
@@ -267,6 +267,7 @@ describe("Config Schema", () => {
       "achievements.enabled": false,
       "digest.enabled": false,
       "rewind.enabled": false,
+      "birthdays.enabled": false,
       "reactionroles.enabled": false,
       "notices.enabled": false,
       "polls.enabled": false,

--- a/__tests__/services/settings-metadata.test.ts
+++ b/__tests__/services/settings-metadata.test.ts
@@ -48,6 +48,7 @@ describe("settingsMetadata", () => {
       "ratelimit",
       "announcements",
       "achievements",
+      "birthdays",
       "reactionroles",
       "wizard",
       "notices",

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import { PollService } from "./services/poll-service.js";
 import { LeaderboardRoleService } from "./services/leaderboard-role-service.js";
 import { DigestService } from "./services/digest-service.js";
 import { RewindNudgeService } from "./services/rewind-nudge-service.js";
+import { BirthdayService } from "./services/birthday-service.js";
 import { WizardService } from "./services/wizard-service.js";
 import { MonitoringService } from "./services/monitoring-service.js";
 import {
@@ -494,6 +495,7 @@ async function gracefulShutdown(signal: string): Promise<void> {
         leaderboardRoleService.destroy();
         digestService.destroy();
         rewindNudgeService.destroy();
+        birthdayService.destroy();
         WizardService.getInstance().shutdown();
         // Persist any metrics still buffered in memory before the DB
         // connection closes below, then stop the flush/logging timers.
@@ -559,6 +561,7 @@ let pollService: PollService;
 let leaderboardRoleService: LeaderboardRoleService;
 let digestService: DigestService;
 let rewindNudgeService: RewindNudgeService;
+let birthdayService: BirthdayService;
 
 // Wrap service instantiation in try-catch to ensure errors are caught
 try {
@@ -585,6 +588,7 @@ try {
   leaderboardRoleService = LeaderboardRoleService.getInstance(client);
   digestService = DigestService.getInstance(client);
   rewindNudgeService = RewindNudgeService.getInstance(client);
+  birthdayService = BirthdayService.getInstance(client);
 } catch (error) {
   logger.error("❌ Fatal error during service instantiation:", error);
   process.exit(1);
@@ -691,6 +695,11 @@ async function initializeServices(): Promise<void> {
     // page itself is served by the user WebUI router regardless of
     // this service — this only schedules the end-of-year DM nudge.
     await rewindNudgeService.start();
+
+    // Initialize birthday celebrations service (#657). Members set their
+    // date on /me/birthday; this schedules the recurring "is it anyone's
+    // birthday today (in their timezone)?" check.
+    await birthdayService.start();
 
     // Start the slash-command audit log cleanup cron (#459)
     CommandAuditCleanupService.getInstance().start();

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -12,6 +12,7 @@ export const CONFIG_CATEGORIES = [
   "achievements",
   "amikool", // Kept for backward compatibility; key removed but legacy rows may exist
   "announcements",
+  "birthdays",
   "core",
   "digest",
   "fun", // Kept for backward compatibility; key removed but legacy rows may exist

--- a/src/models/user-birthday.ts
+++ b/src/models/user-birthday.ts
@@ -1,0 +1,55 @@
+import mongoose, { Document, Schema } from "mongoose";
+
+/**
+ * Per-user birthday, stored per `(userId, guildId)` (#657).
+ *
+ * Greenfield model — there is no birthday data anywhere else. The
+ * feature is fully opt-in: a row only exists once a member sets their
+ * birthday on the `/me/birthday` self-service page, so a missing row
+ * simply means "this member has no birthday on file" and the daily
+ * announcer skips them.
+ *
+ * `year` is **optional** by design (privacy): many people are happy to
+ * share the date but not the age. When omitted, no age is computed or
+ * shown. `lastAnnouncedYear` is the calendar year — evaluated in the
+ * member's own timezone — that the bot last posted a birthday message,
+ * and is the idempotency guard that prevents a double-post across
+ * restarts, DST edges, or a sub-daily cron cadence.
+ *
+ * `roleAssignedAt` records when the temporary "birthday" role was last
+ * granted to the member, so the daily sweep can revoke it once the
+ * configured duration has elapsed even if the process restarted in
+ * between (the grant is not held in memory).
+ */
+export interface IUserBirthday extends Document {
+  userId: string;
+  guildId: string;
+  month: number; // 1-12
+  day: number; // 1-31
+  year?: number; // optional — omitted means "don't show/compute age"
+  lastAnnouncedYear?: number; // year (in the member's tz) last announced
+  roleAssignedAt?: Date; // when the temp birthday role was granted
+  updatedAt: Date;
+}
+
+const UserBirthdaySchema = new Schema<IUserBirthday>(
+  {
+    userId: { type: String, required: true },
+    guildId: { type: String, required: true },
+    month: { type: Number, required: true, min: 1, max: 12 },
+    day: { type: Number, required: true, min: 1, max: 31 },
+    // Optional birth year; absent → age is never computed or displayed.
+    year: { type: Number, required: false },
+    lastAnnouncedYear: { type: Number, required: false },
+    roleAssignedAt: { type: Date, required: false },
+    updatedAt: { type: Date, required: true, default: Date.now },
+  },
+  { timestamps: false },
+);
+
+UserBirthdaySchema.index({ userId: 1, guildId: 1 }, { unique: true });
+
+export const UserBirthday = mongoose.model<IUserBirthday>(
+  "UserBirthday",
+  UserBirthdaySchema,
+);

--- a/src/services/birthday-service.ts
+++ b/src/services/birthday-service.ts
@@ -548,9 +548,12 @@ export class BirthdayService {
     now: Date,
   ): Promise<number> {
     let removed = 0;
+    // Only rows with a stored grant timestamp can have a role to revoke.
+    // (`$ne: null` already excludes missing fields in MongoDB; `$exists`
+    // makes that intent explicit.)
     const expiredRows = await UserBirthday.find({
       guildId,
-      roleAssignedAt: { $ne: null },
+      roleAssignedAt: { $exists: true, $ne: null },
     });
     for (const row of expiredRows) {
       if (!row.roleAssignedAt) continue;

--- a/src/services/birthday-service.ts
+++ b/src/services/birthday-service.ts
@@ -1,0 +1,628 @@
+import { Client, Guild, TextChannel } from "discord.js";
+import { CronJob, CronTime } from "cron";
+import { formatInTimeZone } from "date-fns-tz";
+import { ConfigService } from "./config-service.js";
+import { UserNotificationPrefsService } from "./user-notification-prefs-service.js";
+import { DiscordLogger } from "./discord-logger.js";
+import { UserBirthday, type IUserBirthday } from "../models/user-birthday.js";
+import { resolveTimezone } from "../utils/timezone.js";
+import logger from "../utils/logger.js";
+import { sanitizeForLog } from "../utils/log-sanitize.js";
+
+/**
+ * Birthday celebrations service (#657).
+ *
+ * Mirrors the cron lifecycle of `DigestService` /
+ * `ScheduledAnnouncementService`: the interval handle is stored, every
+ * tick is wrapped so a failure is logged and never crashes the process,
+ * and a reload callback re-reads the gate on `/config reload`.
+ *
+ * The job runs on a sub-daily cadence (hourly by default) and, for each
+ * member with a birthday on file, decides whether "today" matches in
+ * **that member's** timezone (`UserNotificationPrefs.timezone`, #524).
+ * `lastAnnouncedYear` — keyed to the member's local year — makes the
+ * post idempotent regardless of how often the cron fires or whether the
+ * process restarted mid-day.
+ */
+
+const DEFAULT_CRON = "0 * * * *"; // top of every hour
+const DEFAULT_MESSAGE = "🎂 Happy birthday, {user}! 🎉";
+const DEFAULT_ROLE_DURATION_HOURS = 24;
+const MS_PER_HOUR = 60 * 60 * 1000;
+
+export interface BirthdayInput {
+  month: number;
+  day: number;
+  year?: number | null;
+}
+
+export interface StoredBirthday {
+  month: number;
+  day: number;
+  year: number | null;
+}
+
+export interface BirthdayRunSummary {
+  ranAt: Date;
+  candidates: number;
+  announced: number;
+  rolesGranted: number;
+  rolesRemoved: number;
+  failed: number;
+}
+
+function sanitizeCronExpression(expression: string): string {
+  return expression.trim().replace(/^["']|["']$/g, "");
+}
+
+/** Days in each (1-based) month, treating February as 29 so leap-day
+ * birthdays are storable; the announcer handles the non-leap-year case. */
+const DAYS_IN_MONTH = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+/** Gregorian leap-year test. */
+export function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+/**
+ * Validate a calendar month/day pair. Accepts Feb 29 unconditionally
+ * (it's a real birth date); the announcer decides when to celebrate it
+ * in non-leap years.
+ */
+export function isValidMonthDay(month: number, day: number): boolean {
+  if (!Number.isInteger(month) || !Number.isInteger(day)) return false;
+  if (month < 1 || month > 12) return false;
+  if (day < 1) return false;
+  return day <= DAYS_IN_MONTH[month - 1];
+}
+
+/**
+ * The local calendar Y/M/D for `date` in an IANA `timezone`. Used to ask
+ * "is it the member's birthday today in their own zone?" so the post
+ * fires on their local day, not the host's (#524).
+ */
+export function localYmdInZone(
+  date: Date,
+  timezone: string,
+): { year: number; month: number; day: number } {
+  const iso = formatInTimeZone(date, timezone, "yyyy-MM-dd");
+  const [year, month, day] = iso.split("-").map((n) => Number.parseInt(n, 10));
+  return { year, month, day };
+}
+
+/**
+ * Whether `birthday` falls on the given local calendar date. A Feb 29
+ * birthday celebrates on Mar 1 in non-leap years so leap-day members
+ * aren't skipped three years out of four.
+ */
+export function isBirthdayToday(
+  birthday: { month: number; day: number },
+  local: { year: number; month: number; day: number },
+): boolean {
+  if (birthday.month === local.month && birthday.day === local.day) {
+    return true;
+  }
+  if (
+    birthday.month === 2 &&
+    birthday.day === 29 &&
+    !isLeapYear(local.year) &&
+    local.month === 3 &&
+    local.day === 1
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Whether the bot should announce `birthday` given the current local
+ * date. Combines the "is it today (in the member's zone)" test with the
+ * once-per-local-year idempotency guard, so a restart or a sub-daily
+ * cron cadence can't double-post. Kept pure for direct unit testing.
+ */
+export function shouldAnnounceBirthday(
+  birthday: {
+    month: number;
+    day: number;
+    lastAnnouncedYear?: number | null;
+  },
+  local: { year: number; month: number; day: number },
+): boolean {
+  if (!isBirthdayToday(birthday, local)) return false;
+  return birthday.lastAnnouncedYear !== local.year;
+}
+
+function rowToStored(row: IUserBirthday): StoredBirthday {
+  return {
+    month: row.month,
+    day: row.day,
+    year: typeof row.year === "number" ? row.year : null,
+  };
+}
+
+/**
+ * Fill the `{user}` / `{username}` / `{age}` placeholders in a birthday
+ * message template. `{user}` is a real mention (`<@id>`); whether it
+ * pings is decided by the caller's `allowedMentions`. `{age}` resolves
+ * to the empty string (and is tidied up) when no birth year is on file.
+ */
+export function renderBirthdayMessage(
+  template: string,
+  args: { userId: string; displayName: string; age: number | null },
+): string {
+  const ageText = args.age !== null ? String(args.age) : "";
+  let result = template
+    .split("{user}")
+    .join(`<@${args.userId}>`)
+    .split("{username}")
+    .join(args.displayName)
+    .split("{age}")
+    .join(ageText);
+  // If the template referenced {age} but we have no year, collapse the
+  // now-empty spots (e.g. "turns  today" → "turns today").
+  if (args.age === null) {
+    result = result.replace(/\s{2,}/g, " ").trim();
+  }
+  return result;
+}
+
+export class BirthdayService {
+  private static instance: BirthdayService;
+  private client: Client;
+  private configService: ConfigService;
+  private job: CronJob | null = null;
+  private isInitialized = false;
+  private isRunning = false;
+  private inFlight: Promise<BirthdayRunSummary | null> | null = null;
+
+  private constructor(client: Client) {
+    this.client = client;
+    this.configService = ConfigService.getInstance();
+
+    this.configService.registerReloadCallback(async () => {
+      try {
+        logger.info("Birthday configuration changed, reloading...");
+        const enabled = await this.configService.getBoolean(
+          "birthdays.enabled",
+          false,
+        );
+        if (!enabled && this.isInitialized) {
+          logger.info("Birthdays disabled, stopping cron job...");
+          this.destroy();
+        } else if (enabled) {
+          await this.reload();
+        }
+      } catch (error) {
+        logger.error(
+          "Error reloading birthday service after configuration change:",
+          error,
+        );
+      }
+    });
+  }
+
+  public static getInstance(client: Client): BirthdayService {
+    if (!BirthdayService.instance) {
+      BirthdayService.instance = new BirthdayService(client);
+    } else if (BirthdayService.instance.client !== client) {
+      throw new Error(
+        "BirthdayService already initialised with a different client",
+      );
+    }
+    return BirthdayService.instance;
+  }
+
+  public static reset(): void {
+    if (BirthdayService.instance) {
+      BirthdayService.instance.destroy();
+    }
+    BirthdayService.instance = undefined as unknown as BirthdayService;
+  }
+
+  private validateCronExpression(expression: string): boolean {
+    try {
+      new CronTime(expression);
+      return true;
+    } catch (error) {
+      logger.error(
+        `Invalid cron expression for birthdays: ${expression}`,
+        error,
+      );
+      return false;
+    }
+  }
+
+  // ---------------------------------------------------------------
+  // Storage (used by the /me/birthday WebUI surface)
+  // ---------------------------------------------------------------
+
+  /**
+   * Read the stored birthday for a member, or `null` when none is set
+   * (or on a read error — birthdays are non-critical, so we degrade to
+   * "not set" rather than surfacing the error to the page).
+   */
+  public async getBirthday(
+    userId: string,
+    guildId: string,
+  ): Promise<StoredBirthday | null> {
+    if (!userId || !guildId) return null;
+    try {
+      const row = await UserBirthday.findOne({ userId, guildId });
+      return row ? rowToStored(row) : null;
+    } catch (err) {
+      logger.error("Failed to load birthday", err);
+      return null;
+    }
+  }
+
+  /**
+   * Set or clear a member's birthday. Passing `null` removes the row.
+   * The month/day are validated against the calendar (Feb 29 allowed);
+   * the year, when present, must be a plausible four-digit value not in
+   * the future. Resets `lastAnnouncedYear` so a corrected date can still
+   * fire this year. Returns the stored value (or `null` when cleared).
+   */
+  public async setBirthday(
+    userId: string,
+    guildId: string,
+    input: BirthdayInput | null,
+  ): Promise<StoredBirthday | null> {
+    if (!userId) throw new Error("userId required");
+    if (!guildId) throw new Error("guildId required");
+
+    if (input === null) {
+      await UserBirthday.deleteOne({ userId, guildId });
+      return null;
+    }
+
+    const { month, day } = input;
+    if (!isValidMonthDay(month, day)) {
+      throw new Error(`"${month}/${day}" is not a valid month/day`);
+    }
+
+    let year: number | undefined;
+    if (input.year !== null && input.year !== undefined) {
+      const currentYear = new Date().getUTCFullYear();
+      if (
+        !Number.isInteger(input.year) ||
+        input.year < 1900 ||
+        input.year > currentYear
+      ) {
+        throw new Error(`"${input.year}" is not a valid birth year`);
+      }
+      year = input.year;
+    }
+
+    const update: Record<string, unknown> = {
+      $set: { month, day, updatedAt: new Date() },
+      // A changed date should be eligible again this year.
+      $unset: { lastAnnouncedYear: "" } as Record<string, unknown>,
+    };
+    if (year !== undefined) {
+      (update.$set as Record<string, unknown>).year = year;
+    } else {
+      (update.$unset as Record<string, unknown>).year = "";
+    }
+
+    const row = await UserBirthday.findOneAndUpdate(
+      { userId, guildId },
+      update,
+      {
+        new: true,
+        upsert: true,
+        setDefaultsOnInsert: true,
+      },
+    );
+    return row ? rowToStored(row) : { month, day, year: year ?? null };
+  }
+
+  // ---------------------------------------------------------------
+  // Cron lifecycle
+  // ---------------------------------------------------------------
+
+  public async start(): Promise<void> {
+    if (this.isInitialized) {
+      logger.warn("Birthday service is already initialized, skipping...");
+      return;
+    }
+    try {
+      const enabled = await this.configService.getBoolean(
+        "birthdays.enabled",
+        false,
+      );
+      if (!enabled) {
+        logger.info("Birthdays are disabled");
+        this.isInitialized = true;
+        return;
+      }
+
+      const rawCron = await this.configService.getString(
+        "birthdays.cron",
+        DEFAULT_CRON,
+      );
+      const cronExpression = sanitizeCronExpression(rawCron);
+      if (!this.validateCronExpression(cronExpression)) {
+        logger.error(`Birthday service not started: invalid cron "${rawCron}"`);
+        this.isInitialized = true;
+        return;
+      }
+
+      this.job = new CronJob(cronExpression, async () => {
+        try {
+          await this.runNow();
+        } catch (error) {
+          logger.error("Error running birthday job:", error);
+        }
+      });
+      this.job.start();
+
+      const nextRun = this.job.nextDate();
+      logger.info(
+        `Birthday service started (cron: "${cronExpression}", next run: ${nextRun.toLocaleString()})`,
+      );
+      this.isInitialized = true;
+    } catch (error) {
+      logger.error("Error starting birthday service:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Run the birthday job immediately. Concurrent invocations coalesce
+   * onto the first one so a slow run and the next cron tick can't
+   * double-post (in addition to the per-row `lastAnnouncedYear` guard).
+   */
+  public async runNow(): Promise<BirthdayRunSummary | null> {
+    if (this.inFlight) return this.inFlight;
+    this.inFlight = this.runOnce();
+    try {
+      return await this.inFlight;
+    } finally {
+      this.inFlight = null;
+    }
+  }
+
+  private async runOnce(): Promise<BirthdayRunSummary | null> {
+    if (this.isRunning) {
+      logger.warn("Birthday run already in progress, skipping");
+      return null;
+    }
+    this.isRunning = true;
+    try {
+      const enabled = await this.configService.getBoolean(
+        "birthdays.enabled",
+        false,
+      );
+      if (!enabled) {
+        logger.info("Birthday run aborted: feature disabled");
+        return null;
+      }
+
+      const guildId = await this.configService.getString("GUILD_ID", "");
+      if (!guildId) {
+        logger.error("Birthday run aborted: GUILD_ID not configured");
+        return null;
+      }
+
+      const channelId = await this.configService.getString(
+        "birthdays.channel_id",
+        "",
+      );
+      if (!channelId) {
+        logger.warn(
+          "Birthday run aborted: birthdays.channel_id not configured",
+        );
+        return null;
+      }
+
+      const guild = await this.client.guilds.fetch(guildId);
+      if (!guild) {
+        logger.error(`Birthday run aborted: guild ${guildId} not found`);
+        return null;
+      }
+
+      const channel = await guild.channels.fetch(channelId);
+      if (!channel || !(channel instanceof TextChannel)) {
+        logger.error(
+          `Birthday run aborted: channel ${sanitizeForLog(channelId)} not found or not a text channel`,
+        );
+        return null;
+      }
+
+      const messageTemplate = await this.configService.getString(
+        "birthdays.message",
+        DEFAULT_MESSAGE,
+      );
+      const mention = await this.configService.getBoolean(
+        "birthdays.mention",
+        true,
+      );
+      const roleId = await this.configService.getString(
+        "birthdays.role_id",
+        "",
+      );
+      const roleDurationHours = await this.configService.getNumber(
+        "birthdays.role_duration_hours",
+        DEFAULT_ROLE_DURATION_HOURS,
+      );
+
+      const summary: BirthdayRunSummary = {
+        ranAt: new Date(),
+        candidates: 0,
+        announced: 0,
+        rolesGranted: 0,
+        rolesRemoved: 0,
+        failed: 0,
+      };
+
+      // 1. Revoke expired birthday roles first so a member whose window
+      //    closed loses the role even if no one has a birthday today.
+      if (roleId) {
+        summary.rolesRemoved += await this.sweepExpiredRoles(
+          guild,
+          guildId,
+          roleId,
+          Math.max(0, roleDurationHours) * MS_PER_HOUR,
+          summary.ranAt,
+        );
+      }
+
+      // 2. Announce today's birthdays (in each member's own timezone).
+      const prefsService = UserNotificationPrefsService.getInstance();
+      const rows = await UserBirthday.find({ guildId });
+      summary.candidates = rows.length;
+
+      for (const row of rows) {
+        try {
+          const tz = resolveTimezone(
+            await prefsService.getTimezone(row.userId, guildId),
+          );
+          const local = localYmdInZone(summary.ranAt, tz);
+          if (!shouldAnnounceBirthday(row, local)) continue;
+
+          const member = await guild.members
+            .fetch(row.userId)
+            .catch(() => null);
+          if (!member) {
+            // Member left the guild — mark as announced so we don't
+            // retry every tick, and skip.
+            row.lastAnnouncedYear = local.year;
+            await row.save();
+            continue;
+          }
+
+          const age =
+            typeof row.year === "number" ? local.year - row.year : null;
+          const content = renderBirthdayMessage(messageTemplate, {
+            userId: row.userId,
+            displayName: member.displayName,
+            age,
+          });
+
+          await channel.send({
+            content,
+            allowedMentions: mention ? { users: [row.userId] } : { parse: [] },
+          });
+          summary.announced += 1;
+
+          if (roleId) {
+            const granted = await this.grantBirthdayRole(member, roleId);
+            if (granted) {
+              row.roleAssignedAt = summary.ranAt;
+              summary.rolesGranted += 1;
+            }
+          }
+
+          row.lastAnnouncedYear = local.year;
+          await row.save();
+        } catch (error) {
+          summary.failed += 1;
+          logger.error(
+            `Error processing birthday for user ${sanitizeForLog(row.userId)}:`,
+            error,
+          );
+        }
+      }
+
+      logger.info(
+        `Birthday run complete: candidates=${summary.candidates} announced=${summary.announced} ` +
+          `roles_granted=${summary.rolesGranted} roles_removed=${summary.rolesRemoved} failed=${summary.failed}`,
+      );
+      await this.logSummary(summary);
+      return summary;
+    } finally {
+      this.isRunning = false;
+    }
+  }
+
+  /**
+   * Remove the temporary birthday role from every member whose grant has
+   * aged past `durationMs`. Durable across restarts because the grant
+   * time lives on the row, not in memory. Returns the count removed.
+   */
+  private async sweepExpiredRoles(
+    guild: Guild,
+    guildId: string,
+    roleId: string,
+    durationMs: number,
+    now: Date,
+  ): Promise<number> {
+    let removed = 0;
+    const expiredRows = await UserBirthday.find({
+      guildId,
+      roleAssignedAt: { $ne: null },
+    });
+    for (const row of expiredRows) {
+      if (!row.roleAssignedAt) continue;
+      if (now.getTime() - row.roleAssignedAt.getTime() < durationMs) continue;
+      try {
+        const member = await guild.members.fetch(row.userId).catch(() => null);
+        if (member && member.roles.cache.has(roleId)) {
+          await member.roles.remove(roleId, "Birthday role expired");
+          removed += 1;
+        }
+      } catch (error) {
+        logger.warn(
+          `Failed to remove expired birthday role from ${sanitizeForLog(row.userId)}:`,
+          error,
+        );
+      } finally {
+        // Clear the marker regardless: if the role is already gone or the
+        // member left, there's nothing more to sweep.
+        row.roleAssignedAt = undefined;
+        await row.save().catch(() => undefined);
+      }
+    }
+    return removed;
+  }
+
+  private async grantBirthdayRole(
+    member: {
+      roles: { add: (roleId: string, reason?: string) => Promise<unknown> };
+    },
+    roleId: string,
+  ): Promise<boolean> {
+    try {
+      await member.roles.add(roleId, "Birthday role");
+      return true;
+    } catch (error) {
+      logger.warn(`Failed to grant birthday role ${roleId}:`, error);
+      return false;
+    }
+  }
+
+  private async logSummary(summary: BirthdayRunSummary): Promise<void> {
+    // Nothing to report on an empty tick — birthdays are sparse and an
+    // hourly "0 announced" line would bury the cron channel.
+    if (summary.announced === 0 && summary.rolesRemoved === 0) return;
+    try {
+      const discordLogger = DiscordLogger.getInstance(this.client);
+      if (!discordLogger.isReady()) return;
+      const message =
+        `Announced: ${summary.announced} · roles granted: ${summary.rolesGranted} · ` +
+        `roles removed: ${summary.rolesRemoved} · failed: ${summary.failed}`;
+      await discordLogger.logCronSuccess("Birthdays", message);
+    } catch (error) {
+      logger.error("Birthdays: failed to post run summary to Discord:", error);
+    }
+  }
+
+  public async reload(): Promise<void> {
+    logger.info("Reloading birthday service...");
+    if (this.job) {
+      this.job.stop();
+      this.job = null;
+    }
+    this.isInitialized = false;
+    await this.start();
+  }
+
+  public destroy(): void {
+    if (this.job) {
+      this.job.stop();
+      this.job = null;
+    }
+    this.isInitialized = false;
+    logger.info("Birthday service destroyed");
+  }
+}

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -80,6 +80,15 @@ export interface ConfigSchema {
   "rewind.cron": string; // Cron schedule for the end-of-year DM nudge
   "rewind.min_minutes": number; // Min annual minutes to qualify for the nudge
 
+  // Birthdays (#657)
+  "birthdays.enabled": boolean;
+  "birthdays.cron": string; // Cron schedule for the birthday check (sub-daily)
+  "birthdays.channel_id": string; // Channel ID for birthday announcements
+  "birthdays.message": string; // Template; {user} mention, {username}, {age}
+  "birthdays.mention": boolean; // Whether the announcement pings the member
+  "birthdays.role_id": string; // Optional temporary "birthday" role
+  "birthdays.role_duration_hours": number; // How long the temp role is held
+
   // Reaction Roles
   "reactionroles.enabled": boolean;
   "reactionroles.message_channel_id": string; // Channel for reaction role messages
@@ -240,6 +249,19 @@ export const defaultConfig: ConfigSchema = {
   "rewind.nudge.enabled": false,
   "rewind.cron": "0 10 30 12 *", // Dec 30 at 10:00 in the host timezone
   "rewind.min_minutes": 60,
+
+  // Birthday defaults (#657). Master gate off, follows rule 1 — the
+  // hourly check does nothing until an operator opts in and points it at
+  // a channel. The hourly cadence (rather than once-daily) lets the post
+  // fire on each member's *local* day across timezones; the per-row
+  // `lastAnnouncedYear` guard keeps it to one announcement per year.
+  "birthdays.enabled": false,
+  "birthdays.cron": "0 * * * *", // Top of every hour (host timezone)
+  "birthdays.channel_id": "",
+  "birthdays.message": "🎂 Happy birthday, {user}! 🎉",
+  "birthdays.mention": true,
+  "birthdays.role_id": "", // Empty → no temporary role granted
+  "birthdays.role_duration_hours": 24,
 
   // Reaction Roles defaults
   "reactionroles.enabled": false,
@@ -478,6 +500,11 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
     title: "Rewind (Year-in-Review)",
     description:
       "Personalised end-of-year recap at /me/rewind plus a one-shot DM nudge in late December. Opt-out lives on the user's /me/notifications page.",
+  },
+  birthdays: {
+    title: "Birthdays",
+    description:
+      "Celebrate members' birthdays with a daily announcement in their own timezone, optionally granting a temporary birthday role. Members set their date on /me/birthday.",
   },
   reactionroles: {
     title: "Reaction Roles",
@@ -914,6 +941,54 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
   },
 
   // Reaction Roles
+  "birthdays.enabled": {
+    label: "Birthday celebrations enabled",
+    description:
+      "Post a birthday message in a configured channel on each member's birthday, evaluated in their own timezone. Members set their date on /me/birthday.",
+    category: "birthdays",
+    type: "boolean",
+  },
+  "birthdays.cron": {
+    label: "Birthday check schedule (cron)",
+    description:
+      "How often the birthday check runs. Hourly by default so the post lands on each member's local day across timezones — a once-daily schedule can miss members several hours ahead of or behind the host.",
+    category: "birthdays",
+    type: "cron",
+  },
+  "birthdays.channel_id": {
+    label: "Birthday announcement channel",
+    description: "Channel where birthday messages are posted.",
+    category: "birthdays",
+    type: "channel",
+  },
+  "birthdays.message": {
+    label: "Birthday message template",
+    description:
+      "Message posted on a member's birthday. Placeholders: {user} (mention), {username} (display name, no ping), {age} (blank when the member didn't share a birth year).",
+    category: "birthdays",
+    type: "string",
+  },
+  "birthdays.mention": {
+    label: "Ping the birthday member",
+    description:
+      "When on, the {user} placeholder pings the member. When off, their name shows but no notification is sent.",
+    category: "birthdays",
+    type: "boolean",
+  },
+  "birthdays.role_id": {
+    label: "Temporary birthday role",
+    description:
+      "Optional role granted on a member's birthday and removed automatically after the configured duration. Leave empty to skip the role.",
+    category: "birthdays",
+    type: "role",
+  },
+  "birthdays.role_duration_hours": {
+    label: "Birthday role duration (hours)",
+    description:
+      "How long the temporary birthday role is held before the daily sweep removes it.",
+    category: "birthdays",
+    type: "number",
+  },
   "reactionroles.enabled": {
     label: "Reaction roles enabled",
     description: "Enable the reaction-role system and the /reactrole command.",

--- a/src/web/user-layout.ts
+++ b/src/web/user-layout.ts
@@ -36,6 +36,7 @@ export const USER_NAV_ITEMS: UserNavItem[] = [
   { href: "/me/notifications", label: "Notifications" },
   { href: "/me/timezone", label: "Timezone" },
   { href: "/me/voice", label: "Voice", feature: "voice" },
+  { href: "/me/birthday", label: "Birthday" },
   { href: "/me/rewind", label: "Rewind", feature: "rewind" },
 ];
 
@@ -311,6 +312,8 @@ export function renderUserIndexBody(opts: {
     '<li><span class="feature-name"><a href="/me/timezone">Timezone</a></span>' +
       '<span class="feature-desc">Choose the timezone Koolbot uses when it shows you times in digests, Rewind, and voicestats.</span></li>',
     voiceCard,
+    '<li><span class="feature-name"><a href="/me/birthday">Birthday</a></span>' +
+      '<span class="feature-desc">Set your birthday (the year is optional) so Koolbot can celebrate it on the day — in your own timezone.</span></li>',
     rewindCard,
     "</ul>",
     "</div>",
@@ -598,6 +601,88 @@ export function renderUserRewindBody(opts: RewindBodyOptions): string {
     '<div class="card"><h2>Badges earned this year</h2>' +
       renderBadges([...opts.accolades, ...opts.achievements]) +
       "</div>",
+  ].join("");
+}
+
+// --------------------------------------------------------------------
+// Birthday page (#657)
+// --------------------------------------------------------------------
+
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+export interface BirthdayPageBodyOptions {
+  csrfToken: string;
+  /** Currently stored birthday, or null when none is set. */
+  selected: { month: number; day: number; year: number | null } | null;
+  /**
+   * Whether birthday announcements are enabled on the server. When off,
+   * the page still lets a member pre-set their date (mirroring how the
+   * notifications page exposes not-yet-active toggles) but shows a notice
+   * that nothing will be posted until an admin turns the feature on.
+   */
+  featureEnabled: boolean;
+}
+
+function renderMonthOptions(selected: number | null): string {
+  const blank = `<option value=""${selected === null ? " selected" : ""}>— Month —</option>`;
+  const months = MONTH_NAMES.map((name, i) => {
+    const value = i + 1;
+    const sel = value === selected ? " selected" : "";
+    return `<option value="${value}"${sel}>${escapeHtml(name)}</option>`;
+  }).join("");
+  return blank + months;
+}
+
+/**
+ * Inner HTML for `GET /me/birthday` (#657). Month dropdown + day/year
+ * number inputs, one POST. Year is optional (privacy): leave it blank to
+ * share the date without the age. A second "Remove" button clears the
+ * stored birthday.
+ */
+export function renderUserBirthdayBody(opts: BirthdayPageBodyOptions): string {
+  const month = opts.selected?.month ?? null;
+  const day = opts.selected?.day ?? null;
+  const year = opts.selected?.year ?? null;
+  const disabledNotice = opts.featureEnabled
+    ? ""
+    : "<div class=\"notice info\">Birthday announcements aren't enabled on this server yet, but you can set your date now — it'll be ready the moment an admin turns the feature on.</div>";
+  const hasBirthday = opts.selected !== null;
+  return [
+    "<h1>Birthday</h1>",
+    `<p class="subtitle">Set your birthday so Koolbot can celebrate it on the day — evaluated in your own timezone (set that on the <a href="/me/timezone">Timezone</a> page). The year is optional; leave it blank to share the date without your age.</p>`,
+    disabledNotice,
+    '<form method="POST" action="/me/birthday">',
+    `<input type="hidden" name="_csrf" value="${escapeHtml(opts.csrfToken)}">`,
+    '<div class="card">',
+    '<div style="display:flex;gap:.75rem;flex-wrap:wrap;align-items:flex-end">',
+    '<div><label for="bd-month"><strong>Month</strong></label>' +
+      `<div style="margin-top:.35rem"><select id="bd-month" name="month" class="tz-select" style="max-width:12rem">${renderMonthOptions(month)}</select></div></div>`,
+    '<div><label for="bd-day"><strong>Day</strong></label>' +
+      `<div style="margin-top:.35rem"><input id="bd-day" name="day" type="number" min="1" max="31" class="tz-select" style="max-width:6rem" value="${day ?? ""}"></div></div>`,
+    '<div><label for="bd-year"><strong>Year</strong> <span class="muted">(optional)</span></label>' +
+      `<div style="margin-top:.35rem"><input id="bd-year" name="year" type="number" min="1900" placeholder="—" class="tz-select" style="max-width:8rem" value="${year ?? ""}"></div></div>`,
+    "</div>",
+    '<div class="form-actions">',
+    '<button class="btn" type="submit">Save birthday</button>',
+    hasBirthday
+      ? '<button class="btn" type="submit" name="clear" value="1" style="background:#4b5563">Remove my birthday</button>'
+      : "",
+    "</div>",
+    "</div>",
+    "</form>",
   ].join("");
 }
 

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -634,14 +634,13 @@ export function createUserRouter(
       const service = BirthdayService.getInstance(client);
       const before = await service.getBirthday(userId, guildId);
 
-      // A "Remove" submit (its button posts `clear`) or an empty month
-      // field clears the stored date.
+      // Clearing is only ever the explicit "Remove" button (which posts
+      // `clear`). A plain "Save" with no month/day is a validation error,
+      // not a silent delete of an existing birthday.
       const month = parseIntField(body.month);
       const day = parseIntField(body.day);
       const year = parseIntField(body.year);
-      const clearing =
-        (typeof body.clear === "string" && body.clear.length > 0) ||
-        month === null;
+      const clearing = typeof body.clear === "string" && body.clear.length > 0;
 
       let result: "success" | "failure" = "success";
       let errorMessage: string | null = null;
@@ -649,10 +648,12 @@ export function createUserRouter(
       try {
         if (clearing) {
           after = await service.setBirthday(userId, guildId, null);
+        } else if (month === null || day === null) {
+          throw new Error("Please choose a month and enter a day.");
         } else {
           after = await service.setBirthday(userId, guildId, {
-            month: month as number,
-            day: day ?? Number.NaN,
+            month,
+            day,
             year,
           });
         }

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -34,6 +34,7 @@ import {
 } from "./session.js";
 import { getDisplayedRemainingMs } from "./admin-layout.js";
 import {
+  renderUserBirthdayBody,
   renderUserIndexBody,
   renderUserNotificationsBody,
   renderUserPage,
@@ -43,6 +44,7 @@ import {
   type UserFlashMessage,
   type VoicePresetView,
 } from "./user-layout.js";
+import { BirthdayService } from "../services/birthday-service.js";
 import {
   UserVoicePrefsService,
   VoicePrefsValidationError,
@@ -214,6 +216,15 @@ async function isVoicePresetsEnabled(): Promise<boolean> {
 }
 
 /**
+ * Whether birthday celebrations are enabled (#657). Used only to soften
+ * the `/me/birthday` page copy — the page stays reachable either way so
+ * members can pre-set their date before an admin flips the feature on.
+ */
+async function isBirthdayFeatureEnabled(): Promise<boolean> {
+  return ConfigService.getInstance().getBoolean("birthdays.enabled", false);
+}
+
+/**
  * Resolve the session user's display name for the name-pattern preview.
  * Best-effort: falls back to the raw user id when the member can't be
  * fetched (e.g. left the guild), so the page still renders.
@@ -244,6 +255,18 @@ function parseOptionalInt(raw: unknown): number | undefined {
   if (trimmed.length === 0) return undefined;
   const n = Number(trimmed);
   return Number.isInteger(n) ? n : NaN;
+}
+
+/**
+ * Parse an optional integer field from a posted form. Returns `null` for
+ * blank/absent values and `NaN` for non-numeric junk so the caller can
+ * tell "not provided" from "provided but invalid".
+ */
+function parseIntField(raw: unknown): number | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (trimmed === "") return null;
+  return Number.parseInt(trimmed, 10);
 }
 
 function toPresetViews(
@@ -553,6 +576,120 @@ export function createUserRouter(
         flash = { type: "ok", text: `Saved your timezone as ${after}.` };
       }
       res.redirect(303, flashUrl("/me/timezone", flash));
+    }),
+  );
+
+  // ---------- Birthday (#657) ----------
+  router.get(
+    "/birthday",
+    asyncHandler(async (req, res) => {
+      const session = req.webSession;
+      if (!session) {
+        res.status(500).type("text/plain").send("session missing");
+        return;
+      }
+      const { userId, guildId } = assertSelfScope(session, {
+        userId: session.discordUserId,
+        guildId: session.guildId,
+      });
+      const selected = await BirthdayService.getInstance(client).getBirthday(
+        userId,
+        guildId,
+      );
+      const flash = readFlashFromQuery(req);
+      res.type("text/html").send(
+        renderUserPage({
+          title: "Birthday",
+          active: "/me/birthday",
+          body: renderUserBirthdayBody({
+            csrfToken: getCsrfToken(req),
+            selected,
+            featureEnabled: await isBirthdayFeatureEnabled(),
+          }),
+          csrfToken: getCsrfToken(req),
+          remainingMs: getDisplayedRemainingMs(session),
+          isAdmin: session.role === "admin",
+          flash,
+          rewindEnabled: await isRewindFeatureEnabled(),
+        }),
+      );
+    }),
+  );
+
+  router.post(
+    "/birthday",
+    requireCsrf,
+    asyncHandler(async (req, res) => {
+      const session = req.webSession;
+      if (!session) {
+        res.status(500).type("text/plain").send("session missing");
+        return;
+      }
+      const { userId, guildId } = assertSelfScope(session, {
+        userId: session.discordUserId,
+        guildId: session.guildId,
+      });
+
+      const body = (req.body as Record<string, unknown> | undefined) ?? {};
+      const service = BirthdayService.getInstance(client);
+      const before = await service.getBirthday(userId, guildId);
+
+      // A "Remove" submit (its button posts `clear`) or an empty month
+      // field clears the stored date.
+      const month = parseIntField(body.month);
+      const day = parseIntField(body.day);
+      const year = parseIntField(body.year);
+      const clearing =
+        (typeof body.clear === "string" && body.clear.length > 0) ||
+        month === null;
+
+      let result: "success" | "failure" = "success";
+      let errorMessage: string | null = null;
+      let after = before;
+      try {
+        if (clearing) {
+          after = await service.setBirthday(userId, guildId, null);
+        } else {
+          after = await service.setBirthday(userId, guildId, {
+            month: month as number,
+            day: day ?? Number.NaN,
+            year,
+          });
+        }
+      } catch (err) {
+        result = "failure";
+        errorMessage = err instanceof Error ? err.message : String(err);
+        logger.error(
+          `Failed to save birthday: ${sanitizeForLog(errorMessage)}`,
+        );
+      }
+
+      await recordAudit(session, {
+        action: "user.birthday.set",
+        targetId: userId,
+        details:
+          result === "success"
+            ? { before, after }
+            : { attempted: { month, day, year } },
+        result,
+        errorMessage,
+      });
+
+      let flash: UserFlashMessage;
+      if (result === "failure") {
+        flash = {
+          type: "err",
+          text: `Could not save your birthday: ${errorMessage ?? "unknown error"}.`,
+        };
+      } else if (after === null) {
+        flash = { type: "ok", text: "Removed your birthday." };
+      } else {
+        flash = {
+          type: "ok",
+          text: `Saved your birthday as ${after.month}/${after.day}${after.year ? `/${after.year}` : ""}.`,
+        };
+      }
+      res.redirect(303, flashUrl("/me/birthday", flash));
     }),
   );
 


### PR DESCRIPTION
## Summary

Implements **Part 1 (Birthdays)** of #657 — an opt-in feature that celebrates members' birthdays in a configured channel, evaluated in **each member's own timezone**, optionally granting a temporary "birthday" role.

Per the issue's suggestion to ship the two parts separately, **Part 2 (marquee accolade "milestone" celebrations)** is intentionally left for a follow-up PR — it touches the achievements award path and is best reviewed on its own.

## What's included

- **`src/models/user-birthday.ts`** — greenfield model keyed per `(userId, guildId)`: `{ month, day, year?, lastAnnouncedYear?, roleAssignedAt? }`. The year is **optional** (privacy — share the date without the age). `lastAnnouncedYear` (the member's *local* year) is the idempotency guard; `roleAssignedAt` is persisted so the temp role is revoked even across a restart.
- **`src/services/birthday-service.ts`** — mirrors the `DigestService` cron lifecycle: stored interval handle, per-tick error isolation (never crashes the process), reload callback gated on `birthdays.enabled`, and `runNow` coalescing. Runs hourly by default so the post lands on each member's local day across timezones; the per-row guard keeps it to one announcement per year. Feb 29 birthdays are celebrated on Mar 1 in non-leap years.
- **`/me/birthday` self-service page** (`src/web/user-routes.ts` + `user-layout.ts`) — set/clear a birthday with the same self-scope, CSRF, audit-log, and PRG-flash patterns as `/me/timezone`. The page stays reachable when the feature is off (shows an informational notice) so members can pre-set their date.
- **Config** (`config-schema.ts`) — `birthdays.{enabled,cron,channel_id,message,mention,role_id,role_duration_hours}` with WebUI metadata and a new `birthdays` category (also registered in the `Config` model enum). All gated behind `birthdays.enabled` (default `false`).
- **Docs** — `SETTINGS.md` and `WEBUI.md` updated.
- **Service wiring** — `src/index.ts` (instantiate, `start()`, `destroy()` on shutdown).

## Acceptance criteria (Part 1)

- [x] Members set a birthday (month/day, optional year) from `/me/`, stored per `(userId, guildId)`.
- [x] A recurring cron announces birthdays in the configured channel, evaluated in each member's timezone, idempotent across restarts.
- [x] Optional temporary birthday role granted and auto-removed.
- [x] All behaviour gated behind `birthdays.enabled` (default false); keys documented in `SETTINGS.md`, surface in `WEBUI.md`.
- [x] Unit tests: timezone "is it today" logic + double-announce guard (the milestone branch lands with Part 2).

## Testing

- `npm run check:all` (build + lint + format + tests) passes.
- New `__tests__/services/birthday-service.test.ts` (28 tests) covers the timezone "is it today" logic across zones, the Feb-29 fallback, the double-announce guard, message templating, storage validation, and lifecycle/gating.

## Notes / out of scope

- **Part 2** (milestone celebrations) — separate PR, as the issue suggests.
- Join-anniversary announcements (mentioned as optional in the issue) are not included here; they can extend the same model/service later.
- Wiring into the `/setup wizard` could be a follow-up; for now the multi-setting feature is configured via the Settings page.

Closes part 1 of #657.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSCU3YDEfZWQM6zvT5yEmQ)_