### PR TITLE
feat(web): sort enabled features above disabled in wizard and nav

### DIFF
--- a/__tests__/web/admin-layout.test.ts
+++ b/__tests__/web/admin-layout.test.ts
@@ -305,6 +305,38 @@ describe("renderAdminPage grouped sidebar (#613)", () => {
     expect(html).toContain('href="/admin/announcements" class="nav-disabled"');
   });
 
+  it("sorts enabled Features nav items above disabled ones, stable within the group (#706)", () => {
+    // reactionroles + voicechannels on; announcements + polls + notices off.
+    const html = render({
+      "announcements.enabled": false,
+      "polls.enabled": false,
+      "reactionroles.enabled": true,
+      "notices.enabled": false,
+      "voicechannels.enabled": true,
+      "digest.enabled": false,
+      "voicetracking.enabled": false,
+    });
+    // Enabled items sink no lower than any disabled item. Enabled hrefs
+    // (reaction-roles, voice-channels) and disabled hrefs (announcements,
+    // polls, notices, digest, analytics) partition cleanly.
+    const pos = (href: string): number => html.indexOf(`href="${href}"`);
+    const enabled = ["/admin/reaction-roles", "/admin/voice-channels"].map(pos);
+    const disabled = [
+      "/admin/announcements",
+      "/admin/polls",
+      "/admin/notices",
+      "/admin/digest",
+      "/admin/analytics",
+    ].map(pos);
+    for (const p of [...enabled, ...disabled]) expect(p).toBeGreaterThan(-1);
+    expect(Math.max(...enabled)).toBeLessThan(Math.min(...disabled));
+    // Enabled items preserve their fixed NAV_ITEMS order (reaction-roles
+    // precedes voice-channels), confirming the stable secondary sort.
+    expect(pos("/admin/reaction-roles")).toBeLessThan(
+      pos("/admin/voice-channels"),
+    );
+  });
+
   it("ships muted CSS for the group heading consistent with the sidebar", () => {
     expect(render()).toContain("nav.side .nav-group-heading{");
   });

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -1761,6 +1761,42 @@ describe("renderWizardPage", () => {
       /Polls\s*<span class="fc-current"><span class="tag tag-off">OFF<\/span><\/span>/,
     );
   });
+
+  it("sorts enabled features above disabled ones, stable within each group", () => {
+    const html = renderWizardPage({
+      ...COMMON,
+      featureOrder: [
+        "voicechannels",
+        "voicetracking",
+        "quotes",
+        "achievements",
+        "reactionroles",
+        "announcements",
+      ],
+      featureStatus: {
+        voicechannels: true,
+        voicetracking: false,
+        quotes: true,
+        achievements: false,
+        reactionroles: true,
+        announcements: false,
+      },
+    });
+    // Enabled (voicechannels, quotes, reactionroles) keep their relative order
+    // and precede disabled (voicetracking, achievements, announcements), which
+    // also keep their relative order.
+    const order = [
+      "voicechannels",
+      "quotes",
+      "reactionroles",
+      "voicetracking",
+      "achievements",
+      "announcements",
+    ].map((fk) => html.indexOf(`id="feat-${fk}"`));
+    for (const idx of order) expect(idx).toBeGreaterThanOrEqual(0);
+    const sorted = [...order].sort((a, b) => a - b);
+    expect(order).toEqual(sorted);
+  });
 });
 
 describe("renderWizardStepPage", () => {

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -573,7 +573,14 @@ function renderNav(
   // always shown, so a group only renders empty if it genuinely has no items
   // — no dangling header (#613).
   return NAV_GROUP_ORDER.map((group) => {
-    const items = NAV_ITEMS.filter((item) => item.group === group);
+    // Sort enabled/on features to the top and let disabled/off ones sink to the
+    // bottom, preserving the fixed NAV_ITEMS order as a stable secondary sort
+    // within each group (Array.prototype.sort is stable). Non-feature items are
+    // never disabled, so other groups are unaffected. Pure display-order change
+    // (#706).
+    const items = NAV_ITEMS.filter((item) => item.group === group).sort(
+      (a, b) => Number(isDisabled(a)) - Number(isDisabled(b)),
+    );
     if (items.length === 0) return "";
     return (
       `<div class="nav-group">` +

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -1133,7 +1133,15 @@ export function renderWizardPage(props: WizardPageProps): string {
   // on — admins re-tick what they want, untick what they don't. `featureStatus`
   // only feeds the ON/OFF indicator so the admin can see what
   // state they're about to override.
-  const cards = props.featureOrder
+  // Sort enabled/on features to the top and let disabled/off ones sink to the
+  // bottom, keeping `featureOrder` as a stable secondary sort within each group
+  // (Array.prototype.sort is stable). Pure display-order change (#706).
+  const orderedKeys = [...props.featureOrder].sort(
+    (a, b) =>
+      Number(Boolean(props.featureStatus[b])) -
+      Number(Boolean(props.featureStatus[a])),
+  );
+  const cards = orderedKeys
     .map((fk) => {
       const info = WIZARD_FEATURE_LABELS[fk] ?? { name: fk, desc: "" };
       const currentlyOn = Boolean(props.featureStatus[fk]);


### PR DESCRIPTION
## Description

Features were listed in a fixed hardcoded order regardless of their on/off state, so enabled and disabled items were interleaved and admins had to scan past greyed-out entries to find active features.

This change sorts **enabled/on features to the top** and lets **disabled/off features sink to the bottom** in two places:

- **Setup Wizard feature cards** (`renderWizardPage`) — sorts `featureOrder` by `featureStatus[fk]`.
- **Admin "Features" nav group** (`renderNav`) — sorts each group's items by resolved `isDisabled`/`navFeatureStatus`.

The existing fixed order is preserved as a **stable secondary sort** within each group (`Array.prototype.sort` is stable in Node 22+). Non-feature nav groups are unaffected since their items are never disabled. This is a pure display-order change — feature keys and the underlying list are unchanged.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Related Issues

Closes #706

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality

Added focused unit tests:

- `renderWizardPage` — verifies enabled cards precede disabled ones while preserving relative order within each group.
- `renderAdminPage` grouped sidebar — verifies enabled Features nav items sort above disabled ones with a stable secondary order.

Ran `npm run build`, `npm run lint`, `npm run format:check`, and the affected Jest suites — all green.

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

### Documentation

- [x] No user-facing command or configuration keys changed — `COMMANDS.md`/`SETTINGS.md` not affected.

## Additional Notes

This only reorders how existing feature entries are displayed; no config schema, command, or feature-gating logic was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X3P19ioWd5S3n6mjCkeq57

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3P19ioWd5S3n6mjCkeq57)_