### PR TITLE
feat(announcements): one-off "post now" sends + expanded placeholder set

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -401,9 +401,14 @@ page).
 
 - Schedule custom messages to any channel
 - Cron expressions for the schedule
+- One-off "Post now" (fire an existing schedule immediately) and a
+  "Compose & send once" form (post ad-hoc without storing a cron schedule)
 - Embed support with customizable colors
-- Dynamic placeholders (`{server_name}`, `{member_count}`, `{date}`,
-  `{time}`, `{day}`, `{month}`, `{year}`)
+- Dynamic placeholders — server/date tokens (`{server_name}`, `{member_count}`,
+  `{online_count}`, `{owner}`, `{boost_count}`, `{boost_tier}`,
+  `{channel_count}`, `{role_count}`, `{random_member}`, `{date}`, `{time}`,
+  `{day}`, `{month}`, `{year}`) plus locale-independent ISO forms
+  (`{date_iso}`, `{time_iso}`, `{datetime_iso}`)
 - Persistent across bot restarts
 
 CRUD operations happen on the Announcements page.

--- a/__tests__/services/scheduled-announcement-post-now.test.ts
+++ b/__tests__/services/scheduled-announcement-post-now.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import type { Client } from "discord.js";
+
+// ESM-safe module mocks (jest.unstable_mockModule + dynamic import).
+jest.unstable_mockModule("../../src/services/config-service.js", () => ({
+  ConfigService: {
+    getInstance: () => ({
+      registerReloadCallback: jest.fn(),
+      getBoolean: jest.fn().mockResolvedValue(false),
+      getString: jest.fn().mockResolvedValue(""),
+    }),
+  },
+}));
+jest.unstable_mockModule("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const findById = jest.fn();
+jest.unstable_mockModule("../../src/models/scheduled-announcement.js", () => ({
+  ScheduledAnnouncement: {
+    find: jest.fn().mockResolvedValue([]),
+    findById,
+  },
+}));
+
+describe("ScheduledAnnouncementService.postAnnouncementNow", () => {
+  let mockClient: Partial<Client>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const { ScheduledAnnouncementService } = await import(
+      "../../src/services/scheduled-announcement-service.js"
+    );
+    ScheduledAnnouncementService.reset();
+
+    mockClient = {
+      isReady: jest.fn().mockReturnValue(true),
+      guilds: { fetch: jest.fn() } as any,
+    } as Client;
+  });
+
+  it("returns false when the announcement does not exist", async () => {
+    findById.mockResolvedValue(null);
+    const { ScheduledAnnouncementService } = await import(
+      "../../src/services/scheduled-announcement-service.js"
+    );
+    const service = ScheduledAnnouncementService.getInstance(
+      mockClient as Client,
+    );
+
+    await expect(service.postAnnouncementNow("missing", "g1")).resolves.toBe(
+      false,
+    );
+    // Guild is never fetched when the announcement is missing.
+    expect(mockClient.guilds!.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns false when the announcement belongs to another guild", async () => {
+    findById.mockResolvedValue({
+      _id: "a1",
+      guildId: "other-guild",
+      channelId: "c1",
+      message: "hi",
+      placeholders: false,
+    });
+    const { ScheduledAnnouncementService } = await import(
+      "../../src/services/scheduled-announcement-service.js"
+    );
+    const service = ScheduledAnnouncementService.getInstance(
+      mockClient as Client,
+    );
+
+    await expect(service.postAnnouncementNow("a1", "g1")).resolves.toBe(false);
+    // Cross-guild guard short-circuits before touching Discord.
+    expect(mockClient.guilds!.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -1110,6 +1110,44 @@ describe("renderAnnouncementsPage", () => {
     expect(html).toContain("Created announcement abc.");
     expect(html).toContain('class="notice ok"');
   });
+
+  it("renders a per-row Post now action", () => {
+    const html = renderAnnouncementsPage({
+      ...COMMON,
+      enabled: true,
+      rows: [
+        {
+          id: "a1",
+          channelName: "general",
+          cron: "0 9 * * *",
+          enabled: true,
+          messagePreview: "hi",
+          embedTitle: null,
+          placeholders: false,
+          createdAt: "2026-05-08T00:00:00.000Z",
+        },
+      ],
+      textChannels: [{ id: "c1", name: "general" }],
+    });
+    expect(html).toContain("/admin/announcements/a1/post-now");
+    expect(html).toContain(">Post now<");
+  });
+
+  it("renders the compose & send-once form and expanded placeholders", () => {
+    const html = renderAnnouncementsPage({
+      ...COMMON,
+      enabled: true,
+      rows: [],
+      textChannels: [{ id: "c1", name: "general" }],
+    });
+    expect(html).toContain("/admin/announcements/post-once");
+    expect(html).toContain("Compose &amp; send once");
+    // New placeholder tokens surfaced in the reference help.
+    expect(html).toContain("{online_count}");
+    expect(html).toContain("{boost_count}");
+    expect(html).toContain("{random_member}");
+    expect(html).toContain("{datetime_iso}");
+  });
 });
 
 describe("renderPollsPage", () => {

--- a/src/services/scheduled-announcement-service.ts
+++ b/src/services/scheduled-announcement-service.ts
@@ -1,4 +1,4 @@
-import { Client, TextChannel, EmbedBuilder } from "discord.js";
+import { Client, Guild, TextChannel, EmbedBuilder } from "discord.js";
 import { CronJob, CronTime } from "cron";
 import { ConfigService } from "./config-service.js";
 import logger from "../utils/logger.js";
@@ -148,15 +148,17 @@ export class ScheduledAnnouncementService {
     });
   }
 
-  private async processPlaceholders(
-    text: string,
-    guildId: string,
-  ): Promise<string> {
-    await this.waitForClientReady();
-
-    const guild = await this.client.guilds.fetch(guildId);
-    if (!guild) return text;
-
+  /**
+   * Resolve every placeholder token to its value once per announcement. The
+   * async/expensive work (member-cache scan, `fetchOwner()` API call, random
+   * pick) happens here a single time; `applyPlaceholders` then substitutes the
+   * cached map into each text field synchronously. This avoids re-doing the
+   * work (and the owner API call) for every embed field/title/footer, which
+   * matters for the immediate "post now"/"post once" paths.
+   */
+  private async buildPlaceholderMap(
+    guild: Guild,
+  ): Promise<Record<string, string>> {
     const now = new Date();
 
     // Members currently online — best effort. Requires the GUILD_PRESENCES
@@ -183,6 +185,8 @@ export class ScheduledAnnouncementService {
     }
 
     // Random member mention for fun/engagement — best effort from the cache.
+    // Picked once so a single announcement references the same member across
+    // all of its text fields.
     let randomMember = "";
     const members = [...guild.members.cache.values()];
     if (members.length > 0) {
@@ -190,7 +194,7 @@ export class ScheduledAnnouncementService {
       if (picked) randomMember = picked.toString();
     }
 
-    const replacements: Record<string, string> = {
+    return {
       "{server_name}": guild.name,
       "{member_count}": guild.memberCount.toString(),
       "{online_count}": onlineCount.toString(),
@@ -211,7 +215,12 @@ export class ScheduledAnnouncementService {
       "{time_iso}": now.toISOString().slice(11, 19),
       "{datetime_iso}": now.toISOString(),
     };
+  }
 
+  private applyPlaceholders(
+    text: string,
+    replacements: Record<string, string>,
+  ): string {
     let result = text;
     for (const [placeholder, value] of Object.entries(replacements)) {
       // Use split-join pattern for compatibility with older JS versions
@@ -261,31 +270,26 @@ export class ScheduledAnnouncementService {
       );
     }
 
-    let message = announcement.message;
-    if (announcement.placeholders) {
-      message = await this.processPlaceholders(message, announcement.guildId);
-    }
+    // Resolve placeholders once for the whole announcement, then substitute the
+    // cached map into each field synchronously. `expand` is a no-op when the
+    // announcement has placeholders disabled.
+    const placeholderMap = announcement.placeholders
+      ? await this.buildPlaceholderMap(guild)
+      : null;
+    const expand = (text: string): string =>
+      placeholderMap ? this.applyPlaceholders(text, placeholderMap) : text;
+
+    const message = expand(announcement.message);
 
     if (announcement.embedData) {
       const embed = new EmbedBuilder();
 
       if (announcement.embedData.title) {
-        let title = announcement.embedData.title;
-        if (announcement.placeholders) {
-          title = await this.processPlaceholders(title, announcement.guildId);
-        }
-        embed.setTitle(title);
+        embed.setTitle(expand(announcement.embedData.title));
       }
 
       if (announcement.embedData.description) {
-        let description = announcement.embedData.description;
-        if (announcement.placeholders) {
-          description = await this.processPlaceholders(
-            description,
-            announcement.guildId,
-          );
-        }
-        embed.setDescription(description);
+        embed.setDescription(expand(announcement.embedData.description));
       }
 
       if (announcement.embedData.color) {
@@ -294,26 +298,17 @@ export class ScheduledAnnouncementService {
 
       if (announcement.embedData.fields) {
         for (const field of announcement.embedData.fields) {
-          let name = field.name;
-          let value = field.value;
-          if (announcement.placeholders) {
-            name = await this.processPlaceholders(name, announcement.guildId);
-            value = await this.processPlaceholders(value, announcement.guildId);
-          }
-          embed.addFields({ name, value, inline: field.inline });
+          embed.addFields({
+            name: expand(field.name),
+            value: expand(field.value),
+            inline: field.inline,
+          });
         }
       }
 
       if (announcement.embedData.footer) {
-        let footerText = announcement.embedData.footer.text;
-        if (announcement.placeholders) {
-          footerText = await this.processPlaceholders(
-            footerText,
-            announcement.guildId,
-          );
-        }
         embed.setFooter({
-          text: footerText,
+          text: expand(announcement.embedData.footer.text),
           iconURL: announcement.embedData.footer.iconUrl,
         });
       }
@@ -349,7 +344,7 @@ export class ScheduledAnnouncementService {
     }
     if (guildId && announcement.guildId !== guildId) {
       logger.warn(
-        `Attempted to post announcement ${sanitizeForLog(announcementId)} from wrong guild. Expected: ${announcement.guildId}, Got: ${sanitizeForLog(guildId)}`,
+        `Attempted to post announcement ${sanitizeForLog(announcementId)} from wrong guild. Expected: ${sanitizeForLog(announcement.guildId)}, Got: ${sanitizeForLog(guildId)}`,
       );
       return false;
     }

--- a/src/services/scheduled-announcement-service.ts
+++ b/src/services/scheduled-announcement-service.ts
@@ -13,6 +13,19 @@ interface ScheduledJob {
   job: CronJob;
 }
 
+/**
+ * The subset of an announcement needed to actually render + send it. Every
+ * persisted `IScheduledAnnouncement` satisfies this, but a one-off "send once"
+ * (which is never stored) can supply just these fields.
+ */
+export type AnnouncementContent = Pick<
+  IScheduledAnnouncement,
+  "guildId" | "channelId" | "message" | "placeholders"
+> & {
+  _id?: unknown;
+  embedData?: IScheduledAnnouncement["embedData"];
+};
+
 export class ScheduledAnnouncementService {
   private static instance: ScheduledAnnouncementService;
   private client: Client;
@@ -145,14 +158,58 @@ export class ScheduledAnnouncementService {
     if (!guild) return text;
 
     const now = new Date();
+
+    // Members currently online — best effort. Requires the GUILD_PRESENCES
+    // intent and a populated member cache; when presence data is unavailable
+    // this counts 0 rather than throwing.
+    let onlineCount = 0;
+    try {
+      onlineCount = guild.members.cache.filter(
+        (m) => m.presence != null && m.presence.status !== "offline",
+      ).size;
+    } catch {
+      onlineCount = 0;
+    }
+
+    // Server owner mention. fetchOwner can reject if the owner is uncached or
+    // temporarily unavailable — degrade to an empty string rather than fail
+    // the whole announcement.
+    let ownerMention = "";
+    try {
+      const owner = await guild.fetchOwner();
+      ownerMention = owner.toString();
+    } catch {
+      ownerMention = "";
+    }
+
+    // Random member mention for fun/engagement — best effort from the cache.
+    let randomMember = "";
+    const members = [...guild.members.cache.values()];
+    if (members.length > 0) {
+      const picked = members[Math.floor(Math.random() * members.length)];
+      if (picked) randomMember = picked.toString();
+    }
+
     const replacements: Record<string, string> = {
       "{server_name}": guild.name,
       "{member_count}": guild.memberCount.toString(),
+      "{online_count}": onlineCount.toString(),
+      "{owner}": ownerMention,
+      "{boost_count}": (guild.premiumSubscriptionCount ?? 0).toString(),
+      "{boost_tier}": guild.premiumTier.toString(),
+      "{channel_count}": guild.channels.cache.size.toString(),
+      "{role_count}": guild.roles.cache.size.toString(),
+      "{random_member}": randomMember,
       "{date}": now.toLocaleDateString(),
       "{time}": now.toLocaleTimeString(),
       "{day}": now.toLocaleDateString(undefined, { weekday: "long" }),
       "{month}": now.toLocaleDateString(undefined, { month: "long" }),
       "{year}": now.getFullYear().toString(),
+      // Locale-independent ISO 8601 forms for operators who want a stable,
+      // unambiguous format instead of the locale-implicit {date}/{time}.
+      "{date_iso}": now.toISOString().slice(0, 10),
+      "{time_iso}": now.toISOString().slice(11, 19),
+      "{datetime_iso}": now.toISOString(),
     };
 
     let result = text;
@@ -164,100 +221,10 @@ export class ScheduledAnnouncementService {
   }
 
   private async makeAnnouncement(
-    announcement: IScheduledAnnouncement,
+    announcement: AnnouncementContent,
   ): Promise<void> {
     try {
-      await this.waitForClientReady();
-
-      const guild = await this.client.guilds.fetch(announcement.guildId);
-      if (!guild) {
-        logger.error(
-          `Guild not found with ID: ${announcement.guildId} for announcement ${announcement._id}`,
-        );
-        return;
-      }
-
-      const channel = await guild.channels.fetch(announcement.channelId);
-      if (!channel || !(channel instanceof TextChannel)) {
-        logger.error(
-          `Channel not found or not a text channel: ${announcement.channelId} for announcement ${announcement._id}`,
-        );
-        return;
-      }
-
-      let message = announcement.message;
-      if (announcement.placeholders) {
-        message = await this.processPlaceholders(message, announcement.guildId);
-      }
-
-      if (announcement.embedData) {
-        const embed = new EmbedBuilder();
-
-        if (announcement.embedData.title) {
-          let title = announcement.embedData.title;
-          if (announcement.placeholders) {
-            title = await this.processPlaceholders(title, announcement.guildId);
-          }
-          embed.setTitle(title);
-        }
-
-        if (announcement.embedData.description) {
-          let description = announcement.embedData.description;
-          if (announcement.placeholders) {
-            description = await this.processPlaceholders(
-              description,
-              announcement.guildId,
-            );
-          }
-          embed.setDescription(description);
-        }
-
-        if (announcement.embedData.color) {
-          embed.setColor(announcement.embedData.color);
-        }
-
-        if (announcement.embedData.fields) {
-          for (const field of announcement.embedData.fields) {
-            let name = field.name;
-            let value = field.value;
-            if (announcement.placeholders) {
-              name = await this.processPlaceholders(name, announcement.guildId);
-              value = await this.processPlaceholders(
-                value,
-                announcement.guildId,
-              );
-            }
-            embed.addFields({ name, value, inline: field.inline });
-          }
-        }
-
-        if (announcement.embedData.footer) {
-          let footerText = announcement.embedData.footer.text;
-          if (announcement.placeholders) {
-            footerText = await this.processPlaceholders(
-              footerText,
-              announcement.guildId,
-            );
-          }
-          embed.setFooter({
-            text: footerText,
-            iconURL: announcement.embedData.footer.iconUrl,
-          });
-        }
-
-        if (announcement.embedData.thumbnail) {
-          embed.setThumbnail(announcement.embedData.thumbnail);
-        }
-
-        if (announcement.embedData.image) {
-          embed.setImage(announcement.embedData.image);
-        }
-
-        await channel.send({ content: message, embeds: [embed] });
-      } else {
-        await channel.send(message);
-      }
-
+      await this.dispatchAnnouncement(announcement);
       logger.info(
         `Scheduled announcement ${announcement._id} sent successfully to channel ${announcement.channelId}`,
       );
@@ -267,6 +234,143 @@ export class ScheduledAnnouncementService {
         error,
       );
     }
+  }
+
+  /**
+   * Render + send an announcement, throwing on any failure (guild/channel
+   * missing, Discord send error). `makeAnnouncement` wraps this to swallow
+   * errors for fire-and-forget cron jobs; the immediate "post now"/"send once"
+   * paths call it directly so the WebUI can surface failures to the operator.
+   */
+  private async dispatchAnnouncement(
+    announcement: AnnouncementContent,
+  ): Promise<void> {
+    await this.waitForClientReady();
+
+    const guild = await this.client.guilds.fetch(announcement.guildId);
+    if (!guild) {
+      throw new Error(
+        `Guild not found with ID: ${announcement.guildId} for announcement ${announcement._id}`,
+      );
+    }
+
+    const channel = await guild.channels.fetch(announcement.channelId);
+    if (!channel || !(channel instanceof TextChannel)) {
+      throw new Error(
+        `Channel not found or not a text channel: ${announcement.channelId} for announcement ${announcement._id}`,
+      );
+    }
+
+    let message = announcement.message;
+    if (announcement.placeholders) {
+      message = await this.processPlaceholders(message, announcement.guildId);
+    }
+
+    if (announcement.embedData) {
+      const embed = new EmbedBuilder();
+
+      if (announcement.embedData.title) {
+        let title = announcement.embedData.title;
+        if (announcement.placeholders) {
+          title = await this.processPlaceholders(title, announcement.guildId);
+        }
+        embed.setTitle(title);
+      }
+
+      if (announcement.embedData.description) {
+        let description = announcement.embedData.description;
+        if (announcement.placeholders) {
+          description = await this.processPlaceholders(
+            description,
+            announcement.guildId,
+          );
+        }
+        embed.setDescription(description);
+      }
+
+      if (announcement.embedData.color) {
+        embed.setColor(announcement.embedData.color);
+      }
+
+      if (announcement.embedData.fields) {
+        for (const field of announcement.embedData.fields) {
+          let name = field.name;
+          let value = field.value;
+          if (announcement.placeholders) {
+            name = await this.processPlaceholders(name, announcement.guildId);
+            value = await this.processPlaceholders(value, announcement.guildId);
+          }
+          embed.addFields({ name, value, inline: field.inline });
+        }
+      }
+
+      if (announcement.embedData.footer) {
+        let footerText = announcement.embedData.footer.text;
+        if (announcement.placeholders) {
+          footerText = await this.processPlaceholders(
+            footerText,
+            announcement.guildId,
+          );
+        }
+        embed.setFooter({
+          text: footerText,
+          iconURL: announcement.embedData.footer.iconUrl,
+        });
+      }
+
+      if (announcement.embedData.thumbnail) {
+        embed.setThumbnail(announcement.embedData.thumbnail);
+      }
+
+      if (announcement.embedData.image) {
+        embed.setImage(announcement.embedData.image);
+      }
+
+      await channel.send({ content: message, embeds: [embed] });
+    } else {
+      await channel.send(message);
+    }
+  }
+
+  /**
+   * Fire an existing scheduled announcement once, immediately, without waiting
+   * for its cron to elapse. Reuses the announcement's channel/message/embed/
+   * placeholder config. Returns false when the announcement is missing or
+   * belongs to another guild; throws if the send itself fails so the caller
+   * can report the reason.
+   */
+  public async postAnnouncementNow(
+    announcementId: string,
+    guildId?: string,
+  ): Promise<boolean> {
+    const announcement = await ScheduledAnnouncement.findById(announcementId);
+    if (!announcement) {
+      return false;
+    }
+    if (guildId && announcement.guildId !== guildId) {
+      logger.warn(
+        `Attempted to post announcement ${sanitizeForLog(announcementId)} from wrong guild. Expected: ${announcement.guildId}, Got: ${sanitizeForLog(guildId)}`,
+      );
+      return false;
+    }
+
+    await this.dispatchAnnouncement(announcement);
+    logger.info(
+      `Posted announcement ${sanitizeForLog(announcementId)} on demand to channel ${announcement.channelId}`,
+    );
+    return true;
+  }
+
+  /**
+   * Compose-and-send-once: dispatch an ad-hoc announcement immediately without
+   * persisting a cron schedule. Throws if the send fails so the WebUI can
+   * surface the error.
+   */
+  public async postOnce(announcement: AnnouncementContent): Promise<void> {
+    await this.dispatchAnnouncement(announcement);
+    logger.info(
+      `Posted one-off announcement to channel ${announcement.channelId}`,
+    );
   }
 
   private scheduleAnnouncement(

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -1476,11 +1476,21 @@ const PLACEHOLDER_REFERENCE_HTML = `
   <ul class="mono">
     <li><code>{server_name}</code> — guild name</li>
     <li><code>{member_count}</code> — total members</li>
+    <li><code>{online_count}</code> — members currently online</li>
+    <li><code>{owner}</code> — server owner mention</li>
+    <li><code>{boost_count}</code> — active Nitro boosts</li>
+    <li><code>{boost_tier}</code> — Nitro boost tier (0–3)</li>
+    <li><code>{channel_count}</code> — number of channels</li>
+    <li><code>{role_count}</code> — number of roles</li>
+    <li><code>{random_member}</code> — a random member mention</li>
     <li><code>{date}</code> — current date</li>
     <li><code>{time}</code> — current time</li>
     <li><code>{day}</code> — current weekday</li>
     <li><code>{month}</code> — current month</li>
     <li><code>{year}</code> — current year</li>
+    <li><code>{date_iso}</code> — ISO date (YYYY-MM-DD)</li>
+    <li><code>{time_iso}</code> — ISO time (HH:MM:SS, UTC)</li>
+    <li><code>{datetime_iso}</code> — full ISO 8601 timestamp (UTC)</li>
   </ul>
   <p class="muted">Tick "Process placeholders" on the announcement to expand them at send time.</p>
 </details>`;
@@ -1499,6 +1509,7 @@ export function renderAnnouncementsPage(props: AnnouncementsProps): string {
 <td>${a.placeholders ? '<span class="tag tag-info">yes</span>' : '<span class="muted">no</span>'}</td>
 <td class="muted">${escapeHtml(a.createdAt)}</td>
 <td class="actions">
+  <form method="POST" action="/admin/announcements/${escapeHtml(a.id)}/post-now">${csrfInput}<button type="submit" class="btn btn-primary">Post now</button></form>
   <form method="POST" action="/admin/announcements/${escapeHtml(a.id)}/toggle">${csrfInput}<button type="submit" class="btn">${a.enabled ? "Disable" : "Enable"}</button></form>
   <form method="POST" action="/admin/announcements/${escapeHtml(a.id)}/delete" onsubmit="return confirm('Delete announcement ${escapeHtml(a.id)}?');">${csrfInput}<button type="submit" class="btn btn-danger">Delete</button></form>
 </td>
@@ -1563,6 +1574,37 @@ ${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Announcements", 
       </label>
     </fieldset>
     <button type="submit" class="btn btn-primary">Create announcement</button>
+  </form>
+</div>
+<div class="card">
+  <h2>Compose &amp; send once</h2>
+  <p class="subtitle">Post a one-off announcement immediately — no cron schedule is stored.</p>
+  <form method="POST" action="/admin/announcements/post-once" class="stack">
+    ${csrfInput}
+    <label>Channel
+      <select name="channelId" required>${channelOptionsHtml(props.textChannels)}</select>
+    </label>
+    <label>Message
+      <textarea name="message" rows="4" required maxlength="2000" placeholder="Hello {server_name}!"></textarea>
+    </label>
+    <label class="checkbox">
+      <input type="checkbox" name="placeholders" value="1">
+      Process placeholders (replace <code>{server_name}</code>, <code>{date}</code>, etc.)
+    </label>
+    ${PLACEHOLDER_REFERENCE_HTML}
+    <fieldset>
+      <legend>Optional embed</legend>
+      <label>Title
+        <input type="text" name="embedTitle" maxlength="256">
+      </label>
+      <label>Description
+        <textarea name="embedDescription" rows="3" maxlength="4000"></textarea>
+      </label>
+      <label>Colour (hex, e.g. <code>#5865F2</code>)
+        <input type="text" name="embedColor" pattern="^#?[0-9A-Fa-f]{6}$" placeholder="#5865F2">
+      </label>
+    </fieldset>
+    <button type="submit" class="btn btn-primary">Post now</button>
   </form>
 </div>
 `;

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -1476,7 +1476,7 @@ const PLACEHOLDER_REFERENCE_HTML = `
   <ul class="mono">
     <li><code>{server_name}</code> — guild name</li>
     <li><code>{member_count}</code> — total members</li>
-    <li><code>{online_count}</code> — members currently online</li>
+    <li><code>{online_count}</code> — members currently online (best effort; shows 0 without presence data)</li>
     <li><code>{owner}</code> — server owner mention</li>
     <li><code>{boost_count}</code> — active Nitro boosts</li>
     <li><code>{boost_tier}</code> — Nitro boost tier (0–3)</li>

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -1908,6 +1908,143 @@ export function createWriteRouter(
   );
 
   router.post(
+    "/announcements/:id/post-now",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const id = String(req.params.id);
+      const service = ScheduledAnnouncementService.getInstance(client);
+      try {
+        const ok = await service.postAnnouncementNow(id, session.guildId);
+        await recordAudit(session, {
+          action: "announcement.post-now",
+          targetId: id,
+          result: ok ? "success" : "failure",
+          errorMessage: ok ? null : "not found or wrong guild",
+        });
+        flashRedirect(res, "/admin/announcements", {
+          type: ok ? "ok" : "err",
+          text: ok
+            ? `Posted announcement ${id}. Check the configured channel.`
+            : `Announcement ${id} not found.`,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Manual announcement post failed", err);
+        await recordAudit(session, {
+          action: "announcement.post-now",
+          targetId: id,
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/announcements", {
+          type: "err",
+          text: `Failed to post announcement ${id}: ${text}`,
+        });
+      }
+    }),
+  );
+
+  router.post(
+    "/announcements/post-once",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const channelId = getString(req, "channelId");
+      const message = getString(req, "message");
+      const placeholders = getCheckbox(req, "placeholders");
+      const embedTitle = getString(req, "embedTitle");
+      const embedDescription = getString(req, "embedDescription");
+      const embedColorHex = getString(req, "embedColor");
+
+      if (!channelId || !message) {
+        flashRedirect(res, "/admin/announcements", {
+          type: "err",
+          text: "Channel and message are both required.",
+        });
+        return;
+      }
+      // Reject oversized text up front, mirroring the create route (#508).
+      const lengthError = firstLengthError([
+        {
+          label: "Message",
+          value: message,
+          max: TEXT_LIMITS.announcementMessage,
+        },
+        {
+          label: "Embed title",
+          value: embedTitle,
+          max: TEXT_LIMITS.embedTitle,
+        },
+        {
+          label: "Embed description",
+          value: embedDescription,
+          max: TEXT_LIMITS.embedDescription,
+        },
+      ]);
+      if (lengthError) {
+        flashRedirect(res, "/admin/announcements", {
+          type: "err",
+          text: lengthError,
+        });
+        return;
+      }
+
+      let embedData: IScheduledAnnouncement["embedData"] | undefined;
+      if (embedTitle || embedDescription || embedColorHex) {
+        let color: number | undefined;
+        if (embedColorHex) {
+          const parsed = parseHexColor(embedColorHex);
+          if (parsed === null) {
+            flashRedirect(res, "/admin/announcements", {
+              type: "err",
+              text: `Invalid hex colour: ${embedColorHex}`,
+            });
+            return;
+          }
+          color = parsed;
+        }
+        embedData = {
+          title: embedTitle || undefined,
+          description: embedDescription || undefined,
+          color,
+        };
+      }
+
+      const service = ScheduledAnnouncementService.getInstance(client);
+      try {
+        await service.postOnce({
+          guildId: session.guildId,
+          channelId,
+          message,
+          embedData,
+          placeholders,
+        });
+        await recordAudit(session, {
+          action: "announcement.post-once",
+          details: { channelId, placeholders, hasEmbed: !!embedData },
+          result: "success",
+        });
+        flashRedirect(res, "/admin/announcements", {
+          type: "ok",
+          text: "One-off announcement posted. Check the configured channel.",
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("One-off announcement post failed", err);
+        await recordAudit(session, {
+          action: "announcement.post-once",
+          details: { channelId, placeholders },
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/announcements", {
+          type: "err",
+          text: `Failed to post announcement: ${text}`,
+        });
+      }
+    }),
+  );
+
+  router.post(
     "/announcements/post-vc-stats",
     asyncHandler(async (req, res) => {
       const session = requireSessionContext(req);


### PR DESCRIPTION
## Description

Closes the two gaps in the announcements feature described in #707:

**A. One-off "post now" sends.**
- A **Post now** action on each scheduled announcement — reuses its channel/message/embed/placeholder config and fires `makeAnnouncement()` once immediately, without waiting for the cron to elapse.
- A dedicated **Compose & send once** form that posts an announcement immediately without persisting a cron schedule.
- The send logic is split into a throwing `dispatchAnnouncement()` so the WebUI can surface send failures (guild/channel missing, Discord error) to the operator; `makeAnnouncement()` keeps swallowing errors for fire-and-forget cron jobs, so existing cron behaviour is unchanged.

**B. Expanded placeholder set** in `processPlaceholders`:
- `{online_count}` (best-effort, needs the presence intent), `{owner}`, `{boost_count}`, `{boost_tier}`, `{channel_count}`, `{role_count}`, `{random_member}`
- Locale-independent ISO forms: `{date_iso}`, `{time_iso}`, `{datetime_iso}`
- Placeholder-resolution failures degrade gracefully (empty string / 0) rather than failing the whole announcement.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Related Issues

Closes #707

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality

New/updated tests:
- `__tests__/services/scheduled-announcement-post-now.test.ts` — `postAnnouncementNow` returns false (without touching Discord) when the announcement is missing or belongs to another guild.
- `__tests__/web/admin-views.test.ts` — per-row **Post now** action, **Compose & send once** form, and the expanded placeholder reference render.

Full suite: `npm run test:ci` — 119 suites, 1469 passing (1 skipped); coverage thresholds hold. `npm run build`, `npm run lint`, `npm run format:check` all clean.

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary:
  - [x] `SETTINGS.md` (documented the new "post now"/"send once" actions and full placeholder list)

## Additional Notes

`{online_count}` and `{random_member}` are best-effort from the member cache; `{online_count}` requires the `GUILD_PRESENCES` intent and returns 0 when presence data is unavailable. The `{mention}` token from the issue was intentionally left out — it needs a configured target (schema change) and is a ping-safety concern, so it's better handled as a follow-up.

## Pre-Submission Verification

- [x] I have rebased my branch on the latest main branch
- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011zQDwNedUvrQa8qJCHnhBM)_