### PR TITLE
docs: require rebase before PR and resolving handled review comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,8 +146,8 @@ Allowed types (kept in sync with `release-please-config.json` changelog sections
 
 ### Pull request workflow
 
-- **Always rebase onto the latest `main` before creating a PR** (`git fetch origin main && git rebase
-  origin/main`), resolving any conflicts, so the PR is up to date and merges cleanly.
+- **Always rebase onto the latest `main` before creating a PR** — run `git fetch origin main && git rebase origin/main`,
+  resolve any conflicts, so the PR is up to date and merges cleanly.
 - **Always resolve review comments once they are handled** — after addressing a reviewer's comment, mark
   the conversation as resolved so the thread reflects what is still outstanding.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,13 @@ Allowed types (kept in sync with `release-please-config.json` changelog sections
 "chore(main): release x.y.z" PR; merging it tags the release and updates `CHANGELOG.md` and
 `.release-please-manifest.json`.
 
+### Pull request workflow
+
+- **Always rebase onto the latest `main` before creating a PR** (`git fetch origin main && git rebase
+  origin/main`), resolving any conflicts, so the PR is up to date and merges cleanly.
+- **Always resolve review comments once they are handled** — after addressing a reviewer's comment, mark
+  the conversation as resolved so the thread reflects what is still outstanding.
+
 ## Conventions & pitfalls
 
 - ESM throughout: relative imports must use `.js` extensions even from `.ts` sources (NodeNext resolution).


### PR DESCRIPTION
## Description

Adds a **Pull request workflow** subsection to `CLAUDE.md` documenting two expectations for contributors (and Claude Code) working in this repo:

- **Always rebase onto the latest `main` before creating a PR** (`git fetch origin main && git rebase origin/main`), resolving conflicts, so the PR is up to date and merges cleanly.
- **Always resolve review comments once they are handled** — mark the conversation as resolved after addressing a reviewer's comment so the thread reflects what is still outstanding.

The subsection sits under the CI / release chain section, right after "Conventional Commits are mandatory".

## Type of Change

- [x] 📚 Documentation update

## Related Issues

N/A

## How Has This Been Tested?

Documentation-only change; no code paths affected.

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have updated the documentation where necessary

## Additional Notes

Docs-only change to `CLAUDE.md`. Markdown line length stays within the 160-char CI limit.

## Pre-Submission Verification

- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhauScaLbgGcNvFPGcu1nh

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhauScaLbgGcNvFPGcu1nh)_