### PR TITLE
feat(scripts): add sample-data seeder for dev/test databases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,9 @@ npx markdownlint "**/*.md" --ignore node_modules --ignore dist
 ```
 
 Operational scripts (run against compiled output in `dist/`, so `npm run build` first): `validate-config`,
-`migrate-config`, `cleanup-global-commands`, `unregister-guild-commands`.
+`migrate-config`, `cleanup-global-commands`, `unregister-guild-commands`, `seed-sample-data` (dev/test only —
+populates a non-prod DB with deterministic fake activity; guarded by `--yes`, namespaced behind a `seed-` id
+prefix so `--clean` removes only seeded rows; see `DEVELOPER_GUIDE.md`).
 
 ## Architecture
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -12,6 +12,7 @@ Complete guide for developers extending or maintaining KoolBot.
   - [Service Singleton Pattern](#service-singleton-pattern)
   - [Configuration Management](#configuration-management)
 - [Adding New Features](#adding-new-features)
+- [Operational Scripts](#operational-scripts)
 - [Testing Guidelines](#testing-guidelines)
 - [Code Style](#code-style)
 - [Dependency Notes](#dependency-notes)
@@ -665,6 +666,81 @@ discovers settings from `defaultConfig` automatically.
    - [ ] Update `WEBUI.md` if you added a new page or env var
    - [ ] Update `.env.example` if you added a bootstrap env var
    - [ ] Add to `DEVELOPER_GUIDE.md` if you established a reusable pattern
+
+---
+
+## Operational Scripts
+
+These are one-shot maintenance tools in `src/scripts/`, not runtime services or
+Discord commands. They run against **compiled** output, so build first:
+
+```bash
+npm run build
+npm run validate-config        # check required config is present
+npm run migrate-config         # migrate legacy config keys
+npm run seed-sample-data -- --yes   # populate a dev DB with fake activity
+```
+
+### Sample-data seeder (`seed-sample-data`)
+
+`src/scripts/seed-sample-data.ts` populates a **non-production** MongoDB with
+realistic, deterministic fake users and a year's worth of activity so the
+data-heavy surfaces — Rewind / year-in-review, leaderboards, weekly digests,
+achievements, `/stats`, and the WebUI stats pages — can be exercised locally
+without waiting for a real server to accumulate history (#667).
+
+It writes to `VoiceChannelTracking`, `MessageActivityTracking`,
+`UserAchievements`, `ReactionActivityTracking`, `PollParticipationTracking`,
+`UserNotificationPrefs` (carries the timezone for #524) and
+`UserVoicePreferences`.
+
+**Safety model:**
+
+- Every seeded document uses a fake `userId` under a fixed prefix (`seed-`), so
+  `--clean` removes **only** seeded rows and never touches real records.
+- The script **refuses to run without `--yes`** and loudly logs the target URI
+  (password redacted) and database name before any write.
+- Re-runs are **idempotent** (upsert by the deterministic fake ids) and
+  **reproducible** given a fixed `--seed`.
+
+**Options** (all optional; flags take precedence over env vars):
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--yes` | *required* | Explicit opt-in; nothing is written without it. |
+| `--users <n>` | `10` | Number of fake users to generate. |
+| `--seed <n>` | `1337` | RNG seed for reproducible runs. |
+| `--years <n>` | — | Span the history over the last *n* years. |
+| `--from <ISO>` / `--to <ISO>` | current year → now | Explicit date span. |
+| `--guild <id>` | `GUILD_ID` | Guild id for per-guild documents. |
+| `--clean` | — | Remove only previously-seeded data, then exit. |
+
+```bash
+npm run build
+npm run seed-sample-data -- --users 25 --years 1 --seed 42 --yes   # seed
+npm run seed-sample-data -- --clean --yes                          # tidy up
+```
+
+#### Seeding via Docker
+
+The seeder is a dev-only tool, so run it from the **dev** compose stack
+(`docker-compose.dev.yml`), which builds the dev image with devDependencies
+(including `@faker-js/faker`) and mounts the source tree:
+
+```bash
+# Bring up the dev stack (bot + a host-reachable MongoDB)
+docker compose -f docker-compose.dev.yml up -d
+
+# Build once, then seed (the dev container has devDeps + the mounted source)
+docker compose -f docker-compose.dev.yml exec koolbot npm run build
+docker compose -f docker-compose.dev.yml exec koolbot npm run seed-sample-data -- --users 25 --yes
+
+# Remove only the seeded data later
+docker compose -f docker-compose.dev.yml exec koolbot npm run seed-sample-data -- --clean --yes
+```
+
+The production `docker-compose.yml` image prunes devDependencies and is **not**
+intended for seeding — keep sample data out of production.
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -26,8 +26,29 @@ Tests are located in the `__tests__` directory, organized by module:
 __tests__/
 ├── commands/       # Tests for Discord slash commands
 ├── services/       # Tests for business logic services
+├── scripts/        # Tests for operational scripts (src/scripts/)
 └── utils/          # Tests for utility functions
 ```
+
+### Generating sample data for manual testing
+
+To exercise the data-heavy surfaces (Rewind, leaderboards, digests,
+achievements, `/stats`, the WebUI stats pages) without waiting for real
+activity, seed a **dev/test** database:
+
+```bash
+npm run build
+npm run seed-sample-data -- --yes
+# tidy up afterwards (removes only seeded rows):
+npm run seed-sample-data -- --clean --yes
+```
+
+The seeder refuses to run without `--yes`, namespaces everything behind a
+`seed-` id prefix, and is deterministic given a fixed `--seed`. See
+[Operational Scripts](DEVELOPER_GUIDE.md#operational-scripts) for the full
+option list and the Docker recipe. Its pure data-generation helpers are
+covered by `__tests__/scripts/seed-sample-data.test.ts` (the global mongoose
+mock keeps the DB out of the unit tests).
 
 ## Writing Tests
 

--- a/__tests__/scripts/seed-sample-data.test.ts
+++ b/__tests__/scripts/seed-sample-data.test.ts
@@ -92,12 +92,64 @@ describe("seed-sample-data helpers", () => {
     expect(doc.yearlyTotals.some((y) => y.year === "2026")).toBe(true);
   });
 
-  it("uses real accolade type keys from src/content", () => {
+  it("never lets a session run past the end of the span", () => {
+    // A short window: most random durations would overshoot without clamping.
+    const ds = generateSampleDataset({
+      ...baseOptions,
+      from: new Date("2026-05-30T00:00:00Z"),
+      to: new Date("2026-06-01T00:00:00Z"),
+    });
+    for (const doc of ds.voiceTracking) {
+      for (const s of doc.sessions) {
+        expect(s.endTime.getTime()).toBeLessThanOrEqual(
+          new Date("2026-06-01T00:00:00Z").getTime(),
+        );
+        expect(s.duration).toBeGreaterThanOrEqual(1);
+        for (const c of s.companions) {
+          expect(c.seconds).toBeLessThanOrEqual(s.duration);
+        }
+      }
+    }
+  });
+
+  it("gives shared voice channels stable ids shared across users", () => {
+    const ds = generateSampleDataset(baseOptions);
+    const sharedIds = new Set<string>();
+    const personalIds = new Set<string>();
+    for (const doc of ds.voiceTracking) {
+      for (const s of doc.sessions) {
+        if (s.channelId.startsWith("seed-vc-shared-"))
+          sharedIds.add(s.channelId);
+        if (s.channelId.startsWith("seed-vc-personal-"))
+          personalIds.add(s.channelId);
+        // No personal room ever collapses to the buggy "seed-vc-0-*" form.
+        expect(s.channelId).not.toMatch(/^seed-vc-0-/);
+      }
+    }
+    // Shared channel ids carry no user suffix, so the pool is small and reused.
+    expect(sharedIds.size).toBeLessThanOrEqual(5);
+    // Personal rooms are per-user, so there are several distinct ids.
+    expect(personalIds.size).toBeGreaterThan(1);
+  });
+
+  it("uses real, renderable accolade and achievement type keys from src/content", async () => {
+    const { ACCOLADE_METADATA } =
+      await import("../../src/content/accolades.js");
+    const { ACHIEVEMENT_METADATA } =
+      await import("../../src/content/achievements.js");
+    const validAccolades = new Set(Object.keys(ACCOLADE_METADATA));
+    const validAchievements = new Set(Object.keys(ACHIEVEMENT_METADATA));
+
     const ds = generateSampleDataset(baseOptions);
     const doc = ds.achievements[0];
     expect(doc.accolades.length).toBeGreaterThan(0);
     expect(doc.statistics.totalAccolades).toBe(doc.accolades.length);
     expect(doc.statistics.totalAchievements).toBe(doc.achievements.length);
+    // Every seeded type has display metadata, so Rewind/digest will render it.
+    expect(doc.accolades.every((a) => validAccolades.has(a.type))).toBe(true);
+    expect(doc.achievements.every((a) => validAchievements.has(a.type))).toBe(
+      true,
+    );
   });
 
   it("builds per-year reaction and poll buckets that sum to the totals", () => {
@@ -157,5 +209,21 @@ describe("parseOptions", () => {
     expect(() =>
       parseOptions(["--from", "2026-12-31", "--to", "2026-01-01"]),
     ).toThrow();
+  });
+
+  it("fails fast on non-numeric --users / --seed / --years", () => {
+    expect(() => parseOptions(["--users", "foo", "--guild", "g"])).toThrow(
+      /users/,
+    );
+    expect(() => parseOptions(["--seed", "bar", "--guild", "g"])).toThrow(
+      /seed/,
+    );
+    expect(() => parseOptions(["--years", "baz", "--guild", "g"])).toThrow(
+      /years/,
+    );
+  });
+
+  it("rejects a non-positive --years", () => {
+    expect(() => parseOptions(["--years", "0", "--guild", "g"])).toThrow();
   });
 });

--- a/__tests__/scripts/seed-sample-data.test.ts
+++ b/__tests__/scripts/seed-sample-data.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  SEED_USER_PREFIX,
+  seedUserId,
+  redactUri,
+  buildIdentities,
+  generateSampleDataset,
+  parseOptions,
+  type SeedOptions,
+} from "../../src/scripts/seed-sample-data.js";
+
+// Pure-helper coverage for the sample-data seeder (#667). The script's DB
+// writes go through the globally-mocked mongoose (see __tests__/setup.ts), so
+// these tests focus on the deterministic data-generation helpers per
+// TESTING.md.
+
+const baseOptions: SeedOptions = {
+  users: 3,
+  guildId: "guild-123",
+  seed: 42,
+  from: new Date("2026-01-01T00:00:00Z"),
+  to: new Date("2026-06-01T00:00:00Z"),
+};
+
+describe("seed-sample-data helpers", () => {
+  it("namespaces every fake user id behind the seed prefix", () => {
+    const id = seedUserId(7);
+    expect(id.startsWith(SEED_USER_PREFIX)).toBe(true);
+    expect(id).toBe("seed-0007");
+  });
+
+  it("redacts the password embedded in a mongodb URI", () => {
+    expect(redactUri("mongodb://user:s3cret@host:27017/db")).toBe(
+      "mongodb://user:***@host:27017/db",
+    );
+    // URIs without credentials are returned unchanged.
+    expect(redactUri("mongodb://mongodb:27017/koolbot")).toBe(
+      "mongodb://mongodb:27017/koolbot",
+    );
+  });
+
+  it("builds the requested number of distinct prefixed identities", () => {
+    const identities = buildIdentities(5);
+    expect(identities).toHaveLength(5);
+    expect(new Set(identities.map((i) => i.userId)).size).toBe(5);
+    expect(identities.every((i) => i.userId.startsWith(SEED_USER_PREFIX))).toBe(
+      true,
+    );
+    expect(identities.every((i) => i.username.length > 0)).toBe(true);
+  });
+
+  it("is deterministic given a fixed seed and span", () => {
+    const a = generateSampleDataset(baseOptions);
+    const b = generateSampleDataset(baseOptions);
+    expect(JSON.stringify(b)).toEqual(JSON.stringify(a));
+  });
+
+  it("produces different data for a different seed", () => {
+    const a = generateSampleDataset(baseOptions);
+    const b = generateSampleDataset({ ...baseOptions, seed: 999 });
+    expect(JSON.stringify(b)).not.toEqual(JSON.stringify(a));
+  });
+
+  it("populates every targeted surface for each user", () => {
+    const ds = generateSampleDataset(baseOptions);
+    expect(ds.identities).toHaveLength(3);
+    expect(ds.voiceTracking).toHaveLength(3);
+    expect(ds.messageActivity).toHaveLength(3);
+    expect(ds.achievements).toHaveLength(3);
+    expect(ds.reactions).toHaveLength(3);
+    expect(ds.polls).toHaveLength(3);
+    expect(ds.notificationPrefs).toHaveLength(3);
+    expect(ds.voicePreferences).toHaveLength(3);
+  });
+
+  it("spreads voice sessions inside the requested date range with companions", () => {
+    const ds = generateSampleDataset(baseOptions);
+    const doc = ds.voiceTracking[0];
+    expect(doc.sessions.length).toBeGreaterThan(0);
+    for (const s of doc.sessions) {
+      expect(s.startTime.getTime()).toBeGreaterThanOrEqual(
+        baseOptions.from.getTime(),
+      );
+      expect(s.endTime.getTime()).toBeGreaterThanOrEqual(s.startTime.getTime());
+      // otherUsers reference other seeded users, never the user itself.
+      expect(s.otherUsers).not.toContain(doc.userId);
+    }
+    // totalTime equals the sum of session durations.
+    const sum = doc.sessions.reduce((acc, s) => acc + s.duration, 0);
+    expect(doc.totalTime).toBe(sum);
+    // Yearly totals cover 2026.
+    expect(doc.yearlyTotals.some((y) => y.year === "2026")).toBe(true);
+  });
+
+  it("uses real accolade type keys from src/content", () => {
+    const ds = generateSampleDataset(baseOptions);
+    const doc = ds.achievements[0];
+    expect(doc.accolades.length).toBeGreaterThan(0);
+    expect(doc.statistics.totalAccolades).toBe(doc.accolades.length);
+    expect(doc.statistics.totalAchievements).toBe(doc.achievements.length);
+  });
+
+  it("builds per-year reaction and poll buckets that sum to the totals", () => {
+    const ds = generateSampleDataset(baseOptions);
+    const r = ds.reactions[0];
+    expect(r.yearlyGiven["2026"]).toBeGreaterThanOrEqual(0);
+    const given = Object.values(r.yearlyGiven).reduce((a, c) => a + c, 0);
+    expect(r.totalGiven).toBe(given);
+
+    const p = ds.polls[0];
+    const votes = Object.values(p.yearlyVotes).reduce((a, c) => a + c, 0);
+    expect(p.totalVotes).toBe(votes);
+  });
+});
+
+describe("parseOptions", () => {
+  it("applies defaults and the current-year span when no flags are given", () => {
+    const opts = parseOptions(["--guild", "g1"]);
+    expect(opts.users).toBe(10);
+    expect(opts.seed).toBe(1337);
+    expect(opts.guildId).toBe("g1");
+    expect(opts.yes).toBe(false);
+    expect(opts.clean).toBe(false);
+    expect(opts.from.getUTCFullYear()).toBe(new Date().getUTCFullYear());
+  });
+
+  it("parses explicit users, seed, span and flags", () => {
+    const opts = parseOptions([
+      "--users",
+      "25",
+      "--seed",
+      "7",
+      "--from",
+      "2024-01-01",
+      "--to",
+      "2024-12-31",
+      "--guild",
+      "g2",
+      "--yes",
+      "--clean",
+    ]);
+    expect(opts.users).toBe(25);
+    expect(opts.seed).toBe(7);
+    expect(opts.from.getUTCFullYear()).toBe(2024);
+    expect(opts.to.getUTCFullYear()).toBe(2024);
+    expect(opts.yes).toBe(true);
+    expect(opts.clean).toBe(true);
+  });
+
+  it("derives the span from --years", () => {
+    const opts = parseOptions(["--years", "2", "--guild", "g3"]);
+    const span = opts.to.getUTCFullYear() - opts.from.getUTCFullYear();
+    expect(span).toBe(2);
+  });
+
+  it("rejects an inverted date range", () => {
+    expect(() =>
+      parseOptions(["--from", "2026-12-31", "--to", "2026-01-01"]),
+    ).toThrow();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
+        "@faker-js/faker": "^10.5.0",
         "@jest/globals": "^30.4.1",
         "@types/express": "^5.0.6",
         "@types/jest": "^30.0.0",
@@ -891,6 +892,23 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.5.0.tgz",
+      "integrity": "sha512-bsxD8WLS5lIj7aaoCx1YJkktqYj5vlBUE6HWzu2Q51ksrGJ0H737ECCKlFU7Yf8Br45z9t99frBp/J7kzbMPAg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "cleanup-global-commands": "node dist/scripts/cleanup-global-commands.js",
     "migrate-config": "node dist/scripts/migrate-config.js",
     "validate-config": "node dist/scripts/validate-config.js",
+    "seed-sample-data": "node dist/scripts/seed-sample-data.js",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch",
     "test:coverage": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage",
@@ -42,6 +43,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
+    "@faker-js/faker": "^10.5.0",
     "@jest/globals": "^30.4.1",
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",

--- a/src/scripts/seed-sample-data.ts
+++ b/src/scripts/seed-sample-data.ts
@@ -35,6 +35,7 @@ import { PollParticipationTracking } from "../models/poll-participation-tracking
 import { UserNotificationPrefs } from "../models/user-notification-prefs.js";
 import { UserVoicePreferences } from "../models/user-voice-preferences.js";
 import { ACCOLADE_METADATA } from "../content/accolades.js";
+import { ACHIEVEMENT_METADATA } from "../content/achievements.js";
 
 // All seeded fake users share this id prefix. `--clean` matches on it, so it
 // must be something a real Discord snowflake (a numeric string) can never be.
@@ -42,17 +43,6 @@ export const SEED_USER_PREFIX = "seed-";
 
 const DEFAULT_USERS = 10;
 const DEFAULT_SEED = 1337;
-
-// Time-based achievement ids (the `AchievementType` union in
-// `src/content/achievements.ts`). Only `type` is needed at the model level.
-const ACHIEVEMENT_TYPES = [
-  "weekly_champion",
-  "weekly_night_owl",
-  "weekly_marathon",
-  "weekly_social_butterfly",
-  "weekly_active",
-  "weekly_consistent",
-] as const;
 
 // A small pool of IANA zones so timezone-aware bucketing (#524) has something
 // to exercise. `undefined` means "use the server timezone".
@@ -290,15 +280,27 @@ export function generateVoiceTracking(
   const sessions: SeededSession[] = [];
   for (let i = 0; i < sessionCount; i++) {
     const startTime = faker.date.between({ from: opts.from, to: opts.to });
-    // Weighted toward shorter sessions, with the occasional marathon.
-    const duration = faker.number.int({ min: 5 * 60, max: 5 * 60 * 60 });
+    // Weighted toward shorter sessions, with the occasional marathon, but
+    // clamped so the session never runs past the end of the requested span.
+    const rawDuration = faker.number.int({ min: 5 * 60, max: 5 * 60 * 60 });
+    const maxDuration = Math.floor(
+      (opts.to.getTime() - startTime.getTime()) / 1000,
+    );
+    const duration = Math.max(1, Math.min(rawDuration, maxDuration));
     const endTime = new Date(startTime.getTime() + duration * 1000);
     const channelName = faker.helpers.arrayElement(channelPool);
-    const channelId = `seed-vc-${SHARED_VOICE_CHANNELS.indexOf(channelName) + 1}-${identity.userId}`;
+    // Shared channels get a stable id (no user suffix) so they are genuinely
+    // shared across users — companions/overlap stats cluster on them. The
+    // personal room gets a per-user id.
+    const sharedIdx = SHARED_VOICE_CHANNELS.indexOf(channelName);
+    const channelId =
+      sharedIdx === -1
+        ? `seed-vc-personal-${identity.userId}`
+        : `seed-vc-shared-${sharedIdx}`;
     const others = pickSome(otherUserIds, faker.number.int({ min: 0, max: 4 }));
     const companions = others.map((userId) => ({
       userId,
-      seconds: faker.number.int({ min: 60, max: duration }),
+      seconds: faker.number.int({ min: Math.min(60, duration), max: duration }),
     }));
 
     sessions.push({
@@ -404,8 +406,12 @@ export function generateUserAchievements(
     };
   });
 
+  // Only sample achievement ids that have display metadata — Rewind and the
+  // digest skip entries without it (see `rewind-service.ts` lookupAchievement),
+  // so reserved-but-unimplemented ids would never render for seeded users.
+  const achievementKeys = Object.keys(ACHIEVEMENT_METADATA);
   const chosenAchievements = pickSome(
-    [...ACHIEVEMENT_TYPES],
+    achievementKeys,
     faker.number.int({ min: 1, max: 5 }),
   );
   const achievements = chosenAchievements.map((type) => {
@@ -649,6 +655,19 @@ interface ParsedOptions extends SeedOptions {
   yes: boolean;
 }
 
+/** Parse a numeric flag, throwing a clear error when it isn't a valid number. */
+function numericFlag(
+  name: string,
+  raw: string | undefined,
+): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) {
+    throw new Error(`--${name} must be a valid number (got "${raw}")`);
+  }
+  return n;
+}
+
 /** Parse CLI flags / env vars into resolved options. Pure (no DB / no exit). */
 export function parseOptions(argv: string[]): ParsedOptions {
   const { values } = parseArgs({
@@ -666,6 +685,10 @@ export function parseOptions(argv: string[]): ParsedOptions {
     allowPositionals: false,
   });
 
+  const usersFlag = numericFlag("users", values.users);
+  const seedFlag = numericFlag("seed", values.seed);
+  const yearsFlag = numericFlag("years", values.years);
+
   const now = new Date();
   let from: Date;
   let to: Date = now;
@@ -675,10 +698,12 @@ export function parseOptions(argv: string[]): ParsedOptions {
       ? new Date(values.from)
       : new Date(Date.UTC(now.getUTCFullYear(), 0, 1));
     to = values.to ? new Date(values.to) : now;
-  } else if (values.years) {
-    const years = Number(values.years);
+  } else if (yearsFlag !== undefined) {
+    if (yearsFlag <= 0) {
+      throw new Error("--years must be greater than 0");
+    }
     from = new Date(now);
-    from.setUTCFullYear(from.getUTCFullYear() - years);
+    from.setUTCFullYear(from.getUTCFullYear() - yearsFlag);
   } else {
     // Default span: the current calendar year so far.
     from = new Date(Date.UTC(now.getUTCFullYear(), 0, 1));
@@ -694,9 +719,12 @@ export function parseOptions(argv: string[]): ParsedOptions {
   const guildId = values.guild ?? env.guildId ?? "";
 
   return {
-    users: values.users ? Math.max(1, Number(values.users)) : DEFAULT_USERS,
+    users:
+      usersFlag !== undefined
+        ? Math.max(1, Math.floor(usersFlag))
+        : DEFAULT_USERS,
     guildId,
-    seed: values.seed ? Number(values.seed) : DEFAULT_SEED,
+    seed: seedFlag !== undefined ? Math.floor(seedFlag) : DEFAULT_SEED,
     from,
     to,
     clean: values.clean,

--- a/src/scripts/seed-sample-data.ts
+++ b/src/scripts/seed-sample-data.ts
@@ -1,0 +1,787 @@
+/**
+ * Sample-data seeder (dev/test only).
+ *
+ * Populates a NON-PRODUCTION MongoDB with realistic, deterministic fake users
+ * and a year's worth of activity so the data-heavy surfaces — Rewind /
+ * year-in-review, leaderboards, weekly digests, achievements, `/stats` and the
+ * WebUI stats pages — can be exercised locally without waiting for a real
+ * Discord server to accumulate history. See issue #667.
+ *
+ * This is an operational script in the same family as `validate-config` /
+ * `migrate-config`: it is NOT a Discord command or a config-gated runtime
+ * service. Run it against compiled output (`npm run build` first):
+ *
+ *   npm run seed-sample-data -- --yes               # seed defaults (~10 users)
+ *   npm run seed-sample-data -- --users 25 --yes    # more users
+ *   npm run seed-sample-data -- --seed 42 --yes     # reproducible run
+ *   npm run seed-sample-data -- --clean --yes       # remove ONLY seeded data
+ *
+ * Safety: every seeded document is namespaced behind a fixed fake-user-id
+ * prefix (`seed-`), so `--clean` removes exactly the seeded rows and never
+ * touches real records. The script refuses to write anything without the
+ * explicit `--yes` opt-in, and loudly logs the target database before any
+ * write.
+ */
+import { parseArgs } from "node:util";
+import mongoose from "mongoose";
+import { faker } from "@faker-js/faker";
+import { env } from "../config/env.js";
+import logger from "../utils/logger.js";
+import { VoiceChannelTracking } from "../models/voice-channel-tracking.js";
+import { MessageActivityTracking } from "../models/message-activity-tracking.js";
+import { UserAchievements } from "../models/user-achievements.js";
+import { ReactionActivityTracking } from "../models/reaction-activity-tracking.js";
+import { PollParticipationTracking } from "../models/poll-participation-tracking.js";
+import { UserNotificationPrefs } from "../models/user-notification-prefs.js";
+import { UserVoicePreferences } from "../models/user-voice-preferences.js";
+import { ACCOLADE_METADATA } from "../content/accolades.js";
+
+// All seeded fake users share this id prefix. `--clean` matches on it, so it
+// must be something a real Discord snowflake (a numeric string) can never be.
+export const SEED_USER_PREFIX = "seed-";
+
+const DEFAULT_USERS = 10;
+const DEFAULT_SEED = 1337;
+
+// Time-based achievement ids (the `AchievementType` union in
+// `src/content/achievements.ts`). Only `type` is needed at the model level.
+const ACHIEVEMENT_TYPES = [
+  "weekly_champion",
+  "weekly_night_owl",
+  "weekly_marathon",
+  "weekly_social_butterfly",
+  "weekly_active",
+  "weekly_consistent",
+] as const;
+
+// A small pool of IANA zones so timezone-aware bucketing (#524) has something
+// to exercise. `undefined` means "use the server timezone".
+const TIMEZONE_POOL = [
+  undefined,
+  "America/New_York",
+  "America/Los_Angeles",
+  "Europe/London",
+  "Europe/Berlin",
+  "Asia/Tokyo",
+  "Australia/Sydney",
+];
+
+// Shared voice channels every fake user might pass through, in addition to
+// their own personal room. Gives companions/overlap stats realistic clustering.
+const SHARED_VOICE_CHANNELS = [
+  "General",
+  "Gaming",
+  "Music",
+  "AFK",
+  "Late Night",
+];
+
+const TEXT_CHANNELS = [
+  "general",
+  "off-topic",
+  "memes",
+  "gaming",
+  "music",
+  "bot-spam",
+];
+
+export interface SeedOptions {
+  users: number;
+  guildId: string;
+  seed: number;
+  from: Date;
+  to: Date;
+}
+
+export interface SeedIdentity {
+  userId: string;
+  username: string;
+}
+
+// Lean (plain-object) shapes of the documents we write. They intentionally
+// omit Mongoose `Document` machinery so the generation helpers stay pure and
+// trivially testable.
+export interface SeededDataset {
+  identities: SeedIdentity[];
+  voiceTracking: SeededVoiceDoc[];
+  messageActivity: SeededMessageDoc[];
+  achievements: SeededAchievementsDoc[];
+  reactions: SeededReactionDoc[];
+  polls: SeededPollDoc[];
+  notificationPrefs: SeededNotificationPrefsDoc[];
+  voicePreferences: SeededVoicePrefsDoc[];
+}
+
+interface SeededSession {
+  startTime: Date;
+  endTime: Date;
+  duration: number;
+  channelId: string;
+  channelName: string;
+  otherUsers: string[];
+  companions: Array<{ userId: string; seconds: number }>;
+  wasFirst: boolean;
+  joinedExisting: string[];
+}
+
+interface SeededPeriodTotals {
+  totalTime: number;
+  sessionCount: number;
+  channels: string[];
+  averageSessionLength: number;
+}
+
+export interface SeededVoiceDoc {
+  userId: string;
+  username: string;
+  totalTime: number;
+  lastSeen: Date;
+  sessions: SeededSession[];
+  excludedChannels: string[];
+  monthlyTotals: Array<SeededPeriodTotals & { month: string }>;
+  yearlyTotals: Array<SeededPeriodTotals & { year: string }>;
+}
+
+export interface SeededMessageDoc {
+  userId: string;
+  guildId: string;
+  username: string;
+  channels: Array<{ channelId: string; count: number }>;
+  recentMessages: Array<{ sentAt: Date; channelId: string }>;
+  totalCount: number;
+  lastMessageAt: Date | null;
+}
+
+export interface SeededAchievementsDoc {
+  userId: string;
+  username: string;
+  accolades: Array<{
+    type: string;
+    earnedAt: Date;
+    metadata?: { value?: number; description?: string; unit?: string };
+  }>;
+  achievements: Array<{
+    type: string;
+    earnedAt: Date;
+    period: string;
+    rank?: number;
+    metadata?: { value?: number; description?: string; unit?: string };
+  }>;
+  lastChecked: Date;
+  statistics: { totalAccolades: number; totalAchievements: number };
+}
+
+export interface SeededReactionDoc {
+  userId: string;
+  guildId: string;
+  username: string;
+  totalGiven: number;
+  totalReceived: number;
+  yearlyGiven: Record<string, number>;
+  yearlyReceived: Record<string, number>;
+  lastReactionAt: Date | null;
+}
+
+export interface SeededPollDoc {
+  userId: string;
+  guildId: string;
+  username: string;
+  totalVotes: number;
+  yearlyVotes: Record<string, number>;
+  lastVoteAt: Date | null;
+}
+
+export interface SeededNotificationPrefsDoc {
+  userId: string;
+  guildId: string;
+  achievements: boolean;
+  digest: boolean;
+  rewind: boolean;
+  timezone?: string;
+  updatedAt: Date;
+}
+
+export interface SeededVoicePrefsDoc {
+  userId: string;
+  namePattern: string;
+  userLimit: number;
+  bitrate: number;
+  presets: Array<{
+    name: string;
+    channelName?: string;
+    userLimit?: number;
+    bitrate?: number;
+    isDefault?: boolean;
+  }>;
+}
+
+/** Redact any password embedded in a mongodb connection URI for safe logging. */
+export function redactUri(uri: string): string {
+  return uri.replace(/(\/\/[^:/?#]+:)([^@]+)(@)/, "$1***$3");
+}
+
+/** Deterministic fake user id for the Nth seeded user (1-based). */
+export function seedUserId(index: number): string {
+  return `${SEED_USER_PREFIX}${String(index).padStart(4, "0")}`;
+}
+
+function pickSome<T>(items: T[], count: number): T[] {
+  if (count <= 0 || items.length === 0) return [];
+  return faker.helpers.arrayElements(items, Math.min(count, items.length));
+}
+
+/** Build the deterministic id/username pairs for `count` fake users. */
+export function buildIdentities(count: number): SeedIdentity[] {
+  const identities: SeedIdentity[] = [];
+  for (let i = 1; i <= count; i++) {
+    identities.push({
+      userId: seedUserId(i),
+      username: faker.internet.username().slice(0, 32),
+    });
+  }
+  return identities;
+}
+
+function yearKey(date: Date): string {
+  return String(date.getUTCFullYear());
+}
+
+function monthKey(date: Date): string {
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function aggregatePeriods<K extends string>(
+  sessions: SeededSession[],
+  keyOf: (d: Date) => string,
+  field: K,
+): Array<SeededPeriodTotals & Record<K, string>> {
+  const buckets = new Map<string, SeededSession[]>();
+  for (const s of sessions) {
+    const k = keyOf(s.startTime);
+    const list = buckets.get(k) ?? [];
+    list.push(s);
+    buckets.set(k, list);
+  }
+  return Array.from(buckets.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, group]) => {
+      const totalTime = group.reduce((sum, s) => sum + s.duration, 0);
+      const channels = Array.from(new Set(group.map((s) => s.channelName)));
+      return {
+        [field]: key,
+        totalTime,
+        sessionCount: group.length,
+        channels,
+        averageSessionLength: Math.round(totalTime / group.length),
+      } as SeededPeriodTotals & Record<K, string>;
+    });
+}
+
+/** Generate one user's voice-tracking document with spread-out sessions. */
+export function generateVoiceTracking(
+  identity: SeedIdentity,
+  otherUserIds: string[],
+  opts: SeedOptions,
+): SeededVoiceDoc {
+  const personalRoom = `${identity.username}'s Room`;
+  const channelPool = [personalRoom, ...SHARED_VOICE_CHANNELS];
+  const sessionCount = faker.number.int({ min: 20, max: 120 });
+
+  const sessions: SeededSession[] = [];
+  for (let i = 0; i < sessionCount; i++) {
+    const startTime = faker.date.between({ from: opts.from, to: opts.to });
+    // Weighted toward shorter sessions, with the occasional marathon.
+    const duration = faker.number.int({ min: 5 * 60, max: 5 * 60 * 60 });
+    const endTime = new Date(startTime.getTime() + duration * 1000);
+    const channelName = faker.helpers.arrayElement(channelPool);
+    const channelId = `seed-vc-${SHARED_VOICE_CHANNELS.indexOf(channelName) + 1}-${identity.userId}`;
+    const others = pickSome(otherUserIds, faker.number.int({ min: 0, max: 4 }));
+    const companions = others.map((userId) => ({
+      userId,
+      seconds: faker.number.int({ min: 60, max: duration }),
+    }));
+
+    sessions.push({
+      startTime,
+      endTime,
+      duration,
+      channelId,
+      channelName,
+      otherUsers: others,
+      companions,
+      wasFirst: faker.datatype.boolean(),
+      joinedExisting: pickSome(others, faker.number.int({ min: 0, max: 2 })),
+    });
+  }
+
+  sessions.sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
+  const totalTime = sessions.reduce((sum, s) => sum + s.duration, 0);
+  const lastSeen = sessions.length
+    ? sessions[sessions.length - 1].endTime
+    : opts.to;
+
+  return {
+    userId: identity.userId,
+    username: identity.username,
+    totalTime,
+    lastSeen,
+    sessions,
+    excludedChannels: [],
+    monthlyTotals: aggregatePeriods(sessions, monthKey, "month"),
+    yearlyTotals: aggregatePeriods(sessions, yearKey, "year"),
+  };
+}
+
+/** Generate one user's text-message activity document. */
+export function generateMessageActivity(
+  identity: SeedIdentity,
+  opts: SeedOptions,
+): SeededMessageDoc {
+  const messageCount = faker.number.int({ min: 50, max: 400 });
+  const recentMessages: Array<{ sentAt: Date; channelId: string }> = [];
+  const counts = new Map<string, number>();
+
+  for (let i = 0; i < messageCount; i++) {
+    const channelName = faker.helpers.arrayElement(TEXT_CHANNELS);
+    const channelId = `seed-tc-${TEXT_CHANNELS.indexOf(channelName) + 1}`;
+    recentMessages.push({
+      sentAt: faker.date.between({ from: opts.from, to: opts.to }),
+      channelId,
+    });
+    counts.set(channelId, (counts.get(channelId) ?? 0) + 1);
+  }
+
+  recentMessages.sort((a, b) => a.sentAt.getTime() - b.sentAt.getTime());
+
+  return {
+    userId: identity.userId,
+    guildId: opts.guildId,
+    username: identity.username,
+    channels: Array.from(counts.entries()).map(([channelId, count]) => ({
+      channelId,
+      count,
+    })),
+    recentMessages,
+    totalCount: messageCount,
+    lastMessageAt: recentMessages.length
+      ? recentMessages[recentMessages.length - 1].sentAt
+      : null,
+  };
+}
+
+function isoWeek(date: Date): string {
+  const d = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const week = Math.ceil(
+    ((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7,
+  );
+  return `${d.getUTCFullYear()}-W${String(week).padStart(2, "0")}`;
+}
+
+/** Generate one user's achievements/accolades document. */
+export function generateUserAchievements(
+  identity: SeedIdentity,
+  opts: SeedOptions,
+): SeededAchievementsDoc {
+  const accoladeKeys = Object.keys(ACCOLADE_METADATA);
+  const chosenAccolades = pickSome(
+    accoladeKeys,
+    faker.number.int({ min: 2, max: 6 }),
+  );
+  const accolades = chosenAccolades.map((type) => {
+    const earnedAt = faker.date.between({ from: opts.from, to: opts.to });
+    return {
+      type,
+      earnedAt,
+      metadata: {
+        value: faker.number.int({ min: 1, max: 1000 }),
+        unit: "hrs",
+      },
+    };
+  });
+
+  const chosenAchievements = pickSome(
+    [...ACHIEVEMENT_TYPES],
+    faker.number.int({ min: 1, max: 5 }),
+  );
+  const achievements = chosenAchievements.map((type) => {
+    const earnedAt = faker.date.between({ from: opts.from, to: opts.to });
+    return {
+      type,
+      earnedAt,
+      period: isoWeek(earnedAt),
+      rank: faker.number.int({ min: 1, max: 10 }),
+      metadata: { value: faker.number.int({ min: 1, max: 50 }), unit: "hrs" },
+    };
+  });
+
+  return {
+    userId: identity.userId,
+    username: identity.username,
+    accolades,
+    achievements,
+    lastChecked: opts.to,
+    statistics: {
+      totalAccolades: accolades.length,
+      totalAchievements: achievements.length,
+    },
+  };
+}
+
+function yearlyBuckets(
+  opts: SeedOptions,
+  min: number,
+  max: number,
+): Record<string, number> {
+  const buckets: Record<string, number> = {};
+  for (
+    let year = opts.from.getUTCFullYear();
+    year <= opts.to.getUTCFullYear();
+    year++
+  ) {
+    buckets[String(year)] = faker.number.int({ min, max });
+  }
+  return buckets;
+}
+
+/** Generate one user's reaction-activity document (#653 capture). */
+export function generateReactionActivity(
+  identity: SeedIdentity,
+  opts: SeedOptions,
+): SeededReactionDoc {
+  const yearlyGiven = yearlyBuckets(opts, 5, 800);
+  const yearlyReceived = yearlyBuckets(opts, 5, 800);
+  const sum = (b: Record<string, number>): number =>
+    Object.values(b).reduce((a, c) => a + c, 0);
+  return {
+    userId: identity.userId,
+    guildId: opts.guildId,
+    username: identity.username,
+    totalGiven: sum(yearlyGiven),
+    totalReceived: sum(yearlyReceived),
+    yearlyGiven,
+    yearlyReceived,
+    lastReactionAt: faker.date.between({ from: opts.from, to: opts.to }),
+  };
+}
+
+/** Generate one user's poll-participation document (#655 capture). */
+export function generatePollParticipation(
+  identity: SeedIdentity,
+  opts: SeedOptions,
+): SeededPollDoc {
+  const yearlyVotes = yearlyBuckets(opts, 0, 150);
+  const total = Object.values(yearlyVotes).reduce((a, c) => a + c, 0);
+  return {
+    userId: identity.userId,
+    guildId: opts.guildId,
+    username: identity.username,
+    totalVotes: total,
+    yearlyVotes,
+    lastVoteAt:
+      total > 0 ? faker.date.between({ from: opts.from, to: opts.to }) : null,
+  };
+}
+
+/** Generate one user's notification prefs (carries timezone for #524). */
+export function generateNotificationPrefs(
+  identity: SeedIdentity,
+  opts: SeedOptions,
+): SeededNotificationPrefsDoc {
+  return {
+    userId: identity.userId,
+    guildId: opts.guildId,
+    achievements: faker.datatype.boolean(),
+    digest: faker.datatype.boolean(),
+    rewind: faker.datatype.boolean(),
+    timezone: faker.helpers.arrayElement(TIMEZONE_POOL),
+    updatedAt: opts.to,
+  };
+}
+
+/** Generate one user's voice preferences. */
+export function generateVoicePreferences(
+  identity: SeedIdentity,
+): SeededVoicePrefsDoc {
+  return {
+    userId: identity.userId,
+    namePattern: faker.helpers.arrayElement([
+      "{username}'s Room",
+      "🎮 {username}",
+      "{username} HQ",
+    ]),
+    userLimit: faker.helpers.arrayElement([0, 2, 4, 6, 10]),
+    bitrate: faker.helpers.arrayElement([64, 96, 128]),
+    presets: [
+      {
+        name: "Squad night",
+        channelName: `${identity.username}'s Squad`,
+        userLimit: 6,
+        bitrate: 96,
+        isDefault: true,
+      },
+    ],
+  };
+}
+
+/**
+ * Build the full deterministic dataset for `opts`. Pure: no DB access. Calling
+ * it twice with the same `seed`, `users` and date span yields identical output.
+ */
+export function generateSampleDataset(opts: SeedOptions): SeededDataset {
+  faker.seed(opts.seed);
+
+  const identities = buildIdentities(opts.users);
+  const allIds = identities.map((i) => i.userId);
+
+  const dataset: SeededDataset = {
+    identities,
+    voiceTracking: [],
+    messageActivity: [],
+    achievements: [],
+    reactions: [],
+    polls: [],
+    notificationPrefs: [],
+    voicePreferences: [],
+  };
+
+  for (const identity of identities) {
+    const others = allIds.filter((id) => id !== identity.userId);
+    dataset.voiceTracking.push(generateVoiceTracking(identity, others, opts));
+    dataset.messageActivity.push(generateMessageActivity(identity, opts));
+    dataset.achievements.push(generateUserAchievements(identity, opts));
+    dataset.reactions.push(generateReactionActivity(identity, opts));
+    dataset.polls.push(generatePollParticipation(identity, opts));
+    dataset.notificationPrefs.push(generateNotificationPrefs(identity, opts));
+    dataset.voicePreferences.push(generateVoicePreferences(identity));
+  }
+
+  return dataset;
+}
+
+/**
+ * Write a dataset to MongoDB, upserting by the deterministic fake ids so
+ * re-runs are idempotent (no duplicates). Assumes an open connection.
+ */
+export async function writeDataset(dataset: SeededDataset): Promise<void> {
+  for (const doc of dataset.voiceTracking) {
+    await VoiceChannelTracking.updateOne(
+      { userId: doc.userId },
+      { $set: doc },
+      { upsert: true },
+    );
+  }
+  for (const doc of dataset.messageActivity) {
+    await MessageActivityTracking.updateOne(
+      { userId: doc.userId, guildId: doc.guildId },
+      { $set: doc },
+      { upsert: true },
+    );
+  }
+  for (const doc of dataset.achievements) {
+    await UserAchievements.updateOne(
+      { userId: doc.userId },
+      { $set: doc },
+      { upsert: true },
+    );
+  }
+  for (const doc of dataset.reactions) {
+    await ReactionActivityTracking.updateOne(
+      { userId: doc.userId, guildId: doc.guildId },
+      { $set: doc },
+      { upsert: true },
+    );
+  }
+  for (const doc of dataset.polls) {
+    await PollParticipationTracking.updateOne(
+      { userId: doc.userId, guildId: doc.guildId },
+      { $set: doc },
+      { upsert: true },
+    );
+  }
+  for (const doc of dataset.notificationPrefs) {
+    await UserNotificationPrefs.updateOne(
+      { userId: doc.userId, guildId: doc.guildId },
+      { $set: doc },
+      { upsert: true },
+    );
+  }
+  for (const doc of dataset.voicePreferences) {
+    await UserVoicePreferences.updateOne(
+      { userId: doc.userId },
+      { $set: doc },
+      { upsert: true },
+    );
+  }
+}
+
+/** Delete every seeded document (matched by the fake id prefix) and report counts. */
+export async function cleanSampleData(): Promise<number> {
+  const idFilter = { userId: { $regex: `^${SEED_USER_PREFIX}` } };
+  const models: Array<
+    [string, { deleteMany: (f: object) => Promise<{ deletedCount?: number }> }]
+  > = [
+    ["VoiceChannelTracking", VoiceChannelTracking],
+    ["MessageActivityTracking", MessageActivityTracking],
+    ["UserAchievements", UserAchievements],
+    ["ReactionActivityTracking", ReactionActivityTracking],
+    ["PollParticipationTracking", PollParticipationTracking],
+    ["UserNotificationPrefs", UserNotificationPrefs],
+    ["UserVoicePreferences", UserVoicePreferences],
+  ];
+
+  let total = 0;
+  for (const [name, model] of models) {
+    const res = await model.deleteMany(idFilter);
+    const count = res.deletedCount ?? 0;
+    total += count;
+    logger.info(`  • ${name}: removed ${count} seeded document(s)`);
+  }
+  return total;
+}
+
+interface ParsedOptions extends SeedOptions {
+  clean: boolean;
+  yes: boolean;
+}
+
+/** Parse CLI flags / env vars into resolved options. Pure (no DB / no exit). */
+export function parseOptions(argv: string[]): ParsedOptions {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      users: { type: "string" },
+      years: { type: "string" },
+      from: { type: "string" },
+      to: { type: "string" },
+      seed: { type: "string" },
+      guild: { type: "string" },
+      clean: { type: "boolean", default: false },
+      yes: { type: "boolean", default: false },
+    },
+    allowPositionals: false,
+  });
+
+  const now = new Date();
+  let from: Date;
+  let to: Date = now;
+
+  if (values.from || values.to) {
+    from = values.from
+      ? new Date(values.from)
+      : new Date(Date.UTC(now.getUTCFullYear(), 0, 1));
+    to = values.to ? new Date(values.to) : now;
+  } else if (values.years) {
+    const years = Number(values.years);
+    from = new Date(now);
+    from.setUTCFullYear(from.getUTCFullYear() - years);
+  } else {
+    // Default span: the current calendar year so far.
+    from = new Date(Date.UTC(now.getUTCFullYear(), 0, 1));
+  }
+
+  if (isNaN(from.getTime()) || isNaN(to.getTime())) {
+    throw new Error("Invalid --from/--to date");
+  }
+  if (from >= to) {
+    throw new Error("--from must be before --to");
+  }
+
+  const guildId = values.guild ?? env.guildId ?? "";
+
+  return {
+    users: values.users ? Math.max(1, Number(values.users)) : DEFAULT_USERS,
+    guildId,
+    seed: values.seed ? Number(values.seed) : DEFAULT_SEED,
+    from,
+    to,
+    clean: values.clean,
+    yes: values.yes,
+  };
+}
+
+async function main(): Promise<void> {
+  let opts: ParsedOptions;
+  try {
+    opts = parseOptions(process.argv.slice(2));
+  } catch (error) {
+    logger.error(
+      `Invalid arguments: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!opts.yes) {
+    logger.error(
+      "Refusing to run without explicit opt-in. Re-run with --yes once you have " +
+        "confirmed MONGODB_URI points at a dev/test database.",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!opts.clean && !opts.guildId) {
+    logger.error(
+      "No guild id available. Set GUILD_ID or pass --guild <id> so seeded " +
+        "per-guild documents are written under the right server.",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    // Loudly log the target before touching anything (acceptance criterion).
+    logger.warn("⚠️  Sample-data seeder — writing to a REAL database:");
+    logger.warn(`    URI: ${redactUri(env.mongoUri)}`);
+
+    await mongoose.connect(env.mongoUri);
+    logger.warn(`    DB:  ${mongoose.connection.name}`);
+
+    if (opts.clean) {
+      logger.info(
+        `Cleaning seeded data (ids matching "${SEED_USER_PREFIX}*")...`,
+      );
+      const removed = await cleanSampleData();
+      logger.info(`✅ Removed ${removed} seeded document(s).`);
+      return;
+    }
+
+    logger.info(
+      `Seeding ${opts.users} fake user(s) for guild ${opts.guildId} ` +
+        `(seed=${opts.seed}, ${opts.from.toISOString().slice(0, 10)} → ` +
+        `${opts.to.toISOString().slice(0, 10)})...`,
+    );
+
+    const dataset = generateSampleDataset(opts);
+    await writeDataset(dataset);
+
+    logger.info(
+      `✅ Seeded ${dataset.identities.length} users across voice, messages, ` +
+        "achievements, reactions, polls, prefs.",
+    );
+    logger.info(
+      `   Example seeded user: ${dataset.identities[0]?.userId} ` +
+        `(${dataset.identities[0]?.username}).`,
+    );
+    logger.info(
+      `   Remove later with: npm run seed-sample-data -- --clean --yes`,
+    );
+  } catch (error) {
+    logger.error("Fatal error during sample-data seeding:", error);
+    process.exitCode = 1;
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+// Run if invoked directly (mirrors the other operational scripts).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}
+
+export { main as seedSampleData };


### PR DESCRIPTION
Closes #667.

## What

Adds `src/scripts/seed-sample-data.ts` — an operational script (same family as `validate-config` / `migrate-config`, **not** a Discord command or runtime service) that populates a **non-production** MongoDB with realistic, deterministic fake users and a year's worth of activity. This makes "spin up, seed, log in, look at the page" a fast loop for the data-heavy surfaces: Rewind / year-in-review, leaderboards, weekly digests, achievements, `/stats`, and the WebUI stats pages.

## What it populates

Configurable number of fake users (default ~10), written to:

- **`VoiceChannelTracking`** — append-only `sessions[]` spread across the date range, with `otherUsers[]`/`companions[]` (companions & overlap), stored `username`, realistic `channelName`s, plus derived `monthly`/`yearlyTotals`.
- **`MessageActivityTracking`** — `recentMessages[]` + `channels[]`/`totalCount` (text stats, peak-message-day).
- **`UserAchievements`** — sampled `accolades[]`/`achievements[]` using real `type` keys from `src/content/`, `earnedAt` inside the range.
- **`ReactionActivityTracking`** (#653) and **`PollParticipationTracking`** (#655) — totals + per-`YYYY` buckets.
- **`UserNotificationPrefs`** (timezone for #524) and **`UserVoicePreferences`**.

## CLI

`--yes` (required opt-in), `--users <n>`, `--seed <n>`, `--years <n>` or `--from`/`--to`, `--guild <id>`, `--clean`.

```bash
npm run build
npm run seed-sample-data -- --users 25 --years 1 --seed 42 --yes
npm run seed-sample-data -- --clean --yes
```

## Safety guardrails

- Every seeded doc uses a fake `userId` under a fixed **`seed-`** prefix → `--clean` removes only seeded rows, never real records.
- **Refuses to run without `--yes`**; loudly logs the target URI (password redacted) + database name before any write.
- **Idempotent** re-runs (upsert by deterministic ids) and **reproducible** given a fixed `--seed`.

## Decisions (confirmed with the issue author)

- **Marker:** fake user-id prefix only — no schema changes to any model.
- **Deps:** added `@faker-js/faker` as a **devDependency** (`faker.seed()` drives determinism).
- **Opt-in:** `--yes` flag.
- **Scope:** all listed models, including the optional timezone/voice-preference docs.

## Docs & tests

- Unit test `__tests__/scripts/seed-sample-data.test.ts` covers the pure data-generation helpers (the global mongoose mock keeps the DB out of the unit tests), including determinism and the per-year bucket sums.
- `DEVELOPER_GUIDE.md` gains an **Operational Scripts** section with the full option table **and a Docker-based recipe** (run from the `docker-compose.dev.yml` stack, which has devDeps); `TESTING.md` and `CLAUDE.md` updated.

## Acceptance criteria

- [x] `npm run build && npm run seed-sample-data` populates the models above for N users across the chosen range.
- [x] `--clean` removes exactly the seeded data and nothing else (matched by the `seed-` id prefix).
- [x] Runs are deterministic given a fixed `--seed`.
- [x] Will not run without the explicit opt-in; target DB is logged before any write.
- [x] A unit test covers the pure data-generation helpers (mock Mongo).
- [x] Documented in `DEVELOPER_GUIDE.md` / `TESTING.md` and the script list in `CLAUDE.md`.
- [ ] Manual check: after seeding, `/me/rewind` (and stats/leaderboard/digest surfaces) render non-empty data — requires a live DB, not exercisable in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhxE3GiEk18yHJFdnzCe1u)_