### PR TITLE
fix: make birthday day a month-aware dropdown for consistent input

### DIFF
--- a/__tests__/web/user-birthday-body.test.ts
+++ b/__tests__/web/user-birthday-body.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "@jest/globals";
+import { renderUserBirthdayBody } from "../../src/web/user-layout.js";
+
+describe("renderUserBirthdayBody day dropdown (#704)", () => {
+  const base = { csrfToken: "tok", featureEnabled: true };
+
+  it("renders the day as a select, not a free-text number input", () => {
+    const html = renderUserBirthdayBody({ ...base, selected: null });
+    // Day is now a <select> matching the month dropdown.
+    expect(html).toContain('<select id="bd-day" name="day"');
+    expect(html).not.toContain('<input id="bd-day"');
+  });
+
+  it("offers all 31 day options plus a blank placeholder", () => {
+    const html = renderUserBirthdayBody({ ...base, selected: null });
+    expect(html).toContain("— Day —");
+    for (let d = 1; d <= 31; d++) {
+      expect(html).toContain(`<option value="${d}">${d}</option>`);
+    }
+  });
+
+  it("preselects the stored month and day", () => {
+    const html = renderUserBirthdayBody({
+      ...base,
+      selected: { month: 2, day: 29, year: null },
+    });
+    expect(html).toContain('<option value="2" selected>February</option>');
+    expect(html).toContain('<option value="29" selected>29</option>');
+  });
+
+  it("includes the month-aware day-limiting script", () => {
+    const html = renderUserBirthdayBody({ ...base, selected: null });
+    // The script drives the Day dropdown off the selected Month.
+    expect(html).toContain("bd-month");
+    expect(html).toContain("bd-day");
+    // Days-in-month table (Feb capped at 29).
+    expect(html).toContain("[31,29,31,30,31,30,31,31,30,31,30,31]");
+  });
+
+  it("keeps the year as an optional number input", () => {
+    const html = renderUserBirthdayBody({
+      ...base,
+      selected: { month: 6, day: 15, year: 1990 },
+    });
+    expect(html).toContain('<input id="bd-year" name="year" type="number"');
+    expect(html).toContain('value="1990"');
+  });
+});

--- a/src/web/user-layout.ts
+++ b/src/web/user-layout.ts
@@ -845,11 +845,39 @@ function renderMonthOptions(selected: number | null): string {
   return blank + months;
 }
 
+function renderDayOptions(selected: number | null): string {
+  const blank = `<option value=""${selected === null ? " selected" : ""}>— Day —</option>`;
+  const days = Array.from({ length: 31 }, (_, i) => {
+    const value = i + 1;
+    const sel = value === selected ? " selected" : "";
+    return `<option value="${value}"${sel}>${value}</option>`;
+  }).join("");
+  return blank + days;
+}
+
+// Keeps the Day dropdown consistent with the chosen Month: options past the
+// selected month's length are disabled (Feb → 29, Apr/Jun/Sep/Nov → 30) so
+// impossible combinations like Feb 30 can't be picked. Feb allows 29 since
+// the year is optional and may be a leap year. With no JS the full 1–31 list
+// still submits and the server-side calendar check catches invalid dates.
+const BIRTHDAY_DAY_SCRIPT =
+  "(function(){var m=document.getElementById('bd-month');" +
+  "var d=document.getElementById('bd-day');if(!m||!d)return;" +
+  "var max=[31,29,31,30,31,30,31,31,30,31,30,31];" +
+  "function sync(){var mv=parseInt(m.value,10);" +
+  "var lim=mv>=1&&mv<=12?max[mv-1]:31;" +
+  "for(var i=0;i<d.options.length;i++){var o=d.options[i];" +
+  "var dv=parseInt(o.value,10);if(!dv)continue;" +
+  "var bad=dv>lim;o.disabled=bad;o.hidden=bad;}" +
+  "var cur=parseInt(d.value,10);if(cur>lim)d.value=''}" +
+  "m.addEventListener('change',sync);sync()})();";
+
 /**
- * Inner HTML for `GET /me/birthday` (#657). Month dropdown + day/year
- * number inputs, one POST. Year is optional (privacy): leave it blank to
- * share the date without the age. A second "Remove" button clears the
- * stored birthday.
+ * Inner HTML for `GET /me/birthday` (#657). Month + day dropdowns (the day
+ * list reacts to the selected month, see BIRTHDAY_DAY_SCRIPT) plus an
+ * optional year number input, one POST. Year is optional (privacy): leave it
+ * blank to share the date without the age. A second "Remove" button clears
+ * the stored birthday.
  */
 export function renderUserBirthdayBody(opts: BirthdayPageBodyOptions): string {
   const month = opts.selected?.month ?? null;
@@ -870,7 +898,7 @@ export function renderUserBirthdayBody(opts: BirthdayPageBodyOptions): string {
     '<div><label for="bd-month"><strong>Month</strong></label>' +
       `<div style="margin-top:.35rem"><select id="bd-month" name="month" class="tz-select" style="max-width:12rem">${renderMonthOptions(month)}</select></div></div>`,
     '<div><label for="bd-day"><strong>Day</strong></label>' +
-      `<div style="margin-top:.35rem"><input id="bd-day" name="day" type="number" min="1" max="31" class="tz-select" style="max-width:6rem" value="${day ?? ""}"></div></div>`,
+      `<div style="margin-top:.35rem"><select id="bd-day" name="day" class="tz-select" style="max-width:6rem">${renderDayOptions(day)}</select></div></div>`,
     '<div><label for="bd-year"><strong>Year</strong> <span class="muted">(optional)</span></label>' +
       `<div style="margin-top:.35rem"><input id="bd-year" name="year" type="number" min="1900" placeholder="—" class="tz-select" style="max-width:8rem" value="${year ?? ""}"></div></div>`,
     "</div>",
@@ -882,6 +910,7 @@ export function renderUserBirthdayBody(opts: BirthdayPageBodyOptions): string {
     "</div>",
     "</div>",
     "</form>",
+    `<script>${BIRTHDAY_DAY_SCRIPT}</script>`,
   ].join("");
 }
 

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -681,7 +681,7 @@ export function createUserRouter(
         if (clearing) {
           after = await service.setBirthday(userId, guildId, null);
         } else if (month === null || day === null) {
-          throw new Error("Please choose a month and enter a day.");
+          throw new Error("Please choose a month and a day.");
         } else {
           after = await service.setBirthday(userId, guildId, {
             month,


### PR DESCRIPTION
## Description

The `/me/birthday` form mixed input paradigms: **month** was a `<select>` dropdown while **day** was a free-text `<input type="number">`. Two adjacent parts of the same date used two different widgets, which looked unpolished and let impossible dates (Feb 30, Apr 31) through the client entirely — the only guard was server-side validation.

This change makes **day** a `<select>` matching the month dropdown. A small, no-dependency inline script limits the day options to the selected month's length (Feb → 29, Apr/Jun/Sep/Nov → 30, everything else → 31) and clears an out-of-range day when the month changes, so impossible combinations can't be picked. Feb allows 29 because the year is optional and may be a leap year. Without JavaScript the full 1–31 list still submits and the existing server-side calendar check (`birthday-service.ts`) catches invalid dates.

Also tightened the "no month/day" error wording since day is no longer a typed field.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #704

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality

Added `__tests__/web/user-birthday-body.test.ts` covering: day renders as a `<select>` (not a number input), all 31 options plus a blank placeholder are present, stored month/day are preselected, the month-aware limiting script is included, and the year stays an optional number input.

Also ran `npm run build`, `npm run lint`, and `prettier --check` on the changed files — all clean.

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas (inline notes on the day-limiting script)

No config keys or commands changed, so `SETTINGS.md` / `COMMANDS.md` need no updates; `WEBUI.md` already describes the page generically as "month/day".

## Additional Notes

Purely a web-UI polish/consistency fix — no schema, config, or dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y149CrTXEfkQZoor5hU4rr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y149CrTXEfkQZoor5hU4rr)_