### PR TITLE
fix(deps): bump undici to ^7.28.0 — clears 7 Trivy + 7 Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "ts-jest": "^29.4.11",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.3",
-        "undici": "^7.27.2"
+        "undici": "^7.28.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -8200,9 +8200,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -58,10 +58,10 @@
     "ts-jest": "^29.4.11",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3",
-    "undici": "^7.27.2"
+    "undici": "^7.28.0"
   },
   "overrides": {
-    "undici": "^7.27.2",
+    "undici": "^7.28.0",
     "diff": "^8.0.3",
     "picomatch": "^4.0.4",
     "brace-expansion@>=5.0.0 <5.0.6": "5.0.6",


### PR DESCRIPTION
## Description

Both **Trivy code-scanning** and **Dependabot** report the same 7 undici advisories against `package-lock.json`. Our installed **undici 7.27.2** is vulnerable, and every advisory is fixed in **undici@7.28.0** (minimal in-range, non-breaking minor bump — no major/engine change).

The `overrides` block already dedupes the tree to a single top-level copy; the pin was simply one patch too low. This bumps the pin to `^7.28.0` in **both** `devDependencies` and `overrides` (keeping them in sync per the existing convention) and refreshes the lockfile.

Advisories cleared: GHSA-vmh5-mc38-953g, GHSA-hm92-r4w5-c3mj, GHSA-vxpw-j846-p89q (High); GHSA-pr7r-676h-xcf6, GHSA-p88m-4jfj-68fv (Moderate); GHSA-35p6-xmwp-9g52, GHSA-g8m3-5g58-fq7m (Low).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Build/tooling changes

## Related Issues

Fixes #681

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)

Verification run on this branch:

```
npm audit       → found 0 vulnerabilities
npm ls undici   → single undici@7.28.0 (deduped/overridden under discord.js + @discordjs/rest)
npm run check:all → build + lint + format:check + tests all pass (116 suites, 1380 tests)
```

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] My changes generate no new warnings or errors

### Dependencies & Docker

- [x] I have run security checks (`npm audit` reports 0 vulnerabilities)

No `Dockerfile` / `Dockerfile.dev` changes needed — this is a version pin within the existing `undici` dependency, not a new dependency or build-process change.

## Additional Notes

- Dependabot alerts #74–#80 auto-close once this lands on `main`.
- Trivy alerts #147–#153 auto-close on the next image rescan.
- The remaining `usr/.../undici` and `usr/.../tar` alerts (#142–#146) are out of scope — they come from npm bundled in the base image (tracked in #682).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQJy9WCVH4Gk6ncFWXuWTC

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQJy9WCVH4Gk6ncFWXuWTC)_