### PR TITLE
feat(webui): make Voice Channels settings editable in place

### DIFF
--- a/WEBUI.md
+++ b/WEBUI.md
@@ -752,7 +752,7 @@ No dashboard JSON ships with the bot — wire these up to taste:
 | **Reaction Roles** | `/reactrole create`, `archive`, `unarchive`, `delete`, `list`, `status`                             |
 | **Notices**        | `/notice add`, `edit`, `delete`, `sync`                                                             |
 | **Bot Status**     | (new — edit the "Watching …" presence message pools)                                                |
-| **Voice Channels** | `/vc force-reload` (single **Force VC cleanup** button)                                             |
+| **Voice Channels** | `/vc force-reload` (**Force VC cleanup** button) + editable `voicechannels.*` settings              |
 | **Weekly Digest**  | (new — **Preview** the weekly digest dry-run, plus a **Send now** button)                           |
 | **Database**       | `/dbtrunk status`, `/dbtrunk run`                                                                   |
 | **Command Audit**  | (new — read-only Discord slash-command audit log)                                                   |

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -1510,6 +1510,8 @@ describe("renderVoiceChannelsPage", () => {
       totalEmpty: 0,
       channels: [],
       categoryFound: false,
+      settingRows: [],
+      categoryChannels: [],
     });
     expect(html).toContain("Voice channel category not found");
   });
@@ -1544,6 +1546,8 @@ describe("renderVoiceChannelsPage", () => {
         },
       ],
       categoryFound: true,
+      settingRows: [],
+      categoryChannels: [],
     });
     expect(html).toContain('class="tag tag-info">lobby');
     expect(html).toContain('class="tag tag-warn">dynamic');
@@ -1566,11 +1570,105 @@ describe("renderVoiceChannelsPage", () => {
       totalEmpty: 0,
       channels: [],
       categoryFound: false,
+      settingRows: [],
+      categoryChannels: [],
     });
     expect(html).toMatch(
       /<button[^>]*type="submit"[^>]*disabled[^>]*>Force VC cleanup<\/button>/,
     );
     expect(html).not.toContain("Clean up empty channels");
+  });
+
+  it("renders editable voicechannels settings that post through save-section", () => {
+    const html = renderVoiceChannelsPage({
+      ...COMMON,
+      enabled: true,
+      controlPanelEnabled: true,
+      categoryName: "Voice",
+      lobbyName: "Lobby",
+      offlineLobbyName: "Offline Lobby",
+      prefix: "🎮",
+      totalManaged: 0,
+      totalEmpty: 0,
+      channels: [],
+      categoryFound: true,
+      categoryChannels: [{ id: "cat-1", name: "Voice Channels" }],
+      settingRows: [
+        {
+          key: "voicechannels.category_id",
+          label: "Managed category",
+          current: "cat-1",
+          defaultValue: "",
+          type: "category",
+          description: "The managed category.",
+          category: "voicechannels",
+        },
+        {
+          key: "voicechannels.lobby.name",
+          label: "Lobby channel display name",
+          current: "Lobby",
+          defaultValue: "Lobby",
+          type: "string",
+          description: "Lobby name.",
+          category: "voicechannels",
+        },
+        {
+          key: "voicechannels.controlpanel.enabled",
+          label: "In-channel control panel enabled",
+          current: true,
+          defaultValue: true,
+          type: "boolean",
+          description: "Control panel.",
+          category: "voicechannels",
+        },
+      ],
+    });
+    // Posts through the shared settings route, back to this page, cascade off.
+    expect(html).toContain(
+      '<form method="POST" action="/admin/settings/save-section">',
+    );
+    expect(html).toContain(
+      '<input type="hidden" name="redirect" value="/admin/voice-channels">',
+    );
+    expect(html).toContain(
+      '<input type="hidden" name="no_cascade" value="1">',
+    );
+    expect(html).toContain(
+      '<input type="hidden" name="category" value="voicechannels">',
+    );
+    // The category key renders as a picker sourced from categoryChannels.
+    expect(html).toContain(
+      '<option value="cat-1" selected>#Voice Channels</option>',
+    );
+    // The lobby name renders as a text input carrying its current value.
+    expect(html).toContain('name="value_voicechannels.lobby.name"');
+    // The control-panel flag renders as a checkbox.
+    expect(html).toContain('name="value_voicechannels.controlpanel.enabled"');
+    expect(html).toContain(">Save settings</button>");
+  });
+
+  it("omits the settings card when there are no editable rows", () => {
+    const html = renderVoiceChannelsPage({
+      ...COMMON,
+      enabled: true,
+      controlPanelEnabled: true,
+      categoryName: "Voice",
+      lobbyName: "Lobby",
+      offlineLobbyName: "Offline Lobby",
+      prefix: "🎮",
+      totalManaged: 0,
+      totalEmpty: 0,
+      channels: [],
+      categoryFound: true,
+      settingRows: [],
+      categoryChannels: [],
+    });
+    // No settings form is emitted (the substring in the shared AJAX script
+    // doesn't count — assert on this page's own form markup instead).
+    expect(html).not.toContain(
+      '<form method="POST" action="/admin/settings/save-section">',
+    );
+    expect(html).not.toContain(">Save settings</button>");
   });
 });
 

--- a/__tests__/web/read-only-routes.test.ts
+++ b/__tests__/web/read-only-routes.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "@jest/globals";
 import { ChannelType } from "discord.js";
-import { fetchChannelData } from "../../src/web/read-only-routes.js";
+import {
+  buildSettingRows,
+  fetchChannelData,
+  VOICE_CHANNELS_SETTING_KEYS,
+} from "../../src/web/read-only-routes.js";
 import { createMockCollection } from "../test-utils.js";
 
 /**
@@ -74,5 +78,44 @@ describe("fetchChannelData (#611)", () => {
     expect(data.voiceChannels).toEqual([]);
     expect(data.textChannels).toEqual([]);
     expect(data.categoryChannels).toEqual([]);
+  });
+});
+
+describe("buildSettingRows (#705)", () => {
+  it("derives label/type/description from the config schema", () => {
+    const rows = buildSettingRows(
+      ["voicechannels.category_id", "voicechannels.presets.max_per_user"],
+      [],
+    );
+    expect(rows).toHaveLength(2);
+    const [category, maxPerUser] = rows;
+    expect(category.key).toBe("voicechannels.category_id");
+    expect(category.type).toBe("category");
+    expect(category.label).toBe("Managed category");
+    // No stored row → current falls back to the schema default.
+    expect(category.current).toBe("");
+    expect(maxPerUser.type).toBe("number");
+    expect(maxPerUser.current).toBe(3);
+  });
+
+  it("prefers a stored DB value over the schema default", () => {
+    const rows = buildSettingRows(
+      ["voicechannels.lobby.name"],
+      [
+        {
+          key: "voicechannels.lobby.name",
+          value: "General",
+          description: "custom",
+          category: "voicechannels",
+        },
+      ],
+    );
+    expect(rows[0].current).toBe("General");
+    expect(rows[0].description).toBe("custom");
+  });
+
+  it("excludes the feature master voicechannels.enabled from the key list", () => {
+    expect(VOICE_CHANNELS_SETTING_KEYS).not.toContain("voicechannels.enabled");
+    expect(VOICE_CHANNELS_SETTING_KEYS).toContain("voicechannels.category_id");
   });
 });

--- a/__tests__/web/write-routes.test.ts
+++ b/__tests__/web/write-routes.test.ts
@@ -458,6 +458,22 @@ describe("findSectionMasterKey", () => {
   it("returns null for an unknown key that merely ends with .enabled", () => {
     expect(findSectionMasterKey(["bogus.feature.enabled"])).toBeNull();
   });
+
+  it("picks a sub-feature toggle when the true master is absent (#705)", () => {
+    // The Voice Channels feature page (#705) submits its `voicechannels.*`
+    // keys WITHOUT `voicechannels.enabled` (the enable notice owns that). The
+    // shortest `.enabled` among the submitted keys is then a sub-feature
+    // toggle, so unchecking it would wrongly cascade-skip the other keys —
+    // which is exactly why that form opts out of the cascade via `no_cascade`.
+    expect(
+      findSectionMasterKey([
+        "voicechannels.category_id",
+        "voicechannels.lobby.name",
+        "voicechannels.controlpanel.enabled",
+        "voicechannels.presets.enabled",
+      ]),
+    ).toBe("voicechannels.controlpanel.enabled");
+  });
 });
 
 describe("safeAdminRedirect (#610)", () => {

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -2332,7 +2332,68 @@ export interface VoiceChannelsProps extends CommonProps {
   totalEmpty: number;
   channels: VoiceChannelRow[];
   categoryFound: boolean;
+  /**
+   * The editable `voicechannels.*` settings rendered in-place on the feature
+   * page (#705). Built from the config schema the same way the Settings page
+   * builds its rows, so the shared control renderer produces a category
+   * picker, text fields, toggles, etc.
+   */
+  settingRows: SettingRow[];
+  /** Category options backing the `voicechannels.category_id` picker. */
+  categoryChannels: ChannelOption[];
   flash?: FlashMessage | null;
+}
+
+/**
+ * The editable settings card on the Voice Channels feature page (#705). Renders
+ * the `voicechannels.*` keys with the same control renderer the Settings page
+ * uses, so category is a picker, lobby names / prefix / suffix are text fields,
+ * and the control-panel / presets flags are toggles. Posts through the shared
+ * `/admin/settings/save-section` route with `redirect` back to this page and
+ * `no_cascade` set — this form has no section master toggle (that is
+ * `voicechannels.enabled`, owned by the enable notice above), so every
+ * submitted key must be written rather than skipped by the cascade rule.
+ */
+function renderVoiceChannelsSettings(props: VoiceChannelsProps): string {
+  if (props.settingRows.length === 0) return "";
+  const pickers = {
+    textChannels: [] as ChannelOption[],
+    voiceChannels: [] as ChannelOption[],
+    categoryChannels: props.categoryChannels,
+    roles: [] as RoleOption[],
+  };
+  const rows = props.settingRows
+    .map(
+      (r) => `<tr>
+<td>
+  <div><strong>${escapeHtml(r.label || r.key)}</strong></div>
+  <code class="mono muted" style="font-size:.85em">${escapeHtml(r.key)}</code>
+  <input type="hidden" name="keys" value="${escapeHtml(r.key)}">
+</td>
+<td class="settings-value">${renderControlInput(r, pickers)}${renderResetButton(r.key)}${renderWarnBelow(r)}</td>
+<td><span class="tag tag-info">${escapeHtml(r.type)}</span></td>
+<td class="muted">${escapeHtml(r.description)}</td>
+</tr>`,
+    )
+    .join("");
+  return `
+<div class="card">
+  <h2>Settings</h2>
+  <p class="muted" style="margin:.25rem 0 .75rem">Change voice-channel settings here without leaving the page. Saved through the shared settings route.</p>
+  <form method="POST" action="/admin/settings/save-section">
+    <input type="hidden" name="_csrf" value="${escapeHtml(props.csrfToken)}">
+    <input type="hidden" name="category" value="voicechannels">
+    <input type="hidden" name="redirect" value="/admin/voice-channels">
+    <input type="hidden" name="no_cascade" value="1">
+    <table>
+      <thead><tr><th>Setting</th><th>Edit</th><th>Type</th><th>Description</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table>
+    <div class="actions" style="margin-top:.75rem">
+      <button type="submit" class="btn btn-primary">Save settings</button>
+    </div>
+  </form>
+</div>`;
 }
 
 export function renderVoiceChannelsPage(props: VoiceChannelsProps): string {
@@ -2384,6 +2445,7 @@ ${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Voice Channels",
     <dt>Empty channels</dt><dd>${props.totalEmpty}</dd>
   </dl>
 </div>
+${renderVoiceChannelsSettings(props)}
 <div class="card">
   <h2>Cleanup actions</h2>
   <form method="POST" action="/admin/voice-channels/force-reload" class="inline-form" onsubmit="return confirm('Force cleanup of ALL unmanaged channels in the category and re-create lobby channels?');">

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -96,6 +96,57 @@ function describeType(value: unknown): string {
   return typeof value;
 }
 
+/**
+ * The `voicechannels.*` keys surfaced as editable controls on the Voice
+ * Channels feature page (#705). The feature master `voicechannels.enabled`
+ * is intentionally excluded — it is owned by the enable/disable notice.
+ */
+export const VOICE_CHANNELS_SETTING_KEYS = [
+  "voicechannels.category_id",
+  "voicechannels.lobby.name",
+  "voicechannels.lobby.offlinename",
+  "voicechannels.channel.prefix",
+  "voicechannels.channel.suffix",
+  "voicechannels.controlpanel.enabled",
+  "voicechannels.presets.enabled",
+  "voicechannels.presets.max_per_user",
+] as const;
+
+/**
+ * Build the {@link SettingRow}s for a fixed list of config keys, mirroring how
+ * the Settings page derives label/type/description from `settingsMetadata` with
+ * a stored DB row taking precedence. Lets a feature page render its own keys
+ * with the shared control renderer (#705).
+ */
+export function buildSettingRows(
+  keys: readonly string[],
+  stored: ReadonlyArray<{
+    key: string;
+    value: unknown;
+    description?: string;
+    category?: string;
+  }>,
+): SettingRow[] {
+  const storedByKey = new Map(stored.map((s) => [s.key, s]));
+  return keys.map((key) => {
+    const dbEntry = storedByKey.get(key);
+    const meta = settingsMetadata[key as keyof typeof settingsMetadata];
+    const defaultValue = defaultConfig[key as keyof typeof defaultConfig];
+    return {
+      key,
+      label: meta?.label ?? key,
+      current: dbEntry ? dbEntry.value : defaultValue,
+      defaultValue,
+      type: meta?.type ?? describeType(defaultValue),
+      description: dbEntry?.description ?? meta?.description ?? "",
+      category: dbEntry?.category ?? meta?.category ?? deriveCategory(key),
+      options: meta?.options,
+      warnBelow: meta?.warnBelow,
+      channelKind: meta?.channelKind,
+    };
+  });
+}
+
 function getCsrfToken(req: Request): string {
   return (req as Request & { csrfToken?: string }).csrfToken ?? "";
 }
@@ -907,13 +958,20 @@ export function createReadOnlyRouter(
         lobbyName,
         offlineLobbyName,
         prefix,
+        stored,
+        channelData,
       ] = await Promise.all([
         config.getBoolean("voicechannels.enabled", false),
         config.getBoolean("voicechannels.controlpanel.enabled", true),
         config.getString("voicechannels.lobby.name", "Lobby"),
         config.getString("voicechannels.lobby.offlinename", "Offline Lobby"),
         config.getString("voicechannels.channel.prefix", "🎮"),
+        config.getAll().catch(() => []),
+        fetchChannelData(client, common.guildId),
       ]);
+      // Editable `voicechannels.*` settings rendered in place on this page
+      // (#705), built the same way the Settings page builds its rows.
+      const settingRows = buildSettingRows(VOICE_CHANNELS_SETTING_KEYS, stored);
       // Resolved below from the configured `voicechannels.category_id`;
       // falls back to "(not configured)" so the renderer always has
       // a string to show.
@@ -974,6 +1032,8 @@ export function createReadOnlyRouter(
           totalEmpty,
           channels,
           categoryFound,
+          settingRows,
+          categoryChannels: channelData.categoryChannels,
           flash: readFlash(req),
         }),
       );

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -959,7 +959,6 @@ export function createReadOnlyRouter(
         offlineLobbyName,
         prefix,
         stored,
-        channelData,
       ] = await Promise.all([
         config.getBoolean("voicechannels.enabled", false),
         config.getBoolean("voicechannels.controlpanel.enabled", true),
@@ -967,7 +966,6 @@ export function createReadOnlyRouter(
         config.getString("voicechannels.lobby.offlinename", "Offline Lobby"),
         config.getString("voicechannels.channel.prefix", "🎮"),
         config.getAll().catch(() => []),
-        fetchChannelData(client, common.guildId),
       ]);
       // Editable `voicechannels.*` settings rendered in place on this page
       // (#705), built the same way the Settings page builds its rows.
@@ -980,6 +978,11 @@ export function createReadOnlyRouter(
       let categoryFound = false;
       let totalManaged = 0;
       let totalEmpty = 0;
+      // Category picker options for the editable `voicechannels.category_id`
+      // control (#705). Derived from the same guild fetch that builds the
+      // managed-channel table below, so the page fetches the guild/channels
+      // once rather than paying for a second round-trip.
+      const categoryChannels: ChannelOption[] = [];
       const channels: Array<{
         name: string;
         isLobby: boolean;
@@ -992,6 +995,12 @@ export function createReadOnlyRouter(
       try {
         const guild = await client.guilds.fetch(common.guildId);
         await guild.channels.fetch();
+        for (const ch of guild.channels.cache.values()) {
+          if (ch?.type === ChannelType.GuildCategory) {
+            categoryChannels.push({ id: ch.id, name: ch.name ?? ch.id });
+          }
+        }
+        categoryChannels.sort((a, b) => a.name.localeCompare(b.name));
         const category = await resolveManagedCategory(guild);
 
         if (category) {
@@ -1033,7 +1042,7 @@ export function createReadOnlyRouter(
           channels,
           categoryFound,
           settingRows,
-          categoryChannels: channelData.categoryChannels,
+          categoryChannels,
           flash: readFlash(req),
         }),
       );

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -143,12 +143,13 @@ function respondSectionFlash(
   req: AuthenticatedRequest,
   res: Response,
   flash: Flash,
+  redirectTo = "/admin/settings",
 ): void {
   if (wantsJson(req)) {
     res.status(200).json({ type: flash.type, text: truncateFlash(flash.text) });
     return;
   }
-  flashRedirect(res, "/admin/settings", flash);
+  flashRedirect(res, redirectTo, flash);
 }
 
 function getString(req: AuthenticatedRequest, name: string): string {
@@ -622,6 +623,10 @@ export function createWriteRouter(
     asyncHandler(async (req, res) => {
       const session = requireSessionContext(req);
       const key = getString(req, "key");
+      // Feature pages that reuse the settings controls (e.g. Voice Channels,
+      // #705) pass their own page so a per-key Reset lands back where it was
+      // clicked; allowlisted the same way as /settings/set and save-section.
+      const redirectTo = safeAdminRedirect(getString(req, "redirect"));
       if (!(key in defaultConfig)) {
         await recordAudit(session, {
           action: "setting.reset",
@@ -629,7 +634,7 @@ export function createWriteRouter(
           result: "failure",
           errorMessage: "unknown key",
         });
-        flashRedirect(res, "/admin/settings", {
+        flashRedirect(res, redirectTo, {
           type: "err",
           text: `Unknown setting: ${key || "(empty)"}.`,
         });
@@ -654,7 +659,7 @@ export function createWriteRouter(
           },
           result: "success",
         });
-        flashRedirect(res, "/admin/settings", {
+        flashRedirect(res, redirectTo, {
           type: "ok",
           text: `Reset ${key} to default.`,
         });
@@ -667,7 +672,7 @@ export function createWriteRouter(
           result: "failure",
           errorMessage: text,
         });
-        flashRedirect(res, "/admin/settings", {
+        flashRedirect(res, redirectTo, {
           type: "err",
           text: `Failed to reset ${key}: ${text}`,
         });
@@ -805,6 +810,18 @@ export function createWriteRouter(
       const session = requireSessionContext(req);
       const body = (req.body as Record<string, unknown> | undefined) ?? {};
       const category = getString(req, "category");
+      // Where to land after the save. Defaults to /admin/settings (this route's
+      // historical target); a feature page that reuses this route to edit its
+      // own `*.` keys in place passes its own page so the operator returns
+      // there (#705), allowlisted the same way as /settings/set.
+      const redirectTo = safeAdminRedirect(getString(req, "redirect"));
+      // Section forms carry an implicit master toggle (the section's shortest
+      // `.enabled` key) whose cascade skips dependents when off. A feature page
+      // reusing this route has no such master — its master lives elsewhere
+      // (e.g. `voicechannels.enabled`, owned by the enable notice) and is not
+      // among the submitted keys — so it opts out with `no_cascade`, meaning
+      // every submitted key is written rather than skipped.
+      const noCascade = getCheckbox(req, "no_cascade");
 
       const rawKeys = body.keys;
       const keys: string[] = Array.isArray(rawKeys)
@@ -820,10 +837,15 @@ export function createWriteRouter(
           result: "failure",
           errorMessage: "no keys submitted",
         });
-        respondSectionFlash(req, res, {
-          type: "err",
-          text: `No settings submitted for section ${category || "(unknown)"}.`,
-        });
+        respondSectionFlash(
+          req,
+          res,
+          {
+            type: "err",
+            text: `No settings submitted for section ${category || "(unknown)"}.`,
+          },
+          redirectTo,
+        );
         return;
       }
 
@@ -834,7 +856,7 @@ export function createWriteRouter(
       // untouched, so disabling a feature can't silently clobber its
       // sub-settings (an absent number field would otherwise be rejected, an
       // absent string blanked).
-      const masterKey = findSectionMasterKey(keys);
+      const masterKey = noCascade ? null : findSectionMasterKey(keys);
       const masterOff =
         masterKey !== null &&
         body[settingValueFieldName(masterKey)] !== "true" &&
@@ -895,10 +917,15 @@ export function createWriteRouter(
           errorMessage: rejected.map((r) => `${r.key}: ${r.reason}`).join("; "),
         });
         const detail = rejected.map((r) => `${r.key} (${r.reason})`).join(", ");
-        respondSectionFlash(req, res, {
-          type: "err",
-          text: `No changes saved — ${rejected.length} invalid value${rejected.length === 1 ? "" : "s"} in ${category || "section"}: ${detail}.`,
-        });
+        respondSectionFlash(
+          req,
+          res,
+          {
+            type: "err",
+            text: `No changes saved — ${rejected.length} invalid value${rejected.length === 1 ? "" : "s"} in ${category || "section"}: ${detail}.`,
+          },
+          redirectTo,
+        );
         return;
       }
 
@@ -963,17 +990,27 @@ export function createWriteRouter(
 
       const label = category || "section";
       if (failed.length === 0) {
-        respondSectionFlash(req, res, {
-          type: "ok",
-          text: `Saved ${applied.length} setting${applied.length === 1 ? "" : "s"} in ${label}.`,
-        });
+        respondSectionFlash(
+          req,
+          res,
+          {
+            type: "ok",
+            text: `Saved ${applied.length} setting${applied.length === 1 ? "" : "s"} in ${label}.`,
+          },
+          redirectTo,
+        );
         return;
       }
       const firstError = failed[0];
-      respondSectionFlash(req, res, {
-        type: applied.length > 0 ? "warn" : "err",
-        text: `Saved ${applied.length}/${applied.length + failed.length} in ${label}. Failed: ${firstError.key} (${firstError.reason})${failed.length > 1 ? ` and ${failed.length - 1} more` : ""}.`,
-      });
+      respondSectionFlash(
+        req,
+        res,
+        {
+          type: applied.length > 0 ? "warn" : "err",
+          text: `Saved ${applied.length}/${applied.length + failed.length} in ${label}. Failed: ${firstError.key} (${firstError.reason})${failed.length > 1 ? ` and ${failed.length - 1} more` : ""}.`,
+        },
+        redirectTo,
+      );
     }),
   );
 


### PR DESCRIPTION
## Description

The **Voice Channels** feature page (`/admin/voice-channels`) previously showed the key `voicechannels.*` settings only as a **read-only Status card** — to change any of them you had to leave the page and hunt for the dotted keys on the global **Settings** page.

This makes those settings **editable in place**. A new **Settings** card renders the `voicechannels.*` keys with the same shared control renderer the Settings page uses:

- `voicechannels.category_id` → category picker
- `voicechannels.lobby.name` / `lobby.offlinename` / `channel.prefix` / `channel.suffix` → text fields
- `voicechannels.controlpanel.enabled` / `presets.enabled` → toggles
- `voicechannels.presets.max_per_user` → number field

The form posts through the existing `/admin/settings/save-section` route. Two small, backward-compatible additions to that shared route make this work:

- an allowlisted **`redirect`** field (via `safeAdminRedirect`) so the save — and per-key **Reset** — returns to the feature page instead of `/admin/settings`;
- a **`no_cascade`** opt-out that disables the section-master cascade for a form that has no section master. On this page the true master (`voicechannels.enabled`) is owned by the enable/disable notice and is *not* among the submitted keys, so without the opt-out `findSectionMasterKey` would treat a sub-feature toggle (e.g. `voicechannels.controlpanel.enabled`) as the master and skip writing the other keys when it was unchecked.

The existing AJAX section-save script enhances the new form automatically (in-place flash, no reload). The Status card, cleanup actions, and live channel table are unchanged. This also gives `voicechannels.presets.*` — currently absent from the wizard — a natural home in the UI.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Related Issues

Fixes #705

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality

Full suite: `npm run test:ci` → 1471 passing, coverage thresholds met. `npm run build`, `npm run lint`, `npm run format:check`, and `markdownlint` all clean.

New/updated tests:

- `admin-views.test.ts` — the editable settings card renders (category picker, text input, checkbox), carries the `redirect`/`no_cascade`/`category` hidden fields, posts to `save-section`, and is omitted when there are no rows.
- `read-only-routes.test.ts` — `buildSettingRows` derives label/type/description from the schema, prefers stored DB values, and `VOICE_CHANNELS_SETTING_KEYS` excludes the feature master.
- `write-routes.test.ts` — documents the cascade-misfire that motivates `no_cascade` (a sub-feature toggle becomes the master when `voicechannels.enabled` is absent).

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary:
  - [x] `WEBUI.md` (Voice Channels page now offers in-place settings editing)
- [x] I have validated markdown with `npx markdownlint`

No new config keys or commands were added (the keys already exist in `config-schema.ts`), so `SETTINGS.md` / `COMMANDS.md` need no changes.

### Dependencies & Docker

- [x] No dependency or Docker changes.

### Configuration

- [x] No new configuration keys — the surfaced keys already exist in `config-schema.ts`.

## Additional Notes

The two shared-route additions are opt-in and default to the historical behavior, so the global Settings page is unaffected: without a `redirect` field it still lands on `/admin/settings`, and without `no_cascade` the section-master cascade is unchanged.

## Pre-Submission Verification

- [x] I have rebased my branch on the latest main branch
- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBbFuBddzxmnzb23TCGg3Q)_