### PR TITLE
ci(deps): add Dependabot security-updates group for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,11 @@ updates:
         dependency-type: "production"
         update-types:
           - "patch"
+      # Batch all simultaneous security fixes into a single PR
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Description

Follow-up from the undici advisory triage (#681, #682). The npm ecosystem's `groups` in `.github/dependabot.yml` only declared version-update behavior (the implicit default), so security PRs were ungrouped — several packages needing security bumps at once would each open a separate PR.

This adds an `npm-security` group with `applies-to: security-updates` matching all packages (`*`), so simultaneous security advisories batch into a single PR.

```yaml
      npm-security:
        applies-to: security-updates
        patterns:
          - "*"
```

Scoped to the required change only. The optional items in the issue were intentionally left out:
- **Commit prefix `fix(deps)`** — the `commit-message.prefix` is per-ecosystem, not per-group, so switching it would relabel all npm version PRs as `fix`, not just security fixes. Left as `chore(deps)` to avoid that side effect.
- **Cooldown exemption** — left unchanged; per Dependabot's model, security updates already aren't held by the `cooldown` window, which only gates version updates.
- **"Dependabot security updates" toggle** (issue finding #4) is a repo Settings → Code security UI option that can't be set from this config file and needs a manual check.

## Type of Change

- [x] 🔧 Build/tooling changes

## Related Issues

Closes #684
Refs #681, #682

## How Has This Been Tested?

- [x] YAML parses cleanly (`yaml.safe_load`) and conforms to the documented Dependabot `groups` / `applies-to` schema — no `actionlint` / config-validation impact.

No application code is involved (config only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHNDJrj7fFbS4hcXfhSQLL)_