### PR TITLE
fix(deps): refresh base-image npm to clear bundled undici/tar Trivy alerts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,14 @@ FROM node:24-alpine
 
 WORKDIR /app
 
+# Refresh the npm bundled in the base image. node:24-alpine ships an npm whose
+# bundled undici/tar carry known advisories (Trivy #142-#146); upgrading to the
+# latest npm pulls in patched tar (>= 7.5.16) and undici. These live under
+# /usr/local/lib/node_modules/npm and are independent of our own node_modules,
+# so only refreshing npm clears them. Runs as root before the USER switch below.
+# hadolint ignore=DL3016
+RUN npm install -g npm@latest && npm cache clean --force
+
 # Copy only runtime artifacts
 COPY --from=builder --chown=node:node /app/package*.json ./
 COPY --from=builder --chown=node:node /app/dist ./dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ WORKDIR /app
 # /usr/local/lib/node_modules/npm and are independent of our own node_modules,
 # so only refreshing npm clears them. Runs as root before the USER switch below.
 # hadolint ignore=DL3016
-RUN npm install -g npm@latest && npm cache clean --force
+RUN npm install -g npm@latest --no-audit --no-fund && npm cache clean --force
 
 # Copy only runtime artifacts
 COPY --from=builder --chown=node:node /app/package*.json ./

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,6 +2,11 @@ FROM node:24-alpine
 
 WORKDIR /app
 
+# Refresh the npm bundled in the base image so its undici/tar copies are patched
+# (mirrors the production Dockerfile; clears Trivy #142-#146 base-image findings).
+# hadolint ignore=DL3016
+RUN npm install -g npm@latest && npm cache clean --force
+
 # Install development dependencies
 COPY package*.json ./
 RUN npm install --include=dev

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,7 +5,7 @@ WORKDIR /app
 # Refresh the npm bundled in the base image so its undici/tar copies are patched
 # (mirrors the production Dockerfile; clears Trivy #142-#146 base-image findings).
 # hadolint ignore=DL3016
-RUN npm install -g npm@latest && npm cache clean --force
+RUN npm install -g npm@latest --no-audit --no-fund && npm cache clean --force
 
 # Install development dependencies
 COPY package*.json ./


### PR DESCRIPTION
## Description

Five Trivy alerts (#142–#146) flag `undici`/`tar` copies that live **inside npm itself** — bundled under `/usr/local/lib/node_modules/npm/node_modules/` in the `node:24-alpine` base image, not in our application `node_modules`. Because they belong to the base-image npm, our `package.json` `overrides` (which only govern our own dependency tree) cannot clear them; the base-image npm has to be refreshed.

This PR takes **Option B** from #682 — upgrade npm in-image — over Option A (digest-pinning a newer base). Option B fits the repo's existing strategy: `docker.yml` deliberately builds with `pull: true` to *always* pull the freshest `node:24-alpine` so the image keeps absorbing upstream Alpine/base security patches; pinning a digest would work against that. Refreshing npm is also guaranteed independent of whatever npm the base tag happens to ship.

Changes:
- **`Dockerfile`** — add `RUN npm install -g npm@latest && npm cache clean --force` to the production stage, run as root *before* the `USER node` switch (global install needs root). This is the stage whose bundled npm the CI Trivy scan inspects. Pulls in patched `tar` (≥ 7.5.16) and `undici`.
- **`Dockerfile.dev`** — same refresh, mirroring the production image per `CLAUDE.md`'s "update both Dockerfiles together" rule.

A `# hadolint ignore=DL3016` directive accompanies each `RUN` since `npm@latest` is an unpinned tag (matches the maintainer's suggested command in #682 and the "always pull fresh" intent); it keeps the Security tab clean.

Runtime is unaffected: `npm start` simply runs `node dist/index.js`, which doesn't depend on npm internals.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Build/tooling changes

## Related Issues

Fixes #682
Refs #681 (companion app-side `undici` bump)

## How Has This Been Tested?

- [ ] Tested in Docker environment

The Docker daemon, Trivy, and hadolint are not available in this environment, so the build could not be exercised locally — verification runs through CI (`docker.yml`: hadolint + build + Trivy). Per the issue's acceptance criteria, the freshly built image should no longer report `usr/.../undici` or `usr/.../tar` findings, and alerts #142–#146 auto-close on rescan.

Suggested manual verification once built:

```bash
docker build -t koolbot:vuln-check .
docker run --rm koolbot:vuln-check npm --version
docker run --rm koolbot:vuln-check sh -c \
  "grep version /usr/local/lib/node_modules/npm/node_modules/tar/package.json"   # expect >= 7.5.16
trivy image koolbot:vuln-check   # expect no usr/.../{undici,tar} findings
```

## Checklist

### Dependencies & Docker

- [x] I have updated `Dockerfile`
- [x] I have updated `Dockerfile.dev`

No application dependencies, config keys, commands, or docs changed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfoWDoubeMN2ymWUZP6oNL)_