### PR TITLE
fix: warn and short-circuit when leaderboard/digest/achievements run with voice tracking disabled

### DIFF
--- a/__tests__/services/achievements-service.test.ts
+++ b/__tests__/services/achievements-service.test.ts
@@ -47,6 +47,7 @@ import {
   type IVoiceChannelTracking,
 } from "../../src/models/voice-channel-tracking.js";
 import { UserNotificationPrefsService } from "../../src/services/user-notification-prefs-service.js";
+import logger from "../../src/utils/logger.js";
 
 // Helper that mimics a Mongoose query cursor over a fixed set of docs, so
 // tests can exercise the streaming `.find({}).cursor()` path.
@@ -82,8 +83,19 @@ function createAchievementsService(mockClient: Partial<Client>) {
 
 describe("AchievementsService", () => {
   let mockClient: Partial<Client>;
+  // The global ESM logger mock doesn't intercept the singleton the service
+  // imports, so spy on the real logger object (a shared module cache instance)
+  // to observe the voice-tracking-disabled warning. Fresh spy per test.
+  let warnSpy: ReturnType<typeof jest.spyOn>;
 
   beforeEach(() => {
+    warnSpy = jest
+      .spyOn(logger, "warn")
+      .mockImplementation((() => logger) as never);
+    // spyOn returns the same spy across tests once installed, so reset its
+    // call history each run to keep per-test assertions isolated.
+    warnSpy.mockClear();
+
     // Reconfigure mock methods for each test
     (UserAchievements.findOne as jest.Mock).mockResolvedValue(null);
     (UserAchievements.find as jest.Mock).mockReturnValue(mockFindCursor([]));
@@ -244,6 +256,46 @@ describe("AchievementsService", () => {
       expect(Array.isArray(result)).toBe(true);
     });
 
+    it("short-circuits and warns when voice tracking is disabled", async () => {
+      (VoiceChannelTracking.findOne as jest.Mock).mockClear();
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
+      // Achievements on, but its hard dependency (voice tracking) is off.
+      mockConfigService.getBoolean.mockImplementation(async (key: unknown) =>
+        key === "voicetracking.enabled" ? false : true,
+      );
+
+      const result = await service.checkAndAwardAccolades(
+        "user123",
+        "TestUser",
+      );
+
+      expect(result).toEqual([]);
+      // No badge evaluation: the per-user tracking lookup never runs.
+      expect(VoiceChannelTracking.findOne as jest.Mock).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("voice tracking is disabled"),
+      );
+    });
+
+    it("logs the voice-tracking-disabled warning once across many users", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
+      mockConfigService.getBoolean.mockImplementation(async (key: unknown) =>
+        key === "voicetracking.enabled" ? false : true,
+      );
+
+      await service.checkAndAwardAccolades("u1", "U1");
+      await service.checkAndAwardAccolades("u2", "U2");
+      await service.checkAndAwardAccolades("u3", "U3");
+
+      // Throttled: per-user invocations must not spam the log.
+      const warnCalls = warnSpy.mock.calls.filter((c) =>
+        String(c[0]).includes("voice tracking is disabled"),
+      );
+      expect(warnCalls).toHaveLength(1);
+    });
+
     it("should return empty when user has existing accolades already", async () => {
       const { service, mockConfigService } =
         createAchievementsService(mockClient);
@@ -301,6 +353,27 @@ describe("AchievementsService", () => {
         "TestUser",
       );
       expect(Array.isArray(result)).toBe(true);
+    });
+
+    it("short-circuits and warns when voice tracking is disabled", async () => {
+      (UserAchievements.findOne as jest.Mock).mockClear();
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
+      // Achievements on, but its hard dependency (voice tracking) is off.
+      mockConfigService.getBoolean.mockImplementation(async (key: unknown) =>
+        key === "voicetracking.enabled" ? false : true,
+      );
+
+      const result = await service.checkAndAwardAchievements(
+        "user123",
+        "TestUser",
+      );
+
+      expect(result).toEqual([]);
+      expect(UserAchievements.findOne as jest.Mock).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("voice tracking is disabled"),
+      );
     });
 
     it("should handle database errors gracefully", async () => {

--- a/__tests__/services/digest-service.test.ts
+++ b/__tests__/services/digest-service.test.ts
@@ -5,6 +5,7 @@ const mockRegisterReloadCallback = jest.fn();
 const mockConfigGetBoolean = jest.fn();
 const mockConfigGetString = jest.fn();
 const mockConfigGetNumber = jest.fn();
+const mockLoggerWarn = jest.fn();
 
 const mockGetTopUsers = jest.fn();
 const mockTrackerGetInstance = jest.fn(() => ({
@@ -81,7 +82,7 @@ jest.unstable_mockModule("../../src/models/user-achievements.js", () => ({
 jest.unstable_mockModule("../../src/utils/logger.js", () => ({
   default: {
     info: jest.fn(),
-    warn: jest.fn(),
+    warn: mockLoggerWarn,
     error: jest.fn(),
     debug: jest.fn(),
   },
@@ -108,6 +109,7 @@ describe("DigestService", () => {
     mockConfigGetBoolean.mockImplementation(async (key: unknown) => {
       const k = key as string;
       if (k === "digest.enabled") return true;
+      if (k === "voicetracking.enabled") return true;
       if (k === "digest.include_achievements") return false;
       return false;
     });
@@ -185,6 +187,21 @@ describe("DigestService", () => {
       const result = await svc.runNow();
       expect(result).toBeNull();
       expect(mockGetTopUsers).not.toHaveBeenCalled();
+    });
+
+    it("short-circuits and warns when voice tracking is disabled", async () => {
+      // Digest on, but its hard dependency (voice tracking) is off.
+      mockConfigGetBoolean.mockImplementation(async (key: unknown) =>
+        key === "digest.enabled" ? true : false,
+      );
+      const svc: ServiceInstance = DigestService.getInstance(makeClient());
+      const result = await svc.runNow();
+      expect(result).toBeNull();
+      expect(mockGetTopUsers).not.toHaveBeenCalled();
+      expect(mockUserSend).not.toHaveBeenCalled();
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining("voice tracking is disabled"),
+      );
     });
   });
 

--- a/__tests__/services/leaderboard-role-service.test.ts
+++ b/__tests__/services/leaderboard-role-service.test.ts
@@ -4,6 +4,7 @@ import type { Client } from "discord.js";
 const mockRegisterReloadCallback = jest.fn();
 const mockConfigGetBoolean = jest.fn();
 const mockConfigGetString = jest.fn();
+const mockLoggerWarn = jest.fn();
 
 const mockGetTopUsers = jest.fn();
 const mockTrackerGetInstance = jest.fn(() => ({
@@ -49,7 +50,7 @@ jest.unstable_mockModule(
 jest.unstable_mockModule("../../src/utils/logger.js", () => ({
   default: {
     info: jest.fn(),
-    warn: jest.fn(),
+    warn: mockLoggerWarn,
     error: jest.fn(),
     debug: jest.fn(),
   },
@@ -166,6 +167,28 @@ describe("LeaderboardRoleService", () => {
       const result = await svc.runNow();
       expect(result).toBeNull();
       expect(mockGetTopUsers).not.toHaveBeenCalled();
+    });
+
+    it("short-circuits and warns when voice tracking is disabled", async () => {
+      // Feature on, but its hard dependency (voice tracking) is off.
+      mockConfigGetBoolean.mockImplementation(async (key: unknown) =>
+        key === "voicetracking.enabled" ? false : true,
+      );
+      mockConfigGetString.mockImplementation(async (key: unknown) => {
+        const k = key as string;
+        if (k === "GUILD_ID") return "guild-1";
+        if (k === "leaderboard_roles.tiers") return "1:99999001";
+        if (k === "leaderboard_roles.period") return "alltime";
+        return "";
+      });
+      const svc: ServiceInstance =
+        LeaderboardRoleService.getInstance(makeClient());
+      const result = await svc.runNow();
+      expect(result).toBeNull();
+      expect(mockGetTopUsers).not.toHaveBeenCalled();
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining("voice tracking is disabled"),
+      );
     });
 
     it("returns null when no tiers are configured", async () => {

--- a/src/services/achievements-service.ts
+++ b/src/services/achievements-service.ts
@@ -57,10 +57,13 @@ export class AchievementsService {
   private configService: ConfigService;
   private isConnected: boolean = false;
 
-  // Voice tracking is a hard dependency (#659): accolades/achievements are
-  // evaluated against tracked voice sessions. The accolade/achievement checks
-  // fire once per session end (per user), so we throttle the "tracking
-  // disabled" warning instead of logging it for every user.
+  // Accolade/achievement evaluation is driven entirely by the session-end
+  // flow, whose hard dependency is voice tracking (#659): most badges score
+  // tracked voice sessions, and the few quote-based accolades are only
+  // evaluated here too (piggybacked on session end). When voice tracking is
+  // off we short-circuit the whole flow. Those checks fire once per session
+  // end (per user), so we throttle the "tracking disabled" warning instead of
+  // logging it for every user.
   private static readonly VOICE_DISABLED_LOG_INTERVAL_MS = 60 * 60 * 1000; // 1h
   private lastVoiceTrackingDisabledLogAt = 0;
 
@@ -1017,12 +1020,14 @@ export class AchievementsService {
   }
 
   /**
-   * Whether voice tracking — the hard dependency for every accolade and
-   * achievement (#659) — is enabled. When it is off we short-circuit before
-   * evaluating any badge logic against absent voice data, mirroring
-   * `voice-channel-announcer.ts`. The warning is throttled (once per
-   * {@link VOICE_DISABLED_LOG_INTERVAL_MS}) so the per-user invocations don't
-   * spam the logs.
+   * Whether voice tracking — the hard dependency of the session-end badge
+   * evaluation flow (#659) — is enabled. Most accolades/achievements score
+   * tracked voice sessions; the few quote-based accolades are voice-agnostic
+   * but are only evaluated via this same session-end flow, so when voice
+   * tracking is off we short-circuit the whole flow before touching any badge
+   * logic, mirroring `voice-channel-announcer.ts`. The warning is throttled
+   * (once per {@link VOICE_DISABLED_LOG_INTERVAL_MS}) so the per-user
+   * invocations don't spam the logs.
    */
   private async isVoiceTrackingEnabled(): Promise<boolean> {
     const enabled = await this.configService.getBoolean(

--- a/src/services/achievements-service.ts
+++ b/src/services/achievements-service.ts
@@ -57,6 +57,13 @@ export class AchievementsService {
   private configService: ConfigService;
   private isConnected: boolean = false;
 
+  // Voice tracking is a hard dependency (#659): accolades/achievements are
+  // evaluated against tracked voice sessions. The accolade/achievement checks
+  // fire once per session end (per user), so we throttle the "tracking
+  // disabled" warning instead of logging it for every user.
+  private static readonly VOICE_DISABLED_LOG_INTERVAL_MS = 60 * 60 * 1000; // 1h
+  private lastVoiceTrackingDisabledLogAt = 0;
+
   // Minimum duration threshold for consecutive days (5 minutes in seconds)
   private static readonly MIN_DAILY_DURATION_SECONDS = 300;
 
@@ -1010,6 +1017,34 @@ export class AchievementsService {
   }
 
   /**
+   * Whether voice tracking — the hard dependency for every accolade and
+   * achievement (#659) — is enabled. When it is off we short-circuit before
+   * evaluating any badge logic against absent voice data, mirroring
+   * `voice-channel-announcer.ts`. The warning is throttled (once per
+   * {@link VOICE_DISABLED_LOG_INTERVAL_MS}) so the per-user invocations don't
+   * spam the logs.
+   */
+  private async isVoiceTrackingEnabled(): Promise<boolean> {
+    const enabled = await this.configService.getBoolean(
+      "voicetracking.enabled",
+      false,
+    );
+    if (!enabled) {
+      const now = Date.now();
+      if (
+        now - this.lastVoiceTrackingDisabledLogAt >=
+        AchievementsService.VOICE_DISABLED_LOG_INTERVAL_MS
+      ) {
+        this.lastVoiceTrackingDisabledLogAt = now;
+        logger.warn(
+          "Accolade/achievement evaluation skipped: voice tracking is disabled (voicetracking.enabled=false).",
+        );
+      }
+    }
+    return enabled;
+  }
+
+  /**
    * Check and award accolades (persistent badges) to a user
    * Returns newly earned accolades
    */
@@ -1025,6 +1060,10 @@ export class AchievementsService {
         false,
       );
       if (!isEnabled) {
+        return [];
+      }
+
+      if (!(await this.isVoiceTrackingEnabled())) {
         return [];
       }
 
@@ -1116,6 +1155,10 @@ export class AchievementsService {
       );
 
       if (!isEnabled) {
+        return [];
+      }
+
+      if (!(await this.isVoiceTrackingEnabled())) {
         return [];
       }
 

--- a/src/services/digest-service.ts
+++ b/src/services/digest-service.ts
@@ -279,6 +279,20 @@ export class DigestService {
         return null;
       }
 
+      // Voice tracking is a hard dependency (#659): the digest ranks members
+      // by tracked voice time, so without it every DM would report empty/stale
+      // rankings. Mirror voice-channel-announcer.ts and short-circuit.
+      const trackingEnabled = await this.configService.getBoolean(
+        "voicetracking.enabled",
+        false,
+      );
+      if (!trackingEnabled) {
+        logger.warn(
+          "Digest run aborted: voice tracking is disabled (voicetracking.enabled=false).",
+        );
+        return null;
+      }
+
       const guildId = await this.configService.getString("GUILD_ID", "");
       if (!guildId) {
         logger.error("Digest run aborted: GUILD_ID not configured");

--- a/src/services/leaderboard-role-service.ts
+++ b/src/services/leaderboard-role-service.ts
@@ -223,6 +223,20 @@ export class LeaderboardRoleService {
         return null;
       }
 
+      // Voice tracking is a hard dependency (#659): without it there is no
+      // ranking data, so reconciling roles would only churn members against
+      // empty/stale data. Mirror voice-channel-announcer.ts and short-circuit.
+      const trackingEnabled = await this.configService.getBoolean(
+        "voicetracking.enabled",
+        false,
+      );
+      if (!trackingEnabled) {
+        logger.warn(
+          "Leaderboard role reconciliation skipped: voice tracking is disabled (voicetracking.enabled=false).",
+        );
+        return null;
+      }
+
       const guildId = await this.configService.getString("GUILD_ID", "");
       if (!guildId) {
         logger.error("GUILD_ID not configured");


### PR DESCRIPTION
## Summary

Three voice-data consumers gated **only on their own `*.enabled` flag** and never checked `voicetracking.enabled` (their hard dependency, #659). When voice tracking is disabled (or has no data), their scheduled jobs ran silently against empty/stale data — leaderboard roles reconciled against nothing, the digest DMed empty rankings, achievements evaluated against absent voice data — with no warning logged.

This is the runtime **defence-in-depth** half (complements the write-time enforcement in #663), mirroring the existing pattern in `voice-channel-announcer.ts:102-115`.

## Changes

- **`leaderboard-role-service.ts`** — guard `runNow()` (covers the cron path) after the `leaderboard_roles.enabled` check: read `voicetracking.enabled` and short-circuit with a `logger.warn` before fetching top users / reconciling roles.
- **`digest-service.ts`** — guard `runOnce()` after the `digest.enabled` check, before fetching rankings or sending DMs.
- **`achievements-service.ts`** — guard `checkAndAwardAccolades` and `checkAndAwardAchievements`. These fire once per session-end (per user), so the "tracking disabled" warning is **throttled to once per hour** via a new `isVoiceTrackingEnabled()` helper, keeping logging non-spammy as required.

## Tests

Added unit tests to all three suites asserting each service:
- short-circuits and logs a warning when `voicetracking.enabled` is false (no role reconciliation, no digest DMs, no accolade/achievement evaluation), and
- runs normally when it is enabled.

The achievements suite also verifies the warning is logged **once across many per-user invocations**.

## Verification

- `npm run build` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm run test:ci` ✅ — 1340 passing, coverage thresholds held

## Acceptance criteria

- [x] `leaderboard-role-service`, `digest-service`, and `achievements-service` short-circuit and log when `voicetracking.enabled` is false, mirroring `voice-channel-announcer.ts`.
- [x] No empty-data processing occurs when the dependency is off.
- [x] Logging is once-per-run, not per-user.
- [x] Unit tests assert each service short-circuits + logs when disabled, and runs normally when enabled.

Closes #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ha9HYjqT7H8m1MsCwmsRZf)_