### PR TITLE
feat(achievements): add progress indicators and activate reserved weekly achievements

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -260,10 +260,19 @@ Earned: 2026-01-12
 Voiced with 10+ unique users
 Earned: 2026-01-14
 
+🎯 Almost There (Progress)
+🎖️ ▰▰▰▰▰▰▰▰▱▱ Voice Veteran — 90 / 100 hrs
+🦋 ▰▰▰▰▰▰▱▱▱▱ Social Butterfly — 6 / 10 users
+
 📊 Summary
 Total Accolades: 4
 Total Achievements: 0
 ```
+
+The **Almost There (Progress)** section lists the nearest unearned
+threshold accolades (sorted by completion, up to five) with a `current /
+target` bar — the "so close" nudge. It appears as soon as you've made any
+progress toward an accolade, even before you've earned your first badge.
 
 **Available accolades:**
 
@@ -290,6 +299,26 @@ Total Achievements: 0
 - ⭐ **Widely Quoted** — Been quoted 25 times
 - 💫 **Quote Icon** — Been quoted 50 times
 - 🔥 **Viral Quote** — Have a quote with 10+ likes
+- 🗨️ **Chatterbox** — Sent 1,000 messages
+  (only while `messagetracking.enabled` is on)
+- 👍 **Reactor** — Gave 500 reactions
+  (only while `reactiontracking.enabled` is on)
+- 🗳️ **Poll Regular** — Cast 25 poll votes
+  (only while `polls.participation.enabled` is on)
+
+The last three engagement accolades only award (and only show progress)
+while their capture key is enabled; they stay dark when capture is off.
+
+**Weekly achievements (time-based):**
+
+Re-evaluated each week and shown under **Recent Achievements**:
+
+- ⚡ **Active** — 10+ hours in voice chat this week
+- 👑 **Weekly Champion** — finished #1 on the weekly voice leaderboard
+- 🦉 **Night Owl** — 5+ late-night hours this week (10 PM - 6 AM)
+- 🏃 **Marathoner** — a 4+ hour voice session this week
+- 🦋 **Social Butterfly** — voiced with 5+ unique users this week
+- 🔥 **Consistent** — connected on 5+ days this week (5+ min/day)
 
 **Notes on time-based accolades:**
 

--- a/__tests__/commands/achievements.test.ts
+++ b/__tests__/commands/achievements.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, jest } from "@jest/globals";
-import { data, formatMetadata } from "../../src/commands/achievements.js";
+import {
+  data,
+  formatMetadata,
+  formatProgressBar,
+} from "../../src/commands/achievements.js";
 
 jest.mock("../../src/services/achievements-service.js");
 jest.mock("../../src/utils/logger.js");
@@ -186,6 +190,34 @@ describe("Achievements Command", () => {
 
       expect(accoladeText).not.toContain(" - ");
       expect(accoladeText).toContain("🏆 **Some Badge**\n");
+    });
+  });
+
+  describe("formatProgressBar", () => {
+    it("renders an empty bar at 0%", () => {
+      expect(formatProgressBar(0)).toBe("▱▱▱▱▱▱▱▱▱▱");
+    });
+
+    it("renders a full bar at 100%", () => {
+      expect(formatProgressBar(100)).toBe("▰▰▰▰▰▰▰▰▰▰");
+    });
+
+    it("renders a partial bar (80% -> 8 filled)", () => {
+      expect(formatProgressBar(80)).toBe("▰▰▰▰▰▰▰▰▱▱");
+    });
+
+    it("rounds to the nearest segment (e.g. 94% -> 9 filled)", () => {
+      expect(formatProgressBar(94)).toBe("▰▰▰▰▰▰▰▰▰▱");
+    });
+
+    it("clamps out-of-range and non-finite percentages", () => {
+      expect(formatProgressBar(-20)).toBe("▱▱▱▱▱▱▱▱▱▱");
+      expect(formatProgressBar(150)).toBe("▰▰▰▰▰▰▰▰▰▰");
+      expect(formatProgressBar(Number.NaN)).toBe("▱▱▱▱▱▱▱▱▱▱");
+    });
+
+    it("respects a custom segment count", () => {
+      expect(formatProgressBar(50, 4)).toBe("▰▰▱▱");
     });
   });
 

--- a/__tests__/services/achievements-progress-engagement.test.ts
+++ b/__tests__/services/achievements-progress-engagement.test.ts
@@ -256,9 +256,16 @@ describe("AchievementsService — progress & engagement (#654)", () => {
 
     it("weekly_consistent counts distinct active days", async () => {
       const service = createService();
+      // Five distinct days *within this week* (Mon-Fri at noon). The leading
+      // edge is already inside the week, so clipping leaves the day bucketing
+      // intact and the check must see five distinct active days.
       const sessions = [0, 1, 2, 3, 4].map((d) => ({
-        startTime: new Date(Date.UTC(2026, 0, 5 + d, 12, 0, 0)),
-        endTime: new Date(weekStart.getTime() + 3600_000),
+        startTime: new Date(
+          weekStart.getTime() + d * 86400_000 + 12 * 3600_000,
+        ),
+        endTime: new Date(
+          weekStart.getTime() + d * 86400_000 + 12 * 3600_000 + 600_000,
+        ),
         duration: 600,
         otherUsers: [],
       }));
@@ -286,6 +293,27 @@ describe("AchievementsService — progress & engagement (#654)", () => {
       const logic = achievementLogic(service, "weekly_night_owl");
       expect(await logic.checkFunction("u", null, "UTC")).toBe(true);
       expect((await logic.metadataFunction("u", null, "UTC")).value).toBe(6);
+    });
+
+    it("clips a session straddling the week boundary to in-week time", async () => {
+      const service = createService();
+      // Sunday 23:00 UTC -> Monday 02:00 UTC. Unclipped this is 3 late-night
+      // hours; clipped to Monday 00:00 it is only the 2 in-week hours.
+      (VoiceChannelTracking.findOne as jest.Mock).mockResolvedValue({
+        sessions: [
+          {
+            startTime: new Date(weekStart.getTime() - 3600_000),
+            endTime: new Date(weekStart.getTime() + 2 * 3600_000),
+            duration: 3 * 3600,
+            otherUsers: [],
+          },
+        ],
+      });
+      const meta = await achievementLogic(
+        service,
+        "weekly_night_owl",
+      ).metadataFunction("u", null, "UTC");
+      expect(meta.value).toBe(2);
     });
   });
 

--- a/__tests__/services/achievements-progress-engagement.test.ts
+++ b/__tests__/services/achievements-progress-engagement.test.ts
@@ -1,0 +1,426 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import type { Client } from "discord.js";
+
+// Mirrors the proven mocking pattern in achievements-service.test.ts: mock the
+// logger, the UserAchievements model (callable constructor + statics) and the
+// quote service, and rely on the global mongoose mock (setup.ts) for the other
+// models. NB: in this ESM setup every mongoose model shares ONE mocked object,
+// so VoiceChannelTracking/MessageActivityTracking/etc. all share the same
+// `findOne`/`aggregate` — tests craft a single return object that satisfies
+// whichever reader runs.
+
+jest.mock("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock("../../src/models/user-achievements.js", () => ({
+  UserAchievements: Object.assign(
+    jest.fn().mockImplementation(() => ({
+      accolades: [],
+      achievements: [],
+      statistics: { totalAccolades: 0, totalAchievements: 0 },
+      save: jest.fn().mockResolvedValue(undefined),
+    })),
+    { findOne: jest.fn(), find: jest.fn() },
+  ),
+}));
+
+jest.mock("../../src/services/quote-service.js", () => ({
+  quoteService: {
+    getQuotesAuthoredByUser: jest.fn().mockResolvedValue(0),
+    getQuotesAddedByUser: jest.fn().mockResolvedValue(0),
+    getMostLikedQuoteByAuthor: jest.fn().mockResolvedValue(null),
+  },
+}));
+
+import { AchievementsService } from "../../src/services/achievements-service.js";
+import { UserAchievements } from "../../src/models/user-achievements.js";
+import { VoiceChannelTracking } from "../../src/models/voice-channel-tracking.js";
+
+// Start of the current ISO week — Monday 00:00 UTC. Mirrors the service so
+// crafted sessions land deterministically inside "this week".
+function startOfWeekUtc(now = new Date()): Date {
+  const dow = now.getUTCDay();
+  const back = dow === 0 ? 6 : dow - 1;
+  return new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate() - back,
+      0,
+      0,
+      0,
+      0,
+    ),
+  );
+}
+
+// Build a service with an injected config service. `flags` overrides specific
+// boolean keys; everything else defaults to true. `guildId` controls the
+// bootstrap GUILD_ID used by the per-guild engagement lookups.
+function createService(
+  flags: Record<string, boolean> = {},
+  guildId = "",
+): AchievementsService {
+  const service = AchievementsService.getInstance({} as Client);
+  const mockConfigService = {
+    getString: jest.fn(async (key: unknown) =>
+      key === "GUILD_ID" ? guildId : "mongodb://localhost/test",
+    ),
+    getBoolean: jest.fn(async (key: unknown) =>
+      typeof key === "string" && key in flags ? flags[key] : true,
+    ),
+    get: jest.fn().mockResolvedValue(null),
+    getNumber: jest.fn().mockResolvedValue(0),
+    triggerReload: jest.fn().mockResolvedValue(undefined),
+  };
+  (service as never)["configService"] = mockConfigService;
+  (service as never)["isConnected"] = true;
+  return service;
+}
+
+// Every mongoose model shares ONE mocked object in this setup, so a single
+// findOne return has to satisfy every reader (the achievements record AND the
+// voice/message tracking docs). Set the same object on both handles.
+function setSharedDoc(doc: unknown): void {
+  (UserAchievements.findOne as jest.Mock).mockResolvedValue(doc);
+  (VoiceChannelTracking.findOne as jest.Mock).mockResolvedValue(doc);
+}
+
+describe("AchievementsService — progress & engagement (#654)", () => {
+  beforeEach(() => {
+    (UserAchievements.findOne as jest.Mock).mockReset();
+    (UserAchievements.findOne as jest.Mock).mockResolvedValue(null);
+    (VoiceChannelTracking.findOne as jest.Mock).mockReset();
+    (VoiceChannelTracking.findOne as jest.Mock).mockResolvedValue(null);
+    (VoiceChannelTracking.aggregate as jest.Mock).mockReset();
+    (VoiceChannelTracking.aggregate as jest.Mock).mockResolvedValue([]);
+    (AchievementsService as unknown as { instance: unknown }).instance =
+      undefined;
+  });
+
+  describe("reserved weekly achievement metadata", () => {
+    it.each([
+      ["weekly_champion", "Weekly Champion"],
+      ["weekly_night_owl", "Night Owl"],
+      ["weekly_marathon", "Marathoner"],
+      ["weekly_social_butterfly", "Social Butterfly"],
+      ["weekly_consistent", "Consistent"],
+    ])("exposes a definition for %s", (type, name) => {
+      const def = createService().getAchievementDefinition(type);
+      expect(def).toBeDefined();
+      expect(def?.name).toBe(name);
+    });
+  });
+
+  describe("engagement accolade metadata", () => {
+    it.each([
+      ["chatterbox", "Chatterbox"],
+      ["reactor", "Reactor"],
+      ["poll_regular", "Poll Regular"],
+    ])("exposes a definition for %s", (type, name) => {
+      const def = createService().getAccoladeDefinition(type);
+      expect(def).toBeDefined();
+      expect(def?.name).toBe(name);
+    });
+  });
+
+  // Reach into the private logic records the same way achievements-service.test.ts does.
+  function achievementLogic(service: AchievementsService, type: string) {
+    return (service as never)["achievementLogic"][type];
+  }
+
+  describe("weekly_champion logic", () => {
+    it("awards the user who tops this week's leaderboard", async () => {
+      const service = createService();
+      (VoiceChannelTracking.aggregate as jest.Mock).mockResolvedValue([
+        { _id: "user1", totalTime: 7200 },
+      ]);
+      expect(
+        await achievementLogic(service, "weekly_champion").checkFunction(
+          "user1",
+          null,
+          "UTC",
+        ),
+      ).toBe(true);
+    });
+
+    it("does not award a non-leader", async () => {
+      const service = createService();
+      (VoiceChannelTracking.aggregate as jest.Mock).mockResolvedValue([
+        { _id: "someone-else", totalTime: 7200 },
+      ]);
+      expect(
+        await achievementLogic(service, "weekly_champion").checkFunction(
+          "user1",
+          null,
+          "UTC",
+        ),
+      ).toBe(false);
+    });
+
+    it("does not award when there is no weekly activity", async () => {
+      const service = createService();
+      (VoiceChannelTracking.aggregate as jest.Mock).mockResolvedValue([]);
+      expect(
+        await achievementLogic(service, "weekly_champion").checkFunction(
+          "user1",
+          null,
+          "UTC",
+        ),
+      ).toBe(false);
+    });
+
+    it("reports the leader's weekly hours in metadata", async () => {
+      const service = createService();
+      (VoiceChannelTracking.aggregate as jest.Mock).mockResolvedValue([
+        { _id: "user1", totalTime: 10800 }, // 3h
+      ]);
+      const meta = await achievementLogic(
+        service,
+        "weekly_champion",
+      ).metadataFunction("user1", null, "UTC");
+      expect(meta.value).toBe(3);
+      expect(meta.unit).toBe("hrs");
+    });
+  });
+
+  describe("weekly threshold logic", () => {
+    const weekStart = startOfWeekUtc();
+
+    it("weekly_marathon awards on a 4h+ session this week", async () => {
+      const service = createService();
+      (VoiceChannelTracking.findOne as jest.Mock).mockResolvedValue({
+        sessions: [
+          {
+            startTime: new Date(weekStart.getTime() + 3600_000),
+            endTime: new Date(weekStart.getTime() + 3600_000 + 14400_000),
+            duration: 14400,
+            otherUsers: [],
+          },
+        ],
+      });
+      expect(
+        await achievementLogic(service, "weekly_marathon").checkFunction(
+          "u",
+          null,
+          "UTC",
+        ),
+      ).toBe(true);
+    });
+
+    it("weekly_marathon does not award a sub-4h week", async () => {
+      const service = createService();
+      (VoiceChannelTracking.findOne as jest.Mock).mockResolvedValue({
+        sessions: [
+          {
+            startTime: new Date(weekStart.getTime() + 3600_000),
+            endTime: new Date(weekStart.getTime() + 3600_000 + 3600_000),
+            duration: 3600,
+            otherUsers: [],
+          },
+        ],
+      });
+      expect(
+        await achievementLogic(service, "weekly_marathon").checkFunction(
+          "u",
+          null,
+          "UTC",
+        ),
+      ).toBe(false);
+    });
+
+    it("weekly_social_butterfly awards with 5+ unique users this week", async () => {
+      const service = createService();
+      (VoiceChannelTracking.findOne as jest.Mock).mockResolvedValue({
+        sessions: [
+          {
+            startTime: new Date(weekStart.getTime() + 1000),
+            endTime: new Date(weekStart.getTime() + 7200_000),
+            duration: 7200,
+            otherUsers: ["a", "b", "c", "d", "e"],
+          },
+        ],
+      });
+      const logic = achievementLogic(service, "weekly_social_butterfly");
+      expect(await logic.checkFunction("u", null, "UTC")).toBe(true);
+      const meta = await logic.metadataFunction("u", null, "UTC");
+      expect(meta.value).toBe(5);
+      expect(meta.unit).toBe("users");
+    });
+
+    it("weekly_consistent counts distinct active days", async () => {
+      const service = createService();
+      const sessions = [0, 1, 2, 3, 4].map((d) => ({
+        startTime: new Date(Date.UTC(2026, 0, 5 + d, 12, 0, 0)),
+        endTime: new Date(weekStart.getTime() + 3600_000),
+        duration: 600,
+        otherUsers: [],
+      }));
+      (VoiceChannelTracking.findOne as jest.Mock).mockResolvedValue({
+        sessions,
+      });
+      const logic = achievementLogic(service, "weekly_consistent");
+      expect(await logic.checkFunction("u", null, "UTC")).toBe(true);
+      expect((await logic.metadataFunction("u", null, "UTC")).value).toBe(5);
+    });
+
+    it("weekly_night_owl awards on 5h+ of late-night time", async () => {
+      const service = createService();
+      // Monday 23:00 UTC -> Tuesday 05:00 UTC = 6h late-night.
+      (VoiceChannelTracking.findOne as jest.Mock).mockResolvedValue({
+        sessions: [
+          {
+            startTime: new Date(weekStart.getTime() + 23 * 3600_000),
+            endTime: new Date(weekStart.getTime() + 29 * 3600_000),
+            duration: 6 * 3600,
+            otherUsers: [],
+          },
+        ],
+      });
+      const logic = achievementLogic(service, "weekly_night_owl");
+      expect(await logic.checkFunction("u", null, "UTC")).toBe(true);
+      expect((await logic.metadataFunction("u", null, "UTC")).value).toBe(6);
+    });
+  });
+
+  describe("engagement accolade award gating", () => {
+    it("awards chatterbox when messagetracking is on and the milestone is met", async () => {
+      const service = createService(
+        {
+          "messagetracking.enabled": true,
+          "reactiontracking.enabled": false,
+          "polls.participation.enabled": false,
+        },
+        "guild-1",
+      );
+      // One doc doubles as the achievements record and the message doc.
+      setSharedDoc({
+        accolades: [],
+        statistics: { totalAccolades: 0, totalAchievements: 0 },
+        save: jest.fn().mockResolvedValue(undefined),
+        totalCount: 1000,
+        sessions: [],
+      });
+
+      const result = await service.checkAndAwardAccolades("u", "U");
+      expect(result.map((a) => a.type)).toContain("chatterbox");
+    });
+
+    it("never awards chatterbox while messagetracking is off", async () => {
+      const service = createService(
+        { "messagetracking.enabled": false },
+        "guild-1",
+      );
+      setSharedDoc({
+        accolades: [],
+        statistics: { totalAccolades: 0, totalAchievements: 0 },
+        save: jest.fn().mockResolvedValue(undefined),
+        totalCount: 999999,
+        sessions: [],
+      });
+
+      const result = await service.checkAndAwardAccolades("u", "U");
+      expect(result.map((a) => a.type)).not.toContain("chatterbox");
+    });
+  });
+
+  describe("getUnearnedAccoladeProgress", () => {
+    it("returns unearned threshold accolades sorted by completion", async () => {
+      const service = createService({
+        "messagetracking.enabled": false,
+        "reactiontracking.enabled": false,
+        "polls.participation.enabled": false,
+      });
+      setSharedDoc({ accolades: [], totalTime: 90 * 3600, sessions: [] });
+
+      const progress = await service.getUnearnedAccoladeProgress("u", 5);
+
+      expect(progress.length).toBeGreaterThan(0);
+      // voice_veteran_100 is the closest (90/100 = 90%).
+      expect(progress[0].type).toBe("voice_veteran_100");
+      expect(progress[0].current).toBe(90);
+      expect(progress[0].target).toBe(100);
+      expect(progress[0].percent).toBe(90);
+      for (let i = 1; i < progress.length; i++) {
+        expect(progress[i - 1].percent).toBeGreaterThanOrEqual(
+          progress[i].percent,
+        );
+      }
+      // first_hour is already complete (90 >= 1) so it is excluded.
+      expect(progress.map((p) => p.type)).not.toContain("first_hour");
+    });
+
+    it("excludes already-earned accolades", async () => {
+      const service = createService();
+      setSharedDoc({
+        accolades: [{ type: "voice_veteran_100" }],
+        totalTime: 90 * 3600,
+        sessions: [],
+      });
+      const progress = await service.getUnearnedAccoladeProgress("u", 10);
+      expect(progress.map((p) => p.type)).not.toContain("voice_veteran_100");
+    });
+
+    it("caps the result count to the requested limit", async () => {
+      const service = createService();
+      setSharedDoc({ accolades: [], totalTime: 90 * 3600, sessions: [] });
+      const progress = await service.getUnearnedAccoladeProgress("u", 2);
+      expect(progress.length).toBeLessThanOrEqual(2);
+    });
+
+    it("omits engagement accolades whose capture key is off", async () => {
+      const service = createService(
+        { "messagetracking.enabled": false },
+        "guild-1",
+      );
+      setSharedDoc({
+        accolades: [],
+        totalCount: 999,
+        totalTime: 0,
+        sessions: [],
+      });
+      const progress = await service.getUnearnedAccoladeProgress("u", 50);
+      expect(progress.map((p) => p.type)).not.toContain("chatterbox");
+    });
+
+    it("includes engagement progress when the capture key is on", async () => {
+      const service = createService(
+        {
+          "messagetracking.enabled": true,
+          "reactiontracking.enabled": false,
+          "polls.participation.enabled": false,
+        },
+        "guild-1",
+      );
+      // One object doubles as voice data (totalTime 0 → veterans skipped) and
+      // the message-activity doc (totalCount 750 → 75% of the 1,000 target).
+      setSharedDoc({
+        accolades: [],
+        totalTime: 0,
+        totalCount: 750,
+        sessions: [],
+      });
+
+      const progress = await service.getUnearnedAccoladeProgress("u", 50);
+      const chatterbox = progress.find((p) => p.type === "chatterbox");
+      expect(chatterbox).toBeDefined();
+      expect(chatterbox?.current).toBe(750);
+      expect(chatterbox?.target).toBe(1000);
+      expect(chatterbox?.percent).toBe(75);
+    });
+
+    it("returns an empty array on error", async () => {
+      const service = createService();
+      (UserAchievements.findOne as jest.Mock).mockRejectedValue(
+        new Error("DB error"),
+      );
+      expect(await service.getUnearnedAccoladeProgress("u")).toEqual([]);
+    });
+  });
+});

--- a/src/commands/achievements.ts
+++ b/src/commands/achievements.ts
@@ -20,6 +20,19 @@ export function formatMetadata(metadata?: IAccolade["metadata"]): string {
   return ` - ${metadata.value}${unit ? ` ${unit}` : ""}`;
 }
 
+/**
+ * Render a fixed-width unicode progress bar for a 0-100 percentage, e.g.
+ * `▰▰▰▰▰▰▰▰▱▱` for 80%. Used by the unearned-accolade progress display (#654).
+ */
+export function formatProgressBar(percent: number, segments = 10): string {
+  const clamped = Math.max(
+    0,
+    Math.min(100, Number.isFinite(percent) ? percent : 0),
+  );
+  const filled = Math.round((clamped / 100) * segments);
+  return "▰".repeat(filled) + "▱".repeat(segments - filled);
+}
+
 export const data = new SlashCommandBuilder()
   .setName("achievements")
   .setDescription("View earned badges and achievements")
@@ -39,15 +52,17 @@ export async function execute(
       interaction.client,
     );
 
-    const userAchievements = await achievementsService.getUserAchievements(
-      targetUser.id,
-    );
+    const [userAchievements, progress] = await Promise.all([
+      achievementsService.getUserAchievements(targetUser.id),
+      achievementsService.getUnearnedAccoladeProgress(targetUser.id, 5),
+    ]);
 
-    if (
-      !userAchievements ||
-      (userAchievements.accolades.length === 0 &&
-        userAchievements.achievements.length === 0)
-    ) {
+    const hasBadges =
+      !!userAchievements &&
+      (userAchievements.accolades.length > 0 ||
+        userAchievements.achievements.length > 0);
+
+    if (!hasBadges && progress.length === 0) {
       await interaction.reply({
         content: `${targetUser.username} hasn't earned any badges yet. Keep participating in voice channels!`,
         ephemeral: true,
@@ -62,7 +77,7 @@ export async function execute(
       .setTimestamp();
 
     // Add accolades section
-    if (userAchievements.accolades.length > 0) {
+    if (userAchievements && userAchievements.accolades.length > 0) {
       const accoladesList = userAchievements.accolades
         .sort((a, b) => b.earnedAt.getTime() - a.earnedAt.getTime())
         .map((accolade) => {
@@ -126,7 +141,7 @@ export async function execute(
     }
 
     // Add achievements section (time-based)
-    if (userAchievements.achievements.length > 0) {
+    if (userAchievements && userAchievements.achievements.length > 0) {
       const achievementsList = userAchievements.achievements
         .sort((a, b) => b.earnedAt.getTime() - a.earnedAt.getTime())
         .slice(0, 10) // Limit to most recent 10
@@ -153,10 +168,34 @@ export async function execute(
       }
     }
 
+    // Add progress toward the nearest unearned accolades (#654)
+    if (progress.length > 0) {
+      const progressLines = progress.map((p) => {
+        const bar = formatProgressBar(p.percent);
+        const unit = p.unit ? ` ${p.unit}` : "";
+        return `${p.emoji} ${bar} **${p.name}** — ${p.current} / ${p.target}${unit}`;
+      });
+
+      // Each line is short; clamp the joined value to Discord's field limit.
+      let value = progressLines.join("\n");
+      if (value.length > 1024) {
+        value = `${value.slice(0, 1021)}...`;
+      }
+
+      embed.addFields({
+        name: "🎯 Almost There (Progress)",
+        value,
+        inline: false,
+      });
+    }
+
     // Add summary
+    const totalAccolades = userAchievements?.statistics.totalAccolades ?? 0;
+    const totalAchievements =
+      userAchievements?.statistics.totalAchievements ?? 0;
     embed.addFields({
       name: "📊 Summary",
-      value: `Total Accolades: ${userAchievements.statistics.totalAccolades}\nTotal Achievements: ${userAchievements.statistics.totalAchievements}`,
+      value: `Total Accolades: ${totalAccolades}\nTotal Achievements: ${totalAchievements}`,
       inline: false,
     });
 

--- a/src/content/accolades.ts
+++ b/src/content/accolades.ts
@@ -125,6 +125,24 @@ export const ACCOLADE_METADATA = {
     name: "Viral Quote",
     description: "Have a quote with 10+ likes",
   },
+  // Engagement accolades for the now-tracked text/reaction/poll signals.
+  // Each is gated behind its capture key (see ACCOLADE_ENABLED_KEYS in
+  // achievements-service.ts) so it stays dark while capture is off.
+  chatterbox: {
+    emoji: "🗨️",
+    name: "Chatterbox",
+    description: "Sent 1,000 messages",
+  },
+  reactor: {
+    emoji: "👍",
+    name: "Reactor",
+    description: "Gave 500 reactions",
+  },
+  poll_regular: {
+    emoji: "🗳️",
+    name: "Poll Regular",
+    description: "Cast 25 poll votes",
+  },
 } as const;
 
 export type AccoladeType = keyof typeof ACCOLADE_METADATA;

--- a/src/content/achievements.ts
+++ b/src/content/achievements.ts
@@ -15,6 +15,31 @@ export const ACHIEVEMENT_METADATA = {
     name: "Active",
     description: "Reached 10 hours in voice chat this week",
   },
+  weekly_champion: {
+    emoji: "👑",
+    name: "Weekly Champion",
+    description: "Finished #1 on the weekly voice leaderboard",
+  },
+  weekly_night_owl: {
+    emoji: "🦉",
+    name: "Night Owl",
+    description: "Logged 5+ late-night hours this week (10 PM - 6 AM)",
+  },
+  weekly_marathon: {
+    emoji: "🏃",
+    name: "Marathoner",
+    description: "Completed a 4+ hour voice session this week",
+  },
+  weekly_social_butterfly: {
+    emoji: "🦋",
+    name: "Social Butterfly",
+    description: "Voiced with 5+ unique users this week",
+  },
+  weekly_consistent: {
+    emoji: "🔥",
+    name: "Consistent",
+    description: "Connected on 5+ days this week (5+ min/day)",
+  },
 } as const;
 
 export type AchievementType =

--- a/src/services/achievements-service.ts
+++ b/src/services/achievements-service.ts
@@ -59,6 +59,19 @@ interface BadgeLogic {
 }
 
 /**
+ * A voice session clipped to the current week for the weekly_* achievement
+ * checks (#654). `startTime` is the later of the raw start and Monday 00:00
+ * UTC, and `duration` is recomputed from that clipped window, so weekly checks
+ * never count time that bled in from before the week.
+ */
+interface WeeklySession {
+  startTime: Date;
+  endTime: Date;
+  duration: number;
+  otherUsers: string[];
+}
+
+/**
  * One row of the "closest unearned accolades" progress display (#654),
  * surfaced under the earned list in `/achievements`.
  */
@@ -778,10 +791,14 @@ export class AchievementsService {
   // Numeric goal (in the unit returned by each accolade's metadataFunction)
   // used to render progress bars for *unearned* threshold accolades (#654).
   // Types absent here are excluded from the progress display.
+  // `first_hour` and `quotable` are intentionally omitted: their target is 1,
+  // and the progress display filters out both `current <= 0` and
+  // `current >= target`, so with no integer strictly between 0 and 1 they could
+  // never render — listing them would only add wasted evaluation (a quote
+  // lookup, in `quotable`'s case).
   private static readonly ACCOLADE_PROGRESS_TARGETS: Partial<
     Record<AccoladeType, number>
   > = {
-    first_hour: 1,
     voice_veteran_100: 100,
     voice_veteran_500: 500,
     voice_veteran_1000: 1000,
@@ -797,7 +814,6 @@ export class AchievementsService {
     consistent_week: 7,
     consistent_fortnight: 14,
     consistent_month: 30,
-    quotable: 1,
     quote_master: 10,
     quote_collector: 50,
     quote_legend: 100,
@@ -1155,18 +1171,39 @@ export class AchievementsService {
   }
 
   /**
-   * This week's sessions for a user (those ending on/after Monday 00:00 UTC).
-   * Used by the weekly_* achievement checks (#654).
+   * This week's sessions for a user, clipped to the week boundary. A session
+   * counts when it ends on/after Monday 00:00 UTC; its leading edge is then
+   * clamped to that boundary (mirroring `getWeeklyTimeForUser`'s overlap
+   * handling) and its duration recomputed, so a session straddling the
+   * boundary contributes only its in-week portion to the weekly_* checks
+   * (late-night seconds, active-day bucketing, session length). Used by the
+   * weekly_* achievement checks (#654).
    */
-  private async getWeeklySessions(
-    userId: string,
-  ): Promise<IVoiceChannelTracking["sessions"]> {
+  private async getWeeklySessions(userId: string): Promise<WeeklySession[]> {
     const user = await VoiceChannelTracking.findOne({ userId });
     if (!user?.sessions?.length) return [];
     const startOfWeek = this.getStartOfWeekUtc();
-    return user.sessions.filter(
-      (s) => s.endTime && new Date(s.endTime) >= startOfWeek,
-    );
+
+    const weekly: WeeklySession[] = [];
+    for (const session of user.sessions) {
+      if (!session.endTime) continue;
+      const end = new Date(session.endTime);
+      if (end < startOfWeek) continue;
+
+      const rawStart = new Date(session.startTime);
+      const start = rawStart < startOfWeek ? startOfWeek : rawStart;
+      const duration = Math.max(
+        0,
+        Math.floor((end.getTime() - start.getTime()) / 1000),
+      );
+      weekly.push({
+        startTime: start,
+        endTime: end,
+        duration,
+        otherUsers: session.otherUsers ?? [],
+      });
+    }
+    return weekly;
   }
 
   /**
@@ -1218,6 +1255,12 @@ export class AchievementsService {
    * tracking collection directly to avoid a service dependency cycle with
    * VoiceChannelTracker. Returns `{ userId: null, totalTime: 0 }` when there
    * is no qualifying activity.
+   *
+   * Intentionally mirrors `VoiceChannelTracker.getTopUsers`' aggregation —
+   * bucket by `sessions.startTime` and sum full `sessions.duration`, no
+   * boundary clipping — so "champion" matches the leaderboard members actually
+   * see. Clipping here (unlike the per-user weekly_* checks) would make the
+   * award disagree with the displayed ranking.
    */
   private async getWeeklyTopUser(): Promise<{
     userId: string | null;

--- a/src/services/achievements-service.ts
+++ b/src/services/achievements-service.ts
@@ -8,7 +8,20 @@ import {
   VoiceChannelTracking,
   type IVoiceChannelTracking,
 } from "../models/voice-channel-tracking.js";
+import {
+  MessageActivityTracking,
+  type IMessageActivityTracking,
+} from "../models/message-activity-tracking.js";
+import {
+  ReactionActivityTracking,
+  type IReactionActivityTracking,
+} from "../models/reaction-activity-tracking.js";
+import {
+  PollParticipationTracking,
+  type IPollParticipationTracking,
+} from "../models/poll-participation-tracking.js";
 import { ConfigService } from "./config-service.js";
+import type { ConfigSchema } from "./config-schema.js";
 import { UserNotificationPrefsService } from "./user-notification-prefs-service.js";
 import {
   dayOfWeekInZone,
@@ -43,6 +56,21 @@ interface BadgeLogic {
     userData: IVoiceChannelTracking | null,
     timeZone: string,
   ) => Promise<{ value?: number; description?: string; unit?: string }>;
+}
+
+/**
+ * One row of the "closest unearned accolades" progress display (#654),
+ * surfaced under the earned list in `/achievements`.
+ */
+export interface AccoladeProgress {
+  type: AccoladeType;
+  emoji: string;
+  name: string;
+  current: number;
+  target: number;
+  unit: string;
+  /** Clamped 0-100 completion percentage (floored). */
+  percent: number;
 }
 
 interface BadgeDefinition extends BadgeLogic {
@@ -699,6 +727,96 @@ export class AchievementsService {
         };
       },
     },
+    // Engagement accolades for the now-tracked text/reaction/poll signals
+    // (#654). These read their own per-guild tracking collections (resolved
+    // via bootstrap GUILD_ID) and are gated behind their capture key in
+    // ACCOLADE_ENABLED_KEYS, so they stay dark while capture is off.
+    chatterbox: {
+      checkFunction: async (userId: string) => {
+        const doc = await this.getMessageTracking(userId);
+        return (doc?.totalCount ?? 0) >= 1000;
+      },
+      metadataFunction: async (userId: string) => {
+        const doc = await this.getMessageTracking(userId);
+        return {
+          value: doc?.totalCount ?? 0,
+          description: "1,000 messages sent",
+          unit: "msgs",
+        };
+      },
+    },
+    reactor: {
+      checkFunction: async (userId: string) => {
+        const doc = await this.getReactionTracking(userId);
+        return (doc?.totalGiven ?? 0) >= 500;
+      },
+      metadataFunction: async (userId: string) => {
+        const doc = await this.getReactionTracking(userId);
+        return {
+          value: doc?.totalGiven ?? 0,
+          description: "500 reactions given",
+          unit: "reactions",
+        };
+      },
+    },
+    poll_regular: {
+      checkFunction: async (userId: string) => {
+        const doc = await this.getPollTracking(userId);
+        return (doc?.totalVotes ?? 0) >= 25;
+      },
+      metadataFunction: async (userId: string) => {
+        const doc = await this.getPollTracking(userId);
+        return {
+          value: doc?.totalVotes ?? 0,
+          description: "25 poll votes cast",
+          unit: "votes",
+        };
+      },
+    },
+  };
+
+  // Numeric goal (in the unit returned by each accolade's metadataFunction)
+  // used to render progress bars for *unearned* threshold accolades (#654).
+  // Types absent here are excluded from the progress display.
+  private static readonly ACCOLADE_PROGRESS_TARGETS: Partial<
+    Record<AccoladeType, number>
+  > = {
+    first_hour: 1,
+    voice_veteran_100: 100,
+    voice_veteran_500: 500,
+    voice_veteran_1000: 1000,
+    voice_legend_8765: 8765,
+    marathon_runner: 4,
+    ultra_marathoner: 8,
+    social_butterfly: 10,
+    connector: 25,
+    night_owl: 50,
+    early_bird: 50,
+    weekend_warrior: 100,
+    weekday_warrior: 100,
+    consistent_week: 7,
+    consistent_fortnight: 14,
+    consistent_month: 30,
+    quotable: 1,
+    quote_master: 10,
+    quote_collector: 50,
+    quote_legend: 100,
+    widely_quoted: 25,
+    quote_icon: 50,
+    viral_quote: 10,
+    chatterbox: 1000,
+    reactor: 500,
+    poll_regular: 25,
+  };
+
+  // Capture key that must be true for an accolade to be awarded or shown as
+  // progress (#654). Accolades absent here are always active.
+  private static readonly ACCOLADE_ENABLED_KEYS: Partial<
+    Record<AccoladeType, keyof ConfigSchema>
+  > = {
+    chatterbox: "messagetracking.enabled",
+    reactor: "reactiontracking.enabled",
+    poll_regular: "polls.participation.enabled",
   };
 
   // Awarding logic per achievement (display metadata lives in
@@ -716,6 +834,85 @@ export class AchievementsService {
           value: Math.floor(weeklyTime / 3600),
           description: "Hours this week",
           unit: "hrs",
+        };
+      },
+    },
+    // #1 on this week's voice leaderboard (Monday-anchored UTC week, matching
+    // the achievement `period`). Evaluated at session end for the user whose
+    // session just ended, so the badge lands on whoever currently tops the week.
+    weekly_champion: {
+      checkFunction: async (userId: string) => {
+        const top = await this.getWeeklyTopUser();
+        return top.userId === userId && top.totalTime > 0;
+      },
+      metadataFunction: async () => {
+        const top = await this.getWeeklyTopUser();
+        return {
+          value: Math.floor(top.totalTime / 3600),
+          description: "Ranked #1 this week",
+          unit: "hrs",
+        };
+      },
+    },
+    weekly_night_owl: {
+      checkFunction: async (userId: string) => {
+        return (await this.getWeeklyLateNightSeconds(userId)) >= 18000; // 5h
+      },
+      metadataFunction: async (userId: string) => {
+        return {
+          value: Math.floor(
+            (await this.getWeeklyLateNightSeconds(userId)) / 3600,
+          ),
+          description: "Late-night hours this week",
+          unit: "hrs",
+        };
+      },
+    },
+    weekly_marathon: {
+      checkFunction: async (userId: string) => {
+        const sessions = await this.getWeeklySessions(userId);
+        return sessions.some((s) => (s.duration || 0) >= 14400); // 4h
+      },
+      metadataFunction: async (userId: string) => {
+        const sessions = await this.getWeeklySessions(userId);
+        const maxSession = sessions.reduce(
+          (max, s) => Math.max(max, s.duration || 0),
+          0,
+        );
+        return {
+          value: Math.floor(maxSession / 3600),
+          description: "Longest session this week",
+          unit: "hrs",
+        };
+      },
+    },
+    weekly_social_butterfly: {
+      checkFunction: async (userId: string) => {
+        const sessions = await this.getWeeklySessions(userId);
+        const unique = new Set(sessions.flatMap((s) => s.otherUsers || []));
+        return unique.size >= 5;
+      },
+      metadataFunction: async (userId: string) => {
+        const sessions = await this.getWeeklySessions(userId);
+        const unique = new Set(sessions.flatMap((s) => s.otherUsers || []));
+        return {
+          value: unique.size,
+          description: "Unique users this week",
+          unit: "users",
+        };
+      },
+    },
+    weekly_consistent: {
+      checkFunction: async (userId: string) => {
+        const sessions = await this.getWeeklySessions(userId);
+        return this.countQualifyingDays(sessions, "UTC") >= 5;
+      },
+      metadataFunction: async (userId: string) => {
+        const sessions = await this.getWeeklySessions(userId);
+        return {
+          value: this.countQualifyingDays(sessions, "UTC"),
+          description: "Active days this week",
+          unit: "days",
         };
       },
     },
@@ -938,6 +1135,144 @@ export class AchievementsService {
   }
 
   /**
+   * Start of the current week — Monday 00:00:00 UTC. Weekly achievements
+   * (#654) are bucketed in UTC to match the ISO-week `period` string.
+   */
+  private getStartOfWeekUtc(now: Date = new Date()): Date {
+    const dayOfWeek = now.getUTCDay(); // 0 = Sunday, 1 = Monday, etc.
+    const daysToMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1; // Sunday → back 6 days
+    return new Date(
+      Date.UTC(
+        now.getUTCFullYear(),
+        now.getUTCMonth(),
+        now.getUTCDate() - daysToMonday,
+        0,
+        0,
+        0,
+        0,
+      ),
+    );
+  }
+
+  /**
+   * This week's sessions for a user (those ending on/after Monday 00:00 UTC).
+   * Used by the weekly_* achievement checks (#654).
+   */
+  private async getWeeklySessions(
+    userId: string,
+  ): Promise<IVoiceChannelTracking["sessions"]> {
+    const user = await VoiceChannelTracking.findOne({ userId });
+    if (!user?.sessions?.length) return [];
+    const startOfWeek = this.getStartOfWeekUtc();
+    return user.sessions.filter(
+      (s) => s.endTime && new Date(s.endTime) >= startOfWeek,
+    );
+  }
+
+  /**
+   * Sum a user's late-night seconds (10 PM - 6 AM, UTC) across this week's
+   * sessions, for the weekly_night_owl achievement (#654).
+   */
+  private async getWeeklyLateNightSeconds(userId: string): Promise<number> {
+    const sessions = await this.getWeeklySessions(userId);
+    let seconds = 0;
+    for (const session of sessions) {
+      if (session.startTime && session.endTime && session.duration) {
+        seconds += this.calculateLateNightDuration(
+          session.startTime,
+          session.endTime,
+          "UTC",
+        );
+      }
+    }
+    return seconds;
+  }
+
+  /**
+   * Count distinct days this week with at least `minDuration` seconds of
+   * voice (not necessarily consecutive), for the weekly_consistent
+   * achievement (#654).
+   */
+  private countQualifyingDays(
+    sessions: Array<{ startTime: Date; duration?: number }>,
+    timeZone: string,
+    minDuration: number = AchievementsService.MIN_DAILY_DURATION_SECONDS,
+  ): number {
+    const dayTotals = new Map<string, number>();
+    for (const session of sessions) {
+      if (session.startTime && session.duration) {
+        const dayKey = isoDateInZone(new Date(session.startTime), timeZone);
+        dayTotals.set(dayKey, (dayTotals.get(dayKey) || 0) + session.duration);
+      }
+    }
+    let count = 0;
+    for (const total of dayTotals.values()) {
+      if (total >= minDuration) count++;
+    }
+    return count;
+  }
+
+  /**
+   * The single top user on this week's voice leaderboard (Monday-anchored
+   * UTC week), for the weekly_champion achievement (#654). Aggregates the
+   * tracking collection directly to avoid a service dependency cycle with
+   * VoiceChannelTracker. Returns `{ userId: null, totalTime: 0 }` when there
+   * is no qualifying activity.
+   */
+  private async getWeeklyTopUser(): Promise<{
+    userId: string | null;
+    totalTime: number;
+  }> {
+    try {
+      const startDate = this.getStartOfWeekUtc();
+      const rows = await VoiceChannelTracking.aggregate([
+        { $unwind: "$sessions" },
+        { $match: { "sessions.startTime": { $gte: startDate } } },
+        {
+          $group: {
+            _id: "$userId",
+            totalTime: { $sum: "$sessions.duration" },
+          },
+        },
+        { $sort: { totalTime: -1 } },
+        { $limit: 1 },
+      ]);
+      if (!rows.length) return { userId: null, totalTime: 0 };
+      return { userId: rows[0]._id, totalTime: rows[0].totalTime || 0 };
+    } catch (error) {
+      logger.error("Error computing weekly champion:", error);
+      return { userId: null, totalTime: 0 };
+    }
+  }
+
+  /** Resolve the bootstrap guild's message-activity doc for a user (#654). */
+  private async getMessageTracking(
+    userId: string,
+  ): Promise<IMessageActivityTracking | null> {
+    const guildId = await this.configService.getString("GUILD_ID", "");
+    if (!guildId) return null;
+    return MessageActivityTracking.findOne({ userId, guildId });
+  }
+
+  /** Resolve the bootstrap guild's reaction-activity doc for a user (#654). */
+  private async getReactionTracking(
+    userId: string,
+  ): Promise<IReactionActivityTracking | null> {
+    const guildId = await this.configService.getString("GUILD_ID", "");
+    if (!guildId) return null;
+    return ReactionActivityTracking.findOne({ userId, guildId });
+  }
+
+  /** Resolve the bootstrap guild's poll-participation doc for a user (#654). */
+  private async getPollTracking(
+    userId: string,
+  ): Promise<IPollParticipationTracking | null> {
+    const guildId = await this.configService.getString("GUILD_ID", "");
+    if (!guildId) return null;
+    return PollParticipationTracking.findOne({ userId, guildId });
+  }
+
+  /**
    * Get total voice time for a user this week
    */
   private async getWeeklyTimeForUser(userId: string): Promise<number> {
@@ -947,21 +1282,7 @@ export class AchievementsService {
         return 0;
       }
 
-      // Get start of this week (Monday at 00:00:00 UTC)
-      const now = new Date();
-      const dayOfWeek = now.getUTCDay(); // 0 = Sunday, 1 = Monday, etc.
-      const daysToMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1; // If Sunday, go back 6 days
-      const startOfWeek = new Date(
-        Date.UTC(
-          now.getUTCFullYear(),
-          now.getUTCMonth(),
-          now.getUTCDate() - daysToMonday,
-          0,
-          0,
-          0,
-          0,
-        ),
-      );
+      const startOfWeek = this.getStartOfWeekUtc();
 
       // Calculate total time for sessions that overlap with this week
       let weeklyTime = 0;
@@ -1099,36 +1420,52 @@ export class AchievementsService {
       // out of the per-session inner loops — so it costs at most one lookup.
       const timeZone = await this.resolveUserTimezone(userId);
 
-      // Check each accolade type
+      // Check each accolade type. Each is evaluated in its own try/catch so a
+      // single failing check (e.g. a transient query error in one badge's
+      // data source) can't abort the whole sweep and starve the others.
       for (const type of Object.keys(ACCOLADE_METADATA) as AccoladeType[]) {
         if (existingAccoladeTypes.has(type)) {
           continue; // Already earned
         }
 
-        const logic = this.accoladeLogic[type];
-        const earned = await logic.checkFunction(
-          userId,
-          userTrackingData,
-          timeZone,
-        );
-        if (earned) {
-          const metadata = logic.metadataFunction
-            ? await logic.metadataFunction(userId, userTrackingData, timeZone)
-            : {};
+        try {
+          // Engagement accolades (#654) only award while their capture key is
+          // on; skip them entirely otherwise so they stay dark.
+          const enabledKey = AchievementsService.ACCOLADE_ENABLED_KEYS[type];
+          if (
+            enabledKey &&
+            !(await this.configService.getBoolean(enabledKey, false))
+          ) {
+            continue;
+          }
 
-          const accolade: IAccolade = {
-            type,
-            earnedAt: new Date(),
-            metadata,
-          };
-
-          newAccolades.push(accolade);
-          userAchievements.accolades.push(accolade);
-          userAchievements.statistics.totalAccolades += 1;
-
-          logger.info(
-            `User ${username} (${userId}) earned accolade: ${ACCOLADE_METADATA[type].name}`,
+          const logic = this.accoladeLogic[type];
+          const earned = await logic.checkFunction(
+            userId,
+            userTrackingData,
+            timeZone,
           );
+          if (earned) {
+            const metadata = logic.metadataFunction
+              ? await logic.metadataFunction(userId, userTrackingData, timeZone)
+              : {};
+
+            const accolade: IAccolade = {
+              type,
+              earnedAt: new Date(),
+              metadata,
+            };
+
+            newAccolades.push(accolade);
+            userAchievements.accolades.push(accolade);
+            userAchievements.statistics.totalAccolades += 1;
+
+            logger.info(
+              `User ${username} (${userId}) earned accolade: ${ACCOLADE_METADATA[type].name}`,
+            );
+          }
+        } catch (error) {
+          logger.error(`Error evaluating accolade "${type}":`, error);
         }
       }
 
@@ -1277,6 +1614,90 @@ export class AchievementsService {
     } catch (error) {
       logger.error("Error getting user achievements:", error);
       return null;
+    }
+  }
+
+  /**
+   * Progress toward the nearest *unearned* threshold accolades (#654), for
+   * the "so close" nudge under the earned list in `/achievements`.
+   *
+   * For each accolade with a numeric progress target that the user hasn't
+   * earned yet (and whose capture key, if any, is on), this reuses the
+   * accolade's own `metadataFunction` to read the current value, then sorts
+   * by completion percentage and returns at most `limit` rows. Accolades the
+   * user hasn't started (current <= 0) are omitted so the display only shows
+   * meaningful progress.
+   */
+  public async getUnearnedAccoladeProgress(
+    userId: string,
+    limit: number = 5,
+  ): Promise<AccoladeProgress[]> {
+    try {
+      await this.ensureConnection();
+
+      const userAchievements = await UserAchievements.findOne({ userId });
+      const earned = new Set(
+        (userAchievements?.accolades ?? []).map((a) => a.type),
+      );
+
+      // Fetch voice tracking once (shared by the voice-based metadata fns)
+      // and resolve the bucketing timezone once, mirroring the award flow.
+      const userTrackingData = await VoiceChannelTracking.findOne({ userId });
+      const timeZone = await this.resolveUserTimezone(userId);
+
+      const results: AccoladeProgress[] = [];
+
+      for (const type of Object.keys(ACCOLADE_METADATA) as AccoladeType[]) {
+        if (earned.has(type)) continue;
+
+        const target = AchievementsService.ACCOLADE_PROGRESS_TARGETS[type];
+        if (!target) continue; // no numeric target → not a progress accolade
+
+        // One accolade's metadata failing must not blank out the whole
+        // progress list, so evaluate each in isolation.
+        try {
+          const enabledKey = AchievementsService.ACCOLADE_ENABLED_KEYS[type];
+          if (
+            enabledKey &&
+            !(await this.configService.getBoolean(enabledKey, false))
+          ) {
+            continue;
+          }
+
+          const logic = this.accoladeLogic[type];
+          if (!logic.metadataFunction) continue;
+
+          const meta = await logic.metadataFunction(
+            userId,
+            userTrackingData,
+            timeZone,
+          );
+          const current = meta.value ?? 0;
+          // Only surface started-but-incomplete progress.
+          if (current <= 0 || current >= target) continue;
+
+          results.push({
+            type,
+            emoji: ACCOLADE_METADATA[type].emoji,
+            name: ACCOLADE_METADATA[type].name,
+            current,
+            target,
+            unit: meta.unit ?? "",
+            percent: Math.min(100, Math.floor((current / target) * 100)),
+          });
+        } catch (error) {
+          logger.error(
+            `Error computing progress for accolade "${type}":`,
+            error,
+          );
+        }
+      }
+
+      results.sort((a, b) => b.percent - a.percent);
+      return results.slice(0, Math.max(0, limit));
+    } catch (error) {
+      logger.error("Error computing accolade progress:", error);
+      return [];
     }
   }
 


### PR DESCRIPTION
## Description

Closes the two visible gaps in the achievement system from #654.

**Part A — progress indicators.** `/achievements` now renders an **Almost There (Progress)** section showing the nearest *unearned* threshold accolades (sorted by completion, capped at five) with a `current / target` unicode bar — the "so close" retention nudge. It appears as soon as a member has made any progress, even before earning their first badge. A new `AchievementsService.getUnearnedAccoladeProgress()` reuses each accolade's existing `metadataFunction` plus a per-accolade target table; each accolade is evaluated in isolation so one failure can't blank the whole list.

**Part B — activate reserved + data-driven accolades.**
- The five reserved `weekly_*` achievement ids (`weekly_champion`, `weekly_night_owl`, `weekly_marathon`, `weekly_social_butterfly`, `weekly_consistent`) now have metadata and weekly award logic, bucketed in the Monday-anchored UTC week to match the achievement `period`.
- New engagement accolades — **Chatterbox** (1,000 messages), **Reactor** (500 reactions given), **Poll Regular** (25 poll votes) — read the now-tracked `MessageActivityTracking` / `ReactionActivityTracking` / `PollParticipationTracking` collections, each gated behind its `*tracking.enabled` capture key so it stays dark while capture is off.
- The accolade award loop now evaluates each badge in its own try/catch, so one failing check can't abort the whole sweep.

Per the issue, the progress display targets the Discord `/achievements` embed only (the WebUI `/me` surface is left for a follow-up). No new config keys were introduced — the engagement accolades reuse the existing capture keys.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update

## Related Issues

Closes #654

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality

New `__tests__/services/achievements-progress-engagement.test.ts` covers the progress computation (sorting, exclusion of earned/complete accolades, limit cap, capture-key gating), the five weekly achievement checks, and engagement-accolade award gating. `formatProgressBar` is unit-tested in the command test. Full suite: **1391 passed, 1 skipped**; `npm run check` (build + lint + format) is clean and coverage floors hold.

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated `COMMANDS.md` (new accolades, weekly achievements, progress display)
- [x] `SETTINGS.md` unchanged — no new configuration keys were added
- [x] I have validated markdown with `npx markdownlint`

### Configuration (if applicable)

- [x] New engagement accolades stay dark unless their existing `*tracking.enabled` capture key is on
- [x] No new schema entries required (reuses existing keys)

## Additional Notes

The `weekly_*` achievements are evaluated on the existing session-end path and bucket in the Monday-anchored UTC week (matching `getWeeklyTimeForUser`/the `period` string), not the rolling-7-day window used by `getTopUsers`. `weekly_champion` aggregates the tracking collection directly to avoid a service dependency cycle with `VoiceChannelTracker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJ7TPHFx29DFPZuCwbmkuq

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJ7TPHFx29DFPZuCwbmkuq)_