### PR TITLE
fix(wizard): render channel/category/role keys as proper selectors

### DIFF
--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -23,6 +23,15 @@ import {
 
 const COMMON = { csrfToken: "csrf", remainingMs: 60_000 };
 
+// Empty guild picker lists for wizard-step tests that don't exercise the
+// channel/category/role dropdowns (issue #703).
+const EMPTY_PICKERS = {
+  textChannels: [],
+  voiceChannels: [],
+  categoryChannels: [],
+  roles: [],
+};
+
 describe("renderDashboardPage", () => {
   it("renders feature toggles with status tags", () => {
     const html = renderDashboardPage({
@@ -1767,7 +1776,11 @@ describe("renderDigestPage", () => {
             title: "📊 Your weekly voice digest",
             description: "Here's a snapshot, alice.",
             fields: [
-              { name: "This week", value: "5h\n▲ 1h vs last week", inline: true },
+              {
+                name: "This week",
+                value: "5h\n▲ 1h vs last week",
+                inline: true,
+              },
               { name: "Rank", value: "#1", inline: true },
             ],
             footer: "Keep it up!\nDon't want these? Run /config.",
@@ -1939,6 +1952,7 @@ describe("renderWizardStepPage", () => {
   it("renders boolean/number/string inputs with the current value", () => {
     const html = renderWizardStepPage({
       ...COMMON,
+      ...EMPTY_PICKERS,
       stepIndex: 0,
       totalSteps: 2,
       featureKey: "voicechannels",
@@ -1964,19 +1978,22 @@ describe("renderWizardStepPage", () => {
     expect(html).toContain("Step 1 of 2");
     expect(html).toContain('action="/admin/wizard/step/0"');
     expect(html).toContain("Voice Channels");
+    // The wizard now renders through the shared control renderer, so value
+    // fields carry the `value_`-prefixed name (issue #703).
     expect(html).toMatch(
-      /type="checkbox"[^>]*name="voicechannels.enabled"[^>]*value="true" checked/,
+      /type="checkbox"[^>]*name="value_voicechannels.enabled"[^>]*value="true" checked/,
     );
     expect(html).toMatch(
-      /type="number"[^>]*name="quotes.max_length"[^>]*value="500"/,
+      /type="number"[^>]*name="value_quotes.max_length"[^>]*value="500"/,
     );
     expect(html).toContain('value="Lobby"');
     expect(html).toContain("Enable VC");
   });
 
-  it("renders an options-backed key as a <select> using the raw key name and pre-selects the current value", () => {
+  it("renders an options-backed key as a <select> and pre-selects the current value", () => {
     const html = renderWizardStepPage({
       ...COMMON,
+      ...EMPTY_PICKERS,
       stepIndex: 0,
       totalSteps: 1,
       featureKey: "leaderboard_roles",
@@ -1995,22 +2012,21 @@ describe("renderWizardStepPage", () => {
         },
       },
     });
-    // The wizard posts raw key names (not the value_-prefixed settings form
-    // field), so the select must carry the bare key.
-    expect(html).toContain('<select name="leaderboard_roles.period">');
+    // The wizard renders through the shared control renderer, so the select
+    // carries the `value_`-prefixed field name (issue #703).
+    expect(html).toContain('<select name="value_leaderboard_roles.period">');
     expect(html).toContain(
       '<option value="month" selected>This month</option>',
     );
     expect(html).toContain('<option value="week">This week</option>');
     // No free-text input for an options key.
-    expect(html).not.toContain(
-      '<input type="text" id="wiz-leaderboard_roles.period"',
-    );
+    expect(html).not.toContain('<input type="text"');
   });
 
   it("surfaces an out-of-range options value in the wizard as a selected `(unknown)` option", () => {
     const html = renderWizardStepPage({
       ...COMMON,
+      ...EMPTY_PICKERS,
       stepIndex: 0,
       totalSteps: 1,
       featureKey: "leaderboard_roles",
@@ -2038,6 +2054,7 @@ describe("renderWizardStepPage", () => {
   it("renders a flash banner when coercion drops fields", () => {
     const html = renderWizardStepPage({
       ...COMMON,
+      ...EMPTY_PICKERS,
       stepIndex: 0,
       totalSteps: 1,
       featureKey: "quotes",
@@ -2057,6 +2074,7 @@ describe("renderWizardStepPage", () => {
   it("changes the submit label on the final step", () => {
     const html = renderWizardStepPage({
       ...COMMON,
+      ...EMPTY_PICKERS,
       stepIndex: 1,
       totalSteps: 2,
       featureKey: "polls",
@@ -2072,6 +2090,7 @@ describe("renderWizardStepPage", () => {
   it("omits the Previous button on the first step (#485)", () => {
     const html = renderWizardStepPage({
       ...COMMON,
+      ...EMPTY_PICKERS,
       stepIndex: 0,
       totalSteps: 3,
       featureKey: "quotes",
@@ -2086,6 +2105,7 @@ describe("renderWizardStepPage", () => {
   it("shows a Previous button linking to the prior step on later steps (#485)", () => {
     const html = renderWizardStepPage({
       ...COMMON,
+      ...EMPTY_PICKERS,
       stepIndex: 2,
       totalSteps: 3,
       featureKey: "quotes",
@@ -2101,6 +2121,7 @@ describe("renderWizardStepPage", () => {
   it("marks the feature master toggle and form scope for cascading disable (#485)", () => {
     const html = renderWizardStepPage({
       ...COMMON,
+      ...EMPTY_PICKERS,
       stepIndex: 0,
       totalSteps: 1,
       featureKey: "voicetracking",
@@ -2126,11 +2147,75 @@ describe("renderWizardStepPage", () => {
     // Only the top-level feature toggle is the master; the sub-toggle is a
     // dependent (no data-cascade-master attribute).
     expect(html).toMatch(
-      /name="voicetracking.enabled"[^>]*value="true"[^>]*data-cascade-master/,
+      /name="value_voicetracking.enabled"[^>]*value="true"[^>]*data-cascade-master/,
     );
     expect(html).not.toMatch(
-      /name="voicetracking.announcements.enabled"[^>]*data-cascade-master/,
+      /name="value_voicetracking.announcements.enabled"[^>]*data-cascade-master/,
     );
+  });
+
+  it("renders channel/category/role picker keys as dropdowns from the guild lists (issue #703)", () => {
+    const html = renderWizardStepPage({
+      ...COMMON,
+      textChannels: [
+        { id: "chan-1", name: "announcements" },
+        { id: "chan-2", name: "general" },
+      ],
+      voiceChannels: [],
+      categoryChannels: [{ id: "cat-1", name: "Voice Channels" }],
+      roles: [{ id: "role-1", name: "Moderator" }],
+      stepIndex: 0,
+      totalSteps: 1,
+      featureKey: "reactionroles",
+      settingKeys: [
+        "reactionroles.message_channel_id",
+        "voicechannels.category_id",
+        "leaderboard_roles.some_role",
+      ],
+      currentValues: {
+        "reactionroles.message_channel_id": "chan-1",
+        "voicechannels.category_id": "",
+        "leaderboard_roles.some_role": "",
+      },
+      defaultValues: {
+        "reactionroles.message_channel_id": "",
+        "voicechannels.category_id": "",
+        "leaderboard_roles.some_role": "",
+      },
+      metadata: {
+        "reactionroles.message_channel_id": {
+          description: "Message channel",
+          category: "reactionroles",
+          type: "channel",
+        },
+        "voicechannels.category_id": {
+          description: "Voice channel category",
+          category: "voicechannels",
+          type: "category",
+        },
+        "leaderboard_roles.some_role": {
+          description: "A role",
+          category: "leaderboard_roles",
+          type: "role",
+        },
+      },
+    });
+    // Channel key → text-channel dropdown with the current value selected.
+    expect(html).toMatch(
+      /<select name="value_reactionroles.message_channel_id">/,
+    );
+    expect(html).toContain(
+      '<option value="chan-1" selected>#announcements</option>',
+    );
+    expect(html).toContain('<option value="chan-2">#general</option>');
+    // Category key → category dropdown.
+    expect(html).toMatch(/<select name="value_voicechannels.category_id">/);
+    expect(html).toContain('<option value="cat-1">#Voice Channels</option>');
+    // Role key → role dropdown with the `@` prefix.
+    expect(html).toMatch(/<select name="value_leaderboard_roles.some_role">/);
+    expect(html).toContain('<option value="role-1">@Moderator</option>');
+    // No raw free-text input is emitted for any of these picker keys.
+    expect(html).not.toContain('<input type="text"');
   });
 });
 

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -1988,6 +1988,11 @@ describe("renderWizardStepPage", () => {
     );
     expect(html).toContain('value="Lobby"');
     expect(html).toContain("Enable VC");
+    // Each field label is associated with its control via matching for/id so
+    // screen readers and click-to-focus keep working (issue #703 review).
+    expect(html).toContain('<label for="wiz-voicechannels.enabled">');
+    expect(html).toMatch(/type="checkbox" id="wiz-voicechannels.enabled"/);
+    expect(html).toMatch(/type="number" id="wiz-quotes.max_length"/);
   });
 
   it("renders an options-backed key as a <select> and pre-selects the current value", () => {
@@ -2013,8 +2018,14 @@ describe("renderWizardStepPage", () => {
       },
     });
     // The wizard renders through the shared control renderer, so the select
-    // carries the `value_`-prefixed field name (issue #703).
-    expect(html).toContain('<select name="value_leaderboard_roles.period">');
+    // carries the `value_`-prefixed field name and an id the label points at
+    // (issue #703).
+    expect(html).toMatch(
+      /<select name="value_leaderboard_roles.period" id="wiz-leaderboard_roles.period">/,
+    );
+    expect(html).toContain(
+      '<label for="wiz-leaderboard_roles.period">leaderboard_roles.period</label>',
+    );
     expect(html).toContain(
       '<option value="month" selected>This month</option>',
     );
@@ -2200,19 +2211,27 @@ describe("renderWizardStepPage", () => {
         },
       },
     });
-    // Channel key → text-channel dropdown with the current value selected.
+    // Channel key → text-channel dropdown with the current value selected,
+    // carrying an id its label points at (issue #703).
     expect(html).toMatch(
-      /<select name="value_reactionroles.message_channel_id">/,
+      /<select id="wiz-reactionroles.message_channel_id" name="value_reactionroles.message_channel_id">/,
+    );
+    expect(html).toContain(
+      '<label for="wiz-reactionroles.message_channel_id">reactionroles.message_channel_id</label>',
     );
     expect(html).toContain(
       '<option value="chan-1" selected>#announcements</option>',
     );
     expect(html).toContain('<option value="chan-2">#general</option>');
     // Category key → category dropdown.
-    expect(html).toMatch(/<select name="value_voicechannels.category_id">/);
+    expect(html).toMatch(
+      /<select id="wiz-voicechannels.category_id" name="value_voicechannels.category_id">/,
+    );
     expect(html).toContain('<option value="cat-1">#Voice Channels</option>');
     // Role key → role dropdown with the `@` prefix.
-    expect(html).toMatch(/<select name="value_leaderboard_roles.some_role">/);
+    expect(html).toMatch(
+      /<select id="wiz-leaderboard_roles.some_role" name="value_leaderboard_roles.some_role">/,
+    );
     expect(html).toContain('<option value="role-1">@Moderator</option>');
     // No raw free-text input is emitted for any of these picker keys.
     expect(html).not.toContain('<input type="text"');

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -1191,9 +1191,26 @@ export interface WizardStepPageProps extends CommonProps {
   currentValues: Record<string, unknown>;
   metadata: Record<
     string,
-    { description: string; category: string; options?: SettingOption[] }
+    {
+      description: string;
+      category: string;
+      options?: SettingOption[];
+      // The schema `type` (e.g. `channel`, `category`, `role`, `cron`) drives
+      // which control the shared renderer produces; falls back to the runtime
+      // type of the default when a key isn't in the schema. `channelKind`
+      // selects the text- vs voice-channel picker list (issue #703).
+      type?: string;
+      channelKind?: "text" | "voice";
+    }
   >;
   defaultValues: Record<string, unknown>;
+  // Guild picker option lists, threaded through so `channel`/`category`/`role`
+  // keys render as real selectors — the same lists the Settings page feeds to
+  // `renderControlInput` (issue #703).
+  textChannels: ChannelOption[];
+  voiceChannels: ChannelOption[];
+  categoryChannels: ChannelOption[];
+  roles: RoleOption[];
   flash?: FlashMessage | null;
 }
 
@@ -1210,45 +1227,53 @@ export function renderWizardStepPage(props: WizardStepPageProps): string {
   // dependents, not masters.
   const masterKey = `${props.featureKey}.enabled`;
 
+  const pickers = {
+    textChannels: props.textChannels,
+    voiceChannels: props.voiceChannels,
+    categoryChannels: props.categoryChannels,
+    roles: props.roles,
+  };
+
   const fields = props.settingKeys
     .map((k) => {
       const current = props.currentValues[k];
       const meta = props.metadata[k];
       const defaultVal = props.defaultValues[k];
+      // The schema `type` is authoritative — it's what makes `channel` /
+      // `category` / `role` (and `cron`) keys render as their proper pickers
+      // instead of a free-text box (issue #703). Fall back to the runtime type
+      // of the default for keys the schema doesn't declare.
       const type =
-        typeof defaultVal === "boolean"
+        meta?.type ??
+        (typeof defaultVal === "boolean"
           ? "boolean"
           : typeof defaultVal === "number"
             ? "number"
-            : "string";
+            : "string");
       const desc = meta?.description ?? "";
-      const inputId = `wiz-${k}`;
-      const display =
-        typeof current === "boolean" ||
-        typeof current === "number" ||
-        typeof current === "string"
-          ? current
-          : "";
 
-      let control: string;
-      if (meta?.options && meta.options.length > 0) {
-        // Fixed-options keys render as a dropdown in the wizard too, so the
-        // value posted back is always one the server will accept.
-        const currentStr = typeof current === "string" ? current : "";
-        control = renderOptionsSelect(escapeHtml(k), meta.options, currentStr);
-      } else if (type === "boolean") {
-        const checked = current === true ? " checked" : "";
-        const masterAttr = k === masterKey ? " data-cascade-master" : "";
-        control = `<label class="checkbox" style="display:inline-flex;gap:.4rem;align-items:center;cursor:pointer"><input type="checkbox" id="${escapeHtml(inputId)}" name="${escapeHtml(k)}" value="true"${checked}${masterAttr}> Enable</label>`;
-      } else if (type === "number") {
-        control = `<input type="number" id="${escapeHtml(inputId)}" name="${escapeHtml(k)}" value="${escapeHtml(display)}">`;
-      } else {
-        // maxlength mirrors TEXT_LIMITS.configValue in write-routes (#508).
-        control = `<input type="text" id="${escapeHtml(inputId)}" name="${escapeHtml(k)}" maxlength="2000" value="${escapeHtml(display)}">`;
-      }
+      // Route the value control through the same renderer the Settings page
+      // uses (`renderControlInput`) so the two surfaces can't drift: pickers
+      // become dropdowns, fixed-options become selects, cron gets its picker.
+      // The submitted field name is therefore `value_<key>` (as on the
+      // Settings page), which the wizard step handler reads back. The label
+      // isn't consumed by the control renderer, so the raw-key display label
+      // (tracked separately in #702) is unaffected here.
+      const row: SettingRow = {
+        key: k,
+        label: k,
+        current,
+        defaultValue: defaultVal,
+        type,
+        description: desc,
+        category: meta?.category ?? "",
+        options: meta?.options,
+        channelKind: meta?.channelKind,
+      };
+      const control = renderControlInput(row, pickers, k === masterKey);
 
       return `<div class="field-row">
-  <label for="${escapeHtml(inputId)}">${escapeHtml(k)}</label>
+  <label>${escapeHtml(k)}</label>
   ${control}
   <div class="help">${escapeHtml(desc)}</div>
 </div>`;

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -638,10 +638,17 @@ function renderControlInput(
   },
   isCascadeMaster = false,
   depLocked = false,
+  // Optional DOM id stamped onto the primary control element so a caller can
+  // associate a `<label for>` with it (the wizard does this — issue #703). The
+  // Settings page omits it (it labels rows with a `<strong>`, not a `<label>`),
+  // so it defaults to "" and adds nothing there. The cron picker manages its
+  // own inputs and is left unstamped.
+  controlId = "",
 ): string {
   const primitive = coerceToDisplayValue(r.current);
   const currentStr = typeof primitive === "string" ? primitive : "";
   const valueName = escapeHtml(settingValueFieldName(r.key));
+  const idAttr = controlId ? ` id="${escapeHtml(controlId)}"` : "";
   // When a hard dependency is unmet (#666), the control renders disabled so it
   // can't be edited before its requirement is on — the same rule the write-time
   // validator (#663) enforces. `data-dep-locked` tells the cascade-disable
@@ -655,20 +662,25 @@ function renderControlInput(
   // their underlying `type`, so operators pick from the valid set instead
   // of typing a value the server will reject.
   if (r.options && r.options.length > 0) {
-    return renderOptionsSelect(valueName, r.options, currentStr, lockAttr);
+    return renderOptionsSelect(
+      valueName,
+      r.options,
+      currentStr,
+      lockAttr + idAttr,
+    );
   }
   if (r.type === "boolean") {
     const checked = primitive === true ? " checked" : "";
     const masterAttr = isCascadeMaster ? " data-cascade-master" : "";
     return (
       `<label class="checkbox" style="display:inline-flex;gap:.4rem;align-items:center;cursor:pointer">` +
-      `<input type="checkbox" name="${valueName}" value="true"${checked}${masterAttr}${lockAttr}> ` +
+      `<input type="checkbox"${idAttr} name="${valueName}" value="true"${checked}${masterAttr}${lockAttr}> ` +
       `<span class="mono">${primitive === true ? "true" : "false"}</span>` +
       `</label>`
     );
   }
   if (r.type === "number") {
-    return `<input type="number" name="${valueName}" value="${escapeHtml(primitive)}" style="width:8rem"${lockAttr}>`;
+    return `<input type="number"${idAttr} name="${valueName}" value="${escapeHtml(primitive)}" style="width:8rem"${lockAttr}>`;
   }
   if (r.type === "channel" || r.type === "category" || r.type === "role") {
     const options =
@@ -680,7 +692,7 @@ function renderControlInput(
     const prefix = r.type === "role" ? "@" : "#";
     const selected = currentStr ? new Set([currentStr]) : new Set<string>();
     return (
-      `<select name="${valueName}"${lockAttr}>` +
+      `<select${idAttr} name="${valueName}"${lockAttr}>` +
       buildOptionsHtml(options, selected, prefix, true) +
       `</select>`
     );
@@ -696,7 +708,7 @@ function renderControlInput(
         .filter((v) => v !== ""),
     );
     return (
-      `<select name="${valueName}" multiple size="${Math.min(8, Math.max(3, options.length))}"${lockAttr}>` +
+      `<select${idAttr} name="${valueName}" multiple size="${Math.min(8, Math.max(3, options.length))}"${lockAttr}>` +
       buildOptionsHtml(options, selected, prefix, false) +
       `</select>` +
       renderSelectionSummary(options, selected, prefix)
@@ -712,7 +724,7 @@ function renderControlInput(
   // string or unknown type → plain text input. The maxlength mirrors the
   // server-side `TEXT_LIMITS.configValue` cap in write-routes (#508) — kept as
   // a literal here to avoid a circular import (write-routes imports this file).
-  return `<input type="text" name="${valueName}" maxlength="2000" value="${escapeHtml(primitive)}"${lockAttr}>`;
+  return `<input type="text"${idAttr} name="${valueName}" maxlength="2000" value="${escapeHtml(primitive)}"${lockAttr}>`;
 }
 
 /**
@@ -1259,6 +1271,7 @@ export function renderWizardStepPage(props: WizardStepPageProps): string {
       // Settings page), which the wizard step handler reads back. The label
       // isn't consumed by the control renderer, so the raw-key display label
       // (tracked separately in #702) is unaffected here.
+      const inputId = `wiz-${k}`;
       const row: SettingRow = {
         key: k,
         label: k,
@@ -1270,10 +1283,22 @@ export function renderWizardStepPage(props: WizardStepPageProps): string {
         options: meta?.options,
         channelKind: meta?.channelKind,
       };
-      const control = renderControlInput(row, pickers, k === masterKey);
+      const control = renderControlInput(
+        row,
+        pickers,
+        k === masterKey,
+        false,
+        inputId,
+      );
 
+      // The cron picker renders several inputs of its own rather than a single
+      // control, so it takes no id; its label is left unassociated (a `for`
+      // pointing at nothing is worse than none). Every other type stamps
+      // `inputId` onto its control, so `for` restores screen-reader
+      // association and click-to-focus.
+      const labelFor = type === "cron" ? "" : ` for="${escapeHtml(inputId)}"`;
       return `<div class="field-row">
-  <label>${escapeHtml(k)}</label>
+  <label${labelFor}>${escapeHtml(k)}</label>
   ${control}
   <div class="help">${escapeHtml(desc)}</div>
 </div>`;

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -239,7 +239,7 @@ export async function fetchChannelData(
  * Fetch the guild's roles cache once and return both the id→name map
  * and the picker option list (with @everyone filtered out).
  */
-async function fetchRoleData(
+export async function fetchRoleData(
   client: Client,
   guildId: string,
 ): Promise<RoleData> {

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -1474,10 +1474,11 @@ export function createWriteRouter(
             }
           }
           // Guild picker lists so channel/category/role keys render as real
-          // selectors, exactly like the Settings page (issue #703). One guild
-          // fetch, four lists; both helpers swallow their own errors and
-          // return empty lists, so a picker just falls back to an empty
-          // dropdown rather than failing the step.
+          // selectors, exactly like the Settings page (issue #703). Two guild
+          // fetches run in parallel — one for channels/categories, one for
+          // roles; both helpers swallow their own errors and return empty
+          // lists, so a picker just falls back to an empty dropdown rather
+          // than failing the step.
           const [chData, roleData] = await Promise.all([
             fetchChannelData(client, session.guildId),
             fetchRoleData(client, session.guildId),

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -75,6 +75,7 @@ import {
   settingValueFieldName,
   type ImportDiffRow,
 } from "./admin-views.js";
+import { fetchChannelData, fetchRoleData } from "./read-only-routes.js";
 
 type Flash = { type: "ok" | "warn" | "err"; text: string };
 
@@ -1472,6 +1473,15 @@ export function createWriteRouter(
               }
             }
           }
+          // Guild picker lists so channel/category/role keys render as real
+          // selectors, exactly like the Settings page (issue #703). One guild
+          // fetch, four lists; both helpers swallow their own errors and
+          // return empty lists, so a picker just falls back to an empty
+          // dropdown rather than failing the step.
+          const [chData, roleData] = await Promise.all([
+            fetchChannelData(client, session.guildId),
+            fetchRoleData(client, session.guildId),
+          ]);
           res.type("text/html").send(
             renderWizardStepPage({
               csrfToken,
@@ -1487,6 +1497,10 @@ export function createWriteRouter(
                 string,
                 unknown
               >,
+              textChannels: chData.textChannels,
+              voiceChannels: chData.voiceChannels,
+              categoryChannels: chData.categoryChannels,
+              roles: roleData.roles,
               flash,
             }),
           );
@@ -1592,17 +1606,23 @@ export function createWriteRouter(
       // = false` and skip the rest, so absent dependents don't surface as
       // bogus "invalid input" drops (a missing number field would otherwise
       // fail coercion).
+      // The step form submits each value under `value_<key>` — the same field
+      // naming the Settings page uses, now that the wizard renders through the
+      // shared control renderer (issue #703).
       const masterKey = `${featureKey}.enabled`;
       const masterOff =
         settingKeys.includes(masterKey) &&
-        (req.body as Record<string, unknown> | undefined)?.[masterKey] !==
-          "true";
+        (req.body as Record<string, unknown> | undefined)?.[
+          settingValueFieldName(masterKey)
+        ] !== "true";
 
       const saved: Record<string, unknown> = {};
       const dropped: Array<{ key: string; reason: string }> = [];
       for (const k of settingKeys) {
         if (masterOff && k !== masterKey) continue;
-        const raw = (req.body as Record<string, unknown> | undefined)?.[k];
+        const raw = (req.body as Record<string, unknown> | undefined)?.[
+          settingValueFieldName(k)
+        ];
         const coerced = coerceConfigValue(k, raw);
         if (coerced.ok) {
           wizard.addConfiguration(


### PR DESCRIPTION
## Description

In the Setup Wizard, every setting whose schema `type` is a picker (`channel`, `category`, `role`, `cron`, …) was rendered as the **raw dotted key** with a **plain free-text box**, forcing admins to know and paste raw Discord IDs. The main Settings page already renders these same keys as proper dropdowns via `renderControlInput`, so the wizard was inconsistent with the rest of the app.

This routes wizard step fields through the **same control renderer** the Settings page uses (`renderControlInput`) and threads the guild's channel/category/role picker lists into the wizard step props. As a result **all** picker-typed keys render as real dropdowns at once — not just reaction roles — and the two surfaces can't drift apart again.

Key changes:
- `renderWizardStepPage` builds a `SettingRow` per key (resolving the authoritative schema `type` from metadata, with a runtime-type fallback) and delegates to `renderControlInput`, so channel/category/role become dropdowns, fixed-options become selects, and cron gets its picker.
- `WizardStepPageProps` gains the guild picker lists (`textChannels`/`voiceChannels`/`categoryChannels`/`roles`) plus `type`/`channelKind` on its metadata shape.
- The `GET /wizard` route fetches the guild's channel & role lists (reusing `fetchChannelData`/`fetchRoleData`, both error-swallowing) and passes them in.
- Because the wizard now shares the renderer, step fields submit under the `value_<key>` name (as on the Settings page); the `POST /wizard/step/:n` handler reads values and the master-toggle back via `settingValueFieldName`.
- `fetchRoleData` is now exported from `read-only-routes.ts`.

The raw-key **display label** is deliberately left unchanged here — that half of the problem is tracked separately in the wizard UX overhaul (#702).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #703

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality

Added a `renderWizardStepPage` test asserting channel/category/role keys render as dropdowns (`value_`-prefixed names, `#`/`@` prefixed options, no free-text input), and updated the existing wizard tests for the new field naming. Full suite: **1466 passed** (1 skipped) with coverage thresholds met; `npm run build`, `npm run lint`, and `npm run format:check` all pass.

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- No config keys or commands changed, so `SETTINGS.md` / `COMMANDS.md` need no updates.

### Dependencies & Docker

- No dependency or Docker changes.

## Additional Notes

Part of the wizard UX overhaul umbrella (#702). This fix resolves the control-rendering half; the raw-key labels are addressed there.

## Pre-Submission Verification

- [x] I have rebased my branch on the latest main branch
- [x] I have resolved any merge conflicts
- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3StXRBJBeaaJshwyZYoyP)_