### PR TITLE
feat(webui): make disabled-feature handling consistent across /me/* pages

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -573,7 +573,7 @@ expose the page.
 
 | Setting | Default | Description |
 | --- | --- | --- |
-| `rewind.enabled` | `false` | Master switch for the Rewind feature: the `/me/rewind` page, its data aggregation, and the nav link. When off, the page returns a 404 disabled state and is not linked |
+| `rewind.enabled` | `false` | Master switch for the Rewind feature: the `/me/rewind` page, its data aggregation, and the nav link. When off, the page shows a consistent "off" banner (HTTP 200) in place of the recap and its nav link is greyed with an "off" badge (#709) |
 | `rewind.nudge.enabled` | `false` | Send the one-shot end-of-year DM nudge linking eligible users to `/me/rewind`. Independent of `rewind.enabled` |
 | `rewind.cron` | `"0 10 30 12 *"` | Cron schedule for the nudge (default: Dec 30 at 10:00 host timezone) |
 | `rewind.min_minutes` | `60` | Minimum annual voice minutes a user needs to receive the nudge |

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -862,6 +862,17 @@ existing achievements award detection. `celebrations.enabled` depends on
 | **Birthday** (`/me/birthday`)           | Set your birthday (month/day, optional year) so Koolbot can celebrate it on the day in your own timezone. Saving or removing records a `WebAuditLog` row.  |
 | **Rewind** (`/me/rewind`)               | Personal year-in-review: voice time, top voice companions, peak day, longest session, streak, badges, rank, weekly journey, text & reaction activity.      |
 
+**Disabled-feature handling is uniform across `/me/*` (#709).** A
+feature-gated page whose feature an admin has turned off is never hidden
+behind a 404 or silently dropped: the nav link stays visible (greyed with
+an "off" badge, mirroring the admin nav), the Overview lists its card with
+an "off" tag, and opening the page shows one consistent banner — *"Your
+server admin hasn't enabled X yet."* Settings pages (Voice, Birthday) keep
+their editable form so members can pre-set a choice that applies the moment
+the feature is enabled; the read-only Rewind page simply shows the banner in
+place of the recap. This makes "not enabled yet, but my choice is
+remembered" clearly distinguishable from "broken".
+
 When `polls.participation.enabled` is on and you have voted on at least
 one poll, the **Overview** page also shows a read-only **Poll
 participation** card — lifetime votes, this-year votes, and when you last
@@ -885,9 +896,11 @@ announcement itself is evaluated in the member's `/me/timezone`
 preference so it fires on their local day (`#524`).
 
 The whole feature is gated by `rewind.enabled` (`#608`). When it is off
-the route returns a 404 "feature disabled" state and the nav link is
-suppressed on every `/me/*` page; the end-of-year DM nudge is a separate
-toggle (`rewind.nudge.enabled`).
+the route renders the shared "off" banner (HTTP 200) instead of the recap
+and skips the data work — Rewind is read-only, so there is nothing to
+pre-set — while the nav link stays visible, greyed with an "off" badge
+(`#709`); the end-of-year DM nudge is a separate toggle
+(`rewind.nudge.enabled`).
 
 The **Voice** page (`/me/voice`, `#656`) lets a member manage the
 per-user voice preferences that back the Discord control panel's
@@ -903,8 +916,12 @@ your next lobby spawn), and **delete**. Every write goes through the same
 max-per-user cap, name/limit/bitrate bounds, and name-pattern length are
 identical on both surfaces — and records a `WebAuditLog` row
 (`user.voice.namepattern.set`, `user.voice.preset.edit|default|delete`).
-The whole page is gated by `voicechannels.presets.enabled`: when off it
-returns a 404 "feature disabled" state and its nav link is suppressed.
+The whole page is gated by `voicechannels.presets.enabled`, but stays
+reachable when off: the editable form still renders (so a member can
+pre-set their name pattern and manage presets before an admin enables the
+feature) above the shared "off" banner, and its nav link stays visible,
+greyed with an "off" badge (`#709`) — mirroring how the Birthday page has
+always let members pre-set their date.
 
 The bare **Rewind** page (`/me/rewind`) lands on the most recent year you
 actually have data for, so visiting right after the year rolls over shows

--- a/__tests__/models/user-voice-preferences.test.ts
+++ b/__tests__/models/user-voice-preferences.test.ts
@@ -20,14 +20,15 @@ describe("UserVoicePreferences Model Schema", () => {
       const testDoc = {
         userId: "test-user-123",
         namePattern: "{username}'s Room",
-        userLimit: 10,
-        bitrate: 96,
+        presets: [
+          { name: "Squad", channelName: "Squad HQ", userLimit: 10, bitrate: 96 },
+        ],
       };
 
       expect(testDoc.userId).toBe("test-user-123");
       expect(testDoc.namePattern).toBe("{username}'s Room");
-      expect(testDoc.userLimit).toBe(10);
-      expect(testDoc.bitrate).toBe(96);
+      expect(testDoc.presets[0].userLimit).toBe(10);
+      expect(testDoc.presets[0].bitrate).toBe(96);
     });
   });
 });

--- a/__tests__/web/user-routes.test.ts
+++ b/__tests__/web/user-routes.test.ts
@@ -976,28 +976,33 @@ describe("/me/rewind", () => {
     expect(out.body).toContain("Could not load your year-in-review");
   });
 
-  it("returns a 404 disabled state and does not query data when rewind.enabled is off (#608)", async () => {
+  it("renders a consistent disabled banner (200) and skips data work when rewind.enabled is off (#709)", async () => {
     const out = await dispatchRewind({
       pathSuffix: "",
       summary: makeSummary(),
       rewindEnabled: false,
     });
-    expect(out.statusCode).toBe(404);
-    expect(out.body).toContain("Rewind) feature is currently disabled");
-    // The gate short-circuits before any data work.
+    // No longer a 404 — the gated page renders like every other /me/*
+    // surface, with the shared "off" banner instead of a hard error (#709).
+    expect(out.statusCode).toBe(200);
+    expect(out.body).toContain("hasn't enabled the year-in-review (Rewind)");
+    // The banner short-circuits before any data work.
     expect(out.getSummary).not.toHaveBeenCalled();
     expect(out.getDefaultRewindYear).not.toHaveBeenCalled();
-    // And the disabled feature drops out of the page nav.
-    expect(out.body).not.toContain('href="/me/rewind"');
+    // The nav link stays visible (greyed with an "off" badge) rather than
+    // being suppressed.
+    expect(out.body).toContain('href="/me/rewind"');
+    expect(out.body).toContain('class="nav-badge">off</span>');
   });
 
-  it("gates the explicit :year deep-link too when disabled (#608)", async () => {
+  it("shows the banner on the explicit :year deep-link too when disabled (#709)", async () => {
     const out = await dispatchRewind({
       pathSuffix: "/2024",
       summary: makeSummary({ year: 2024 }),
       rewindEnabled: false,
     });
-    expect(out.statusCode).toBe(404);
+    expect(out.statusCode).toBe(200);
+    expect(out.body).toContain("hasn't enabled the year-in-review (Rewind)");
     expect(out.getSummary).not.toHaveBeenCalled();
   });
 });
@@ -1182,11 +1187,33 @@ describe("/me/voice (#656)", () => {
     expect(out.body).toContain("Preview:");
   });
 
-  it("returns a 404 disabled state when presets are off, and hides the nav link", async () => {
+  it("renders the editable page with a consistent banner (200) when presets are off, keeping the nav link (#709)", async () => {
     const out = await dispatch({ method: "GET", presetsEnabled: false });
-    expect(out.statusCode).toBe(404);
-    expect(out.body).toContain("voice presets are currently disabled");
-    expect(out.body).not.toContain('href="/me/voice"');
+    // No longer a 404 — the member can still pre-set their name pattern and
+    // manage presets, so the form renders with the shared "off" banner (#709).
+    expect(out.statusCode).toBe(200);
+    expect(out.body).toContain("hasn't enabled voice presets");
+    // The editable form is still present.
+    expect(out.body).toContain('action="/me/voice/name-pattern"');
+    // The nav link stays visible (greyed with an "off" badge).
+    expect(out.body).toContain('href="/me/voice"');
+    expect(out.body).toContain('class="nav-badge">off</span>');
+  });
+
+  it("still saves the name pattern when presets are off, so pre-setting works (#709)", async () => {
+    const setNamePattern = jest
+      .fn<(u: string, raw: string) => Promise<string | null>>()
+      .mockResolvedValue("{username} HQ");
+    const out = await dispatch({
+      method: "POST",
+      url: "/voice/name-pattern",
+      presetsEnabled: false,
+      body: { namePattern: "{username} HQ" },
+      csrfHeader: "csrf-1",
+      serviceImpl: { setNamePattern },
+    });
+    expect(setNamePattern).toHaveBeenCalledWith("user-1", "{username} HQ");
+    expect(out.redirectedTo).toMatch(/^\/me\/voice\?/);
   });
 
   it("saves the name pattern and audits it", async () => {

--- a/src/models/user-voice-preferences.ts
+++ b/src/models/user-voice-preferences.ts
@@ -11,8 +11,6 @@ export interface IChannelPreset {
 export interface IUserVoicePreferences extends Document {
   userId: string;
   namePattern?: string; // Custom channel naming pattern (e.g., "{username}'s Room", "🎮 {username}")
-  userLimit?: number; // Channel user limit (0 = unlimited)
-  bitrate?: number; // Bitrate in kbps (8-384 for most servers, up to 128 for non-boosted)
   presets: IChannelPreset[];
   createdAt: Date;
   updatedAt: Date;
@@ -33,8 +31,6 @@ const UserVoicePreferencesSchema = new Schema(
   {
     userId: { type: String, required: true, unique: true },
     namePattern: { type: String },
-    userLimit: { type: Number, min: 0, max: 99 },
-    bitrate: { type: Number, min: 8, max: 384 }, // Discord limits: 8kbps min, 384kbps max (with boost)
     presets: { type: [ChannelPresetSchema], default: [] },
   },
   {

--- a/src/scripts/seed-sample-data.ts
+++ b/src/scripts/seed-sample-data.ts
@@ -194,8 +194,6 @@ export interface SeededNotificationPrefsDoc {
 export interface SeededVoicePrefsDoc {
   userId: string;
   namePattern: string;
-  userLimit: number;
-  bitrate: number;
   presets: Array<{
     name: string;
     channelName?: string;
@@ -520,8 +518,6 @@ export function generateVoicePreferences(
       "🎮 {username}",
       "{username} HQ",
     ]),
-    userLimit: faker.helpers.arrayElement([0, 2, 4, 6, 10]),
-    bitrate: faker.helpers.arrayElement([64, 96, 128]),
     presets: [
       {
         name: "Squad night",

--- a/src/web/user-layout.ts
+++ b/src/web/user-layout.ts
@@ -30,6 +30,13 @@ interface UserNavItem {
    * always followed.
    */
   feature?: "rewind" | "voice" | "birthday";
+  /**
+   * Whether the gated page lets the member pre-set a choice (Voice, Birthday)
+   * versus being read-only (Rewind). Drives the disabled tooltip copy so a
+   * read-only page doesn't claim a "choice is saved" it never had (#709).
+   * Only meaningful alongside `feature`; defaults to read-only.
+   */
+  presettable?: boolean;
 }
 
 /**
@@ -42,8 +49,13 @@ export const USER_NAV_ITEMS: UserNavItem[] = [
   { href: "/me/", label: "Overview" },
   { href: "/me/notifications", label: "Notifications" },
   { href: "/me/timezone", label: "Timezone" },
-  { href: "/me/voice", label: "Voice", feature: "voice" },
-  { href: "/me/birthday", label: "Birthday", feature: "birthday" },
+  { href: "/me/voice", label: "Voice", feature: "voice", presettable: true },
+  {
+    href: "/me/birthday",
+    label: "Birthday",
+    feature: "birthday",
+    presettable: true,
+  },
   { href: "/me/rewind", label: "Rewind", feature: "rewind" },
 ];
 
@@ -325,8 +337,11 @@ function renderPageNav(active: string, flags: UserFeatureFlags): string {
       .filter(Boolean)
       .join(" ");
     const cls = classes ? ` class="${classes}"` : "";
+    // Read-only pages (Rewind) have no choice to save, so don't claim one.
     const title = disabled
-      ? ' title="Your server admin hasn\'t enabled this yet — your choice is still saved"'
+      ? item.presettable
+        ? ' title="Your server admin hasn\'t enabled this yet — your choice is still saved"'
+        : ' title="Your server admin hasn\'t enabled this yet"'
       : "";
     const badge = disabled ? '<span class="nav-badge">off</span>' : "";
     return `<a href="${escapeHtml(item.href)}"${cls}${title}>${escapeHtml(item.label)}${badge}</a>`;

--- a/src/web/user-layout.ts
+++ b/src/web/user-layout.ts
@@ -22,12 +22,14 @@ interface UserNavItem {
   href: string;
   label: string;
   /**
-   * When set, the item is only advertised in the nav while the named
-   * feature is enabled. Mirrors the admin layout's `featureKey` gate
-   * (#608): a disabled feature drops out of the nav but the URL stays
-   * reachable by direct navigation (the route itself enforces the gate).
+   * When set, the item is feature-gated. A disabled feature is NOT hidden:
+   * the link stays visible but is greyed with an "off" badge (#709),
+   * mirroring the admin nav's `featureKey` treatment (#610). Its page stays
+   * reachable so members can pre-set their choice before an admin flips the
+   * feature on — the same "let users pre-set" intent the birthday page has
+   * always followed.
    */
-  feature?: "rewind" | "voice";
+  feature?: "rewind" | "voice" | "birthday";
 }
 
 /**
@@ -41,9 +43,33 @@ export const USER_NAV_ITEMS: UserNavItem[] = [
   { href: "/me/notifications", label: "Notifications" },
   { href: "/me/timezone", label: "Timezone" },
   { href: "/me/voice", label: "Voice", feature: "voice" },
-  { href: "/me/birthday", label: "Birthday" },
+  { href: "/me/birthday", label: "Birthday", feature: "birthday" },
   { href: "/me/rewind", label: "Rewind", feature: "rewind" },
 ];
+
+/**
+ * Enabled-state of every feature-gated `/me/*` surface, threaded from the
+ * routes into the layout so the nav and overview cards can render a
+ * consistent "off" treatment (#709). Each flag defaults to enabled
+ * (`undefined` → treated as on) so non-gating callers and tests that don't
+ * care about gating render every item as a plain link.
+ */
+export interface UserFeatureFlags {
+  rewindEnabled?: boolean;
+  presetsEnabled?: boolean;
+  birthdayEnabled?: boolean;
+}
+
+/** Whether a given nav item's feature is disabled per the supplied flags. */
+function isNavItemDisabled(
+  item: UserNavItem,
+  flags: UserFeatureFlags,
+): boolean {
+  if (item.feature === "rewind") return flags.rewindEnabled === false;
+  if (item.feature === "voice") return flags.presetsEnabled === false;
+  if (item.feature === "birthday") return flags.birthdayEnabled === false;
+  return false;
+}
 
 export interface UserFlashMessage {
   type: "ok" | "warn" | "err";
@@ -71,17 +97,24 @@ export interface UserPageOptions {
   flash?: UserFlashMessage | null;
   /**
    * Enabled-state of the feature-gated Rewind page (#608). When `false`,
-   * the Rewind nav link is suppressed. Omitted/`undefined` keeps the link
-   * visible, so direct callers and tests that don't care about gating work
-   * unchanged.
+   * the Rewind nav link is greyed with an "off" badge rather than hidden
+   * (#709). Omitted/`undefined` keeps the link plain, so direct callers and
+   * tests that don't care about gating work unchanged.
    */
   rewindEnabled?: boolean;
   /**
    * Enabled-state of the feature-gated Voice-preferences page (#656). When
-   * `false`, the Voice nav link is suppressed. Omitted/`undefined` keeps the
-   * link visible, mirroring `rewindEnabled`.
+   * `false`, the Voice nav link is greyed with an "off" badge, mirroring
+   * `rewindEnabled` (#709).
    */
   presetsEnabled?: boolean;
+  /**
+   * Enabled-state of the feature-gated Birthday page (#657). When `false`,
+   * the Birthday nav link is greyed with an "off" badge, mirroring
+   * `rewindEnabled`/`presetsEnabled` (#709). The page itself stays reachable
+   * either way so members can pre-set their date.
+   */
+  birthdayEnabled?: boolean;
 }
 
 const STYLE = [
@@ -111,6 +144,9 @@ const STYLE = [
   ".pill{background:#374151;color:#d1d5db;padding:.15rem .5rem;border-radius:999px;font-size:.75rem}",
   ".tag{display:inline-block;padding:.1rem .45rem;border-radius:4px;font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.04em}",
   ".tag-info{background:#1e3a8a;color:#bfdbfe}",
+  // Disabled-feature "off" tag on the overview cards, mirroring the admin
+  // Settings palette (#709).
+  ".tag-off{background:#4b1e1e;color:#fecaca}",
   ".notice{padding:.6rem .8rem;border-radius:6px;margin:0 0 1rem}",
   ".notice.info{background:#1d2a44;color:#bfdbfe}",
   ".notice.ok{background:#14532d;color:#bbf7d0}",
@@ -146,6 +182,13 @@ const STYLE = [
   ".page-nav a{padding:.35rem .75rem;border-radius:4px;background:#161a22;border:1px solid #2d3748;color:#cbd5e1;font-size:.85rem;font-weight:600}",
   ".page-nav a:hover{background:#1f2937;text-decoration:none;color:#fff}",
   ".page-nav a.active{background:#1e3a8a;border-color:#1e3a8a;color:#fff}",
+  // Feature-gated pages whose feature is off are shown but greyed with an
+  // "off" badge so they stay discoverable and pre-settable (#709), mirroring
+  // the admin side nav (#610). The active page keeps its highlight even when
+  // disabled, so the greying only applies while inactive.
+  ".page-nav a.nav-disabled:not(.active){color:#6b7280;border-style:dashed}",
+  ".page-nav a.nav-disabled:not(.active):hover{color:#94a3b8}",
+  ".page-nav a .nav-badge{font-size:.6rem;font-weight:600;text-transform:uppercase;letter-spacing:.04em;color:#cbd5e1;background:#374151;border-radius:4px;padding:.05rem .3rem;margin-left:.35rem}",
   ".rw-hero{background:linear-gradient(135deg,#1e1b4b 0%,#312e81 100%);border:1px solid #4338ca;border-radius:8px;padding:1.5rem;margin:0 0 1rem;text-align:center}",
   ".rw-hero .total{font-size:2.5rem;font-weight:700;color:#fff;line-height:1.1}",
   ".rw-hero .compare{margin-top:.4rem;color:#c7d2fe;font-size:1rem}",
@@ -258,33 +301,36 @@ export function renderUserPage(opts: UserPageOptions): string {
     '<button type="submit">Finish</button>',
     "</form></div></div>",
     '<div class="shell">',
-    `<main>${renderPageNav(opts.active, opts.rewindEnabled, opts.presetsEnabled)}${renderFlash(opts.flash)}${opts.body}</main></div>`,
+    `<main>${renderPageNav(opts.active, {
+      rewindEnabled: opts.rewindEnabled,
+      presetsEnabled: opts.presetsEnabled,
+      birthdayEnabled: opts.birthdayEnabled,
+    })}${renderFlash(opts.flash)}${opts.body}</main></div>`,
     `<script>${SCRIPT}</script>`,
     "</body></html>",
   ].join("");
 }
 
-function renderPageNav(
-  active: string,
-  rewindEnabled?: boolean,
-  presetsEnabled?: boolean,
-): string {
-  const items = USER_NAV_ITEMS.filter((item) => {
-    // A feature-gated item only shows while its feature is enabled.
-    // `undefined` is treated as enabled so non-gating callers are
-    // unaffected (#608/#656).
-    if (item.feature === "rewind") return rewindEnabled !== false;
-    if (item.feature === "voice") return presetsEnabled !== false;
-    return true;
-  })
-    .map((item) => {
-      const isActive =
-        item.href === active ||
-        (item.href === "/me/" && (active === "/me" || active === "/me/"));
-      const cls = isActive ? ' class="active"' : "";
-      return `<a href="${escapeHtml(item.href)}"${cls}>${escapeHtml(item.label)}</a>`;
-    })
-    .join("");
+function renderPageNav(active: string, flags: UserFeatureFlags): string {
+  // Every item always renders (#709): a feature-gated page whose feature is
+  // off is greyed with an "off" badge rather than hidden, so it stays
+  // discoverable and its choice stays pre-settable. `undefined` flags are
+  // treated as enabled so non-gating callers/tests render plain links.
+  const items = USER_NAV_ITEMS.map((item) => {
+    const isActive =
+      item.href === active ||
+      (item.href === "/me/" && (active === "/me" || active === "/me/"));
+    const disabled = isNavItemDisabled(item, flags);
+    const classes = [isActive ? "active" : "", disabled ? "nav-disabled" : ""]
+      .filter(Boolean)
+      .join(" ");
+    const cls = classes ? ` class="${classes}"` : "";
+    const title = disabled
+      ? ' title="Your server admin hasn\'t enabled this yet — your choice is still saved"'
+      : "";
+    const badge = disabled ? '<span class="nav-badge">off</span>' : "";
+    return `<a href="${escapeHtml(item.href)}"${cls}${title}>${escapeHtml(item.label)}${badge}</a>`;
+  }).join("");
   return `<nav class="page-nav">${items}</nav>`;
 }
 
@@ -296,6 +342,33 @@ function renderFlash(flash?: UserFlashMessage | null): string {
 }
 
 /**
+ * The single, consistent "this feature is off" banner shown on every gated
+ * `/me/*` page when its feature is disabled (#709). Replaces the old mix of
+ * hard 404s, bespoke per-page notices, and silent omissions with one
+ * predictable message. Members can't enable features (that's admin-only), so
+ * the banner is purely informational — no action button.
+ *
+ * `label` names the feature (e.g. "Voice presets"). When `presettable` is
+ * true the copy reassures the member their choice is saved and will apply
+ * once an admin turns the feature on; when false (read-only surfaces like
+ * Rewind, where there is nothing to pre-set) it simply says the content will
+ * appear once the feature is enabled. Returns "" when `enabled` is true so
+ * callers can drop it in unconditionally.
+ */
+export function renderUserFeatureDisabledNotice(opts: {
+  enabled: boolean;
+  label: string;
+  presettable: boolean;
+}): string {
+  if (opts.enabled) return "";
+  const label = escapeHtml(opts.label);
+  const tail = opts.presettable
+    ? "Your choice is saved and will apply automatically once they turn it on."
+    : "Once they enable it, it'll show up here.";
+  return `<div class="notice info"><strong>Your server admin hasn't enabled ${label} yet.</strong> ${tail}</div>`;
+}
+
+/**
  * Page body for `/me/`. Self-contained — the layout supplies the chrome,
  * this function supplies just the inner HTML. The Notifications card
  * landed in #482; later cards (#484 Rewind, etc.) bolt on as they ship.
@@ -304,12 +377,16 @@ export function renderUserIndexBody(opts: {
   discordUserId: string;
   guildId: string;
   isAdmin: boolean;
-  // Whether the feature-gated Rewind page is enabled (#608). When false,
-  // its card is omitted so the overview never links to a disabled page.
+  // Whether the feature-gated Rewind page is enabled (#608). When false, its
+  // card is still shown but tagged "off" (#709) so the overview lists every
+  // manageable surface consistently rather than making some vanish.
   rewindEnabled?: boolean;
-  // Whether the feature-gated Voice page is enabled (#656). When false,
-  // its card is omitted so the overview never links to a disabled page.
+  // Whether the feature-gated Voice page is enabled (#656). When false, its
+  // card is shown tagged "off" (#709), mirroring `rewindEnabled`.
   presetsEnabled?: boolean;
+  // Whether the feature-gated Birthday page is enabled (#657). When false,
+  // its card is shown tagged "off" (#709), mirroring `rewindEnabled`.
+  birthdayEnabled?: boolean;
   // The member's poll-participation summary (#655), or null/undefined when
   // poll-participation capture is off or the member has never voted. When
   // present, a small read-only "Poll participation" card surfaces their
@@ -324,16 +401,36 @@ export function renderUserIndexBody(opts: {
   const greeting = opts.isAdmin
     ? `<p class="subtitle">Signed in as an administrator viewing your own preferences. Use the <em>Back to admin panel</em> link above to manage the server.</p>`
     : `<p class="subtitle">These pages are scoped to <strong>you</strong> — what you see and change here only affects your own data on this server.</p>`;
-  const rewindCard =
-    opts.rewindEnabled === false
-      ? ""
-      : '<li><span class="feature-name"><a href="/me/rewind">Rewind</a></span>' +
-        '<span class="feature-desc">Your personal year-in-review of voice activity, top voice companions, peak day, and badges earned.</span></li>';
-  const voiceCard =
-    opts.presetsEnabled === false
-      ? ""
-      : '<li><span class="feature-name"><a href="/me/voice">Voice</a></span>' +
-        '<span class="feature-desc">Manage your channel name pattern and saved voice-channel presets.</span></li>';
+  // Each manageable surface is always listed (#709); a disabled feature is
+  // tagged "off" rather than dropped, so the overview reads the same whether
+  // or not an admin has flipped the feature on.
+  const offTag = ' <span class="tag tag-off">off</span>';
+  const featureCard = (
+    href: string,
+    label: string,
+    desc: string,
+    enabled: boolean,
+  ): string =>
+    `<li><span class="feature-name"><a href="${href}">${label}</a>${enabled ? "" : offTag}</span>` +
+    `<span class="feature-desc">${desc}</span></li>`;
+  const voiceCard = featureCard(
+    "/me/voice",
+    "Voice",
+    "Manage your channel name pattern and saved voice-channel presets.",
+    opts.presetsEnabled !== false,
+  );
+  const birthdayCard = featureCard(
+    "/me/birthday",
+    "Birthday",
+    "Set your birthday (the year is optional) so Koolbot can celebrate it on the day — in your own timezone.",
+    opts.birthdayEnabled !== false,
+  );
+  const rewindCard = featureCard(
+    "/me/rewind",
+    "Rewind",
+    "Your personal year-in-review of voice activity, top voice companions, peak day, and badges earned.",
+    opts.rewindEnabled !== false,
+  );
   // Read-only poll-participation summary (#655). Only rendered when the
   // route supplies a summary (capture on + the member has a tracking row).
   const poll = opts.pollParticipation;
@@ -369,8 +466,7 @@ export function renderUserIndexBody(opts: {
     '<li><span class="feature-name"><a href="/me/timezone">Timezone</a></span>' +
       '<span class="feature-desc">Choose the timezone Koolbot uses when it shows you times in digests, Rewind, and voicestats.</span></li>',
     voiceCard,
-    '<li><span class="feature-name"><a href="/me/birthday">Birthday</a></span>' +
-      '<span class="feature-desc">Set your birthday (the year is optional) so Koolbot can celebrate it on the day — in your own timezone.</span></li>',
+    birthdayCard,
     rewindCard,
     "</ul>",
     "</div>",
@@ -883,9 +979,11 @@ export function renderUserBirthdayBody(opts: BirthdayPageBodyOptions): string {
   const month = opts.selected?.month ?? null;
   const day = opts.selected?.day ?? null;
   const year = opts.selected?.year ?? null;
-  const disabledNotice = opts.featureEnabled
-    ? ""
-    : "<div class=\"notice info\">Birthday announcements aren't enabled on this server yet, but you can set your date now — it'll be ready the moment an admin turns the feature on.</div>";
+  const disabledNotice = renderUserFeatureDisabledNotice({
+    enabled: opts.featureEnabled,
+    label: "birthday announcements",
+    presettable: true,
+  });
   const hasBirthday = opts.selected !== null;
   return [
     "<h1>Birthday</h1>",
@@ -1092,6 +1190,13 @@ export interface VoicePageBodyOptions {
   presets: VoicePresetView[];
   /** Configured max presets per user (shown as guidance). */
   maxPerUser: number;
+  /**
+   * Whether the voice-presets feature is enabled on the server. When off the
+   * page still renders the editable form (so a member can pre-set their name
+   * pattern and manage presets) but shows the shared "off" banner (#709),
+   * mirroring the birthday page's pre-set affordance.
+   */
+  featureEnabled: boolean;
 }
 
 function renderPresetRow(p: VoicePresetView, csrfToken: string): string {
@@ -1157,6 +1262,11 @@ export function renderUserVoiceBody(opts: VoicePageBodyOptions): string {
   return [
     "<h1>Voice preferences</h1>",
     '<p class="subtitle">Manage how your dynamic voice channels are named and the presets you can apply to them.</p>',
+    renderUserFeatureDisabledNotice({
+      enabled: opts.featureEnabled,
+      label: "voice presets",
+      presettable: true,
+    }),
     // ---- Name pattern ----
     '<form method="POST" action="/me/voice/name-pattern">',
     `<input type="hidden" name="_csrf" value="${escapeHtml(opts.csrfToken)}">`,

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -42,6 +42,7 @@ import {
   renderUserRewindBody,
   renderUserTimezoneBody,
   renderUserVoiceBody,
+  type UserFeatureFlags,
   type UserFlashMessage,
   type VoicePresetView,
 } from "./user-layout.js";
@@ -244,11 +245,7 @@ async function isBirthdayFeatureEnabled(): Promise<boolean> {
  * every page so the nav renders a consistent "off" badge for whichever
  * features are disabled — regardless of which page you're on.
  */
-async function readUserFeatureFlags(): Promise<{
-  rewindEnabled: boolean;
-  presetsEnabled: boolean;
-  birthdayEnabled: boolean;
-}> {
+async function readUserFeatureFlags(): Promise<Required<UserFeatureFlags>> {
   const [rewindEnabled, presetsEnabled, birthdayEnabled] = await Promise.all([
     isRewindFeatureEnabled(),
     isVoicePresetsEnabled(),

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -38,6 +38,7 @@ import {
   renderUserIndexBody,
   renderUserNotificationsBody,
   renderUserPage,
+  renderUserFeatureDisabledNotice,
   renderUserRewindBody,
   renderUserTimezoneBody,
   renderUserVoiceBody,
@@ -238,6 +239,25 @@ async function isBirthdayFeatureEnabled(): Promise<boolean> {
 }
 
 /**
+ * Resolve the enabled-state of every feature-gated `/me/*` surface in one
+ * shot (#709). Threaded into `renderUserPage` (and the overview body) on
+ * every page so the nav renders a consistent "off" badge for whichever
+ * features are disabled — regardless of which page you're on.
+ */
+async function readUserFeatureFlags(): Promise<{
+  rewindEnabled: boolean;
+  presetsEnabled: boolean;
+  birthdayEnabled: boolean;
+}> {
+  const [rewindEnabled, presetsEnabled, birthdayEnabled] = await Promise.all([
+    isRewindFeatureEnabled(),
+    isVoicePresetsEnabled(),
+    isBirthdayFeatureEnabled(),
+  ]);
+  return { rewindEnabled, presetsEnabled, birthdayEnabled };
+}
+
+/**
  * Resolve the session user's display name for the name-pattern preview.
  * Best-effort: falls back to the raw user id when the member can't be
  * fetched (e.g. left the guild), so the page still renders.
@@ -339,8 +359,7 @@ export function createUserRouter(
         res.status(500).type("text/plain").send("session missing");
         return;
       }
-      const rewindEnabled = await isRewindFeatureEnabled();
-      const presetsEnabled = await isVoicePresetsEnabled();
+      const flags = await readUserFeatureFlags();
 
       // Read-only poll-participation summary for the overview card (#655).
       // Only fetched when capture is on; a member who has never voted has no
@@ -359,8 +378,7 @@ export function createUserRouter(
             discordUserId: session.discordUserId,
             guildId: session.guildId,
             isAdmin: session.role === "admin",
-            rewindEnabled,
-            presetsEnabled,
+            ...flags,
             pollParticipation: pollParticipation
               ? {
                   totalVotes: pollParticipation.totalVotes,
@@ -374,8 +392,7 @@ export function createUserRouter(
           csrfToken: getCsrfToken(req),
           remainingMs: getDisplayedRemainingMs(session),
           isAdmin: session.role === "admin",
-          rewindEnabled,
-          presetsEnabled,
+          ...flags,
         }),
       );
     }),
@@ -411,8 +428,7 @@ export function createUserRouter(
           remainingMs: getDisplayedRemainingMs(session),
           isAdmin: session.role === "admin",
           flash,
-          rewindEnabled: await isRewindFeatureEnabled(),
-          presetsEnabled: await isVoicePresetsEnabled(),
+          ...(await readUserFeatureFlags()),
         }),
       );
     }),
@@ -533,8 +549,7 @@ export function createUserRouter(
           remainingMs: getDisplayedRemainingMs(session),
           isAdmin: session.role === "admin",
           flash,
-          rewindEnabled: await isRewindFeatureEnabled(),
-          presetsEnabled: await isVoicePresetsEnabled(),
+          ...(await readUserFeatureFlags()),
         }),
       );
     }),
@@ -629,6 +644,7 @@ export function createUserRouter(
         guildId,
       );
       const flash = readFlashFromQuery(req);
+      const flags = await readUserFeatureFlags();
       res.type("text/html").send(
         renderUserPage({
           title: "Birthday",
@@ -636,13 +652,13 @@ export function createUserRouter(
           body: renderUserBirthdayBody({
             csrfToken: getCsrfToken(req),
             selected,
-            featureEnabled: await isBirthdayFeatureEnabled(),
+            featureEnabled: flags.birthdayEnabled,
           }),
           csrfToken: getCsrfToken(req),
           remainingMs: getDisplayedRemainingMs(session),
           isAdmin: session.role === "admin",
           flash,
-          rewindEnabled: await isRewindFeatureEnabled(),
+          ...flags,
         }),
       );
     }),
@@ -740,30 +756,32 @@ export function createUserRouter(
       userId: session.discordUserId,
       guildId: session.guildId,
     });
-    const presetsEnabled = await isVoicePresetsEnabled();
+    const flags = await readUserFeatureFlags();
 
-    // Feature gate (#608): when Rewind is disabled the page is not served
-    // (and the nav link is already suppressed). Return a friendly disabled
-    // state with 404 so the route can't be used to reach the recap while
-    // off, mirroring how the nav advertisement is hidden.
-    if (!(await isRewindFeatureEnabled())) {
-      res
-        .status(404)
-        .type("text/html")
-        .send(
-          renderUserPage({
-            title: "Rewind",
-            active: "/me/rewind",
-            body:
-              "<h1>Rewind</h1>" +
-              '<div class="notice info">The year-in-review (Rewind) feature is currently disabled on this server.</div>',
-            csrfToken: getCsrfToken(req),
-            remainingMs: getDisplayedRemainingMs(session),
-            isAdmin: session.role === "admin",
-            rewindEnabled: false,
-            presetsEnabled,
-          }),
-        );
+    // Feature gate (#608/#709): when Rewind is disabled the recap can't be
+    // computed (there's nothing to pre-set here — it's a read-only view), so
+    // we render the consistent "off" banner instead of the recap and skip the
+    // data work. Unlike the old 404 this returns 200 and keeps the nav link
+    // visible (greyed), matching every other gated `/me/*` surface.
+    if (!flags.rewindEnabled) {
+      res.type("text/html").send(
+        renderUserPage({
+          title: "Rewind",
+          active: "/me/rewind",
+          body:
+            "<h1>Rewind</h1>" +
+            '<p class="subtitle">Your personal year-in-review.</p>' +
+            renderUserFeatureDisabledNotice({
+              enabled: false,
+              label: "the year-in-review (Rewind) feature",
+              presettable: false,
+            }),
+          csrfToken: getCsrfToken(req),
+          remainingMs: getDisplayedRemainingMs(session),
+          isAdmin: session.role === "admin",
+          ...flags,
+        }),
+      );
       return;
     }
 
@@ -808,8 +826,7 @@ export function createUserRouter(
             csrfToken: getCsrfToken(req),
             remainingMs: getDisplayedRemainingMs(session),
             isAdmin: session.role === "admin",
-            rewindEnabled: true,
-            presetsEnabled,
+            ...flags,
           }),
         );
       return;
@@ -881,8 +898,7 @@ export function createUserRouter(
         csrfToken: getCsrfToken(req),
         remainingMs: getDisplayedRemainingMs(session),
         isAdmin: session.role === "admin",
-        rewindEnabled: true,
-        presetsEnabled,
+        ...flags,
       }),
     );
   });
@@ -897,31 +913,11 @@ export function createUserRouter(
   // Discord (snapshot of a live channel); the web surface edits, sets the
   // default, and deletes the ones you already have.
 
-  // Helper shared by every voice route: 404 with a friendly disabled
-  // state when the feature is off (mirrors the Rewind gate, #608).
-  const renderVoiceDisabled = async (
-    req: AuthenticatedRequest,
-    res: Response,
-    session: WebSessionContext,
-  ): Promise<void> => {
-    res
-      .status(404)
-      .type("text/html")
-      .send(
-        renderUserPage({
-          title: "Voice preferences",
-          active: "/me/voice",
-          body:
-            "<h1>Voice preferences</h1>" +
-            '<div class="notice info">Per-user voice presets are currently disabled on this server.</div>',
-          csrfToken: getCsrfToken(req),
-          remainingMs: getDisplayedRemainingMs(session),
-          isAdmin: session.role === "admin",
-          rewindEnabled: await isRewindFeatureEnabled(),
-          presetsEnabled: false,
-        }),
-      );
-  };
+  // The page and its POST routes stay reachable even when the feature is off
+  // (#709): a member can pre-set their name pattern and manage presets before
+  // an admin flips `voicechannels.presets.enabled` on, mirroring the birthday
+  // page. The GET renders the shared "off" banner via `featureEnabled`; the
+  // POSTs persist regardless, exactly like the birthday POST.
 
   router.get(
     "/voice",
@@ -929,10 +925,6 @@ export function createUserRouter(
       const session = req.webSession;
       if (!session) {
         res.status(500).type("text/plain").send("session missing");
-        return;
-      }
-      if (!(await isVoicePresetsEnabled())) {
-        await renderVoiceDisabled(req, res, session);
         return;
       }
       const { userId } = assertSelfScope(session, {
@@ -952,6 +944,7 @@ export function createUserRouter(
         3,
       );
       const flash = readFlashFromQuery(req);
+      const flags = await readUserFeatureFlags();
 
       res.type("text/html").send(
         renderUserPage({
@@ -963,13 +956,13 @@ export function createUserRouter(
             displayName,
             presets: toPresetViews(prefs.presets),
             maxPerUser,
+            featureEnabled: flags.presetsEnabled,
           }),
           csrfToken: getCsrfToken(req),
           remainingMs: getDisplayedRemainingMs(session),
           isAdmin: session.role === "admin",
           flash,
-          rewindEnabled: await isRewindFeatureEnabled(),
-          presetsEnabled: true,
+          ...flags,
         }),
       );
     }),
@@ -982,10 +975,6 @@ export function createUserRouter(
       const session = req.webSession;
       if (!session) {
         res.status(500).type("text/plain").send("session missing");
-        return;
-      }
-      if (!(await isVoicePresetsEnabled())) {
-        await renderVoiceDisabled(req, res, session);
         return;
       }
       const { userId } = assertSelfScope(session, {
@@ -1055,10 +1044,6 @@ export function createUserRouter(
       const session = req.webSession;
       if (!session) {
         res.status(500).type("text/plain").send("session missing");
-        return;
-      }
-      if (!(await isVoicePresetsEnabled())) {
-        await renderVoiceDisabled(req, res, session);
         return;
       }
       const { userId } = assertSelfScope(session, {


### PR DESCRIPTION
## Description

Gated user surfaces under `/me/*` behaved four different ways when their feature was
turned off by an admin, which made "not enabled yet, but my choice is saved"
indistinguishable from "broken":

| Surface | Old behavior when disabled |
|---|---|
| `/me/rewind` | **404** + nav link hidden |
| `/me/voice` | **404** + nav link hidden |
| `/me/birthday` | form + soft notice (kept working) |
| `/me/` cards | silently omitted |

This PR adopts **one policy uniformly** — the birthday page's existing "let members
pre-set before the feature ships" intent (the recommended direction in #709):

- **Nav links** for every gated page (Voice, Birthday, Rewind) always render, greyed
  with an "off" badge instead of being hidden — mirroring the admin side nav (#610).
- **Every gated page renders (HTTP 200)** with a single shared banner
  (`renderUserFeatureDisabledNotice`): *"Your server admin hasn't enabled X yet."* —
  replacing the 404s and the bespoke per-page notice.
- **Voice** keeps its editable form and its POST routes work while disabled, so a member
  can pre-set their name pattern / manage presets (exactly like Birthday already did).
  **Rewind**, being read-only, shows the banner in place of the recap and skips the data
  work.
- **The Overview** lists the Voice / Birthday / Rewind cards consistently with an "off"
  tag rather than dropping them.

Also removes the one genuine dead setting called out in the issue: the top-level
`UserVoicePreferences.userLimit` / `bitrate` model fields. They were only ever *written*
(by the seed script) and never *read* — the voice-channel manager and Discord handlers
use the per-preset fields. Dropped from the model and the seed generator.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ♻️ Code refactoring (no functional changes)
- [x] 📚 Documentation update

## Related Issues

Closes #709
Refs #706 (admin-side counterpart), #610 (admin "off"-badge pattern)

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`) — 120 suites, 1477 passing
- [x] Added new tests for new functionality
- [x] Manually tested in development environment (rendered the pages via the layout
  helpers and verified nav badges / overview "off" tags / banners)

Updated `__tests__/web/user-routes.test.ts`:
- Rewind disabled: now asserts 200 + shared banner + visible (greyed) nav link, and that
  data work is still skipped.
- Voice disabled: now asserts 200 + editable form + banner + nav link, plus a new test
  proving the name-pattern POST still persists while disabled (pre-setting works).

Also ran `npm run check` (build + lint + format:check) and markdownlint on the changed
docs — all green.

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format`
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective / that the feature works
- [x] New and existing unit tests pass locally with my changes

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary:
  - [x] `SETTINGS.md` (`rewind.enabled` behavior)
  - [x] `WEBUI.md` (user self-service section — uniform disabled-feature policy)
- [x] I have validated markdown with `npx markdownlint`

### Configuration

- [x] No new config keys — behavior change only; existing feature gates
  (`rewind.enabled`, `voicechannels.presets.enabled`, `birthdays.enabled`) still gate.

## Additional Notes

Members can't enable features (that's admin-only), so the shared banner is purely
informational with no action button — unlike the admin-side `renderFeatureDisabledNotice`
which offers an inline "Enable" button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVLUqTz9Bq86ZddUBCpGLf)_