### PR TITLE
docs: remove undocumented quotes.add_roles config key references

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -348,8 +348,7 @@ channel. All quotes are posted in a channel where users can react with
 
 - `quotes.enabled = true`
 - `quotes.channel_id = <channel-id>`
-- (Optional) `quotes.cooldown`, `quotes.max_length`, `quotes.add_roles`,
-  `quotes.delete_roles`
+- (Optional) `quotes.cooldown`, `quotes.max_length`, `quotes.delete_roles`
 
 Then reload commands.
 

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -194,7 +194,6 @@ Configure the quote management system.
 | `quotes.channel_id` | `""` | Channel ID for quote messages (empty = use command channel) |
 | `quotes.cooldown` | `60` | Seconds between quote additions (per user) |
 | `quotes.max_length` | `1000` | Maximum character length for quotes |
-| `quotes.add_roles` | `""` | Role IDs allowed to add quotes (comma-separated, empty = all) |
 | `quotes.delete_roles` | `""` | Role IDs allowed to delete quotes (comma-separated, empty = admins only) |
 | `quotes.header_enabled` | `true` | Show informational header post in quote channel |
 | `quotes.header_pin_enabled` | `true` | Pin the header post for easy access |
@@ -1045,7 +1044,6 @@ leave the graph in a broken state.
 - `quotes.channel_id` (string, default: "")
 - `quotes.cooldown` (number, default: 60)
 - `quotes.max_length` (number, default: 1000)
-- `quotes.add_roles` (string, default: "")
 - `quotes.delete_roles` (string, default: "")
 - `quotes.header_enabled` (bool, default: true)
 - `quotes.header_pin_enabled` (bool, default: true)


### PR DESCRIPTION
## Description

`quotes.add_roles` was documented as a config key but **does not exist** anywhere in the codebase — it is never declared in `src/services/config-schema.ts` (no interface entry, `defaultConfig` value, or `settingsMetadata` entry) and is never read at runtime. The docs therefore misled operators into thinking an add-role gate existed.

Per issue #680, this takes **option 1** (the recommended path): remove the three stale references rather than implement the gate. Anyone can add quotes today, gated only by `quotes.enabled` + channel permissions, and that behavior is unchanged. The sibling key `quotes.delete_roles` is genuinely implemented and is left in place.

Removed references:

- `SETTINGS.md` — the `quotes.add_roles` row in the quotes settings table
- `SETTINGS.md` — the `quotes.add_roles` bullet in the Quote System list
- `COMMANDS.md` — the `quotes.add_roles` mention in the quotes setup section

## Type of Change

- [x] 📚 Documentation update

## Related Issues

Closes #680

## How Has This Been Tested?

- [x] Confirmed via grep that `quotes.add_roles` no longer appears anywhere in the repo and was never present in `src/`.

Docs-only change; no code paths affected.

## Checklist

### Documentation

- [x] Updated `SETTINGS.md` and `COMMANDS.md` to drop the non-existent key
- [x] Validated the changed docs leave no dangling reference

## Additional Notes

Surfaced by a Copilot review on #676 (the `quotes.clear_on_sync` PR) and split out in #680 as a pre-existing inaccuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrFDw1H6fEsKhLsuT1ZSt3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrFDw1H6fEsKhLsuT1ZSt3)_