### PR TITLE
feat(privacy): never DM users unprompted — make notification DMs opt-in (default off)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -12,8 +12,9 @@ single `/config` launcher.
 sign-in link it DMs you lands on the surface that matches your
 permissions: administrators get the **admin panel** (`/admin/`) plus
 their own **personal preferences** (`/me/`), while everyone else gets
-the personal self-service surface (`/me/`) only — opt out of DM
-notifications, view your Rewind, and manage your own settings. There are
+the personal self-service surface (`/me/`) only — opt in to DM
+notifications (off by default), view your Rewind, and manage your own
+settings. There are
 deliberately **no per-feature slash commands** (no `/notifications`,
 `/digest`, `/rewind`); those preferences live behind `/config` → `/me/`.
 See [WEBUI.md](WEBUI.md) for the full surface breakdown.
@@ -480,8 +481,9 @@ permissions:
   can jump to their own **personal preferences** (`/me/`) from a header
   link without re-running `/config`.
 - **Everyone else** reaches the **personal self-service surface**
-  (`/me/`) — opt out of DM notifications, view their Rewind, and manage
-  their own per-user settings. They never see the admin panel.
+  (`/me/`) — opt in to DM notifications (off by default), view their
+  Rewind, and manage their own per-user settings. They never see the
+  admin panel.
 
 **Permission:** Open to **every guild member**. `/config` is no longer
 registered with `setDefaultMemberPermissions(Administrator)` — any member
@@ -799,7 +801,7 @@ reach it from a header link on any admin page):
 | Page          | What it does                                                                        |
 | ------------- | ----------------------------------------------------------------------------------- |
 | Overview      | `/me/` index linking to your per-user pages                                         |
-| Notifications | `/me/notifications` — opt in/out of DM nudges (achievements, weekly digest, Rewind) |
+| Notifications | `/me/notifications` — opt in to DM nudges; off by default                           |
 | Rewind        | `/me/rewind` — personal year-in-review (voice time, top channels, rank journey, …)  |
 
 ---

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -419,7 +419,7 @@ Persistent accolade system to encourage voice channel participation.
 | --- | --- | --- |
 | `achievements.enabled` | `false` | Enable/disable achievements system |
 | `achievements.announcements.enabled` | `true` | Include new accolades in weekly announcements |
-| `achievements.dm_notifications.enabled` | `true` | Send DM to users when they earn accolades |
+| `achievements.dm_notifications.enabled` | `true` | Server-wide switch for accolade DMs. Even when on, each user must opt in per-user on `/me/notifications` (off by default) — Koolbot never DMs a member who has not opted in |
 
 **Features:**
 
@@ -456,9 +456,10 @@ accolade list and usage.
 
 A loud, server-wide shout-out the first time **anyone** crosses a
 _marquee_ accolade — the rare, top-tier crossings worth cheering as a
-community. Every accolade still gets its usual personal DM and weekly
-round-up; this adds a single extra announcement in a dedicated channel
-for just the headline milestones.
+community. Every accolade still gets its usual personal DM (for users
+who have opted in on `/me/notifications`) and weekly round-up; this adds
+a single extra announcement in a dedicated channel for just the headline
+milestones.
 
 | Setting | Default | Description |
 | --- | --- | --- |
@@ -493,8 +494,10 @@ for just the headline milestones.
 ## 📬 Weekly Digest
 
 Per-user weekly DM that summarises voice activity, leaderboard rank,
-streak, and achievements earned in the last 7 days. Opt-out lives on
-the user's **/me/notifications** page (no slash command).
+streak, and achievements earned in the last 7 days. The digest DM is
+**opt-in (off by default)**: a user receives it only after enabling it
+on their **/me/notifications** page (no slash command). Koolbot never
+DMs a member who has not opted in.
 
 | Setting | Default | Description |
 | --- | --- | --- |
@@ -508,8 +511,9 @@ the user's **/me/notifications** page (no slash command).
 
 - Requires `voicetracking.enabled = true` so the underlying weekly stats
   exist.
-- Per-user opt-out is honoured before each send via the
-  `prefs.digest` field set on `/me/notifications`.
+- Per-user opt-in is required before each send: the `prefs.digest`
+  field set on `/me/notifications` must be `true` (it defaults to off),
+  and a missing row or read error fails closed (no DM).
 - Users with DMs closed are silently skipped (same pattern the
   `AchievementsService` already uses).
 - A summary row (qualifying / sent / opted-out / DMs closed / failed)
@@ -578,8 +582,9 @@ expose the page.
   data to exist; when off, only that section is empty — the page itself
   still renders (see the graceful-degradation table above). The end-of-year
   nudge, however, is voice-based and still keys off annual voice minutes.
-- Per-user opt-out is honoured before sending each nudge via the
-  `prefs.rewind` field set on `/me/notifications`.
+- Per-user opt-in is required before sending each nudge: the
+  `prefs.rewind` field set on `/me/notifications` must be `true` (it
+  defaults to off), and a missing row or read error fails closed (no DM).
 - Users with DMs closed are silently skipped (same pattern the digest
   and `AchievementsService` already use).
 - Aggregation is on-demand and not cached in v1. If real data shows

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -838,7 +838,7 @@ existing achievements award detection. `celebrations.enabled` depends on
 | Page                                    | What it's for                                                                                                                                              |
 | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Overview** (`/me/`)                   | Index for your own settings — links to the available per-user pages.                                                                                       |
-| **Notifications** (`/me/notifications`) | Opt in or out of DM nudges from Koolbot (achievements, weekly digest, Rewind nudge). Each toggle records a `WebAuditLog` row.                              |
+| **Notifications** (`/me/notifications`) | Opt in to DM nudges (achievements, weekly digest, Rewind). Off by default — Koolbot never DMs you until you opt in here. Records a `WebAuditLog` row.      |
 | **Voice** (`/me/voice`)                 | Manage your channel name pattern and saved voice-channel presets (rename, edit, set-default, delete). Gated by `voicechannels.presets.enabled`.            |
 | **Timezone** (`/me/timezone`)           | Pick the IANA timezone Koolbot renders your times in (digest, Rewind, voicestats) and uses to evaluate your birthday. Saving records a `WebAuditLog` row.  |
 | **Birthday** (`/me/birthday`)           | Set your birthday (month/day, optional year) so Koolbot can celebrate it on the day in your own timezone. Saving or removing records a `WebAuditLog` row.  |

--- a/__tests__/services/achievements-service.test.ts
+++ b/__tests__/services/achievements-service.test.ts
@@ -532,7 +532,9 @@ describe("AchievementsService", () => {
       expect(sent).toContain("Manage notifications: run `/config`");
     });
 
-    it("falls through and DMs when GUILD_ID is unset (no prefs lookup possible)", async () => {
+    it("fails closed and skips the DM when GUILD_ID is unset (#686)", async () => {
+      // With no guildId we can't confirm the user opted in, so the
+      // privacy-by-default posture is to stay silent rather than DM.
       const { service, mockConfigService } =
         createAchievementsService(mockClient);
       mockConfigService.getBoolean.mockResolvedValue(true);
@@ -554,7 +556,37 @@ describe("AchievementsService", () => {
       ]);
 
       expect(getPrefsSpy).not.toHaveBeenCalled();
-      expect(mockUser.send).toHaveBeenCalledTimes(1);
+      expect(mockUser.send).not.toHaveBeenCalled();
+    });
+
+    it("skips the DM for a user with no prefs row (opt-in default off, #686)", async () => {
+      // A brand-new user has no UserNotificationPrefs row, so getPrefs
+      // resolves to DEFAULT_PREFS (all false) and no DM is sent.
+      const { service, mockConfigService } =
+        createAchievementsService(mockClient);
+      mockConfigService.getBoolean.mockResolvedValue(true);
+      mockConfigService.getString.mockResolvedValue("guild-1");
+
+      const mockUser = {
+        username: "TestUser",
+        send: jest.fn().mockResolvedValue(undefined),
+      };
+      (mockClient.users as any).fetch = jest.fn().mockResolvedValue(mockUser);
+
+      const getPrefsSpy = jest
+        .spyOn(UserNotificationPrefsService.prototype, "getPrefs")
+        .mockResolvedValue({
+          achievements: false,
+          digest: false,
+          rewind: false,
+        });
+
+      await service.notifyUserOfAccolades("user123", [
+        { type: "first_hour", earnedAt: new Date(), metadata: {} },
+      ]);
+
+      expect(getPrefsSpy).toHaveBeenCalledWith("user123", "guild-1");
+      expect(mockUser.send).not.toHaveBeenCalled();
     });
   });
 

--- a/__tests__/services/achievements-service.test.ts
+++ b/__tests__/services/achievements-service.test.ts
@@ -587,6 +587,9 @@ describe("AchievementsService", () => {
 
       expect(getPrefsSpy).toHaveBeenCalledWith("user123", "guild-1");
       expect(mockUser.send).not.toHaveBeenCalled();
+      // The opt-in gate runs before the Discord user fetch, so the common
+      // "opted out" case costs no REST call.
+      expect((mockClient.users as any).fetch).not.toHaveBeenCalled();
     });
   });
 

--- a/__tests__/services/digest-service.test.ts
+++ b/__tests__/services/digest-service.test.ts
@@ -228,6 +228,27 @@ describe("DigestService", () => {
       expect(mockDigestStateFindOneAndUpdate).not.toHaveBeenCalled();
     });
 
+    it("sends no DM for a user with no prefs row (opt-in default off, #686)", async () => {
+      // A missing UserNotificationPrefs row resolves to DEFAULT_PREFS
+      // (all false), so an unconfigured user is never DM'd.
+      mockGetTopUsers.mockResolvedValue([
+        { userId: "u1", username: "u1", totalTime: 60 * 60 },
+      ]);
+      mockGetPrefsWithTimezone.mockResolvedValue({
+        prefs: { achievements: false, digest: false, rewind: false },
+        timezone: null,
+      });
+
+      const svc: ServiceInstance = DigestService.getInstance(makeClient());
+      const result = await svc.runNow();
+
+      expect(result).not.toBeNull();
+      expect(result!.sent).toBe(0);
+      expect(result!.skippedOptOut).toBe(1);
+      expect(mockUserSend).not.toHaveBeenCalled();
+      expect(mockDigestStateFindOneAndUpdate).not.toHaveBeenCalled();
+    });
+
     it("sends a DM and persists DigestState when prefs.digest is true", async () => {
       mockGetTopUsers.mockResolvedValue([
         { userId: "u1", username: "u1", totalTime: 60 * 60 },

--- a/__tests__/services/rewind-nudge-service.test.ts
+++ b/__tests__/services/rewind-nudge-service.test.ts
@@ -259,6 +259,27 @@ describe("RewindNudgeService", () => {
       expect(mockUserSend).not.toHaveBeenCalled();
     });
 
+    it("sends no DM for a user with no prefs row (opt-in default off, #686)", async () => {
+      // A missing UserNotificationPrefs row resolves to DEFAULT_PREFS
+      // (all false), so an unconfigured user is never DM'd.
+      mockTrackingAggregate.mockResolvedValueOnce([
+        { _id: "u1", username: "u1", totalTime: 60 * 60 * 5 },
+      ]);
+      mockGetPrefs.mockResolvedValue({
+        achievements: false,
+        digest: false,
+        rewind: false,
+      });
+
+      const svc: ServiceInstance = RewindNudgeService.getInstance(makeClient());
+      const result = await svc.runNow();
+
+      expect(result).not.toBeNull();
+      expect(result!.sent).toBe(0);
+      expect(result!.skippedOptOut).toBe(1);
+      expect(mockUserSend).not.toHaveBeenCalled();
+    });
+
     it("sends a DM when prefs.rewind is true and writes the delivery marker", async () => {
       mockTrackingAggregate.mockResolvedValueOnce([
         { _id: "u1", username: "u1", totalTime: 60 * 60 * 5 },

--- a/__tests__/services/user-notification-prefs-service.test.ts
+++ b/__tests__/services/user-notification-prefs-service.test.ts
@@ -1,10 +1,11 @@
 /**
- * Unit tests for UserNotificationPrefsService (#482).
+ * Unit tests for UserNotificationPrefsService (#482, opt-in #686).
  *
  * Covers:
- *  - missing row → all defaults true
- *  - DB error → all defaults true (so a transient outage cannot
- *    silence every DM by misreporting "user opted out")
+ *  - DMs are opt-in: DEFAULT_PREFS is all-false
+ *  - missing row → all defaults (off), so an unconfigured user is never DM'd
+ *  - DB error → all defaults (off) so a transient outage fails closed
+ *    (stays silent) rather than sending an unprompted DM
  *  - setPrefs writes a row via findOneAndUpdate + upsert and returns
  *    the merged result
  *  - setPrefs ignores non-boolean keys in the patch
@@ -50,8 +51,16 @@ describe("UserNotificationPrefsService", () => {
     ).instance = null;
   });
 
+  it("defaults every channel to off so DMs are opt-in (#686)", () => {
+    expect(DEFAULT_PREFS).toEqual({
+      achievements: false,
+      digest: false,
+      rewind: false,
+    });
+  });
+
   describe("getPrefs", () => {
-    it("returns all defaults when no row exists", async () => {
+    it("returns all defaults (off) when no row exists", async () => {
       findOne.mockResolvedValueOnce(null);
       const prefs = await UserNotificationPrefsService.getInstance().getPrefs(
         "u1",
@@ -81,7 +90,7 @@ describe("UserNotificationPrefsService", () => {
       });
     });
 
-    it("collapses to defaults on DB error so a transient outage cannot silence DMs", async () => {
+    it("collapses to defaults (off) on DB error so a transient outage fails closed", async () => {
       findOne.mockRejectedValueOnce(new Error("mongo down"));
       const prefs = await UserNotificationPrefsService.getInstance().getPrefs(
         "u1",

--- a/src/models/user-notification-prefs.ts
+++ b/src/models/user-notification-prefs.ts
@@ -3,8 +3,10 @@ import mongoose, { Document, Schema } from "mongoose";
 /**
  * Per-user notification preferences (#482).
  *
- * A missing row means "all defaults true" — see
- * `UserNotificationPrefsService.getPrefs`. Storage is per `(userId, guildId)`.
+ * Notification DMs are opt-in (#686): a missing row means "all defaults
+ * false" — see `UserNotificationPrefsService.getPrefs` — so Koolbot never
+ * DMs a member who has not explicitly enabled a channel via the web UI.
+ * Storage is per `(userId, guildId)`.
  *
  * The `digest` (#483) and `rewind` (#484) fields ship from day one with
  * defaulting writes so the schema is stable across all three sub-issues:
@@ -29,9 +31,12 @@ const UserNotificationPrefsSchema = new Schema<IUserNotificationPrefs>(
   {
     userId: { type: String, required: true },
     guildId: { type: String, required: true },
-    achievements: { type: Boolean, required: true, default: true },
-    digest: { type: Boolean, required: true, default: true },
-    rewind: { type: Boolean, required: true, default: true },
+    // Opt-in (#686): default false so a row created as a side effect of
+    // setting an unrelated field (e.g. timezone via setDefaultsOnInsert)
+    // never silently opts the user into DMs.
+    achievements: { type: Boolean, required: true, default: false },
+    digest: { type: Boolean, required: true, default: false },
+    rewind: { type: Boolean, required: true, default: false },
     // Optional IANA zone (e.g. "Europe/Berlin"); absent → server timezone.
     timezone: { type: String, required: false },
     updatedAt: { type: Date, required: true, default: Date.now },

--- a/src/services/achievements-service.ts
+++ b/src/services/achievements-service.ts
@@ -1784,16 +1784,12 @@ export class AchievementsService {
         return;
       }
 
-      const user = await this.client.users.fetch(userId);
-      if (!user) {
-        logger.warn(`Could not find user ${userId} to send DM`);
-        return;
-      }
-
       // Per-user opt-in (#686, #482). Single-guild bot: resolve guildId
       // from bootstrap config. Fail closed — an empty/unset GUILD_ID means
       // we can't look up the user's pref, so we must NOT send (a
-      // misconfiguration must never cause an unprompted DM).
+      // misconfiguration must never cause an unprompted DM). This gate runs
+      // before the Discord user fetch so the common "opted out" case (now
+      // the default) costs no REST call.
       const guildId = await this.configService.getString("GUILD_ID", "");
       if (!guildId) {
         logger.info(
@@ -1809,6 +1805,12 @@ export class AchievementsService {
         logger.info(
           `Skipping accolade DM for ${userId}: per-user achievements pref is off`,
         );
+        return;
+      }
+
+      const user = await this.client.users.fetch(userId);
+      if (!user) {
+        logger.warn(`Could not find user ${userId} to send DM`);
         return;
       }
 

--- a/src/services/achievements-service.ts
+++ b/src/services/achievements-service.ts
@@ -1790,23 +1790,26 @@ export class AchievementsService {
         return;
       }
 
-      // Per-user opt-out (#482). Single-guild bot: resolve guildId from
-      // bootstrap config so this guard works whether or not the caller
-      // threaded it through. An empty/unset GUILD_ID falls through to the
-      // legacy "always send when global toggle is on" behaviour so a
-      // misconfiguration doesn't silence every DM.
+      // Per-user opt-in (#686, #482). Single-guild bot: resolve guildId
+      // from bootstrap config. Fail closed — an empty/unset GUILD_ID means
+      // we can't look up the user's pref, so we must NOT send (a
+      // misconfiguration must never cause an unprompted DM).
       const guildId = await this.configService.getString("GUILD_ID", "");
-      if (guildId) {
-        const prefs = await UserNotificationPrefsService.getInstance().getPrefs(
-          userId,
-          guildId,
+      if (!guildId) {
+        logger.info(
+          `Skipping accolade DM for ${userId}: GUILD_ID unset, cannot confirm opt-in`,
         );
-        if (!prefs.achievements) {
-          logger.info(
-            `Skipping accolade DM for ${userId}: per-user achievements pref is off`,
-          );
-          return;
-        }
+        return;
+      }
+      const prefs = await UserNotificationPrefsService.getInstance().getPrefs(
+        userId,
+        guildId,
+      );
+      if (!prefs.achievements) {
+        logger.info(
+          `Skipping accolade DM for ${userId}: per-user achievements pref is off`,
+        );
+        return;
       }
 
       const messages = accolades

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -654,12 +654,12 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
   digest: {
     title: "Weekly Digest",
     description:
-      "Personalised weekly DM summarising each user's voice activity, rank, streak, and new achievements. Opt-out lives on the user's /me/notifications page.",
+      "Personalised weekly DM summarising each user's voice activity, rank, streak, and new achievements. Opt-in (off by default) on the user's /me/notifications page.",
   },
   rewind: {
     title: "Rewind (Year-in-Review)",
     description:
-      "Personalised end-of-year recap at /me/rewind plus a one-shot DM nudge in late December. Opt-out lives on the user's /me/notifications page.",
+      "Personalised end-of-year recap at /me/rewind plus a one-shot DM nudge in late December. The nudge is opt-in (off by default) on the user's /me/notifications page.",
   },
   birthdays: {
     title: "Birthdays",

--- a/src/services/digest-service.ts
+++ b/src/services/digest-service.ts
@@ -41,7 +41,7 @@ export interface DigestPreviewEntry {
   description: string;
   /** The embed fields exactly as they would appear in the DM'd embed. */
   fields: Array<{ name: string; value: string; inline: boolean }>;
-  /** Embed footer text (motivational line + opt-out hint). */
+  /** Embed footer text (motivational line + manage-notifications hint). */
   footer: string;
 }
 
@@ -336,7 +336,7 @@ export class DigestService {
 
       for (const user of qualifying) {
         try {
-          // One read for both the opt-out flag and the display timezone
+          // One read for both the opt-in flag and the display timezone
           // (used for the week range), so the cron loop stays at a single
           // prefs query per user even for large guilds (#524).
           const { prefs, timezone } = await prefsService.getPrefsWithTimezone(
@@ -755,7 +755,7 @@ export class DigestService {
       )
       .addFields(fields)
       .setFooter({
-        text: `${footer}\nDon't want these? Run /config to manage your notifications.`,
+        text: `${footer}\nYou opted in to these. Manage them anytime on the web UI at /me/notifications.`,
       })
       .setTimestamp(new Date());
   }

--- a/src/services/digest-service.ts
+++ b/src/services/digest-service.ts
@@ -755,7 +755,7 @@ export class DigestService {
       )
       .addFields(fields)
       .setFooter({
-        text: `${footer}\nYou opted in to these. Manage them anytime on the web UI at /me/notifications.`,
+        text: `${footer}\nYou opted in to these. Run /config → Notifications to manage your preferences.`,
       })
       .setTimestamp(new Date());
   }

--- a/src/services/user-notification-prefs-service.ts
+++ b/src/services/user-notification-prefs-service.ts
@@ -24,19 +24,25 @@ export const NOTIFICATION_PREF_KEYS: readonly NotificationPrefKey[] = [
   "rewind",
 ];
 
+/**
+ * Notification DMs are opt-in (#686): every channel defaults to `false`,
+ * so a user who has never opened `/me/notifications` receives nothing.
+ * This is also the fail-closed posture for read errors and missing ids —
+ * a transient failure can never cause an unprompted DM.
+ */
 export const DEFAULT_PREFS: NotificationPrefs = {
-  achievements: true,
-  digest: true,
-  rewind: true,
+  achievements: false,
+  digest: false,
+  rewind: false,
 };
 
 /**
  * Per-user notification preferences service (#482).
  *
  * Backed by `UserNotificationPrefs` (one row per `(userId, guildId)`).
- * A missing row is treated as "all defaults true", so guards in DM-send
- * paths can call `getPrefs` unconditionally without first checking
- * whether the user has ever opened `/me/notifications`.
+ * DMs are opt-in (#686): a missing row is treated as "all defaults false",
+ * so guards in DM-send paths can call `getPrefs` unconditionally and a
+ * member who has never opened `/me/notifications` is never DM'd.
  */
 export class UserNotificationPrefsService {
   private static instance: UserNotificationPrefsService | null = null;
@@ -53,8 +59,9 @@ export class UserNotificationPrefsService {
 
   /**
    * Read the prefs for a user in a guild. Missing row → defaults
-   * (everything enabled). DB errors are logged and also collapse to
-   * defaults so a transient failure can't accidentally silence every DM.
+   * (everything off, #686). DB errors are logged and also collapse to
+   * defaults so a transient failure fails closed (stays silent) rather
+   * than sending an unprompted DM.
    */
   public async getPrefs(
     userId: string,
@@ -76,7 +83,7 @@ export class UserNotificationPrefsService {
    * notably the weekly digest cron, which renders the week range in the
    * user's zone — use this to avoid a second `findOne` per user. Same
    * defaulting rules as `getPrefs`/`getTimezone` (missing row / error →
-   * all-defaults + null zone).
+   * all-off defaults + null zone, i.e. fail closed, #686).
    */
   public async getPrefsWithTimezone(
     userId: string,
@@ -187,9 +194,11 @@ export class UserNotificationPrefsService {
 }
 
 function rowToPrefs(row: IUserNotificationPrefs): NotificationPrefs {
+  // Opt-in (#686): only an explicit stored `true` enables a channel. A
+  // missing/undefined field reads as off (fail closed), matching DEFAULT_PREFS.
   return {
-    achievements: row.achievements !== false,
-    digest: row.digest !== false,
-    rewind: row.rewind !== false,
+    achievements: row.achievements === true,
+    digest: row.digest === true,
+    rewind: row.rewind === true,
   };
 }

--- a/src/web/user-layout.ts
+++ b/src/web/user-layout.ts
@@ -848,7 +848,7 @@ export function renderUserNotificationsBody(
     .join("");
   return [
     "<h1>Notifications</h1>",
-    `<p class="subtitle">Choose which DMs Koolbot may send you on this server. Untoggling a row stops the matching DM immediately.</p>`,
+    `<p class="subtitle">Choose which DMs Koolbot may send you on this server. Every channel is off until you turn it on — Koolbot never DMs you unprompted. Untoggling a row stops the matching DM immediately.</p>`,
     '<form method="POST" action="/me/notifications">',
     `<input type="hidden" name="_csrf" value="${escapeHtml(opts.csrfToken)}">`,
     '<div class="card">',
@@ -860,7 +860,7 @@ export function renderUserNotificationsBody(
     "</tbody></table>",
     '<div class="form-actions">',
     '<button class="btn" type="submit">Save preferences</button>',
-    '<span class="muted">Missing record on first save → defaults to all-enabled.</span>',
+    '<span class="muted">DMs are opt-in: every channel starts off until you enable it here.</span>',
     "</div>",
     "</div>",
     "</form>",


### PR DESCRIPTION
## Description

Flips the per-user notification system from **opt-out** to **opt-in** so Koolbot **never DMs a member who has not explicitly enabled a channel** via the web UI (`/me/notifications`). Today the defaults are all `true`, so a user who has never opened the preferences page still receives unprompted DMs (accolades/achievements, weekly digest, Rewind nudge).

All three DM paths already short-circuit on a falsy pref (`if (!prefs.x) skip`), so the change is primarily a default flip plus a fail-closed fix:

- **`DEFAULT_PREFS` and the `UserNotificationPrefs` schema defaults → `false`.** The schema default is flipped too so a row created as a side effect of setting an unrelated field (e.g. timezone via `setDefaultsOnInsert`) never silently opts the user in. `rowToPrefs` now treats only an explicit stored `true` as enabled.
- **Fail closed everywhere.** A missing row, a DB read error, or a missing `guildId` all resolve to "off". `achievements-service.notifyUserOfAccolades` previously *fell through and sent* when `GUILD_ID` was unset — it now skips. Digest and rewind-nudge already abort on unset `GUILD_ID` and gate on a falsy pref, so they cascade for free.
- **Wording.** Web UI copy (`user-layout.ts`), the digest footer, and the `config-schema` digest/rewind descriptions now describe opt-in semantics.

Chose **option (a)** from the issue (clean default flip): existing explicit opt-ins stored as rows are preserved; no back-fill. This is an intentional, observable UX change (`feat` → minor bump) — members who currently receive these DMs without a saved row will stop until they opt in.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update

> Note: behaviour-changing for end users (DMs stop until opt-in), but no code-level API break.

## Related Issues

Closes #686
Refs #482, #524, #658

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality

`npm run check:all` passes locally: build, ESLint, Prettier, and the full Jest suite (1420 passed, 1 skipped) with coverage above the configured floors. `markdownlint-cli2` is clean on the changed docs.

New/updated tests:
- `user-notification-prefs-service.test.ts`: guard asserting `DEFAULT_PREFS` is all-false; updated docstrings/names for fail-closed semantics.
- `achievements-service.test.ts`: unset `GUILD_ID` → no DM (fail closed); no-prefs-row → no DM.
- `digest-service.test.ts` and `rewind-nudge-service.test.ts`: missing-row (all-false prefs) → no DM.

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format`
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove the change works
- [x] New and existing unit tests pass locally with my changes

### Documentation

- [x] I have commented hard-to-understand areas
- [x] I have updated the documentation where necessary:
  - [x] `COMMANDS.md`
  - [x] `SETTINGS.md`
  - [x] `WEBUI.md`
  - [x] Inline code comments
- [x] I have validated markdown with markdownlint

### Configuration

- [x] Documented behaviour in `SETTINGS.md` and `config-schema.ts` descriptions

## Additional Notes

The accolade DM footer text (`Manage notifications: run /config`) and the `skippedOptOut` summary counter names are left unchanged to keep the diff scoped to the default flip. The out-of-scope in-Discord first-touch consent prompt noted in the issue is not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMs2E98oCmCv557AZHmeLR

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMs2E98oCmCv557AZHmeLR)_