### PR TITLE
feat(webui): grey out settings toggles with unmet dependencies and a "requires X" hint

### DIFF
--- a/WEBUI.md
+++ b/WEBUI.md
@@ -769,6 +769,16 @@ page renders a banner explaining the state with an inline **Enable** button
 (flips the flag via `/admin/settings/set` and returns you to the page) plus
 an **Open Settings** link.
 
+On the **Settings** page, a toggle whose feature declares a hard dependency
+(`dependsOn` in `settingsMetadata`) is rendered **disabled and greyed** with an
+inline *"Requires X enabled"* hint until every dependency is on — the hint names
+each unmet dependency by its human label and links to its section (#666). This is
+the friendly front for the write-time validator (#663): both read the same
+`dependsOn` graph, so the greyed control and the server-side rejection never
+disagree. The greying survives an enabled parent section (a dependency lock wins
+over the per-section cascade), and Rewind toggles are never greyed this way
+because Rewind is a graceful aggregator that declares no `dependsOn`.
+
 The **Bot Status** page (`/admin/bot-status`) edits the three "Watching …"
 presence message pools the bot rotates through, picked by how many users
 are in voice: the *empty*, *one user*, and *multiple users* pools. Each

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -819,6 +819,85 @@ describe("renderSettingsPage", () => {
     );
   });
 
+  it("round-trips a dep-locked control's current value via a hidden input so a section Save can't clobber it (#666)", () => {
+    const html = renderSettingsPage({
+      ...COMMON,
+      groups: [
+        {
+          category: "voicetracking",
+          rows: [
+            {
+              key: "voicetracking.enabled",
+              current: true,
+              defaultValue: false,
+              type: "boolean",
+              description: "",
+              category: "voicetracking",
+            },
+          ],
+        },
+        {
+          category: "achievements",
+          rows: [
+            {
+              key: "achievements.enabled",
+              current: false,
+              defaultValue: false,
+              type: "boolean",
+              description: "",
+              category: "achievements",
+            },
+          ],
+        },
+        {
+          category: "digest",
+          rows: [
+            // Section master is ON (depends only on voice tracking, which is
+            // on), so the cascade-skip in save-section does NOT protect the
+            // dependent below — it's the cross-section case the hidden
+            // round-trip exists for.
+            {
+              key: "digest.enabled",
+              current: true,
+              defaultValue: false,
+              type: "boolean",
+              description: "",
+              category: "digest",
+            },
+            // Dep-locked: depends on achievements.enabled, which is off. Its
+            // disabled checkbox wouldn't be submitted, so a hidden input must
+            // round-trip the stored `true` or Save would flip it to false.
+            {
+              key: "digest.include_achievements",
+              current: true,
+              defaultValue: false,
+              type: "boolean",
+              description: "",
+              category: "digest",
+            },
+          ],
+        },
+      ],
+    });
+    // Hidden input carries the current value so the disabled (unsubmitted)
+    // checkbox can't be clobbered on Save.
+    expect(html).toContain(
+      '<input type="hidden" name="value_digest.include_achievements" value="true">',
+    );
+    // The visible checkbox is still disabled + dep-locked.
+    expect(html).toMatch(
+      /type="checkbox" name="value_digest\.include_achievements"[^>]*\bdisabled\b[^>]*data-dep-locked/,
+    );
+    // The master toggle (dependency met) is neither locked nor round-tripped
+    // with a hidden value field.
+    expect(html).not.toMatch(
+      /name="value_digest\.enabled"[^>]*data-dep-locked/,
+    );
+    expect(html).not.toContain(
+      '<input type="hidden" name="value_digest.enabled"',
+    );
+  });
+
   it("leaves the control editable once its dependency is enabled", () => {
     const html = renderSettingsPage({
       ...COMMON,

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -770,6 +770,138 @@ describe("renderSettingsPage", () => {
     );
     expect(html).not.toMatch(/value="(week|month|alltime)" selected/);
   });
+
+  // ---- Feature-dependency greying (#666) ----
+
+  it("greys + disables a control whose hard dependsOn target is off, with a 'requires X' hint", () => {
+    const html = renderSettingsPage({
+      ...COMMON,
+      groups: [
+        {
+          category: "voicetracking",
+          rows: [
+            {
+              key: "voicetracking.enabled",
+              current: false,
+              defaultValue: false,
+              type: "boolean",
+              description: "",
+              category: "voicetracking",
+            },
+          ],
+        },
+        {
+          category: "achievements",
+          rows: [
+            {
+              key: "achievements.enabled",
+              current: false,
+              defaultValue: false,
+              type: "boolean",
+              description: "",
+              category: "achievements",
+            },
+          ],
+        },
+      ],
+    });
+    // The dependent control renders disabled and dep-locked so the cascade
+    // script can't re-enable it under an enabled section master.
+    expect(html).toMatch(
+      /name="value_achievements\.enabled"[^>]*\bdisabled\b[^>]*data-dep-locked/,
+    );
+    // Its row is greyed via the static dependency class.
+    expect(html).toContain('<tr class="dep-off">');
+    // The hint names the unmet dependency by its human label and links to its
+    // section, using the same dependsOn graph the write-time validator uses.
+    expect(html).toContain(
+      'Requires <a href="#section-voicetracking">Voice Tracking enabled</a> enabled',
+    );
+  });
+
+  it("leaves the control editable once its dependency is enabled", () => {
+    const html = renderSettingsPage({
+      ...COMMON,
+      groups: [
+        {
+          category: "voicetracking",
+          rows: [
+            {
+              key: "voicetracking.enabled",
+              current: true,
+              defaultValue: false,
+              type: "boolean",
+              description: "",
+              category: "voicetracking",
+            },
+          ],
+        },
+        {
+          category: "achievements",
+          rows: [
+            {
+              key: "achievements.enabled",
+              current: false,
+              defaultValue: false,
+              type: "boolean",
+              description: "",
+              category: "achievements",
+            },
+          ],
+        },
+      ],
+    });
+    // Dependency met → the control isn't locked, greyed, or hinted. (The
+    // cascade script always mentions `data-dep-locked`, so assert against the
+    // specific control rather than the whole document.)
+    expect(html).not.toMatch(
+      /name="value_achievements\.enabled"[^>]*data-dep-locked/,
+    );
+    expect(html).not.toContain('<tr class="dep-off">');
+    expect(html).not.toContain("settings-dep-hint");
+  });
+
+  it("never greys rewind toggles for dependency reasons even when voice tracking is off", () => {
+    const html = renderSettingsPage({
+      ...COMMON,
+      groups: [
+        {
+          category: "voicetracking",
+          rows: [
+            {
+              key: "voicetracking.enabled",
+              current: false,
+              defaultValue: false,
+              type: "boolean",
+              description: "",
+              category: "voicetracking",
+            },
+          ],
+        },
+        {
+          category: "rewind",
+          rows: [
+            {
+              key: "rewind.nudge.enabled",
+              current: false,
+              defaultValue: false,
+              type: "boolean",
+              description: "",
+              category: "rewind",
+            },
+          ],
+        },
+      ],
+    });
+    // Rewind declares no dependsOn, so its control is never dep-locked or
+    // dep-greyed regardless of voice-tracking state. (The cascade script always
+    // mentions `data-dep-locked`, so assert against the specific control.)
+    expect(html).not.toMatch(
+      /name="value_rewind\.nudge\.enabled"[^>]*data-dep-locked/,
+    );
+    expect(html).not.toContain('<tr class="dep-off">');
+    expect(html).not.toContain("settings-dep-hint");
+  });
 });
 
 describe("renderPermissionsPage", () => {

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -278,6 +278,10 @@ const STYLE = [
   ".field-row .help{font-size:.75rem;color:#6b7280;margin-top:.15rem}",
   // Cascade greying: rows whose master `.enabled` toggle is off (#485).
   ".cascade-off{opacity:.5}",
+  // Dependency greying: rows whose hard `dependsOn` target is off (#666).
+  // A static class (not toggled by the cascade script) so an enabled section
+  // master can't strip the greying off a still-dependency-locked control.
+  ".dep-off{opacity:.5}",
   ".wizard-features{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:.75rem;margin-bottom:1rem}",
   ".feature-card{background:#0f1115;border:1px solid #2d3748;border-radius:6px;padding:.75rem 1rem;display:flex;gap:.75rem;align-items:flex-start}",
   ".feature-card input{margin-top:.2rem;flex-shrink:0}",
@@ -417,6 +421,12 @@ const CRON_PICKER_SCRIPT =
 // inputs (csrf/keys/category) and buttons are left alone so the form still
 // submits correctly. Used by both the wizard step form and the per-section
 // Settings forms.
+//
+// Dependency locks (#666) win over the master: a control marked
+// `[data-dep-locked]` (its hard `dependsOn` target is off) stays disabled even
+// when the section master is on, and its row keeps the static `.dep-off`
+// greying. So `apply()` only ever *adds* disabling to such controls — it never
+// re-enables them.
 const CASCADE_DISABLE_SCRIPT =
   "(function(){" +
   "function wire(master){" +
@@ -424,7 +434,8 @@ const CASCADE_DISABLE_SCRIPT =
   "function apply(){var off=!master.checked;" +
   "scope.querySelectorAll('input,select,textarea').forEach(function(el){" +
   "if(el===master||el.type==='hidden')return;" +
-  "el.disabled=off;" +
+  "var locked=el.hasAttribute('data-dep-locked');" +
+  "el.disabled=off||locked;" +
   "var row=el.closest('.field-row,tr');" +
   "if(row)row.classList.toggle('cascade-off',off)})}" +
   "master.addEventListener('change',apply);apply()}" +

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -587,7 +587,46 @@ function renderSelectionSummary(
   );
 }
 
+/**
+ * Render a setting's value control, plus — when the control is
+ * dependency-locked (#666) — a hidden input that round-trips its current value.
+ * A `disabled` control isn't submitted by the browser, and the per-section Save
+ * handler coerces a missing value to `false`/`""` (see `coerceConfigValue` in
+ * write-routes), so without this a dep-locked boolean would be silently flipped
+ * off (and other types blanked) whenever its section is saved while the lock is
+ * active. The same-section / master-off case is already protected by the
+ * cascade-skip in `save-section`, but a cross-section dependent (e.g.
+ * `digest.include_achievements` under an enabled digest section) is not.
+ *
+ * Cron is skipped: it already submits via its own non-disabled `.cron-hidden`
+ * input, which carries the `value_<key>` name. The disabled visible control
+ * keeps the same name but isn't submitted, so only the hidden value is sent.
+ */
 function renderSettingControl(
+  r: SettingRow,
+  pickers: {
+    textChannels: ChannelOption[];
+    voiceChannels: ChannelOption[];
+    categoryChannels: ChannelOption[];
+    roles: RoleOption[];
+  },
+  isCascadeMaster = false,
+  depLocked = false,
+): string {
+  const control = renderControlInput(r, pickers, isCascadeMaster, depLocked);
+  if (!depLocked || r.type === "cron") return control;
+  const primitive = coerceToDisplayValue(r.current);
+  const roundTrip =
+    r.type === "boolean"
+      ? primitive === true
+        ? "true"
+        : "false"
+      : escapeHtml(primitive);
+  const valueName = escapeHtml(settingValueFieldName(r.key));
+  return `<input type="hidden" name="${valueName}" value="${roundTrip}">${control}`;
+}
+
+function renderControlInput(
   r: SettingRow,
   pickers: {
     textChannels: ChannelOption[];
@@ -605,7 +644,9 @@ function renderSettingControl(
   // can't be edited before its requirement is on — the same rule the write-time
   // validator (#663) enforces. `data-dep-locked` tells the cascade-disable
   // script (admin-layout) never to re-enable it when a section master is on, so
-  // a dependency lock survives an enabled parent section.
+  // a dependency lock survives an enabled parent section. The current value is
+  // round-tripped via a sibling hidden input in `renderSettingControl` so the
+  // disabled (and therefore unsubmitted) control can't be clobbered on Save.
   const lockAttr = depLocked ? " disabled data-dep-locked" : "";
 
   // Fixed-options keys render as a single-select dropdown regardless of

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -12,6 +12,10 @@ import {
 } from "./admin-layout.js";
 import {
   categoryMetadata,
+  getDependencies,
+  isEnabledValue,
+  settingsMetadata,
+  type ConfigSchema,
   type SettingOption,
 } from "../services/config-schema.js";
 import type { BotStatusPool } from "../content/statuses.js";
@@ -202,6 +206,69 @@ export interface SettingRow {
   channelKind?: "text" | "voice";
 }
 
+/**
+ * An unmet hard dependency for a settings row: a `dependsOn` target that
+ * isn't currently enabled. `key` is the dotted target key; `label` is its
+ * human name from `settingsMetadata`; `category` is its settings section so
+ * the hint can link to it. Computed inside {@link renderSettingsPage} from
+ * the `dependsOn` graph (#666) — the same graph the write-time validator
+ * (#663) enforces, so the UI hint and the server error never disagree.
+ */
+interface UnmetDependency {
+  key: string;
+  label: string;
+  category: string;
+}
+
+/**
+ * Compute which of `key`'s hard `dependsOn` targets are not currently enabled,
+ * given the page-wide enabled-state of every key. Returns an empty array when
+ * the key declares no dependencies or all of them are on. The enabled-state is
+ * derived from the same `current` values the page renders, so the "requires X"
+ * hint always matches the toggle states shown alongside it.
+ */
+function unmetDependenciesFor(
+  key: string,
+  enabledByKey: Map<string, boolean>,
+): UnmetDependency[] {
+  const unmet: UnmetDependency[] = [];
+  for (const target of getDependencies(key as keyof ConfigSchema)) {
+    if (enabledByKey.get(target) === true) continue;
+    const meta = settingsMetadata[target];
+    unmet.push({
+      key: target,
+      label: meta?.label ?? target,
+      category: meta?.category ?? "",
+    });
+  }
+  return unmet;
+}
+
+/**
+ * Render the inline "requires X enabled" hint shown under a control whose
+ * hard dependencies aren't all met (#666). Each unmet dependency links to its
+ * settings section so the operator can jump straight to the toggle that
+ * unlocks this one. Returns an empty string when nothing is unmet. Uses the
+ * dependency's human label from `settingsMetadata`, mirroring the greyed-nav
+ * treatment's muted styling.
+ */
+export function renderDependencyHint(unmet: UnmetDependency[]): string {
+  if (unmet.length === 0) return "";
+  const names = unmet
+    .map((d) => {
+      const label = escapeHtml(d.label);
+      return d.category
+        ? `<a href="#section-${escapeHtml(d.category)}">${label}</a>`
+        : label;
+    })
+    .join(", ");
+  // role="note" keeps this advisory out of the assertive live-region path; the
+  // muted-grey tone matches the greyed-nav treatment (admin-layout's
+  // `.nav-disabled` colour) so a dependency lock reads as a gentle "not
+  // available yet" rather than an error.
+  return `<div class="settings-dep-hint" role="note" style="margin-top:.4rem;color:#94a3b8;font-size:.85em">Requires ${names} enabled</div>`;
+}
+
 export interface SettingsProps extends CommonProps {
   groups: Array<{ category: string; rows: SettingRow[] }>;
   textChannels: ChannelOption[];
@@ -359,12 +426,21 @@ const WEEKDAY_NAMES = [
   "Saturday",
 ];
 
-function renderCronPicker(currentValue: string, valueName: string): string {
+function renderCronPicker(
+  currentValue: string,
+  valueName: string,
+  depLocked = false,
+): string {
   const state = parseCronToPickerState(currentValue);
   const pad = (n: number): string => String(n).padStart(2, "0");
   const timeAttr = `${pad(state.hour)}:${pad(state.minute)}`;
   const sel = (cond: boolean): string => (cond ? " selected" : "");
   const hidden = (cond: boolean): string => (cond ? " hidden" : "");
+  // When the key's dependency is unmet (#666) every interactive cron control
+  // renders disabled; `data-dep-locked` on the visible inputs keeps the cascade
+  // script from re-enabling them under an enabled section master. The hidden
+  // input is left editable-by-name so the row still round-trips its value.
+  const lockAttr = depLocked ? " disabled data-dep-locked" : "";
 
   const dowOptions = WEEKDAY_NAMES.map(
     (name, i) =>
@@ -378,23 +454,23 @@ function renderCronPicker(currentValue: string, valueName: string): string {
   return (
     `<div class="cron-picker" data-mode="${state.mode}">` +
     `<input type="hidden" class="cron-hidden" name="${escapeHtml(valueName)}" value="${escapeHtml(currentValue)}">` +
-    `<select class="cron-mode" aria-label="Schedule type">` +
+    `<select class="cron-mode" aria-label="Schedule type"${lockAttr}>` +
     `<option value="daily"${sel(state.mode === "daily")}>Daily</option>` +
     `<option value="weekly"${sel(state.mode === "weekly")}>Weekly</option>` +
     `<option value="monthly"${sel(state.mode === "monthly")}>Monthly</option>` +
     `<option value="custom"${sel(state.mode === "custom")}>Custom (cron)</option>` +
     `</select>` +
     `<span class="cron-time-wrap"${hidden(state.mode === "custom")}>` +
-    ` at <input type="time" class="cron-time" value="${timeAttr}">` +
+    ` at <input type="time" class="cron-time" value="${timeAttr}"${lockAttr}>` +
     `</span>` +
     `<span class="cron-dow-wrap"${hidden(state.mode !== "weekly")}>` +
-    ` on <select class="cron-dow" aria-label="Day of week">${dowOptions}</select>` +
+    ` on <select class="cron-dow" aria-label="Day of week"${lockAttr}>${dowOptions}</select>` +
     `</span>` +
     `<span class="cron-dom-wrap"${hidden(state.mode !== "monthly")}>` +
-    ` on day <input type="number" class="cron-dom" min="1" max="31" value="${state.dayOfMonth}" style="width:5rem">` +
+    ` on day <input type="number" class="cron-dom" min="1" max="31" value="${state.dayOfMonth}" style="width:5rem"${lockAttr}>` +
     `</span>` +
     `<span class="cron-custom-wrap"${hidden(state.mode !== "custom")}>` +
-    `<input type="text" class="cron-custom" value="${escapeHtml(state.raw)}" placeholder="0 16 * * 5" style="width:12rem">` +
+    `<input type="text" class="cron-custom" value="${escapeHtml(state.raw)}" placeholder="0 16 * * 5" style="width:12rem"${lockAttr}>` +
     `</span>` +
     `</div>`
   );
@@ -450,6 +526,7 @@ function renderOptionsSelect(
   valueName: string,
   options: SettingOption[],
   current: string,
+  extraAttr = "",
 ): string {
   const known = options.some((o) => o.value === current);
   const opts = options
@@ -463,7 +540,7 @@ function renderOptionsSelect(
     : `<option value="${escapeHtml(current)}" selected>${
         current === "" ? "(choose a value)" : `(unknown) ${escapeHtml(current)}`
       }</option>`;
-  return `<select name="${valueName}">${opts}${placeholder}</select>`;
+  return `<select name="${valueName}"${extraAttr}>${opts}${placeholder}</select>`;
 }
 
 /**
@@ -519,29 +596,36 @@ function renderSettingControl(
     roles: RoleOption[];
   },
   isCascadeMaster = false,
+  depLocked = false,
 ): string {
   const primitive = coerceToDisplayValue(r.current);
   const currentStr = typeof primitive === "string" ? primitive : "";
   const valueName = escapeHtml(settingValueFieldName(r.key));
+  // When a hard dependency is unmet (#666), the control renders disabled so it
+  // can't be edited before its requirement is on — the same rule the write-time
+  // validator (#663) enforces. `data-dep-locked` tells the cascade-disable
+  // script (admin-layout) never to re-enable it when a section master is on, so
+  // a dependency lock survives an enabled parent section.
+  const lockAttr = depLocked ? " disabled data-dep-locked" : "";
 
   // Fixed-options keys render as a single-select dropdown regardless of
   // their underlying `type`, so operators pick from the valid set instead
   // of typing a value the server will reject.
   if (r.options && r.options.length > 0) {
-    return renderOptionsSelect(valueName, r.options, currentStr);
+    return renderOptionsSelect(valueName, r.options, currentStr, lockAttr);
   }
   if (r.type === "boolean") {
     const checked = primitive === true ? " checked" : "";
     const masterAttr = isCascadeMaster ? " data-cascade-master" : "";
     return (
       `<label class="checkbox" style="display:inline-flex;gap:.4rem;align-items:center;cursor:pointer">` +
-      `<input type="checkbox" name="${valueName}" value="true"${checked}${masterAttr}> ` +
+      `<input type="checkbox" name="${valueName}" value="true"${checked}${masterAttr}${lockAttr}> ` +
       `<span class="mono">${primitive === true ? "true" : "false"}</span>` +
       `</label>`
     );
   }
   if (r.type === "number") {
-    return `<input type="number" name="${valueName}" value="${escapeHtml(primitive)}" style="width:8rem">`;
+    return `<input type="number" name="${valueName}" value="${escapeHtml(primitive)}" style="width:8rem"${lockAttr}>`;
   }
   if (r.type === "channel" || r.type === "category" || r.type === "role") {
     const options =
@@ -553,7 +637,7 @@ function renderSettingControl(
     const prefix = r.type === "role" ? "@" : "#";
     const selected = currentStr ? new Set([currentStr]) : new Set<string>();
     return (
-      `<select name="${valueName}">` +
+      `<select name="${valueName}"${lockAttr}>` +
       buildOptionsHtml(options, selected, prefix, true) +
       `</select>`
     );
@@ -569,19 +653,23 @@ function renderSettingControl(
         .filter((v) => v !== ""),
     );
     return (
-      `<select name="${valueName}" multiple size="${Math.min(8, Math.max(3, options.length))}">` +
+      `<select name="${valueName}" multiple size="${Math.min(8, Math.max(3, options.length))}"${lockAttr}>` +
       buildOptionsHtml(options, selected, prefix, false) +
       `</select>` +
       renderSelectionSummary(options, selected, prefix)
     );
   }
   if (r.type === "cron") {
-    return renderCronPicker(currentStr, settingValueFieldName(r.key));
+    return renderCronPicker(
+      currentStr,
+      settingValueFieldName(r.key),
+      depLocked,
+    );
   }
   // string or unknown type → plain text input. The maxlength mirrors the
   // server-side `TEXT_LIMITS.configValue` cap in write-routes (#508) — kept as
   // a literal here to avoid a circular import (write-routes imports this file).
-  return `<input type="text" name="${valueName}" maxlength="2000" value="${escapeHtml(primitive)}">`;
+  return `<input type="text" name="${valueName}" maxlength="2000" value="${escapeHtml(primitive)}"${lockAttr}>`;
 }
 
 /**
@@ -642,6 +730,16 @@ export function renderSettingsPage(props: SettingsProps): string {
     categoryChannels: props.categoryChannels,
     roles: props.roles,
   };
+  // Page-wide enabled-state of every rendered key, derived from the same
+  // `current` values shown in the controls. Dependency hints (#666) read from
+  // this so they always agree with the toggle states on the page. A dependency
+  // target can live in any section, so this must span all groups, not just one.
+  const enabledByKey = new Map<string, boolean>();
+  for (const g of props.groups) {
+    for (const r of g.rows) {
+      enabledByKey.set(r.key, isEnabledValue(r.current));
+    }
+  }
   const sections = props.groups
     .map((g) => {
       const meta = categoryMetadata[g.category] ?? {
@@ -656,19 +754,26 @@ export function renderSettingsPage(props: SettingsProps): string {
       // they aren't clobbered (issue #485).
       const cascadeMasterKey = findCascadeMasterKey(g.rows);
       const rows = g.rows
-        .map(
-          (r) => `<tr>
+        .map((r) => {
+          // Grey + disable any control whose hard dependencies aren't all on
+          // (#666). `dep-off` is a static row class (not the cascade script's
+          // `.cascade-off`), so an enabled section master can't strip the
+          // greying off a still-dependency-locked control.
+          const unmet = unmetDependenciesFor(r.key, enabledByKey);
+          const depLocked = unmet.length > 0;
+          const rowClass = depLocked ? ' class="dep-off"' : "";
+          return `<tr${rowClass}>
 <td>
   <div><strong>${escapeHtml(r.label || r.key)}</strong></div>
   <code class="mono muted" style="font-size:.85em">${escapeHtml(r.key)}</code>
   <input type="hidden" name="keys" value="${escapeHtml(r.key)}">
 </td>
-<td class="settings-value">${renderSettingControl(r, pickers, r.key === cascadeMasterKey)}${renderResetButton(r.key)}${renderWarnBelow(r)}</td>
+<td class="settings-value">${renderSettingControl(r, pickers, r.key === cascadeMasterKey, depLocked)}${renderResetButton(r.key)}${renderWarnBelow(r)}${renderDependencyHint(unmet)}</td>
 <td><span class="tag tag-info">${escapeHtml(r.type)}</span></td>
 <td class="settings-default">${formatValue(r.defaultValue)}</td>
 <td class="muted">${escapeHtml(r.description)}</td>
-</tr>`,
-        )
+</tr>`;
+        })
         .join("");
       const descHtml = meta.description
         ? `<p class="muted" style="margin:.25rem 0 .75rem">${escapeHtml(meta.description)}</p>`


### PR DESCRIPTION
## Description

Surfaces feature dependencies on the Settings page. Any control whose feature declares a hard dependency (`dependsOn` in `settingsMetadata`, from #662) is rendered **disabled and greyed** with an inline *"Requires `<label>` enabled"* hint until every dependency is on. The hint names each unmet dependency by its human label and links to its settings section. This is the friendly front for the write-time validator (#663): both read the same `dependsOn` graph, so the greyed control and the server-side rejection can never disagree.

Key implementation points:

- **`renderSettingsPage`** computes each row's unmet dependencies from a page-wide enabled-state map derived from the same `current` values it renders, so the hint always matches the toggle states shown alongside it.
- **`renderSettingControl`** disables every control type (boolean, number, options-select, channel/role pickers, cron picker, text) when dependency-locked and marks the element `data-dep-locked`.
- The **cascade-disable script** (#485) now never re-enables a `data-dep-locked` control, so a dependency lock survives an *enabled* parent section (e.g. `digest.include_achievements` stays locked while `digest.enabled` is on but `achievements.enabled` is off).
- The row is greyed with a static **`.dep-off`** class (independent of the cascade script's `.cascade-off`), visually consistent with the existing greyed-nav treatment.
- **Rewind toggles** declare no `dependsOn`, so they are never greyed this way.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update

## Related Issues

Closes #666
Refs #659, #662, #663

## How Has This Been Tested?

- [x] Existing tests pass (`npm test` — 1383 passing)
- [x] Added new tests for new functionality

Added three `renderSettingsPage` test cases in `__tests__/web/admin-views.test.ts`:
- greys + disables a control whose `dependsOn` target is off, emitting the `data-dep-locked` lock, the `dep-off` row class, and a linked "Requires Voice Tracking enabled" hint;
- leaves the control editable (no lock, no greying, no hint) once the dependency is enabled;
- never greys Rewind toggles for dependency reasons even when voice tracking is off.

`npm run check:all` passes locally (build + lint + format:check + test).

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary:
  - [x] `WEBUI.md` (Settings dependency-greying behaviour)
- [x] I have validated markdown with markdownlint

### Configuration

- No new configuration keys: this is a read-only presentation layer over the existing `dependsOn` graph; no schema changes.

## Additional Notes

The greying is computed server-side and reflects on the next render after a dependency is enabled and saved, matching the issue's "otherwise on next render" allowance. Cross-section dependencies (e.g. an achievements toggle depending on voice tracking) are handled because the enabled-state map spans every group on the page, not just the current section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9dUNPXp7ZhF2JXW1abGfp)_