### PR TITLE
feat: surface reaction activity on Rewind year-in-review

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -484,9 +484,15 @@ the user's **/me/notifications** page (no slash command).
 ## ✨ Rewind (Year-in-Review)
 
 Per-user year-in-review page at **`/me/rewind`** (also `/me/rewind/:year`
-for past years). Renders total voice time, top channels, peak day,
-longest streak, badges earned, annual rank, and a first/best/last
-weekly-rank journey. Year picker bottom-anchored to years with data.
+for past years). Renders total voice time, top voice companions, peak day,
+longest session, longest streak, badges earned, annual rank, a
+first/best/last weekly-rank journey, text activity, and reaction activity
+(given / received). Year picker bottom-anchored to years with data.
+
+The text- and reaction-activity blocks read from `MessageActivityTracking`
+and `ReactionActivityTracking` respectively, and only appear when their
+tracking is enabled (`messagetracking.enabled` / `reactiontracking.enabled`)
+and the user has data for the year — otherwise the block is hidden.
 
 The feature and the end-of-year DM nudge have **separate** switches
 (#608). `rewind.enabled` gates the page itself; `rewind.nudge.enabled`

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -824,7 +824,7 @@ slash command** — the Web UI is the admin surface.
 | **Voice** (`/me/voice`)                 | Manage your channel name pattern and saved voice-channel presets (rename, edit, set-default, delete). Gated by `voicechannels.presets.enabled`.            |
 | **Timezone** (`/me/timezone`)           | Pick the IANA timezone Koolbot renders your times in (digest, Rewind, voicestats) and uses to evaluate your birthday. Saving records a `WebAuditLog` row.  |
 | **Birthday** (`/me/birthday`)           | Set your birthday (month/day, optional year) so Koolbot can celebrate it on the day in your own timezone. Saving or removing records a `WebAuditLog` row.  |
-| **Rewind** (`/me/rewind`)               | Personal year-in-review: voice time, top voice companions, peak day, longest session, streak, badges, annual rank, weekly-rank journey, and text activity. |
+| **Rewind** (`/me/rewind`)               | Personal year-in-review: voice time, top voice companions, peak day, longest session, streak, badges, rank, weekly journey, text & reaction activity.      |
 
 Notification preferences are scoped per `(userId, guildId)`. The page
 lists every notification type with the current state and a checkbox;

--- a/__tests__/services/rewind-service.test.ts
+++ b/__tests__/services/rewind-service.test.ts
@@ -36,6 +36,29 @@ jest.unstable_mockModule("../../src/models/user-achievements.js", () => ({
   },
 }));
 
+// Reaction activity (#653). `findOne(...).lean()` returns the per-year
+// buckets; the default `mockGetBoolean` leaves reaction tracking disabled so
+// existing getSummary tests never reach this model.
+const mockFindOneReaction = jest.fn();
+jest.unstable_mockModule(
+  "../../src/models/reaction-activity-tracking.js",
+  () => ({
+    ReactionActivityTracking: {
+      findOne: mockFindOneReaction,
+    },
+  }),
+);
+
+// Config is consulted by `computeTextActivity` / `computeReactionActivity`
+// for their `*.enabled` gates. Default everything off so the voice-only
+// tests are unaffected; individual tests override per key as needed.
+const mockGetBoolean = jest.fn(async () => false);
+jest.unstable_mockModule("../../src/services/config-service.js", () => ({
+  ConfigService: {
+    getInstance: () => ({ getBoolean: mockGetBoolean }),
+  },
+}));
+
 jest.unstable_mockModule("../../src/content/accolades.js", () => ({
   ACCOLADE_METADATA: {
     night_owl: {
@@ -75,6 +98,7 @@ const {
   computeTopCompanions,
   computePeakMessageDay,
   computeTopTextChannels,
+  extractYearlyReactionCount,
   messagesInWindow,
   formatFunComparison,
   formatHoursMinutes,
@@ -937,6 +961,24 @@ describe("RewindService snapshots (#574)", () => {
       expect(empty.hasData).toBe(false);
       expect(empty.availableYears).toEqual([]);
     });
+
+    it("defaults reaction fields to 0 for pre-#653 (schema v1) snapshots", () => {
+      const norm = normalizeSnapshotSummary(
+        { totalSeconds: 5, hasData: true },
+        { userId: "u", guildId: "g", year: 2021 },
+      );
+      expect(norm.reactionsGiven).toBe(0);
+      expect(norm.reactionsReceived).toBe(0);
+    });
+
+    it("preserves stored reaction counts when present", () => {
+      const norm = normalizeSnapshotSummary(
+        { reactionsGiven: 11, reactionsReceived: 4 },
+        { userId: "u", guildId: "g", year: 2021 },
+      );
+      expect(norm.reactionsGiven).toBe(11);
+      expect(norm.reactionsReceived).toBe(4);
+    });
   });
 
   describe("getSummary serving", () => {
@@ -1144,6 +1186,117 @@ describe("RewindService text helpers (#496)", () => {
 
     it("returns null when there are no messages", () => {
       expect(computePeakMessageDay([])).toBeNull();
+    });
+  });
+});
+
+describe("RewindService reaction helpers (#653)", () => {
+  describe("extractYearlyReactionCount", () => {
+    it("reads the requested year's count from a plain object (lean shape)", () => {
+      const bucket = { "2025": 7, "2026": 12 };
+      expect(extractYearlyReactionCount(bucket, 2026)).toBe(12);
+    });
+
+    it("reads the requested year's count from a Map (hydrated shape)", () => {
+      const bucket = new Map([
+        ["2025", 7],
+        ["2026", 12],
+      ]);
+      expect(extractYearlyReactionCount(bucket, 2026)).toBe(12);
+    });
+
+    it("returns 0 for a year absent from a populated bucket", () => {
+      expect(extractYearlyReactionCount({ "2025": 7 }, 2026)).toBe(0);
+    });
+
+    it("returns 0 for an empty / missing bucket (zero-data)", () => {
+      expect(extractYearlyReactionCount({}, 2026)).toBe(0);
+      expect(extractYearlyReactionCount(null, 2026)).toBe(0);
+      expect(extractYearlyReactionCount(undefined, 2026)).toBe(0);
+    });
+
+    it("coerces malformed / non-positive bucket values to 0", () => {
+      expect(
+        extractYearlyReactionCount(
+          { "2026": Number.NaN } as Record<string, number>,
+          2026,
+        ),
+      ).toBe(0);
+      expect(extractYearlyReactionCount({ "2026": 0 }, 2026)).toBe(0);
+    });
+  });
+
+  describe("getSummary reaction wiring", () => {
+    function lean<T>(value: T): { lean: () => Promise<T> } {
+      return { lean: jest.fn(async () => value) };
+    }
+    function selectLean<T>(value: T): {
+      select: () => { lean: () => Promise<T> };
+    } {
+      return { select: jest.fn(() => lean(value)) };
+    }
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      resetSingleton();
+      mockFindOneVc.mockReturnValue(lean({ sessions: [] }));
+      mockFindVc.mockReturnValue(selectLean([]));
+      mockFindOneAch.mockReturnValue(lean(null));
+      mockAggregateVc.mockResolvedValue([]);
+      mockSnapFindOne.mockReturnValue(lean(null));
+      mockSnapFind.mockReturnValue(lean([]));
+      mockSnapCreate.mockResolvedValue({});
+      mockFindOneReaction.mockReturnValue(lean(null));
+      // Reaction tracking on by default for this block; other gates off.
+      mockGetBoolean.mockImplementation(
+        async (key: string) => key === "reactiontracking.enabled",
+      );
+    });
+
+    function makeSvc() {
+      return RewindService.getInstance(
+        makeClient() as Parameters<typeof RewindService.getInstance>[0],
+      );
+    }
+
+    it("surfaces the requested year's given/received counts", async () => {
+      mockFindOneReaction.mockReturnValueOnce(
+        lean({
+          yearlyGiven: { "2025": 3, "2026": 9 },
+          yearlyReceived: { "2026": 4 },
+        }),
+      );
+
+      const summary = await makeSvc().getSummary("u1", "g1", 2026);
+      expect(summary!.reactionsGiven).toBe(9);
+      expect(summary!.reactionsReceived).toBe(4);
+    });
+
+    it("reads 0 for a year the user has no bucket entry for", async () => {
+      mockFindOneReaction.mockReturnValueOnce(
+        lean({ yearlyGiven: { "2024": 5 }, yearlyReceived: { "2024": 2 } }),
+      );
+
+      const summary = await makeSvc().getSummary("u1", "g1", 2026);
+      expect(summary!.reactionsGiven).toBe(0);
+      expect(summary!.reactionsReceived).toBe(0);
+    });
+
+    it("reads 0 (and never queries the model) when reaction tracking is off", async () => {
+      mockGetBoolean.mockImplementation(async () => false);
+
+      const summary = await makeSvc().getSummary("u1", "g1", 2026);
+      expect(summary!.reactionsGiven).toBe(0);
+      expect(summary!.reactionsReceived).toBe(0);
+      expect(mockFindOneReaction).not.toHaveBeenCalled();
+    });
+
+    it("reads 0 when the user has no reaction row", async () => {
+      mockFindOneReaction.mockReturnValueOnce(lean(null));
+
+      const summary = await makeSvc().getSummary("u1", "g1", 2026);
+      expect(summary!.reactionsGiven).toBe(0);
+      expect(summary!.reactionsReceived).toBe(0);
     });
   });
 });

--- a/__tests__/services/rewind-service.test.ts
+++ b/__tests__/services/rewind-service.test.ts
@@ -99,6 +99,7 @@ const {
   computePeakMessageDay,
   computeTopTextChannels,
   extractYearlyReactionCount,
+  reactionActivityYears,
   messagesInWindow,
   formatFunComparison,
   formatHoursMinutes,
@@ -837,6 +838,10 @@ describe("RewindService.getDefaultRewindYear (#573)", () => {
     mockFindOneAch.mockReturnValue(lean(null));
     mockAggregateVc.mockResolvedValue([]);
     mockSnapFind.mockReturnValue(lean([]));
+    // Reset the shared config + reaction mocks (implementations survive
+    // clearAllMocks): tracking off, no reaction row, unless a test opts in.
+    mockGetBoolean.mockImplementation(async () => false);
+    mockFindOneReaction.mockReturnValue(lean(null));
   });
 
   it("lands on the prior year when the current year has no data", async () => {
@@ -860,6 +865,21 @@ describe("RewindService.getDefaultRewindYear (#573)", () => {
   it("falls back to the current year when the user has no data anywhere", async () => {
     const year = await makeSvc().getDefaultRewindYear("u1", "g1");
     expect(year).toBe(currentYear);
+  });
+
+  it("lands on a reaction-only past year when it is the newest data (#653)", async () => {
+    mockGetBoolean.mockImplementation(
+      async (key: string) => key === "reactiontracking.enabled",
+    );
+    mockFindOneReaction.mockReturnValueOnce(
+      lean({
+        yearlyGiven: { [String(currentYear - 1)]: 4 },
+        yearlyReceived: {},
+      }),
+    );
+
+    const year = await makeSvc().getDefaultRewindYear("u1", "g1");
+    expect(year).toBe(currentYear - 1);
   });
 
   it("considers snapshotted years that have outlived their raw data", async () => {
@@ -914,6 +934,10 @@ describe("RewindService snapshots (#574)", () => {
     mockSnapFindOne.mockReturnValue(lean(null));
     mockSnapFind.mockReturnValue(lean([]));
     mockSnapCreate.mockResolvedValue({});
+    // Reaction tracking off so getSummary's live path skips the reaction
+    // query (implementations survive clearAllMocks).
+    mockGetBoolean.mockImplementation(async () => false);
+    mockFindOneReaction.mockReturnValue(lean(null));
   });
 
   describe("normalizeSnapshotSummary", () => {
@@ -1226,6 +1250,40 @@ describe("RewindService reaction helpers (#653)", () => {
     });
   });
 
+  describe("reactionActivityYears", () => {
+    it("unions the distinct years across both buckets (object shape)", () => {
+      expect(
+        reactionActivityYears(
+          { "2024": 5, "2026": 9 },
+          { "2025": 2, "2026": 4 },
+        ).sort(),
+      ).toEqual([2024, 2025, 2026]);
+    });
+
+    it("reads Map buckets too (hydrated shape)", () => {
+      expect(
+        reactionActivityYears(
+          new Map([["2023", 1]]),
+          new Map([["2024", 3]]),
+        ).sort(),
+      ).toEqual([2023, 2024]);
+    });
+
+    it("skips non-positive counts and unparseable keys", () => {
+      expect(
+        reactionActivityYears({
+          "2024": 0,
+          "2025": 7,
+          notayear: 3,
+        } as Record<string, number>),
+      ).toEqual([2025]);
+    });
+
+    it("returns an empty array for nullish / empty buckets (zero-data)", () => {
+      expect(reactionActivityYears(null, undefined, {})).toEqual([]);
+    });
+  });
+
   describe("getSummary reaction wiring", () => {
     function lean<T>(value: T): { lean: () => Promise<T> } {
       return { lean: jest.fn(async () => value) };
@@ -1270,6 +1328,34 @@ describe("RewindService reaction helpers (#653)", () => {
       const summary = await makeSvc().getSummary("u1", "g1", 2026);
       expect(summary!.reactionsGiven).toBe(9);
       expect(summary!.reactionsReceived).toBe(4);
+    });
+
+    it("treats a reaction-only year as data and offers its years in the picker", async () => {
+      // No voice / text / achievements — reactions are the only activity.
+      mockFindOneReaction.mockReturnValueOnce(
+        lean({
+          yearlyGiven: { "2025": 3, "2026": 9 },
+          yearlyReceived: { "2026": 4 },
+        }),
+      );
+
+      const summary = await makeSvc().getSummary("u1", "g1", 2026);
+      expect(summary!.hasData).toBe(true);
+      // Both reaction years are navigable, newest first.
+      expect(summary!.availableYears).toEqual([2026, 2025]);
+    });
+
+    it("does not mark hasData when the requested year has no reactions", async () => {
+      // Buckets exist for another year only — the requested 2026 is empty,
+      // so with no other activity the page stays in its empty state.
+      mockFindOneReaction.mockReturnValueOnce(
+        lean({ yearlyGiven: { "2024": 5 }, yearlyReceived: {} }),
+      );
+
+      const summary = await makeSvc().getSummary("u1", "g1", 2026);
+      expect(summary!.hasData).toBe(false);
+      // 2024 is still offered so the user can navigate to it.
+      expect(summary!.availableYears).toEqual([2024]);
     });
 
     it("reads 0 for a year the user has no bucket entry for", async () => {

--- a/__tests__/web/user-routes.test.ts
+++ b/__tests__/web/user-routes.test.ts
@@ -713,6 +713,8 @@ describe("/me/rewind", () => {
       messagesSent: 0,
       topTextChannels: [],
       peakMessageDay: null,
+      reactionsGiven: 0,
+      reactionsReceived: 0,
       longestStreakDays: 4,
       longestStreakRange: { startDate: "2026-03-12", endDate: "2026-03-15" },
       accolades: [],
@@ -813,6 +815,28 @@ describe("/me/rewind", () => {
     });
     expect(out.statusCode).toBe(200);
     expect(out.body).not.toContain("Text activity");
+  });
+
+  it("renders the reaction-activity block when reaction data exists (#653)", async () => {
+    const out = await dispatchRewind({
+      pathSuffix: "",
+      summary: makeSummary({ reactionsGiven: 24, reactionsReceived: 9 }),
+    });
+    expect(out.statusCode).toBe(200);
+    expect(out.body).toContain("Reactions");
+    expect(out.body).toContain("Reactions given");
+    expect(out.body).toContain("24");
+    expect(out.body).toContain("Reactions received");
+    expect(out.body).toContain("9");
+  });
+
+  it("hides the reaction-activity block when both counts are 0 (#653)", async () => {
+    const out = await dispatchRewind({
+      pathSuffix: "",
+      summary: makeSummary(), // reactions default to 0
+    });
+    expect(out.statusCode).toBe(200);
+    expect(out.body).not.toContain("Reactions given");
   });
 
   it("renders the empty-state body when the user has no data", async () => {

--- a/src/services/rewind-service.ts
+++ b/src/services/rewind-service.ts
@@ -115,8 +115,8 @@ export interface RewindSummary {
     best: RewindWeeklyRank | null;
   };
   // Years for which the user has any data (voice sessions, text-message
-  // activity, or achievements). Used by the page to render a small year
-  // picker.
+  // activity, reaction activity, or achievements). Used by the page to
+  // render a small year picker.
   availableYears: number[];
   // How this summary was produced (#574): "live" recomputes from raw
   // activity, "snapshot" is served verbatim from a frozen completed-year
@@ -378,6 +378,36 @@ export function extractYearlyReactionCount(
       ? bucket.get(key)
       : (bucket as Record<string, number>)[key];
   return typeof raw === "number" && Number.isFinite(raw) && raw > 0 ? raw : 0;
+}
+
+/**
+ * The distinct numeric years present across a user's reaction buckets
+ * (#653), so reaction-only years stay navigable in the picker and the bare
+ * `/me/rewind` landing-year resolver — mirroring how text-activity years
+ * feed `availableYears`. Accepts the same Map / plain-object / nullish
+ * shapes as `extractYearlyReactionCount`; only `"YYYY"` keys with a
+ * positive count are counted, and unparseable keys are dropped.
+ */
+export function reactionActivityYears(
+  ...buckets: Array<
+    Map<string, number> | Record<string, number> | null | undefined
+  >
+): number[] {
+  const years = new Set<number>();
+  for (const bucket of buckets) {
+    if (!bucket) continue;
+    const entries =
+      bucket instanceof Map
+        ? bucket.entries()
+        : Object.entries(bucket as Record<string, number>);
+    for (const [key, value] of entries) {
+      const year = Number(key);
+      if (Number.isInteger(year) && typeof value === "number" && value > 0) {
+        years.add(year);
+      }
+    }
+  }
+  return [...years];
 }
 
 /**
@@ -668,18 +698,27 @@ export class RewindService {
         });
       }
 
-      // The picker should offer any year the user has either kind of data,
-      // plus any snapshotted year — those must stay navigable even after
-      // their raw sessions/messages have been truncated away (#574).
+      // The picker should offer any year the user has any kind of data
+      // (voice, text, or reactions), plus any snapshotted year — those must
+      // stay navigable even after their raw sessions/messages have been
+      // truncated away (#574). Reaction years come straight from the
+      // already-fetched per-year buckets, so no extra query (#653).
       const mergedYears = [
-        ...new Set([...availableYears, ...text.years, ...snapshotYears]),
+        ...new Set([
+          ...availableYears,
+          ...text.years,
+          ...reactions.years,
+          ...snapshotYears,
+        ]),
       ].sort((a, b) => b - a);
 
       const hasData =
         totalSeconds > 0 ||
         accolades.length > 0 ||
         achievements.length > 0 ||
-        text.messagesSent > 0;
+        text.messagesSent > 0 ||
+        reactions.given > 0 ||
+        reactions.received > 0;
 
       return {
         userId,
@@ -744,12 +783,17 @@ export class RewindService {
         achievements?: Array<{ earnedAt: Date }>;
       }>();
 
-      const [sessionAndAchievementYears, textYears, snapshotYears] =
-        await Promise.all([
-          this.collectAvailableYears(userId, achievementsDoc),
-          this.collectTextActivityYears(userId, guildId),
-          this.collectSnapshotYears(userId, guildId),
-        ]);
+      const [
+        sessionAndAchievementYears,
+        textYears,
+        reactionYears,
+        snapshotYears,
+      ] = await Promise.all([
+        this.collectAvailableYears(userId, achievementsDoc),
+        this.collectTextActivityYears(userId, guildId),
+        this.collectReactionActivityYears(userId, guildId),
+        this.collectSnapshotYears(userId, guildId),
+      ]);
 
       // Guard against a non-finite year slipping through any collector
       // (e.g. a corrupt `sentAt`/`earnedAt` yielding `NaN` — which passes a
@@ -759,6 +803,7 @@ export class RewindService {
       const years = [
         ...sessionAndAchievementYears,
         ...textYears,
+        ...reactionYears,
         ...snapshotYears,
       ].filter((y) => Number.isFinite(y));
       // No data anywhere → land on the (empty) current year, preserving
@@ -935,6 +980,42 @@ export class RewindService {
   }
 
   /**
+   * Distinct years present in the user's reaction buckets (#653). The
+   * reaction cousin of `collectTextActivityYears`, used purely for
+   * landing-year resolution so a reaction-only past year is still offered by
+   * the bare `/me/rewind` route. Respects the `reactiontracking.enabled`
+   * gate; a failure (or disabled feature) degrades to an empty list.
+   */
+  private async collectReactionActivityYears(
+    userId: string,
+    guildId: string,
+  ): Promise<number[]> {
+    try {
+      const enabled = await this.configService.getBoolean(
+        "reactiontracking.enabled",
+        false,
+      );
+      if (!enabled) return [];
+
+      const doc = await ReactionActivityTracking.findOne(
+        { userId, guildId },
+        { yearlyGiven: 1, yearlyReceived: 1 },
+      ).lean<{
+        yearlyGiven?: Map<string, number> | Record<string, number>;
+        yearlyReceived?: Map<string, number> | Record<string, number>;
+      }>();
+      if (!doc) return [];
+      return reactionActivityYears(doc.yearlyGiven, doc.yearlyReceived);
+    } catch (error) {
+      logger.warn(
+        `RewindService.collectReactionActivityYears failed for ${userId}:`,
+        error,
+      );
+      return [];
+    }
+  }
+
+  /**
    * Years for which we have any data (sessions or achievements). Used by
    * the year picker so the page only offers years that won't render an
    * empty state. Reuses the already-fetched achievements doc to avoid a
@@ -1057,13 +1138,16 @@ export class RewindService {
    * host-timezone year at capture time and intentionally retain no
    * per-reaction timestamps, so they are *not* re-bucketed into the user's
    * zone — see the `RewindSummary` field comment and the model header.
+   *
+   * `years` reflects every year present in either bucket so reaction-only
+   * years stay navigable in the picker, mirroring `computeTextActivity`.
    */
   private async computeReactionActivity(
     userId: string,
     guildId: string,
     year: number,
-  ): Promise<{ given: number; received: number }> {
-    const empty = { given: 0, received: 0 };
+  ): Promise<{ given: number; received: number; years: number[] }> {
+    const empty = { given: 0, received: 0, years: [] as number[] };
     try {
       const enabled = await this.configService.getBoolean(
         "reactiontracking.enabled",
@@ -1085,6 +1169,7 @@ export class RewindService {
       return {
         given: extractYearlyReactionCount(doc.yearlyGiven, year),
         received: extractYearlyReactionCount(doc.yearlyReceived, year),
+        years: reactionActivityYears(doc.yearlyGiven, doc.yearlyReceived),
       };
     } catch (error) {
       logger.warn(

--- a/src/services/rewind-service.ts
+++ b/src/services/rewind-service.ts
@@ -2,6 +2,7 @@ import { Client } from "discord.js";
 import { VoiceChannelTracking } from "../models/voice-channel-tracking.js";
 import { UserAchievements } from "../models/user-achievements.js";
 import { MessageActivityTracking } from "../models/message-activity-tracking.js";
+import { ReactionActivityTracking } from "../models/reaction-activity-tracking.js";
 import { RewindSnapshot } from "../models/rewind-snapshot.js";
 import { ConfigService } from "./config-service.js";
 import { ACCOLADE_METADATA } from "../content/accolades.js";
@@ -91,6 +92,16 @@ export interface RewindSummary {
   messagesSent: number;
   topTextChannels: RewindTextChannel[];
   peakMessageDay: { date: string; count: number } | null; // ISO date (YYYY-MM-DD)
+  // Reaction activity for the year (#653, a #570 spin-off). Reads as zero
+  // when reaction tracking is disabled or the user has no row. Sourced from
+  // the per-year `yearlyGiven` / `yearlyReceived` buckets on
+  // `ReactionActivityTracking`, which are keyed by **host-timezone** year at
+  // capture time — unlike the user-timezone day bucketing used for voice and
+  // text peaks (#524). The model retains only counts, not per-reaction
+  // timestamps, so these buckets cannot be re-bucketed into a user zone; the
+  // minor inconsistency is accepted (see the model header).
+  reactionsGiven: number;
+  reactionsReceived: number;
   longestStreakDays: number;
   longestStreakRange: { startDate: string; endDate: string } | null;
   accolades: RewindAchievement[];
@@ -119,7 +130,7 @@ export interface RewindSummary {
  * keep their stored version and are rendered tolerantly by
  * `normalizeSnapshotSummary`.
  */
-export const SNAPSHOT_SCHEMA_VERSION = 1;
+export const SNAPSHOT_SCHEMA_VERSION = 2;
 
 /** How many voice companions the Rewind card renders (#567). */
 export const TOP_COMPANIONS_SHOWN = 5;
@@ -348,6 +359,28 @@ export function computePeakMessageDay(
 }
 
 /**
+ * Pull a single year's reaction count out of a `yearly*` bucket (#653).
+ *
+ * The bucket is the model's `Map<"YYYY", number>` field. Mongoose returns
+ * Map fields as a real `Map` from a hydrated doc but as a plain object from
+ * a `.lean()` read, so we accept both shapes (plus null/undefined for a
+ * user with no row). Missing year, malformed value, or absent bucket all
+ * read as `0` so the caller and view never special-case empty data.
+ */
+export function extractYearlyReactionCount(
+  bucket: Map<string, number> | Record<string, number> | null | undefined,
+  year: number,
+): number {
+  if (!bucket) return 0;
+  const key = String(year);
+  const raw =
+    bucket instanceof Map
+      ? bucket.get(key)
+      : (bucket as Record<string, number>)[key];
+  return typeof raw === "number" && Number.isFinite(raw) && raw > 0 ? raw : 0;
+}
+
+/**
  * Longest run of consecutive days that contain ≥1 session. Returns the
  * day count and the start/end ISO dates of the winning run. A single day
  * of activity counts as a streak of 1. Days are bucketed in UTC by
@@ -460,6 +493,10 @@ export function normalizeSnapshotSummary(
     messagesSent: s.messagesSent ?? 0,
     topTextChannels: s.topTextChannels ?? [],
     peakMessageDay: s.peakMessageDay ?? null,
+    // Snapshots frozen before #653 (schema v1) carry no reaction fields;
+    // default them to 0 so the card stays hidden rather than rendering NaN.
+    reactionsGiven: s.reactionsGiven ?? 0,
+    reactionsReceived: s.reactionsReceived ?? 0,
     longestStreakDays: s.longestStreakDays ?? 0,
     longestStreakRange: s.longestStreakRange ?? null,
     accolades: s.accolades ?? [],
@@ -600,12 +637,14 @@ export class RewindService {
         { annualRank, annualGuildMembers, percentAboveMedian },
         weeklyJourney,
         text,
+        reactions,
         snapshotYears,
         storedCompanionNames,
       ] = await Promise.all([
         this.computeAnnualRank(userId, start, end, totalSeconds),
         this.computeWeeklyJourney(userId, start, end),
         this.computeTextActivity(userId, guildId, start, end, dayZone),
+        this.computeReactionActivity(userId, guildId, year),
         this.collectSnapshotYears(userId, guildId),
         this.fetchStoredUsernames(companionCandidates.map((c) => c.userId)),
       ]);
@@ -656,6 +695,8 @@ export class RewindService {
         messagesSent: text.messagesSent,
         topTextChannels: text.topTextChannels,
         peakMessageDay: text.peakMessageDay,
+        reactionsGiven: reactions.given,
+        reactionsReceived: reactions.received,
         longestStreakDays: streak.days,
         longestStreakRange:
           streak.startDate && streak.endDate
@@ -998,6 +1039,56 @@ export class RewindService {
     } catch (error) {
       logger.warn(
         `RewindService.computeTextActivity failed for ${userId}:`,
+        error,
+      );
+      return empty;
+    }
+  }
+
+  /**
+   * Read the user's reaction activity for the year (#653). One indexed
+   * `(userId, guildId)` lookup pulling just the two `yearly*` buckets, then
+   * the requested year's count out of each — consistent with the model's
+   * "read a single year's count in one lookup" design. Returns zero when
+   * reaction tracking is disabled (per the gate) or the user has no row, so
+   * the view can hide the card without special-casing.
+   *
+   * Note: unlike the voice/text peaks, these buckets are keyed by
+   * host-timezone year at capture time and intentionally retain no
+   * per-reaction timestamps, so they are *not* re-bucketed into the user's
+   * zone — see the `RewindSummary` field comment and the model header.
+   */
+  private async computeReactionActivity(
+    userId: string,
+    guildId: string,
+    year: number,
+  ): Promise<{ given: number; received: number }> {
+    const empty = { given: 0, received: 0 };
+    try {
+      const enabled = await this.configService.getBoolean(
+        "reactiontracking.enabled",
+        false,
+      );
+      if (!enabled) return empty;
+
+      const doc = await ReactionActivityTracking.findOne(
+        { userId, guildId },
+        // Only the per-year buckets are needed — skip lifetime totals
+        // (which span all years) and the username/timestamp fields.
+        { yearlyGiven: 1, yearlyReceived: 1 },
+      ).lean<{
+        yearlyGiven?: Map<string, number> | Record<string, number>;
+        yearlyReceived?: Map<string, number> | Record<string, number>;
+      }>();
+      if (!doc) return empty;
+
+      return {
+        given: extractYearlyReactionCount(doc.yearlyGiven, year),
+        received: extractYearlyReactionCount(doc.yearlyReceived, year),
+      };
+    } catch (error) {
+      logger.warn(
+        `RewindService.computeReactionActivity failed for ${userId}:`,
         error,
       );
       return empty;

--- a/src/web/user-layout.ts
+++ b/src/web/user-layout.ts
@@ -385,6 +385,10 @@ export interface RewindBodyOptions {
   messagesSent: number;
   topTextChannels: RewindTextChannelView[];
   peakMessageDay: { date: string; count: number } | null;
+  // Reaction activity (#653). Given / received counts for the year; the
+  // block is hidden when both are 0 (no data or reaction tracking off).
+  reactionsGiven: number;
+  reactionsReceived: number;
 }
 
 function renderYearPicker(current: number, years: number[]): string {
@@ -494,6 +498,28 @@ function renderTextActivity(opts: RewindBodyOptions): string {
   ].join("");
 }
 
+/**
+ * Reaction-activity stat pair (#653). Reuses the voice/text `.rw-stat`
+ * styling. Returns "" when the user gave and received no reactions this
+ * year (no data or reaction tracking off) so the route can append it
+ * unconditionally and the block simply disappears.
+ */
+function renderReactionActivity(opts: RewindBodyOptions): string {
+  const given = opts.reactionsGiven > 0 ? opts.reactionsGiven : 0;
+  const received = opts.reactionsReceived > 0 ? opts.reactionsReceived : 0;
+  if (given <= 0 && received <= 0) return "";
+
+  return [
+    "<h2>Reactions</h2>",
+    '<div class="rw-grid">',
+    '<div class="rw-stat"><div class="label">Reactions given</div>' +
+      `<div class="value">${given}</div></div>`,
+    '<div class="rw-stat"><div class="label">Reactions received</div>' +
+      `<div class="value">${received}</div></div>`,
+    "</div>",
+  ].join("");
+}
+
 export function renderUserRewindBody(opts: RewindBodyOptions): string {
   const years = opts.availableYears.includes(opts.year)
     ? opts.availableYears
@@ -595,6 +621,7 @@ export function renderUserRewindBody(opts: RewindBodyOptions): string {
     "</div>",
     '<div class="card"><h2>Top voice companions</h2>' + companions + "</div>",
     renderTextActivity(opts),
+    renderReactionActivity(opts),
     '<div class="card"><h2>Rank journey</h2>' +
       renderJourney(opts.weeklyJourney) +
       "</div>",

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -840,6 +840,8 @@ export function createUserRouter(
             count: c.count,
           })),
           peakMessageDay: summary.peakMessageDay,
+          reactionsGiven: summary.reactionsGiven,
+          reactionsReceived: summary.reactionsReceived,
         }),
         csrfToken: getCsrfToken(req),
         remainingMs: getDisplayedRemainingMs(session),


### PR DESCRIPTION
Closes #653.

Surfaces the per-user reaction counts already captured by `ReactionActivityTracking` on the Rewind year-in-review. This is the **rendering step only** — no new capture — mirroring the text-activity surface (#496).

## Changes

### `RewindSummary` (`src/services/rewind-service.ts`)
- Adds `reactionsGiven` / `reactionsReceived` for the requested year, sourced from the year's `yearlyGiven` / `yearlyReceived` bucket via a **single indexed `(userId, guildId)` lookup** (consistent with the model's "one lookup per year" design). Gated on `reactiontracking.enabled`; reads `0` when disabled or the user has no row.
- New pure, exported helper `extractYearlyReactionCount` tolerates both the `.lean()` plain-object shape and the hydrated `Map` shape, and coerces missing/malformed/non-positive values to `0`.
- **Does not** sum lifetime totals (those span all years) and does not re-bucket: the per-year buckets are keyed by **host-timezone** year at capture time, and the model retains counts only (no per-reaction timestamps), so they can't be re-bucketed into the user zone. This minor inconsistency with the user-timezone day bucketing (#524) is documented on the summary field and the helper.

### Rewind card (`src/web/user-layout.ts` + `src/web/user-routes.ts`)
- A "Reactions" stat pair (given / received) using the existing `.rw-stat` styling, placed alongside the voice/text blocks. Hidden entirely when both are `0`, matching the text-activity empty-state convention.

### Snapshot compatibility (#574)
- `SNAPSHOT_SCHEMA_VERSION` bumped `1 → 2`. New snapshots include the reaction counts (frozen via the existing `getSummary` path); `normalizeSnapshotSummary` defaults the fields to `0` so older snapshots that lack them still render with the card hidden.

## Out of scope (per the issue)
- No standalone `/reactions top` leaderboard or non-Rewind page.
- No "top emoji used" — the model keeps counts only, which would need new capture.

## Tests
- `extractYearlyReactionCount`: zero-data, present-year, absent-year, and malformed/non-positive cases.
- `getSummary` wiring: enabled (present + absent year), disabled (never queries the model), and no-row.
- `normalizeSnapshotSummary`: defaults reaction fields to `0` for pre-#653 snapshots; preserves stored counts.
- Route render: shows the block when data exists, hides it when both are `0`.

Docs updated in `SETTINGS.md` and `WEBUI.md`. Full suite green (`build` + `lint` + `format:check` + 1348 tests + markdownlint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHu1hfAfTqU929f3LGZYd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHu1hfAfTqU929f3LGZYd2)_