### PR TITLE
feat(web): bring setup wizard to parity with the Settings page controls

### DIFF
--- a/WEBUI.md
+++ b/WEBUI.md
@@ -779,6 +779,16 @@ disagree. The greying survives an enabled parent section (a dependency lock wins
 over the per-section cascade), and Rewind toggles are never greyed this way
 because Rewind is a graceful aggregator that declares no `dependsOn`.
 
+The **Setup Wizard** (`/admin/wizard`) renders each step's fields through the
+same shared control renderer the Settings page uses (#702), so a channel /
+role / category key gets a real picker dropdown instead of a raw-ID text box,
+fixed-option keys get a `<select>`, and each field is titled by its
+human-readable label (`SettingMetadata.label`) with the dotted config key kept
+only as monospace helper text. The cascade-disable behaviour and the
+*"Requires X enabled"* dependency hints/locks (including cross-feature targets
+that live on another wizard step) carry over as well, so the two surfaces stay
+in lockstep and can't drift apart.
+
 The **Bot Status** page (`/admin/bot-status`) edits the three "Watching …"
 presence message pools the bot rotates through, picked by how many users
 are in voice: the *empty*, *one user*, and *multiple users* pools. Each

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -23,13 +23,15 @@ import {
 
 const COMMON = { csrfToken: "csrf", remainingMs: 60_000 };
 
-// Empty guild picker lists for wizard-step tests that don't exercise the
-// channel/category/role dropdowns (issue #703).
+// Empty guild picker lists + dependency map for wizard-step tests that don't
+// exercise the channel/category/role dropdowns or dependency locking. Tests
+// override the pieces they need (issues #702 / #703 / #666).
 const EMPTY_PICKERS = {
-  textChannels: [],
-  voiceChannels: [],
-  categoryChannels: [],
-  roles: [],
+  textChannels: [] as Array<{ id: string; name: string }>,
+  voiceChannels: [] as Array<{ id: string; name: string }>,
+  categoryChannels: [] as Array<{ id: string; name: string }>,
+  roles: [] as Array<{ id: string; name: string }>,
+  enabledByKey: {} as Record<string, boolean>,
 };
 
 describe("renderDashboardPage", () => {
@@ -1949,7 +1951,7 @@ describe("renderWizardPage", () => {
 });
 
 describe("renderWizardStepPage", () => {
-  it("renders boolean/number/string inputs with the current value", () => {
+  it("renders boolean/number/string controls with the current value and human labels", () => {
     const html = renderWizardStepPage({
       ...COMMON,
       ...EMPTY_PICKERS,
@@ -1972,14 +1974,33 @@ describe("renderWizardStepPage", () => {
         "voicechannels.lobby.name": "Lobby",
       },
       metadata: {
-        "voicechannels.enabled": { description: "Enable VC", category: "vc" },
+        "voicechannels.enabled": {
+          label: "Voice Channel Management enabled",
+          description: "Enable VC",
+          category: "voicechannels",
+          type: "boolean",
+        },
+        "quotes.max_length": {
+          label: "Max quote length",
+          description: "Max characters",
+          category: "quotes",
+          type: "number",
+        },
+        "voicechannels.lobby.name": {
+          label: "Lobby channel display name",
+          description: "Lobby name",
+          category: "voicechannels",
+          type: "string",
+        },
       },
     });
     expect(html).toContain("Step 1 of 2");
     expect(html).toContain('action="/admin/wizard/step/0"');
-    expect(html).toContain("Voice Channels");
-    // The wizard now renders through the shared control renderer, so value
-    // fields carry the `value_`-prefixed name (issue #703).
+    // Human-readable label shown; the raw dotted key is demoted to monospace
+    // helper text rather than used as the field label (#702).
+    expect(html).toContain("Voice Channel Management enabled");
+    expect(html).toContain('<code class="mono muted"');
+    // Every field posts the value_-prefixed name shared with the Settings page.
     expect(html).toMatch(
       /type="checkbox"[^>]*name="value_voicechannels.enabled"[^>]*value="true" checked/,
     );
@@ -1989,13 +2010,138 @@ describe("renderWizardStepPage", () => {
     expect(html).toContain('value="Lobby"');
     expect(html).toContain("Enable VC");
     // Each field label is associated with its control via matching for/id so
-    // screen readers and click-to-focus keep working (issue #703 review).
-    expect(html).toContain('<label for="wiz-voicechannels.enabled">');
+    // screen readers and click-to-focus keep working (#703).
+    expect(html).toContain('for="wiz-voicechannels.enabled"');
     expect(html).toMatch(/type="checkbox" id="wiz-voicechannels.enabled"/);
     expect(html).toMatch(/type="number" id="wiz-quotes.max_length"/);
   });
 
-  it("renders an options-backed key as a <select> and pre-selects the current value", () => {
+  it("renders a channel key as a real channel dropdown instead of a free-text ID box (#703)", () => {
+    const html = renderWizardStepPage({
+      ...COMMON,
+      ...EMPTY_PICKERS,
+      textChannels: [
+        { id: "chan-1", name: "general" },
+        { id: "chan-2", name: "announcements" },
+      ],
+      stepIndex: 0,
+      totalSteps: 1,
+      featureKey: "reactionroles",
+      settingKeys: [
+        "reactionroles.enabled",
+        "reactionroles.message_channel_id",
+      ],
+      currentValues: {
+        "reactionroles.enabled": true,
+        "reactionroles.message_channel_id": "chan-2",
+      },
+      defaultValues: {
+        "reactionroles.enabled": false,
+        "reactionroles.message_channel_id": "",
+      },
+      metadata: {
+        "reactionroles.enabled": {
+          label: "Reaction roles enabled",
+          description: "",
+          category: "reactionroles",
+          type: "boolean",
+        },
+        "reactionroles.message_channel_id": {
+          label: "Reaction-role message channel",
+          description: "Channel that hosts the reaction-role message",
+          category: "reactionroles",
+          type: "channel",
+        },
+      },
+    });
+    // A real channel <select> populated from the picker, with the current
+    // channel pre-selected — not a raw-ID text box.
+    expect(html).toMatch(
+      /<select[^>]*name="value_reactionroles.message_channel_id"/,
+    );
+    expect(html).toContain(
+      '<option value="chan-2" selected>#announcements</option>',
+    );
+    expect(html).toContain("Reaction-role message channel");
+    expect(html).not.toMatch(
+      /type="text"[^>]*name="value_reactionroles.message_channel_id"/,
+    );
+  });
+
+  it("renders channel/category/role picker keys as dropdowns from the guild lists (#703)", () => {
+    const html = renderWizardStepPage({
+      ...COMMON,
+      ...EMPTY_PICKERS,
+      textChannels: [
+        { id: "chan-1", name: "announcements" },
+        { id: "chan-2", name: "general" },
+      ],
+      categoryChannels: [{ id: "cat-1", name: "Voice Channels" }],
+      roles: [{ id: "role-1", name: "Moderator" }],
+      stepIndex: 0,
+      totalSteps: 1,
+      featureKey: "reactionroles",
+      settingKeys: [
+        "reactionroles.message_channel_id",
+        "voicechannels.category_id",
+        "leaderboard_roles.some_role",
+      ],
+      currentValues: {
+        "reactionroles.message_channel_id": "chan-1",
+        "voicechannels.category_id": "",
+        "leaderboard_roles.some_role": "",
+      },
+      defaultValues: {
+        "reactionroles.message_channel_id": "",
+        "voicechannels.category_id": "",
+        "leaderboard_roles.some_role": "",
+      },
+      metadata: {
+        "reactionroles.message_channel_id": {
+          label: "Message channel",
+          description: "Message channel",
+          category: "reactionroles",
+          type: "channel",
+        },
+        "voicechannels.category_id": {
+          label: "Managed category",
+          description: "Voice channel category",
+          category: "voicechannels",
+          type: "category",
+        },
+        "leaderboard_roles.some_role": {
+          label: "Reward role",
+          description: "A role",
+          category: "leaderboard_roles",
+          type: "role",
+        },
+      },
+    });
+    // Channel key → text-channel dropdown with the current value selected,
+    // carrying an id its label points at (#703).
+    expect(html).toMatch(
+      /<select id="wiz-reactionroles.message_channel_id" name="value_reactionroles.message_channel_id">/,
+    );
+    expect(html).toContain('for="wiz-reactionroles.message_channel_id"');
+    expect(html).toContain(
+      '<option value="chan-1" selected>#announcements</option>',
+    );
+    expect(html).toContain('<option value="chan-2">#general</option>');
+    // Category key → category dropdown.
+    expect(html).toMatch(
+      /<select id="wiz-voicechannels.category_id" name="value_voicechannels.category_id">/,
+    );
+    expect(html).toContain('<option value="cat-1">#Voice Channels</option>');
+    // Role key → role dropdown with the `@` prefix.
+    expect(html).toMatch(
+      /<select id="wiz-leaderboard_roles.some_role" name="value_leaderboard_roles.some_role">/,
+    );
+    expect(html).toContain('<option value="role-1">@Moderator</option>');
+    // No raw free-text input is emitted for any of these picker keys.
+    expect(html).not.toContain('<input type="text"');
+  });
+
+  it("renders an options-backed key as a <select> using the value_ field name and pre-selects the current value", () => {
     const html = renderWizardStepPage({
       ...COMMON,
       ...EMPTY_PICKERS,
@@ -2007,8 +2153,10 @@ describe("renderWizardStepPage", () => {
       defaultValues: { "leaderboard_roles.period": "alltime" },
       metadata: {
         "leaderboard_roles.period": {
+          label: "Leaderboard window",
           description: "Activity window",
           category: "leaderboard_roles",
+          type: "string",
           options: [
             { value: "week", label: "This week" },
             { value: "month", label: "This month" },
@@ -2017,21 +2165,20 @@ describe("renderWizardStepPage", () => {
         },
       },
     });
-    // The wizard renders through the shared control renderer, so the select
-    // carries the `value_`-prefixed field name and an id the label points at
-    // (issue #703).
+    // The wizard shares the Settings page's value_-prefixed field name, with an
+    // id the label points at.
     expect(html).toMatch(
       /<select name="value_leaderboard_roles.period" id="wiz-leaderboard_roles.period">/,
     );
-    expect(html).toContain(
-      '<label for="wiz-leaderboard_roles.period">leaderboard_roles.period</label>',
-    );
+    expect(html).toContain('for="wiz-leaderboard_roles.period"');
     expect(html).toContain(
       '<option value="month" selected>This month</option>',
     );
     expect(html).toContain('<option value="week">This week</option>');
     // No free-text input for an options key.
-    expect(html).not.toContain('<input type="text"');
+    expect(html).not.toMatch(
+      /type="text"[^>]*name="value_leaderboard_roles.period"/,
+    );
   });
 
   it("surfaces an out-of-range options value in the wizard as a selected `(unknown)` option", () => {
@@ -2046,8 +2193,10 @@ describe("renderWizardStepPage", () => {
       defaultValues: { "leaderboard_roles.period": "alltime" },
       metadata: {
         "leaderboard_roles.period": {
+          label: "Leaderboard window",
           description: "Activity window",
           category: "leaderboard_roles",
+          type: "string",
           options: [
             { value: "week", label: "This week" },
             { value: "month", label: "This month" },
@@ -2151,7 +2300,26 @@ describe("renderWizardStepPage", () => {
         "voicetracking.announcements.enabled": false,
         "voicetracking.announcements.channel_id": "",
       },
-      metadata: {},
+      metadata: {
+        "voicetracking.enabled": {
+          label: "Voice Tracking enabled",
+          description: "",
+          category: "voicetracking",
+          type: "boolean",
+        },
+        "voicetracking.announcements.enabled": {
+          label: "Scheduled announcements enabled",
+          description: "",
+          category: "voicetracking",
+          type: "boolean",
+        },
+        "voicetracking.announcements.channel_id": {
+          label: "Announcement channel",
+          description: "",
+          category: "voicetracking",
+          type: "channel",
+        },
+      },
     });
     // The step form is the cascade scope.
     expect(html).toContain('action="/admin/wizard/step/0" data-cascade-scope');
@@ -2165,76 +2333,37 @@ describe("renderWizardStepPage", () => {
     );
   });
 
-  it("renders channel/category/role picker keys as dropdowns from the guild lists (issue #703)", () => {
+  it("greys out a control whose cross-feature dependency is unmet (#666)", () => {
     const html = renderWizardStepPage({
       ...COMMON,
-      textChannels: [
-        { id: "chan-1", name: "announcements" },
-        { id: "chan-2", name: "general" },
-      ],
-      voiceChannels: [],
-      categoryChannels: [{ id: "cat-1", name: "Voice Channels" }],
-      roles: [{ id: "role-1", name: "Moderator" }],
+      ...EMPTY_PICKERS,
       stepIndex: 0,
       totalSteps: 1,
-      featureKey: "reactionroles",
-      settingKeys: [
-        "reactionroles.message_channel_id",
-        "voicechannels.category_id",
-        "leaderboard_roles.some_role",
-      ],
-      currentValues: {
-        "reactionroles.message_channel_id": "chan-1",
-        "voicechannels.category_id": "",
-        "leaderboard_roles.some_role": "",
-      },
-      defaultValues: {
-        "reactionroles.message_channel_id": "",
-        "voicechannels.category_id": "",
-        "leaderboard_roles.some_role": "",
+      featureKey: "achievements",
+      settingKeys: ["achievements.enabled"],
+      currentValues: { "achievements.enabled": false },
+      defaultValues: { "achievements.enabled": false },
+      // achievements.enabled depends on voicetracking.enabled, which lives on
+      // another step and is currently off.
+      enabledByKey: {
+        "achievements.enabled": false,
+        "voicetracking.enabled": false,
       },
       metadata: {
-        "reactionroles.message_channel_id": {
-          description: "Message channel",
-          category: "reactionroles",
-          type: "channel",
-        },
-        "voicechannels.category_id": {
-          description: "Voice channel category",
-          category: "voicechannels",
-          type: "category",
-        },
-        "leaderboard_roles.some_role": {
-          description: "A role",
-          category: "leaderboard_roles",
-          type: "role",
+        "achievements.enabled": {
+          label: "Achievements enabled",
+          description: "",
+          category: "achievements",
+          type: "boolean",
         },
       },
     });
-    // Channel key → text-channel dropdown with the current value selected,
-    // carrying an id its label points at (issue #703).
+    expect(html).toContain("dep-off");
+    expect(html).toContain("Requires");
+    // The disabled control round-trips its value via a sibling hidden input.
     expect(html).toMatch(
-      /<select id="wiz-reactionroles.message_channel_id" name="value_reactionroles.message_channel_id">/,
+      /type="checkbox"[^>]*name="value_achievements.enabled"[^>]*disabled/,
     );
-    expect(html).toContain(
-      '<label for="wiz-reactionroles.message_channel_id">reactionroles.message_channel_id</label>',
-    );
-    expect(html).toContain(
-      '<option value="chan-1" selected>#announcements</option>',
-    );
-    expect(html).toContain('<option value="chan-2">#general</option>');
-    // Category key → category dropdown.
-    expect(html).toMatch(
-      /<select id="wiz-voicechannels.category_id" name="value_voicechannels.category_id">/,
-    );
-    expect(html).toContain('<option value="cat-1">#Voice Channels</option>');
-    // Role key → role dropdown with the `@` prefix.
-    expect(html).toMatch(
-      /<select id="wiz-leaderboard_roles.some_role" name="value_leaderboard_roles.some_role">/,
-    );
-    expect(html).toContain('<option value="role-1">@Moderator</option>');
-    // No raw free-text input is emitted for any of these picker keys.
-    expect(html).not.toContain('<input type="text"');
   });
 });
 

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -2360,6 +2360,10 @@ describe("renderWizardStepPage", () => {
     });
     expect(html).toContain("dep-off");
     expect(html).toContain("Requires");
+    // The wizard renders no `#section-*` anchors, so the dependency hint must be
+    // plain text rather than a link that points at a non-existent section
+    // (PR #715 review).
+    expect(html).not.toContain('href="#section-');
     // The disabled control round-trips its value via a sibling hidden input.
     expect(html).toMatch(
       /type="checkbox"[^>]*name="value_achievements.enabled"[^>]*disabled/,

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -16,6 +16,7 @@ import {
   isEnabledValue,
   settingsMetadata,
   type ConfigSchema,
+  type SettingMetadata,
   type SettingOption,
 } from "../services/config-schema.js";
 import { DAY_NAMES, formatHourLabel } from "../services/rewind-service.js";
@@ -614,8 +615,15 @@ function renderSettingControl(
   },
   isCascadeMaster = false,
   depLocked = false,
+  controlId = "",
 ): string {
-  const control = renderControlInput(r, pickers, isCascadeMaster, depLocked);
+  const control = renderControlInput(
+    r,
+    pickers,
+    isCascadeMaster,
+    depLocked,
+    controlId,
+  );
   if (!depLocked || r.type === "cron") return control;
   const primitive = coerceToDisplayValue(r.current);
   const roundTrip =
@@ -1201,28 +1209,26 @@ export interface WizardStepPageProps extends CommonProps {
   featureKey: string;
   settingKeys: string[];
   currentValues: Record<string, unknown>;
-  metadata: Record<
-    string,
-    {
-      description: string;
-      category: string;
-      options?: SettingOption[];
-      // The schema `type` (e.g. `channel`, `category`, `role`, `cron`) drives
-      // which control the shared renderer produces; falls back to the runtime
-      // type of the default when a key isn't in the schema. `channelKind`
-      // selects the text- vs voice-channel picker list (issue #703).
-      type?: string;
-      channelKind?: "text" | "voice";
-    }
-  >;
+  metadata: Record<string, SettingMetadata>;
   defaultValues: Record<string, unknown>;
-  // Guild picker option lists, threaded through so `channel`/`category`/`role`
-  // keys render as real selectors — the same lists the Settings page feeds to
-  // `renderControlInput` (issue #703).
+  /**
+   * Guild channel/role option lists that back the picker dropdowns, shared
+   * verbatim with the Settings page's `renderControlInput` so a channel/role/
+   * category key gets a real selector in the wizard instead of a free-text ID
+   * box (#702 / #703).
+   */
   textChannels: ChannelOption[];
   voiceChannels: ChannelOption[];
   categoryChannels: ChannelOption[];
   roles: RoleOption[];
+  /**
+   * Enabled-state of every key on this step *plus* the cross-feature
+   * dependency targets those keys reference (e.g. `achievements.enabled`
+   * depends on `voicetracking.enabled`, which lives on another step). The
+   * shared dependency-hint / lock logic (#666) reads this so the wizard greys
+   * out the same controls the Settings page does.
+   */
+  enabledByKey: Record<string, boolean>;
   flash?: FlashMessage | null;
 }
 
@@ -1233,12 +1239,6 @@ export function renderWizardStepPage(props: WizardStepPageProps): string {
     desc: "",
   };
 
-  // The feature's top-level `.enabled` toggle is the "master" for this step:
-  // when it's off, every other control greys out and is ignored on submit
-  // (issue #485). Sub-toggles like `voicetracking.announcements.enabled` are
-  // dependents, not masters.
-  const masterKey = `${props.featureKey}.enabled`;
-
   const pickers = {
     textChannels: props.textChannels,
     voiceChannels: props.voiceChannels,
@@ -1246,61 +1246,85 @@ export function renderWizardStepPage(props: WizardStepPageProps): string {
     roles: props.roles,
   };
 
-  const fields = props.settingKeys
-    .map((k) => {
-      const current = props.currentValues[k];
-      const meta = props.metadata[k];
-      const defaultVal = props.defaultValues[k];
-      // The schema `type` is authoritative — it's what makes `channel` /
-      // `category` / `role` (and `cron`) keys render as their proper pickers
-      // instead of a free-text box (issue #703). Fall back to the runtime type
-      // of the default for keys the schema doesn't declare.
-      const type =
-        meta?.type ??
-        (typeof defaultVal === "boolean"
-          ? "boolean"
-          : typeof defaultVal === "number"
-            ? "number"
-            : "string");
-      const desc = meta?.description ?? "";
+  // Build the same `SettingRow` shape the Settings page feeds to
+  // `renderControlInput`, so the wizard reuses its rich channel/role/category
+  // selectors, multi-selects, fixed-option dropdowns, cron picker and
+  // dependency handling instead of the old free-text boxes (#702). Metadata is
+  // authoritative for the control type; the runtime type of the default value
+  // is only a fallback for keys the schema doesn't describe.
+  const rows: SettingRow[] = props.settingKeys.map((k) => {
+    const meta = props.metadata[k];
+    const defaultVal = props.defaultValues[k];
+    const fallbackType =
+      typeof defaultVal === "boolean"
+        ? "boolean"
+        : typeof defaultVal === "number"
+          ? "number"
+          : "string";
+    return {
+      key: k,
+      label: meta?.label ?? k,
+      current: props.currentValues[k],
+      defaultValue: defaultVal,
+      type: meta?.type ?? fallbackType,
+      description: meta?.description ?? "",
+      category: meta?.category ?? props.featureKey,
+      options: meta?.options,
+      warnBelow: meta?.warnBelow,
+      channelKind: meta?.channelKind,
+    };
+  });
 
-      // Route the value control through the same renderer the Settings page
-      // uses (`renderControlInput`) so the two surfaces can't drift: pickers
-      // become dropdowns, fixed-options become selects, cron gets its picker.
-      // The submitted field name is therefore `value_<key>` (as on the
-      // Settings page), which the wizard step handler reads back. The label
-      // isn't consumed by the control renderer, so the raw-key display label
-      // (tracked separately in #702) is unaffected here.
-      const inputId = `wiz-${k}`;
-      const row: SettingRow = {
-        key: k,
-        label: k,
-        current,
-        defaultValue: defaultVal,
-        type,
-        description: desc,
-        category: meta?.category ?? "",
-        options: meta?.options,
-        channelKind: meta?.channelKind,
-      };
-      const control = renderControlInput(
-        row,
+  // The feature's top-level `.enabled` toggle is the cascade "master" for this
+  // step: when it's off, every other control greys out and is ignored on submit
+  // (issue #485). Picked the same way as the Settings page (shortest `.enabled`
+  // boolean) so both surfaces cascade identically.
+  const masterKey = findCascadeMasterKey(rows);
+
+  // Enabled-state map for the shared dependency-hint / lock logic (#666). The
+  // route supplies it (covering cross-feature targets); fall back to this
+  // step's own current values so within-feature dependencies still resolve.
+  const enabledByKey = new Map<string, boolean>(
+    Object.entries(props.enabledByKey),
+  );
+  for (const r of rows) {
+    if (!enabledByKey.has(r.key)) {
+      enabledByKey.set(r.key, isEnabledValue(r.current));
+    }
+  }
+
+  const fields = rows
+    .map((r) => {
+      // Grey + disable any control whose hard dependencies aren't all on
+      // (#666), mirroring the Settings page's `dep-off` treatment.
+      const unmet = unmetDependenciesFor(r.key, enabledByKey);
+      const depLocked = unmet.length > 0;
+      const rowClass = depLocked ? " dep-off" : "";
+      // Stamp an id onto the primary control so the human-readable label can
+      // associate with it via `for` (#703). The cron picker manages its own
+      // inputs and takes no id, so its label is left unassociated rather than
+      // pointing `for` at nothing.
+      const inputId = `wiz-${r.key}`;
+      const control = renderSettingControl(
+        r,
         pickers,
-        k === masterKey,
-        false,
+        r.key === masterKey,
+        depLocked,
         inputId,
       );
-
-      // The cron picker renders several inputs of its own rather than a single
-      // control, so it takes no id; its label is left unassociated (a `for`
-      // pointing at nothing is worse than none). Every other type stamps
-      // `inputId` onto its control, so `for` restores screen-reader
-      // association and click-to-focus.
-      const labelFor = type === "cron" ? "" : ` for="${escapeHtml(inputId)}"`;
-      return `<div class="field-row">
-  <label${labelFor}>${escapeHtml(k)}</label>
+      const labelFor = r.type === "cron" ? "" : ` for="${escapeHtml(inputId)}"`;
+      // Human-readable label (#702) with the raw dotted key demoted to
+      // monospace helper text — the same treatment the Settings page gives its
+      // rows, wrapped in a `<label>` so the whole caption stays clickable.
+      return `<div class="field-row${rowClass}">
+  <label class="field-label"${labelFor}>
+    <strong>${escapeHtml(r.label)}</strong>
+    <code class="mono muted" style="font-size:.85em">${escapeHtml(r.key)}</code>
+  </label>
   ${control}
-  <div class="help">${escapeHtml(desc)}</div>
+  ${renderWarnBelow(r)}
+  ${renderDependencyHint(unmet)}
+  <div class="help">${escapeHtml(r.description)}</div>
 </div>`;
     })
     .join("");

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -249,18 +249,25 @@ function unmetDependenciesFor(
 
 /**
  * Render the inline "requires X enabled" hint shown under a control whose
- * hard dependencies aren't all met (#666). Each unmet dependency links to its
- * settings section so the operator can jump straight to the toggle that
- * unlocks this one. Returns an empty string when nothing is unmet. Uses the
- * dependency's human label from `settingsMetadata`, mirroring the greyed-nav
- * treatment's muted styling.
+ * hard dependencies aren't all met (#666). Returns an empty string when nothing
+ * is unmet. Uses the dependency's human label from `settingsMetadata`, mirroring
+ * the greyed-nav treatment's muted styling.
+ *
+ * `linkSections` controls whether each dependency name becomes an in-page
+ * `#section-<category>` anchor. The Settings page (default) renders those
+ * sections, so the link jumps straight to the toggle that unlocks this one. The
+ * wizard renders no such anchors, so it passes `false` to emit plain text —
+ * otherwise the link would point at a non-existent section (PR #715 review).
  */
-export function renderDependencyHint(unmet: UnmetDependency[]): string {
+export function renderDependencyHint(
+  unmet: UnmetDependency[],
+  linkSections = true,
+): string {
   if (unmet.length === 0) return "";
   const names = unmet
     .map((d) => {
       const label = escapeHtml(d.label);
-      return d.category
+      return linkSections && d.category
         ? `<a href="#section-${escapeHtml(d.category)}">${label}</a>`
         : label;
     })
@@ -1323,7 +1330,7 @@ export function renderWizardStepPage(props: WizardStepPageProps): string {
   </label>
   ${control}
   ${renderWarnBelow(r)}
-  ${renderDependencyHint(unmet)}
+  ${renderDependencyHint(unmet, false)}
   <div class="help">${escapeHtml(r.description)}</div>
 </div>`;
     })

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -30,7 +30,12 @@ import { PermissionsService } from "../services/permissions-service.js";
 import { WizardService } from "../services/wizard-service.js";
 import { BotStatusService } from "../services/bot-status-service.js";
 import { CommandManager } from "../services/command-manager.js";
-import { defaultConfig, settingsMetadata } from "../services/config-schema.js";
+import {
+  defaultConfig,
+  settingsMetadata,
+  getDependencies,
+  isEnabledValue,
+} from "../services/config-schema.js";
 import type { IScheduledAnnouncement } from "../models/scheduled-announcement.js";
 import type { IPollSchedule } from "../models/poll-schedule.js";
 import type { IPollItem } from "../models/poll-item.js";
@@ -1455,30 +1460,52 @@ export function createWriteRouter(
           const featureKey = features[step];
           const settingKeys = WIZARD_FEATURE_SETTINGS[featureKey] ?? [];
           const config = ConfigService.getInstance();
-          const currentValues: Record<string, unknown> = {};
-          for (const k of settingKeys) {
+
+          // Resolve a key's effective current value: prefer what the admin
+          // already entered earlier in this wizard run, then the persisted
+          // config, then the schema default. Used for both the visible fields
+          // and the cross-feature dependency targets below.
+          const resolveCurrent = async (k: string): Promise<unknown> => {
             const fromWizard = wizard.getConfiguration(
               session.discordUserId,
               session.guildId,
               k,
             );
-            if (fromWizard !== undefined) {
-              currentValues[k] = fromWizard;
-            } else {
-              try {
-                currentValues[k] = await config.get(k);
-              } catch {
-                currentValues[k] =
-                  defaultConfig[k as keyof typeof defaultConfig];
-              }
+            if (fromWizard !== undefined) return fromWizard;
+            try {
+              return await config.get(k);
+            } catch {
+              return defaultConfig[k as keyof typeof defaultConfig];
+            }
+          };
+
+          const currentValues: Record<string, unknown> = {};
+          for (const k of settingKeys) {
+            currentValues[k] = await resolveCurrent(k);
+          }
+
+          // Enabled-state of this step's keys plus any dependency targets they
+          // reference on other steps (e.g. `achievements.enabled` depends on
+          // `voicetracking.enabled`), so the shared dependency-lock logic knows
+          // whether a cross-feature requirement is actually satisfied (#666).
+          const enabledByKey: Record<string, boolean> = {};
+          for (const k of settingKeys) {
+            enabledByKey[k] = isEnabledValue(currentValues[k]);
+          }
+          for (const k of settingKeys) {
+            for (const dep of getDependencies(
+              k as keyof typeof defaultConfig,
+            )) {
+              if (dep in enabledByKey) continue;
+              enabledByKey[dep] = isEnabledValue(await resolveCurrent(dep));
             }
           }
           // Guild picker lists so channel/category/role keys render as real
-          // selectors, exactly like the Settings page (issue #703). Two guild
-          // fetches run in parallel — one for channels/categories, one for
-          // roles; both helpers swallow their own errors and return empty
-          // lists, so a picker just falls back to an empty dropdown rather
-          // than failing the step.
+          // selectors, exactly like the Settings page (issues #702 / #703).
+          // Two guild fetches run in parallel — one for channels/categories,
+          // one for roles; both helpers swallow their own errors and return
+          // empty lists, so a picker just falls back to an empty dropdown
+          // rather than failing the step.
           const [chData, roleData] = await Promise.all([
             fetchChannelData(client, session.guildId),
             fetchRoleData(client, session.guildId),
@@ -1502,6 +1529,7 @@ export function createWriteRouter(
               voiceChannels: chData.voiceChannels,
               categoryChannels: chData.categoryChannels,
               roles: roleData.roles,
+              enabledByKey,
               flash,
             }),
           );
@@ -1607,23 +1635,21 @@ export function createWriteRouter(
       // = false` and skip the rest, so absent dependents don't surface as
       // bogus "invalid input" drops (a missing number field would otherwise
       // fail coercion).
-      // The step form submits each value under `value_<key>` — the same field
-      // naming the Settings page uses, now that the wizard renders through the
-      // shared control renderer (issue #703).
+      // The wizard now renders each control through the shared
+      // `renderControlInput`, which names every value field `value_<key>`
+      // (`settingValueFieldName`) exactly like the Settings page — read the
+      // same field names back here (issues #702 / #703).
+      const body = req.body as Record<string, unknown> | undefined;
       const masterKey = `${featureKey}.enabled`;
       const masterOff =
         settingKeys.includes(masterKey) &&
-        (req.body as Record<string, unknown> | undefined)?.[
-          settingValueFieldName(masterKey)
-        ] !== "true";
+        body?.[settingValueFieldName(masterKey)] !== "true";
 
       const saved: Record<string, unknown> = {};
       const dropped: Array<{ key: string; reason: string }> = [];
       for (const k of settingKeys) {
         if (masterOff && k !== masterKey) continue;
-        const raw = (req.body as Record<string, unknown> | undefined)?.[
-          settingValueFieldName(k)
-        ];
+        const raw = body?.[settingValueFieldName(k)];
         const coerced = coerceConfigValue(k, raw);
         if (coerced.ok) {
           wizard.addConfiguration(


### PR DESCRIPTION
## Description

The web Setup Wizard (`/admin/wizard`) was the weakest editor in the app: raw dotted config keys as labels and only four control types, so channel/role/category keys showed as raw-ID text boxes.

Since this PR opened, **#713 merged the core selector work** (routing the wizard through the shared `renderControlInput` so channel/category/role keys become real dropdowns — the concrete #703 symptom). This PR has been **rebased on top of #713** and now delivers the rest of the #702 umbrella parity that #713 didn't cover:

- **Human-readable labels** — each field is titled by its `SettingMetadata.label`, with the dotted config key demoted to monospace helper text (the same treatment the Settings page gives its rows), instead of using the raw key as the label.
- **Dependency hints & cascade parity (#666/#485)** — the wizard now greys/disables a control whose hard `dependsOn` targets aren't all enabled and shows the *"Requires X enabled"* hint, plus `renderWarnBelow`. Cross-feature dependency targets that live on another wizard step (e.g. `achievements.enabled` → `voicetracking.enabled`) are resolved in the route (wizard session → config → default) and threaded in via a new `enabledByKey` prop, so the wizard lock agrees with the write-time validator.
- **Shared master selection** — the cascade master is picked with `findCascadeMasterKey`, exactly like the Settings page.
- **Kept #713's accessibility** — `renderSettingControl` now forwards a `controlId` so the human label still associates with its control via `for`/`id` (cron left unassociated, as it manages its own inputs).

This collapses the two surfaces onto one control-rendering path so they can't drift again.

## Type of Change

- [x] ♻️ Code refactoring (single shared control-rendering path)
- [x] ✨ New feature (human labels + dependency parity in the wizard)

## Related Issues

Closes #702
Refs #703 (core selector symptom already fixed by #713; this completes the umbrella)

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`) — full suite: 120 suites, 1485 passing
- [x] Added/updated wizard tests: real channel/category/role dropdowns, human labels + monospace key + `for`/`id` association, `value_`-prefixed field names, and cross-feature dependency greying (#666)
- [x] `npm run build`, `npm run lint`, `npm run format:check`, and markdownlint all pass
- [x] Rebased cleanly onto latest `main` (resolving overlap with #713/#714)

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run lint` and `npm run format`
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally

### Documentation

- [x] I updated `WEBUI.md` to document the wizard sharing the Settings controls
- [x] Validated markdown with `markdownlint`

### Configuration

- [x] No config keys added or changed — rendering-path refactor only, so `SETTINGS.md` / `config-schema.ts` are untouched

## Additional Notes

The wizard's apply/coercion pipeline (`coerceConfigValue`) is unchanged; only the field names it reads were realigned with the Settings page's `value_<key>`. Optional grouping / inline ID validation from the umbrella issue are left as future follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQ2269hYBqX84gXQPptnuQ