### PR TITLE
feat(celebrations): announce marquee accolade milestones server-wide (#657)

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -36,6 +36,7 @@ Complete configuration reference for all KoolBot settings.
 - [Reaction Tracking](#-reaction-tracking)
 - [Announcements](#-announcements)
 - [Achievements System](#-achievements-system)
+- [Milestone Celebrations](#-milestone-celebrations)
 - [Weekly Digest](#-weekly-digest)
 - [Rewind (Year-in-Review)](#-rewind-year-in-review)
 - [Reaction Roles](#-reaction-roles)
@@ -447,6 +448,44 @@ accolade list and usage.
 
 ---
 
+## 🎊 Milestone Celebrations
+
+A loud, server-wide shout-out the first time **anyone** crosses a
+_marquee_ accolade — the rare, top-tier crossings worth cheering as a
+community. Every accolade still gets its usual personal DM and weekly
+round-up; this adds a single extra announcement in a dedicated channel
+for just the headline milestones.
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `celebrations.enabled` | `false` | Master switch — posts a celebration when a marquee accolade is first earned. Requires `achievements.enabled` |
+| `celebrations.channel_id` | `""` | Channel where milestone celebrations are posted. Leave empty to disable the post (the accolade is still awarded) |
+
+**Which accolades are "marquee":**
+
+- 🏆 **Voice Master** — 1000 hours in voice (`voice_veteran_1000`)
+- 👑 **Voice Legend** — a full year, 8765 hours, in voice (`voice_legend_8765`)
+- 💀 **No-Lifer** — a 30-day connection streak (`consistent_month`)
+- 🏆 **Quote Legend** — 100 quotes added (`quote_legend`)
+
+**Notes:**
+
+- Reuses the existing accolade award detection (after each voice session
+  ends) — nothing new is tracked, and a celebration never fires twice for
+  the same user/accolade because accolades are awarded once.
+- The post pings the member. Failures (missing channel, missing
+  permissions) are logged and never break the underlying award flow.
+- The curated marquee list lives in `src/content/accolades.ts`
+  (`MILESTONE_ACCOLADES`).
+
+**Requirements:**
+
+- Requires `achievements.enabled = true` (which in turn requires
+  `voicetracking.enabled = true`). The celebration is inert without the
+  achievements award path that detects the crossing.
+
+---
+
 ## 📬 Weekly Digest
 
 Per-user weekly DM that summarises voice activity, leaderboard rank,
@@ -511,7 +550,7 @@ expose the page.
 
 - **Upgrade note (#608):** before this change, the single `rewind.enabled`
   key only controlled the nudge and the page was always live. The key now
-  gates the *feature*; the nudge moved to `rewind.nudge.enabled`. Installs
+  gates the _feature_; the nudge moved to `rewind.nudge.enabled`. Installs
   that had set `rewind.enabled = true` keep both the page and the nudge on
   (the nudge reads `rewind.nudge.enabled`, falling back to the old
   `rewind.enabled` value when unset). Installs that never enabled it now
@@ -942,6 +981,7 @@ Current hard dependencies:
 | `digest.enabled` | `voicetracking.enabled` |
 | `digest.include_achievements` | `achievements.enabled` |
 | `achievements.enabled` | `voicetracking.enabled` |
+| `celebrations.enabled` | `achievements.enabled` |
 | `voicetracking.announcements.enabled` | `voicetracking.enabled` |
 
 **Write-time enforcement.** Every config write surface — `ConfigService.set`,
@@ -950,9 +990,9 @@ wizard apply — validates these dependencies before persisting, so the rule
 holds no matter how a value is changed:
 
 - **Enabling** a key whose dependency is off is **rejected** with a message
-  naming the unmet dependency (e.g. *"Cannot enable Achievements: requires
+  naming the unmet dependency (e.g. _"Cannot enable Achievements: requires
   Voice Tracking enabled (`voicetracking.enabled`) to be enabled. Enable it
-  first."*). Enabling a feature **and** its dependency together in one wizard
+  first."_). Enabling a feature **and** its dependency together in one wizard
   run or one section save is allowed — the batch is validated as a whole.
 - **Disabling** a key while another enabled feature still depends on it is
   **blocked** (not silently cascade-disabled), with a message naming the
@@ -1034,6 +1074,11 @@ leave the graph in a broken state.
 - `achievements.enabled` (bool, default: false)
 - `achievements.announcements.enabled` (bool, default: true)
 - `achievements.dm_notifications.enabled` (bool, default: true)
+
+#### Milestone Celebrations
+
+- `celebrations.enabled` (bool, default: false)
+- `celebrations.channel_id` (string, default: "")
 
 #### Weekly Digest
 

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -532,7 +532,7 @@ longest session, longest streak, badges earned, annual rank, a
 first/best/last weekly-rank journey, text activity, and reaction activity
 (given / received). Year picker bottom-anchored to years with data.
 
-**Graceful degradation (#665):** Rewind is an *aggregator* — every section
+**Graceful degradation (#665):** Rewind is an _aggregator_ — every section
 is gated on its own source feature and degrades independently, so the page
 renders whatever subset of sources happens to be on and simply hides the
 rest. It is never blocked or rejected because a source is off (this is the

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -815,6 +815,14 @@ streak/state updates; concurrent runs coalesce, so clicking it during a
 scheduled tick can't double-deliver. There is intentionally **no `/digest`
 slash command** — the Web UI is the admin surface.
 
+**Milestone celebrations** (`#657`, Part 2) have no dedicated page: they are
+configured entirely under **Settings** (`celebrations.enabled`,
+`celebrations.channel_id`). When enabled, the bot posts a loud, server-wide
+shout-out to the configured channel the first time anyone crosses a marquee
+accolade (Voice Legend, 1000 hours, a 30-day streak, 100 quotes), reusing the
+existing achievements award detection. `celebrations.enabled` depends on
+`achievements.enabled`, so Settings greys it until achievements are on.
+
 ### User self-service (`/me/*`, both admin and user roles)
 
 | Page                                    | What it's for                                                                                                                                              |

--- a/__tests__/content/accolades.test.ts
+++ b/__tests__/content/accolades.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+  ACCOLADE_METADATA,
+  MILESTONE_ACCOLADES,
+  isMilestoneAccolade,
+  type AccoladeType,
+} from "../../src/content/accolades.js";
+
+describe("MILESTONE_ACCOLADES (#657, Part 2)", () => {
+  it("references only real accolade types", () => {
+    for (const type of MILESTONE_ACCOLADES) {
+      expect(ACCOLADE_METADATA[type]).toBeDefined();
+    }
+  });
+
+  it("has no duplicate entries", () => {
+    expect(new Set(MILESTONE_ACCOLADES).size).toBe(MILESTONE_ACCOLADES.length);
+  });
+
+  it("stays a small, curated subset of all accolades", () => {
+    const total = Object.keys(ACCOLADE_METADATA).length;
+    // Loud, server-wide shout-outs should be rare — well under half of all
+    // accolades. Guards against someone accidentally flagging the bulk of
+    // the list and spamming the celebrations channel.
+    expect(MILESTONE_ACCOLADES.length).toBeGreaterThan(0);
+    expect(MILESTONE_ACCOLADES.length).toBeLessThan(total / 2);
+  });
+
+  it("includes the marquee crossings called out in the issue", () => {
+    expect(MILESTONE_ACCOLADES).toContain("voice_legend_8765");
+    expect(MILESTONE_ACCOLADES).toContain("voice_veteran_1000");
+    expect(MILESTONE_ACCOLADES).toContain("quote_legend");
+  });
+});
+
+describe("isMilestoneAccolade", () => {
+  it("returns true for every flagged accolade", () => {
+    for (const type of MILESTONE_ACCOLADES) {
+      expect(isMilestoneAccolade(type)).toBe(true);
+    }
+  });
+
+  it("returns false for a non-marquee accolade", () => {
+    expect(isMilestoneAccolade("first_hour")).toBe(false);
+    expect(isMilestoneAccolade("quotable")).toBe(false);
+  });
+
+  it("returns false for an unknown / non-accolade string", () => {
+    expect(isMilestoneAccolade("not_a_real_type")).toBe(false);
+    expect(isMilestoneAccolade("")).toBe(false);
+  });
+
+  it("agrees with the MILESTONE_ACCOLADES set across all accolades", () => {
+    for (const type of Object.keys(ACCOLADE_METADATA) as AccoladeType[]) {
+      expect(isMilestoneAccolade(type)).toBe(
+        (MILESTONE_ACCOLADES as readonly string[]).includes(type),
+      );
+    }
+  });
+});

--- a/__tests__/services/achievements-service.test.ts
+++ b/__tests__/services/achievements-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
-import type { Client } from "discord.js";
+import { type Client, TextChannel } from "discord.js";
 
 // Do NOT override the global mongoose mock from setup.ts — rely on it for stable jest.fn() instances.
 
@@ -555,6 +555,146 @@ describe("AchievementsService", () => {
 
       expect(getPrefsSpy).not.toHaveBeenCalled();
       expect(mockUser.send).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("announceMilestones (#657, Part 2)", () => {
+    // A stand-in that passes `channel instanceof TextChannel` without
+    // constructing the real (heavy) discord.js channel.
+    function makeTextChannel() {
+      const channel = Object.create(TextChannel.prototype) as TextChannel & {
+        send: jest.Mock;
+      };
+      channel.send = jest.fn().mockResolvedValue(undefined as never) as never;
+      return channel as unknown as TextChannel & { send: jest.Mock };
+    }
+
+    // Wire a service whose client + config resolve a usable celebrations
+    // channel. `celebrations.enabled` is the only boolean read.
+    function wireCelebrations(
+      service: AchievementsService,
+      mockConfigService: ReturnType<
+        typeof createAchievementsService
+      >["mockConfigService"],
+      opts: { enabled?: boolean; channelId?: string; guildId?: string } = {},
+    ) {
+      const { enabled = true, channelId = "chan-1", guildId = "guild-1" } = opts;
+      mockConfigService.getBoolean.mockResolvedValue(enabled);
+      (mockConfigService.getString as jest.Mock).mockImplementation(
+        (key: unknown) => {
+          if (key === "celebrations.channel_id")
+            return Promise.resolve(channelId);
+          if (key === "GUILD_ID") return Promise.resolve(guildId);
+          return Promise.resolve("");
+        },
+      );
+      const channel = makeTextChannel();
+      const channelsFetch = jest.fn().mockResolvedValue(channel as never);
+      (service as never)["client"] = {
+        guilds: {
+          fetch: jest
+            .fn()
+            .mockResolvedValue({ channels: { fetch: channelsFetch } } as never),
+        },
+      };
+      return { channel };
+    }
+
+    it("posts a celebration for a flagged marquee accolade", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
+      const { channel } = wireCelebrations(service, mockConfigService);
+
+      await service.announceMilestones("user1", "User1", [
+        { type: "voice_legend_8765", earnedAt: new Date(), metadata: {} },
+      ]);
+
+      expect(channel.send).toHaveBeenCalledTimes(1);
+      const arg = (channel.send as jest.Mock).mock.calls[0][0] as {
+        content: string;
+        allowedMentions: { users: string[] };
+      };
+      expect(arg.content).toContain("<@user1>");
+      expect(arg.content).toContain("Voice Legend");
+      expect(arg.allowedMentions).toEqual({ users: ["user1"] });
+    });
+
+    it("does nothing when celebrations are disabled", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
+      const { channel } = wireCelebrations(service, mockConfigService, {
+        enabled: false,
+      });
+
+      await service.announceMilestones("user1", "User1", [
+        { type: "voice_legend_8765", earnedAt: new Date(), metadata: {} },
+      ]);
+
+      expect(channel.send).not.toHaveBeenCalled();
+    });
+
+    it("does nothing for a non-marquee accolade", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
+      const { channel } = wireCelebrations(service, mockConfigService);
+
+      await service.announceMilestones("user1", "User1", [
+        { type: "first_hour", earnedAt: new Date(), metadata: {} },
+      ]);
+
+      expect(channel.send).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when the accolade list is empty", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
+      const { channel } = wireCelebrations(service, mockConfigService);
+
+      await service.announceMilestones("user1", "User1", []);
+
+      expect(channel.send).not.toHaveBeenCalled();
+    });
+
+    it("skips (and warns) when no celebrations channel is configured", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
+      wireCelebrations(service, mockConfigService, { channelId: "" });
+
+      await expect(
+        service.announceMilestones("user1", "User1", [
+          { type: "quote_legend", earnedAt: new Date(), metadata: {} },
+        ]),
+      ).resolves.not.toThrow();
+      expect(warnSpy).toHaveBeenCalled();
+    });
+
+    it("posts once per marquee accolade and ignores non-marquee ones in the batch", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
+      const { channel } = wireCelebrations(service, mockConfigService);
+
+      await service.announceMilestones("user1", "User1", [
+        { type: "voice_veteran_1000", earnedAt: new Date(), metadata: {} },
+        { type: "first_hour", earnedAt: new Date(), metadata: {} },
+        { type: "quote_legend", earnedAt: new Date(), metadata: {} },
+      ]);
+
+      expect(channel.send).toHaveBeenCalledTimes(2);
+    });
+
+    it("never throws when posting fails", async () => {
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
+      const { channel } = wireCelebrations(service, mockConfigService);
+      (channel.send as jest.Mock).mockRejectedValue(
+        new Error("Missing Permissions") as never,
+      );
+
+      await expect(
+        service.announceMilestones("user1", "User1", [
+          { type: "voice_legend_8765", earnedAt: new Date(), metadata: {} },
+        ]),
+      ).resolves.not.toThrow();
     });
   });
 

--- a/__tests__/services/config-schema.test.ts
+++ b/__tests__/services/config-schema.test.ts
@@ -185,6 +185,7 @@ describe("Config Schema", () => {
       "digest.enabled": ["voicetracking.enabled"],
       "digest.include_achievements": ["achievements.enabled"],
       "achievements.enabled": ["voicetracking.enabled"],
+      "celebrations.enabled": ["achievements.enabled"],
       "voicetracking.announcements.enabled": ["voicetracking.enabled"],
     } satisfies Partial<Record<keyof ConfigSchema, (keyof ConfigSchema)[]>>;
 
@@ -243,15 +244,16 @@ describe("Config Schema", () => {
       );
     });
 
-    it("follows a single edge for a leaf dependency", () => {
-      expect(getDependents("achievements.enabled")).toEqual([
-        "digest.include_achievements",
-      ]);
+    it("lists every key that declares achievements.enabled as a dependency", () => {
+      expect(new Set(getDependents("achievements.enabled"))).toEqual(
+        new Set(["digest.include_achievements", "celebrations.enabled"]),
+      );
     });
 
     it("returns an empty array for keys nothing depends on", () => {
       expect(getDependents("quotes.enabled")).toEqual([]);
       expect(getDependents("digest.include_achievements")).toEqual([]);
+      expect(getDependents("celebrations.enabled")).toEqual([]);
     });
   });
 
@@ -412,6 +414,7 @@ describe("Config Schema", () => {
       "ratelimit.enabled": false,
       "announcements.enabled": false,
       "achievements.enabled": false,
+      "celebrations.enabled": false,
       "digest.enabled": false,
       "rewind.enabled": false,
       "birthdays.enabled": false,

--- a/__tests__/services/settings-metadata.test.ts
+++ b/__tests__/services/settings-metadata.test.ts
@@ -48,6 +48,7 @@ describe("settingsMetadata", () => {
       "ratelimit",
       "announcements",
       "achievements",
+      "celebrations",
       "birthdays",
       "reactionroles",
       "wizard",

--- a/__tests__/services/voice-channel-tracker.test.ts
+++ b/__tests__/services/voice-channel-tracker.test.ts
@@ -19,6 +19,7 @@ jest.mock("../../src/services/achievements-service.js", () => ({
       checkAndAwardAccolades: jest.fn().mockResolvedValue([]),
       checkAndAwardAchievements: jest.fn().mockResolvedValue(undefined),
       notifyUserOfAccolades: jest.fn().mockResolvedValue(undefined),
+      announceMilestones: jest.fn().mockResolvedValue(undefined),
     })),
   },
 }));

--- a/src/content/accolades.ts
+++ b/src/content/accolades.ts
@@ -128,3 +128,38 @@ export const ACCOLADE_METADATA = {
 } as const;
 
 export type AccoladeType = keyof typeof ACCOLADE_METADATA;
+
+/**
+ * The curated subset of "marquee" accolades whose first earning is loud
+ * enough to warrant a shared, server-wide celebration post (#657, Part 2)
+ * — not just the per-user DM + weekly round-up every accolade already
+ * gets. These are the rare, top-tier crossings (a full year in voice, a
+ * thousand hours, a month-long streak, a hundred quotes) where the whole
+ * server would want to cheer. Gated behind `celebrations.enabled`; the
+ * announcement reuses the existing session-end award detection rather than
+ * tracking anything new.
+ *
+ * Keep this list short and genuinely rare: every entry here means another
+ * announcement in the celebrations channel.
+ */
+export const MILESTONE_ACCOLADES = [
+  "voice_veteran_1000", // Voice Master — 1000 hours in voice
+  "voice_legend_8765", // Voice Legend — a full year (8765 hours) in voice
+  "consistent_month", // No-Lifer — a 30-day connection streak
+  "quote_legend", // Quote Legend — 100 quotes added
+] as const satisfies readonly AccoladeType[];
+
+export type MilestoneAccolade = (typeof MILESTONE_ACCOLADES)[number];
+
+const MILESTONE_ACCOLADE_SET: ReadonlySet<AccoladeType> = new Set(
+  MILESTONE_ACCOLADES,
+);
+
+/**
+ * Whether an accolade type is a marquee milestone (see
+ * {@link MILESTONE_ACCOLADES}). Accepts a plain string so callers can pass
+ * a stored `IAccolade.type` without a cast.
+ */
+export function isMilestoneAccolade(type: string): boolean {
+  return MILESTONE_ACCOLADE_SET.has(type as AccoladeType);
+}

--- a/src/services/achievements-service.ts
+++ b/src/services/achievements-service.ts
@@ -1,4 +1,4 @@
-import { Client } from "discord.js";
+import { Client, TextChannel } from "discord.js";
 import {
   UserAchievements,
   IAccolade,
@@ -20,11 +20,16 @@ import {
 import logger from "../utils/logger.js";
 import mongoose from "mongoose";
 import { quoteService } from "./quote-service.js";
-import { ACCOLADE_METADATA, type AccoladeType } from "../content/accolades.js";
+import {
+  ACCOLADE_METADATA,
+  isMilestoneAccolade,
+  type AccoladeType,
+} from "../content/accolades.js";
 import {
   ACHIEVEMENT_METADATA,
   type AchievementType,
 } from "../content/achievements.js";
+import { sanitizeForLog } from "../utils/log-sanitize.js";
 
 export type { AccoladeType, AchievementType };
 
@@ -1371,6 +1376,97 @@ export class AchievementsService {
     } catch (error) {
       logger.error("Error sending accolade notification DM:", error);
       // Don't throw - DM failures shouldn't break the flow
+    }
+  }
+
+  /**
+   * Post a loud, server-wide celebration for any *marquee* accolades the
+   * user just earned (#657, Part 2). This is the shared shout-out that
+   * complements — and never replaces — the personal DM
+   * ({@link notifyUserOfAccolades}) and the weekly round-up: only the
+   * curated, rare crossings listed in `MILESTONE_ACCOLADES` are loud
+   * enough to warrant pinging the whole channel.
+   *
+   * Reuses the existing session-end award detection — `accolades` is the
+   * exact `newAccolades` array the caller already has — so nothing extra is
+   * tracked. Gated behind `celebrations.enabled` (off by default) and a
+   * configured `celebrations.channel_id`; when either is missing it no-ops.
+   * Failures are swallowed: a celebration must never break the award flow.
+   */
+  public async announceMilestones(
+    userId: string,
+    username: string,
+    accolades: IAccolade[],
+  ): Promise<void> {
+    try {
+      if (accolades.length === 0) return;
+
+      const enabled = await this.configService.getBoolean(
+        "celebrations.enabled",
+        false,
+      );
+      if (!enabled) return;
+
+      // Of the freshly-earned accolades, keep only the marquee ones.
+      const milestones = accolades.filter((a) => isMilestoneAccolade(a.type));
+      if (milestones.length === 0) return;
+
+      const channelId = await this.configService.getString(
+        "celebrations.channel_id",
+        "",
+      );
+      if (!channelId) {
+        logger.warn(
+          "Milestone celebration skipped: celebrations.channel_id not configured",
+        );
+        return;
+      }
+
+      const guildId = await this.configService.getString("GUILD_ID", "");
+      if (!guildId) {
+        logger.warn("Milestone celebration skipped: GUILD_ID not configured");
+        return;
+      }
+
+      const guild = await this.client.guilds.fetch(guildId);
+      if (!guild) {
+        logger.error(
+          `Milestone celebration skipped: guild ${sanitizeForLog(guildId)} not found`,
+        );
+        return;
+      }
+
+      const channel = await guild.channels.fetch(channelId);
+      if (!channel || !(channel instanceof TextChannel)) {
+        logger.error(
+          `Milestone celebration skipped: channel ${sanitizeForLog(channelId)} not found or not a text channel`,
+        );
+        return;
+      }
+
+      for (const accolade of milestones) {
+        const definition = this.getAccoladeDefinition(accolade.type);
+        if (!definition) continue;
+
+        const message = [
+          `${definition.emoji} **Milestone unlocked!** ${definition.emoji}`,
+          "",
+          `🎉 <@${userId}> just earned **${definition.name}** — ${definition.description}!`,
+          "",
+          "Huge congratulations from the whole server! 🥳",
+        ].join("\n");
+
+        await channel.send({
+          content: message,
+          allowedMentions: { users: [userId] },
+        });
+        logger.info(
+          `Announced milestone celebration for ${username} (${userId}): ${definition.name}`,
+        );
+      }
+    } catch (error) {
+      logger.error("Error announcing milestone celebration:", error);
+      // Don't throw — a celebration failure must not break the award flow.
     }
   }
 

--- a/src/services/achievements-service.ts
+++ b/src/services/achievements-service.ts
@@ -1461,7 +1461,7 @@ export class AchievementsService {
           allowedMentions: { users: [userId] },
         });
         logger.info(
-          `Announced milestone celebration for ${username} (${userId}): ${definition.name}`,
+          `Announced milestone celebration for ${sanitizeForLog(username)} (${sanitizeForLog(userId)}): ${definition.name}`,
         );
       }
     } catch (error) {

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -67,6 +67,10 @@ export interface ConfigSchema {
   "achievements.announcements.enabled": boolean;
   "achievements.dm_notifications.enabled": boolean;
 
+  // Marquee Milestone Celebrations (#657, Part 2)
+  "celebrations.enabled": boolean;
+  "celebrations.channel_id": string; // Channel for server-wide milestone shout-outs
+
   // Weekly Personal Voice-Activity Digest (#483)
   "digest.enabled": boolean;
   "digest.cron": string; // Cron schedule, default Monday 09:00
@@ -230,6 +234,15 @@ export const defaultConfig: ConfigSchema = {
   "achievements.enabled": false,
   "achievements.announcements.enabled": true,
   "achievements.dm_notifications.enabled": true,
+
+  // Marquee milestone celebrations (#657, Part 2). Master gate off,
+  // follows rule 1 — when on, the bot posts a loud, server-wide shout-out
+  // to `celebrations.channel_id` the first time anyone crosses a curated
+  // rare accolade (Voice Legend, 1000 hours, etc.). Reuses the existing
+  // session-end award detection, so it's inert without achievements
+  // (hard dependency below) and stays silent until a channel is set.
+  "celebrations.enabled": false,
+  "celebrations.channel_id": "",
 
   // Weekly digest defaults (#483). Master gate off, follows rule 1. The
   // achievements sub-toggle defaults on so an operator who flips the
@@ -630,6 +643,11 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
     description:
       "Award badges based on voice activity, optionally with channel and DM notifications.",
   },
+  celebrations: {
+    title: "Milestone Celebrations",
+    description:
+      "Post a loud, server-wide shout-out the first time anyone crosses a marquee accolade (Voice Legend, 1000 hours, a month-long streak, 100 quotes). Reuses the achievements award path; no extra tracking.",
+  },
   digest: {
     title: "Weekly Digest",
     description:
@@ -1008,6 +1026,23 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
     description: "DM users when they earn a new achievement.",
     category: "achievements",
     type: "boolean",
+  },
+
+  // Marquee Milestone Celebrations (#657, Part 2)
+  "celebrations.enabled": {
+    label: "Milestone celebrations enabled",
+    description:
+      "Post a server-wide celebration in a configured channel the first time anyone crosses a marquee accolade (Voice Legend, 1000 hours, a 30-day streak, 100 quotes). Reuses the existing accolade award detection; requires achievements to be enabled.",
+    category: "celebrations",
+    type: "boolean",
+    dependsOn: ["achievements.enabled"],
+  },
+  "celebrations.channel_id": {
+    label: "Celebrations channel",
+    description:
+      "Channel where marquee milestone celebrations are posted. Leave empty to disable the announcement (the underlying accolade is still awarded).",
+    category: "celebrations",
+    type: "channel",
   },
 
   // Weekly Personal Voice-Activity Digest (#483)

--- a/src/services/voice-channel-tracker.ts
+++ b/src/services/voice-channel-tracker.ts
@@ -504,6 +504,14 @@ export class VoiceChannelTracker {
         if (newAccolades.length > 0) {
           // Send DM notification for accolades
           await achievementsService.notifyUserOfAccolades(userId, newAccolades);
+          // Loud, server-wide shout-out for any marquee crossings (#657,
+          // Part 2). Reuses this same detection point; gated/no-ops unless
+          // celebrations are enabled and a channel is configured.
+          await achievementsService.announceMilestones(
+            userId,
+            user.username,
+            newAccolades,
+          );
         }
 
         // Check for weekly achievements (these are NOT sent as DM notifications)


### PR DESCRIPTION
## Description

Part 2 of #657 — **Milestone celebrations**. Adds an opt-in, server-wide celebration the first time **anyone** crosses a *marquee* accolade (the rare, top-tier crossings worth cheering as a community). Every accolade still gets its usual personal DM and weekly round-up; this adds a single extra, louder announcement in a dedicated channel for just the headline milestones.

It reuses the **existing session-end accolade award detection** — nothing new is tracked. When a flagged accolade is first earned, the bot posts a shout-out (pinging the member) to `celebrations.channel_id`.

Curated marquee set (in `src/content/accolades.ts` → `MILESTONE_ACCOLADES`):

- 🏆 **Voice Master** — 1000 hours (`voice_veteran_1000`)
- 👑 **Voice Legend** — a full year, 8765 hours (`voice_legend_8765`)
- 💀 **No-Lifer** — a 30-day streak (`consistent_month`)
- 🏆 **Quote Legend** — 100 quotes added (`quote_legend`)

> Part 1 (Birthdays) of #657 already shipped in #670, so this PR covers only Part 2 (the issue recommended splitting the two).

### What changed

- **content** — `MILESTONE_ACCOLADES` allow-list + `isMilestoneAccolade()` helper.
- **config** — `celebrations.enabled` (default false) and `celebrations.channel_id`; a new *Milestone Celebrations* category; a hard `dependsOn: ["achievements.enabled"]` (the feature is inert without the award path that detects the crossing).
- **service** — `AchievementsService.announceMilestones()`: gated, channel-validated, and failure-swallowing so a celebration can never break the award flow. Wired into the voice-channel-tracker award path immediately after the accolade DM.
- **docs** — keys + dependency documented in `SETTINGS.md` (section, TOC, dependency table, quick reference); the page-less surface noted in `WEBUI.md`. (Also tidied two pre-existing `MD049` emphasis stragglers in `SETTINGS.md` so the markdown-lint job stays green.)

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update
- [x] 🧪 Test updates

## Related Issues

Refs #657

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`) — 116 suites, 1375 passing
- [x] Added new tests for new functionality
- [x] `npm run check` (build + lint + format:check) passes; markdown-lint clean

New/updated tests:

- `__tests__/content/accolades.test.ts` — milestone allow-list + `isMilestoneAccolade`.
- `__tests__/services/achievements-service.test.ts` — `announceMilestones` branch: posts for a marquee accolade, no-ops when disabled / non-marquee / empty / no channel, one post per marquee in a mixed batch, and never throws on a send failure.
- `__tests__/services/config-schema.test.ts` + `settings-metadata.test.ts` — dependency-graph, enabled-default audit, and category expectations.

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check` and all checks pass
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] `SETTINGS.md` updated (new configuration)
- [x] I have validated markdown with markdownlint

### Configuration

- [x] New feature is disabled by default and toggleable via configuration
- [x] I have added configuration schema entries in `config-schema.ts`
- [x] I have documented new configuration keys in `SETTINGS.md`

## Additional Notes

- No `Dockerfile` / dependency changes.
- No new slash command and no `/me` surface — the feature is configured entirely from the existing admin **Settings** page (like achievements itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013viw2PkTv8YbpA14mESpza

---
_Generated by [Claude Code](https://claude.ai/code/session_013viw2PkTv8YbpA14mESpza)_