### PR TITLE
feat(events): scheduled events with temporary voice channels and RSVPs

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -35,6 +35,7 @@ See [WEBUI.md](WEBUI.md) for the full surface breakdown.
   - [/seen](#seen)
   - [/achievements](#achievements)
   - [/quote](#quote)
+  - [/event](#event)
 - [Web UI launcher](#-web-ui-launcher)
   - [/config](#config)
 - [Voice Channel Control Panel](#voice-channel-control-panel)
@@ -462,6 +463,87 @@ and is auto-recreated if deleted.
 
 ---
 
+### `/event`
+
+Schedule server events backed by a **temporary voice channel**. For servers
+that don't run static voice channels: instead of pre-creating a channel by
+hand, you schedule an event and KoolBot spins up a voice channel shortly
+before it starts, collects RSVPs, reminds attendees beforehand, and deletes
+the channel once the event ends and empties.
+
+Gated by the `events.enabled` feature flag. The `create`, `cancel`, and
+`start` subcommands require the **Administrator** permission; `list` is open
+to everyone.
+
+Configure the channel category, announcement channel, timezone, and timing
+windows under **Settings → Events** (or the `/admin/events` page). See
+[SETTINGS.md](SETTINGS.md#events).
+
+#### `/event create` (admin)
+
+Schedule a new event.
+
+```text
+/event create title:"Game Night" date:2026-07-04 time:20:00
+/event create title:"Movie Night" date:2026-07-05 time:21:30 description:"Bring snacks" duration:180 timezone:Europe/London
+```
+
+**Options:**
+
+- `title` (required) — event title (also used to name the voice channel)
+- `date` (required) — start date, `YYYY-MM-DD`
+- `time` (required) — start time, 24-hour `HH:MM`
+- `description` (optional) — shown on the RSVP message
+- `duration` (optional) — length in minutes (1–1440); defaults to
+  `events.default_duration_minutes`
+- `timezone` (optional) — IANA zone the date/time is interpreted in
+  (e.g. `Europe/London`); defaults to `events.timezone`
+
+On creation the bot posts an RSVP message in the configured announcement
+channel with **Going / Maybe / Can't** buttons and a live attendee count.
+
+#### `/event list`
+
+List upcoming and in-progress events with their RSVP tallies and IDs.
+
+```text
+/event list
+```
+
+#### `/event cancel` (admin)
+
+Cancel an event and remove its voice channel (if already created). The RSVP
+message is updated to show the event as cancelled.
+
+```text
+/event cancel id:697bdfe2808f7d245289392c
+```
+
+#### `/event start` (admin)
+
+Spin up the event's voice channel immediately, ahead of its scheduled
+creation window.
+
+```text
+/event start id:697bdfe2808f7d245289392c
+```
+
+**How it works:**
+
+1. Admin schedules an event via `/event create` or the `/admin/events` page
+2. Bot posts an RSVP message with Going / Maybe / Can't buttons
+3. A reminder is posted `events.reminder_minutes` before start, pinging
+   members who RSVP'd Going or Maybe
+4. The temporary voice channel is created `events.create_lead_minutes`
+   before start (or immediately via `/event start`)
+5. Once the event's duration elapses it is marked ended; the empty channel
+   is removed after `events.channel_grace_minutes`
+
+The whole lifecycle is driven by a once-a-minute scan, so it is
+restart-safe — progress is tracked on the stored event, not in memory.
+
+---
+
 ## 🔧 Web UI launcher
 
 KoolBot has exactly one Web UI slash command. It does one thing: mint a
@@ -702,13 +784,15 @@ button to admit them. **🗑️ Remove Waiting Room** deletes it.
 
 ### User command permissions
 
-| Command         | Permission Level | Additional Requirements                    |
-| --------------- | ---------------- | ------------------------------------------ |
-| `/ping`         | Everyone\*       | Command must be enabled                    |
-| `/voicestats`   | Everyone\*       | Voice tracking enabled                     |
-| `/achievements` | Everyone\*       | Achievements enabled                       |
-| `/seen`         | Everyone\*       | Voice tracking + seen enabled              |
-| `/quote`        | Everyone\*       | Quotes enabled                             |
+| Command                        | Permission Level | Additional Requirements       |
+| ------------------------------ | ---------------- | ----------------------------- |
+| `/ping`                        | Everyone\*       | Command must be enabled       |
+| `/voicestats`                  | Everyone\*       | Voice tracking enabled        |
+| `/achievements`                | Everyone\*       | Achievements enabled          |
+| `/seen`                        | Everyone\*       | Voice tracking + seen enabled |
+| `/quote`                       | Everyone\*       | Quotes enabled                |
+| `/event list`                  | Everyone\*       | Events enabled                |
+| `/event` create/cancel/start   | Administrator    | Events enabled                |
 
 \* Per-command role gating can be added in the Web UI's **Permissions** page.
 
@@ -768,6 +852,8 @@ The bot needs these Discord permissions:
 /seen user:@User                    # Last-seen lookup
 /quote add text:"..." author:@User  # Add a quote
 /quote edit id:"..." [text:"..."] [author:@User]
+/event list                         # List upcoming events
+/event create title:"..." date:YYYY-MM-DD time:HH:MM  # (admin) schedule an event
 ```
 
 ### Web UI launcher
@@ -789,6 +875,7 @@ Once in the admin Web UI (admin sessions):
 | Permissions    | `/permissions set/add/remove/clear/list/view`                              |
 | Setup Wizard   | `/setup wizard`                                                            |
 | Announcements  | `/announce create/list/delete`, `/announce-vc-stats`                       |
+| Events         | `/event create/list/cancel/start`                                          |
 | Polls          | `/poll create/list/add-item/delete/delete-item/test/list-items`            |
 | Reaction Roles | `/reactrole create/archive/unarchive/delete/list/status`                   |
 | Notices        | `/notice add/edit/delete/sync`                                             |

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -39,6 +39,8 @@ Complete configuration reference for all KoolBot settings.
 - [Milestone Celebrations](#-milestone-celebrations)
 - [Weekly Digest](#-weekly-digest)
 - [Rewind (Year-in-Review)](#-rewind-year-in-review)
+- [Birthdays](#-birthdays)
+- [Events](#-events)
 - [Reaction Roles](#-reaction-roles)
 - [Leaderboard Role Rewards](#-leaderboard-role-rewards)
 - [Rate Limiting](#-rate-limiting)
@@ -638,6 +640,46 @@ optional for privacy); there is no slash command.
 - A summary row (announced / roles granted / roles removed / failed) is
   posted to the configured cron log channel after a run that did
   anything (empty hourly ticks are silent).
+
+---
+
+## 📅 Events
+
+Schedule server events backed by a **temporary voice channel** — for
+servers that don't run static voice channels. Instead of pre-creating a
+channel by hand, an admin schedules an event and KoolBot spins up a voice
+channel shortly before it starts, collects RSVPs via **Going / Maybe /
+Can't** buttons with a live attendee count, posts a reminder beforehand,
+and deletes the channel once the event ends and empties.
+
+Manage events from the **`/admin/events`** page or the **`/event`** slash
+command (see [COMMANDS.md](COMMANDS.md#event)).
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `events.enabled` | `false` | Master switch — enables the feature, the `/event` command, and the `/admin/events` page |
+| `events.category_id` | `""` | Category the temporary event voice channels are created under (**required** for channels to spin up) |
+| `events.announcement_channel_id` | `""` | Text channel where the RSVP message and the pre-start reminder are posted |
+| `events.timezone` | `""` | IANA zone used to interpret an event's wall-clock start time (e.g. `Europe/London`). Empty falls back to the host/server timezone |
+| `events.channel_prefix` | `"📅"` | Prefix prepended to the event title when naming the voice channel |
+| `events.reminder_minutes` | `30` | How long before start the reminder is posted. Set to `0` to disable reminders |
+| `events.create_lead_minutes` | `15` | How long before start the temporary voice channel is created |
+| `events.default_duration_minutes` | `120` | Duration applied to an event when the organiser doesn't specify one |
+| `events.channel_grace_minutes` | `15` | How long after an event ends the bot waits before deleting its (now empty) channel |
+
+**Notes:**
+
+- The lifecycle is driven by a once-a-minute scan that decides each
+  transition from the stored event (`state`, `reminderSent`, `channelId`),
+  so it is **restart-safe** — no work is lost if the bot restarts mid-event.
+- Event start times are stored as absolute UTC instants; `events.timezone`
+  (or a per-event `timezone` option) only affects how the entered
+  wall-clock time is interpreted and displayed.
+- The temporary channel is a plain managed voice channel; if voice
+  tracking is enabled, time spent in it is tracked like any other channel.
+- Only administrators can create, cancel, or start events; `/event list`
+  is open to everyone. A configurable creator role is a possible future
+  enhancement. Recurring events are not yet supported.
 
 ---
 

--- a/__tests__/services/config-schema.test.ts
+++ b/__tests__/services/config-schema.test.ts
@@ -418,6 +418,7 @@ describe("Config Schema", () => {
       "digest.enabled": false,
       "rewind.enabled": false,
       "birthdays.enabled": false,
+      "events.enabled": false,
       "reactionroles.enabled": false,
       "notices.enabled": false,
       "polls.enabled": false,

--- a/__tests__/services/event-service.test.ts
+++ b/__tests__/services/event-service.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, jest } from "@jest/globals";
+
+// The event-service module registers a config reload callback and touches a
+// Mongoose model at import time. Mock the heavy dependencies so the pure
+// helpers can be imported and exercised in isolation (mirrors the birthday
+// service test).
+jest.unstable_mockModule("../../src/services/config-service.js", () => ({
+  ConfigService: {
+    getInstance: jest.fn(() => ({
+      registerReloadCallback: jest.fn(),
+      getBoolean: jest.fn(),
+      getString: jest.fn(),
+      getNumber: jest.fn(),
+    })),
+  },
+}));
+
+jest.unstable_mockModule("../../src/services/discord-logger.js", () => ({
+  DiscordLogger: { getInstance: jest.fn() },
+}));
+
+jest.unstable_mockModule("../../src/models/event.js", () => ({
+  Event: jest.fn(),
+}));
+
+jest.unstable_mockModule("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const {
+  computeEndTime,
+  parseEventDateTime,
+  countRsvps,
+  upsertRsvp,
+  shouldCreateChannel,
+  shouldSendReminder,
+  shouldEndEvent,
+  shouldCleanupChannel,
+  formatEventWhen,
+} = await import("../../src/services/event-service.js");
+
+const MIN = 60 * 1000;
+
+function view(overrides: Record<string, unknown> = {}): {
+  state: "scheduled" | "active" | "ended" | "cancelled";
+  startTime: Date;
+  durationMinutes: number;
+  channelId: string | null;
+  reminderSent: boolean;
+} {
+  return {
+    state: "scheduled",
+    startTime: new Date("2026-07-04T20:00:00Z"),
+    durationMinutes: 120,
+    channelId: null,
+    reminderSent: false,
+    ...overrides,
+  } as never;
+}
+
+describe("computeEndTime", () => {
+  it("adds the duration in minutes", () => {
+    const start = new Date("2026-07-04T20:00:00Z");
+    expect(computeEndTime(start, 120).toISOString()).toBe(
+      "2026-07-04T22:00:00.000Z",
+    );
+  });
+  it("treats a negative duration as zero", () => {
+    const start = new Date("2026-07-04T20:00:00Z");
+    expect(computeEndTime(start, -30).getTime()).toBe(start.getTime());
+  });
+});
+
+describe("parseEventDateTime", () => {
+  it("interprets wall-clock time in UTC", () => {
+    const d = parseEventDateTime("2026-07-04", "20:00", "UTC");
+    expect(d?.toISOString()).toBe("2026-07-04T20:00:00.000Z");
+  });
+  it("applies a zone offset (America/New_York, EDT = UTC-4)", () => {
+    const d = parseEventDateTime("2026-07-04", "20:00", "America/New_York");
+    expect(d?.toISOString()).toBe("2026-07-05T00:00:00.000Z");
+  });
+  it("rejects a malformed date", () => {
+    expect(parseEventDateTime("2026-7-4", "20:00", "UTC")).toBeNull();
+  });
+  it("rejects a malformed time", () => {
+    expect(parseEventDateTime("2026-07-04", "8pm", "UTC")).toBeNull();
+  });
+  it("rejects an impossible calendar date", () => {
+    expect(parseEventDateTime("2026-02-30", "12:00", "UTC")).toBeNull();
+  });
+  it("rejects an out-of-range hour that rolls over", () => {
+    expect(parseEventDateTime("2026-07-04", "25:00", "UTC")).toBeNull();
+  });
+});
+
+describe("countRsvps", () => {
+  it("tallies each response type", () => {
+    const counts = countRsvps([
+      { status: "going" },
+      { status: "going" },
+      { status: "maybe" },
+      { status: "cant" },
+    ]);
+    expect(counts).toEqual({ going: 2, maybe: 1, cant: 1 });
+  });
+  it("returns zeros for an empty list", () => {
+    expect(countRsvps([])).toEqual({ going: 0, maybe: 0, cant: 0 });
+  });
+});
+
+describe("upsertRsvp", () => {
+  const now = new Date("2026-07-01T00:00:00Z");
+  it("adds a new RSVP without mutating the input", () => {
+    const original = [
+      { userId: "a", status: "going" as const, respondedAt: now },
+    ];
+    const next = upsertRsvp(original, "b", "maybe", now);
+    expect(next).toHaveLength(2);
+    expect(original).toHaveLength(1);
+  });
+  it("replaces an existing member's response", () => {
+    const original = [
+      { userId: "a", status: "going" as const, respondedAt: now },
+    ];
+    const next = upsertRsvp(original, "a", "cant", now);
+    expect(next).toHaveLength(1);
+    expect(next[0]).toMatchObject({ userId: "a", status: "cant" });
+  });
+});
+
+describe("shouldCreateChannel", () => {
+  const lead = 15 * MIN;
+  it("fires once within the lead window before start", () => {
+    const now = new Date("2026-07-04T19:50:00Z"); // 10 min before start
+    expect(shouldCreateChannel(view(), now, lead)).toBe(true);
+  });
+  it("does not fire before the lead window opens", () => {
+    const now = new Date("2026-07-04T19:00:00Z"); // 60 min before
+    expect(shouldCreateChannel(view(), now, lead)).toBe(false);
+  });
+  it("does not fire once a channel already exists", () => {
+    const now = new Date("2026-07-04T19:50:00Z");
+    expect(shouldCreateChannel(view({ channelId: "c1" }), now, lead)).toBe(
+      false,
+    );
+  });
+  it("does not fire after the event has ended", () => {
+    const now = new Date("2026-07-04T23:00:00Z"); // past end (22:00)
+    expect(shouldCreateChannel(view(), now, lead)).toBe(false);
+  });
+  it("does not fire for a cancelled event", () => {
+    const now = new Date("2026-07-04T19:50:00Z");
+    expect(shouldCreateChannel(view({ state: "cancelled" }), now, lead)).toBe(
+      false,
+    );
+  });
+});
+
+describe("shouldSendReminder", () => {
+  const reminder = 30 * MIN;
+  it("fires inside the reminder window before start", () => {
+    const now = new Date("2026-07-04T19:40:00Z"); // 20 min before
+    expect(shouldSendReminder(view(), now, reminder)).toBe(true);
+  });
+  it("does not fire once already sent", () => {
+    const now = new Date("2026-07-04T19:40:00Z");
+    expect(
+      shouldSendReminder(view({ reminderSent: true }), now, reminder),
+    ).toBe(false);
+  });
+  it("does not fire after start", () => {
+    const now = new Date("2026-07-04T20:05:00Z");
+    expect(shouldSendReminder(view(), now, reminder)).toBe(false);
+  });
+  it("is disabled when the window is zero", () => {
+    const now = new Date("2026-07-04T19:40:00Z");
+    expect(shouldSendReminder(view(), now, 0)).toBe(false);
+  });
+});
+
+describe("shouldEndEvent", () => {
+  it("fires at or after the end time", () => {
+    const now = new Date("2026-07-04T22:00:00Z");
+    expect(shouldEndEvent(view(), now)).toBe(true);
+  });
+  it("does not fire before the end time", () => {
+    const now = new Date("2026-07-04T21:59:00Z");
+    expect(shouldEndEvent(view(), now)).toBe(false);
+  });
+  it("does not re-fire for an ended event", () => {
+    const now = new Date("2026-07-04T23:00:00Z");
+    expect(shouldEndEvent(view({ state: "ended" }), now)).toBe(false);
+  });
+});
+
+describe("shouldCleanupChannel", () => {
+  const grace = 15 * MIN;
+  const ended = view({ state: "ended", channelId: "c1" });
+  it("fires once ended, empty and past the grace period", () => {
+    const now = new Date("2026-07-04T22:20:00Z"); // 20 min after end
+    expect(shouldCleanupChannel(ended, now, grace, true)).toBe(true);
+  });
+  it("waits while the channel still has members", () => {
+    const now = new Date("2026-07-04T22:20:00Z");
+    expect(shouldCleanupChannel(ended, now, grace, false)).toBe(false);
+  });
+  it("waits until the grace period elapses", () => {
+    const now = new Date("2026-07-04T22:05:00Z"); // only 5 min after end
+    expect(shouldCleanupChannel(ended, now, grace, true)).toBe(false);
+  });
+  it("does nothing without a channel", () => {
+    const now = new Date("2026-07-04T22:20:00Z");
+    expect(
+      shouldCleanupChannel(view({ state: "ended" }), now, grace, true),
+    ).toBe(false);
+  });
+});
+
+describe("formatEventWhen", () => {
+  it("renders the local wall-clock time and zone", () => {
+    const event = {
+      startTime: new Date("2026-07-05T00:00:00Z"),
+      timezone: "America/New_York",
+    };
+    expect(formatEventWhen(event)).toBe("2026-07-04 20:00 (America/New_York)");
+  });
+});

--- a/__tests__/services/settings-metadata.test.ts
+++ b/__tests__/services/settings-metadata.test.ts
@@ -44,6 +44,7 @@ describe("settingsMetadata", () => {
       "quotes",
       "core",
       "digest",
+      "events",
       "rewind",
       "ratelimit",
       "announcements",

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -9,6 +9,7 @@ import {
   renderDashboardPage,
   renderDatabasePage,
   renderDigestPage,
+  renderEventsPage,
   renderImportDiffPage,
   renderNoticesPage,
   renderPermissionsPage,
@@ -1150,6 +1151,95 @@ describe("renderAnnouncementsPage", () => {
   });
 });
 
+describe("renderEventsPage", () => {
+  const EVENTS_COMMON = {
+    ...COMMON,
+    categoryConfigured: true,
+    announcementConfigured: true,
+    timezone: "UTC",
+  };
+
+  it("shows the empty state and disabled notice", () => {
+    const html = renderEventsPage({
+      ...EVENTS_COMMON,
+      enabled: false,
+      rows: [],
+    });
+    expect(html).toContain("No events scheduled yet.");
+    expect(html).toContain("Events are disabled");
+  });
+
+  it("renders a scheduled event row with RSVP counts and actions", () => {
+    const html = renderEventsPage({
+      ...EVENTS_COMMON,
+      enabled: true,
+      rows: [
+        {
+          id: "e1",
+          title: "Game <Night>",
+          when: "2026-07-04 20:00 (UTC)",
+          state: "scheduled",
+          going: 3,
+          maybe: 1,
+          cant: 0,
+          channelId: null,
+        },
+      ],
+    });
+    // Title is HTML-escaped.
+    expect(html).toContain("Game &lt;Night&gt;");
+    expect(html).toContain("✅ 3");
+    expect(html).toContain("/admin/events/e1/start-now");
+    expect(html).toContain("/admin/events/e1/cancel");
+  });
+
+  it("hides actions for a finished (cancelled) event", () => {
+    const html = renderEventsPage({
+      ...EVENTS_COMMON,
+      enabled: true,
+      rows: [
+        {
+          id: "e2",
+          title: "Old Event",
+          when: "2026-01-01 12:00 (UTC)",
+          state: "cancelled",
+          going: 0,
+          maybe: 0,
+          cant: 0,
+          channelId: null,
+        },
+      ],
+    });
+    expect(html).not.toContain("/admin/events/e2/start-now");
+    expect(html).toContain("cancelled");
+  });
+
+  it("warns when the category or announcement channel is unset", () => {
+    const html = renderEventsPage({
+      ...COMMON,
+      enabled: true,
+      categoryConfigured: false,
+      announcementConfigured: false,
+      timezone: "UTC",
+      rows: [],
+    });
+    expect(html).toContain("events.category_id");
+    expect(html).toContain("events.announcement_channel_id");
+  });
+
+  it("renders the create form", () => {
+    const html = renderEventsPage({
+      ...EVENTS_COMMON,
+      enabled: true,
+      rows: [],
+    });
+    expect(html).toContain("/admin/events/create");
+    expect(html).toContain('name="title"');
+    expect(html).toContain('name="date"');
+    expect(html).toContain('name="time"');
+  });
+});
+
 describe("renderPollsPage", () => {
   it("shows empty state for both schedules and items", () => {
     const html = renderPollsPage({
@@ -1669,7 +1759,11 @@ describe("renderDigestPage", () => {
             title: "📊 Your weekly voice digest",
             description: "Here's a snapshot, alice.",
             fields: [
-              { name: "This week", value: "5h\n▲ 1h vs last week", inline: true },
+              {
+                name: "This week",
+                value: "5h\n▲ 1h vs last week",
+                inline: true,
+              },
               { name: "Rank", value: "#1", inline: true },
             ],
             footer: "Keep it up!\nDon't want these? Run /config.",

--- a/src/commands/event.ts
+++ b/src/commands/event.ts
@@ -18,9 +18,9 @@ import logger from "../utils/logger.js";
 export const data = new SlashCommandBuilder()
   .setName("event")
   .setDescription("Schedule and manage server events")
-  // Admin-gated by default; /event list is still reachable via the shared
-  // command but the mutating subcommands re-check below.
-  .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
+  // No command-wide permission default: `/event list` is open to everyone,
+  // while create/cancel/start enforce an Administrator check at runtime
+  // (setDefaultMemberPermissions would hide the whole command, list included).
   .addSubcommand((sub) =>
     sub
       .setName("create")

--- a/src/commands/event.ts
+++ b/src/commands/event.ts
@@ -1,0 +1,276 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  PermissionFlagsBits,
+  GuildMember,
+} from "discord.js";
+import { ConfigService } from "../services/config-service.js";
+import {
+  EventService,
+  parseEventDateTime,
+  formatEventWhen,
+  countRsvps,
+} from "../services/event-service.js";
+import { isValidTimezone, resolveTimezone } from "../utils/timezone.js";
+import logger from "../utils/logger.js";
+
+export const data = new SlashCommandBuilder()
+  .setName("event")
+  .setDescription("Schedule and manage server events")
+  // Admin-gated by default; /event list is still reachable via the shared
+  // command but the mutating subcommands re-check below.
+  .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
+  .addSubcommand((sub) =>
+    sub
+      .setName("create")
+      .setDescription("Schedule a new event with a temporary voice channel")
+      .addStringOption((o) =>
+        o
+          .setName("title")
+          .setDescription("Event title")
+          .setRequired(true)
+          .setMaxLength(100),
+      )
+      .addStringOption((o) =>
+        o
+          .setName("date")
+          .setDescription("Start date (YYYY-MM-DD)")
+          .setRequired(true),
+      )
+      .addStringOption((o) =>
+        o
+          .setName("time")
+          .setDescription("Start time (24h HH:MM)")
+          .setRequired(true),
+      )
+      .addStringOption((o) =>
+        o
+          .setName("description")
+          .setDescription("What's the event about?")
+          .setMaxLength(1000),
+      )
+      .addIntegerOption((o) =>
+        o
+          .setName("duration")
+          .setDescription("Duration in minutes")
+          .setMinValue(1)
+          .setMaxValue(1440),
+      )
+      .addStringOption((o) =>
+        o
+          .setName("timezone")
+          .setDescription("IANA timezone (e.g. Europe/London)"),
+      ),
+  )
+  .addSubcommand((sub) =>
+    sub.setName("list").setDescription("List upcoming and recent events"),
+  )
+  .addSubcommand((sub) =>
+    sub
+      .setName("cancel")
+      .setDescription("Cancel an event and remove its channel")
+      .addStringOption((o) =>
+        o
+          .setName("id")
+          .setDescription("Event ID (from /event list)")
+          .setRequired(true),
+      ),
+  )
+  .addSubcommand((sub) =>
+    sub
+      .setName("start")
+      .setDescription("Spin up an event's voice channel now")
+      .addStringOption((o) =>
+        o
+          .setName("id")
+          .setDescription("Event ID (from /event list)")
+          .setRequired(true),
+      ),
+  );
+
+function isAdmin(interaction: ChatInputCommandInteraction): boolean {
+  const member = interaction.member;
+  if (!member || !("permissions" in member)) return false;
+  const perms = (member as GuildMember).permissions;
+  return (
+    typeof perms === "object" && perms.has(PermissionFlagsBits.Administrator)
+  );
+}
+
+export async function execute(
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  const config = ConfigService.getInstance();
+  const enabled = await config.getBoolean("events.enabled", false);
+  if (!enabled) {
+    await interaction.reply({
+      content: "The events feature is currently disabled.",
+      ephemeral: true,
+    });
+    return;
+  }
+  if (!interaction.guildId) {
+    await interaction.reply({
+      content: "This command must be run inside a guild.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const sub = interaction.options.getSubcommand();
+  try {
+    if (sub === "list") {
+      await handleList(interaction);
+      return;
+    }
+
+    // create / cancel / start are admin-only.
+    if (!isAdmin(interaction)) {
+      await interaction.reply({
+        content: "❌ Only administrators can manage events.",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    if (sub === "create") await handleCreate(interaction, config);
+    else if (sub === "cancel") await handleCancel(interaction);
+    else if (sub === "start") await handleStart(interaction);
+  } catch (error) {
+    logger.error(`Error in /event ${sub}:`, error);
+    const msg = "❌ There was an error running this command.";
+    if (interaction.replied || interaction.deferred) {
+      await interaction.followUp({ content: msg, ephemeral: true });
+    } else {
+      await interaction.reply({ content: msg, ephemeral: true });
+    }
+  }
+}
+
+async function handleCreate(
+  interaction: ChatInputCommandInteraction,
+  config: ConfigService,
+): Promise<void> {
+  await interaction.deferReply({ ephemeral: true });
+
+  const title = interaction.options.getString("title", true).trim();
+  const date = interaction.options.getString("date", true).trim();
+  const time = interaction.options.getString("time", true).trim();
+  const description =
+    interaction.options.getString("description")?.trim() ?? "";
+  const durationOpt = interaction.options.getInteger("duration");
+  const tzOpt = interaction.options.getString("timezone")?.trim();
+
+  const configuredTz = await config.getString("events.timezone", "");
+  const timezone = tzOpt || configuredTz;
+  if (tzOpt && !isValidTimezone(tzOpt)) {
+    await interaction.editReply(
+      `❌ "${tzOpt}" is not a recognised IANA timezone.`,
+    );
+    return;
+  }
+
+  const startTime = parseEventDateTime(date, time, timezone);
+  if (!startTime) {
+    await interaction.editReply(
+      "❌ Invalid date/time. Use date `YYYY-MM-DD` and time `HH:MM` (24-hour).",
+    );
+    return;
+  }
+  if (startTime.getTime() <= Date.now()) {
+    await interaction.editReply(
+      "❌ The event start time must be in the future.",
+    );
+    return;
+  }
+
+  const defaultDuration = await config.getNumber(
+    "events.default_duration_minutes",
+    120,
+  );
+  const durationMinutes = durationOpt ?? defaultDuration;
+
+  const service = EventService.getInstance(interaction.client);
+  const event = await service.createEvent({
+    guildId: interaction.guildId as string,
+    title,
+    description,
+    startTime,
+    timezone: resolveTimezone(timezone),
+    durationMinutes,
+    createdBy: interaction.user.id,
+  });
+
+  await interaction.editReply(
+    `✅ Created event **${title}** for ${formatEventWhen(event)}.\n` +
+      `ID: \`${event._id}\` · duration: ${durationMinutes} min`,
+  );
+}
+
+async function handleList(
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  await interaction.deferReply({ ephemeral: true });
+  const service = EventService.getInstance(interaction.client);
+  const events = await service.listEvents(interaction.guildId as string);
+
+  const upcoming = events.filter(
+    (e) => e.state === "scheduled" || e.state === "active",
+  );
+  if (upcoming.length === 0) {
+    await interaction.editReply(
+      "No upcoming events. Create one with `/event create`.",
+    );
+    return;
+  }
+
+  const embed = new EmbedBuilder()
+    .setTitle("📅 Upcoming events")
+    .setColor(0x5865f2);
+
+  for (const e of upcoming.slice(0, 15)) {
+    const counts = countRsvps(e.rsvps);
+    embed.addFields({
+      name: e.title,
+      value:
+        `${formatEventWhen(e)} · ${e.state}\n` +
+        `✅ ${counts.going} · 🤔 ${counts.maybe} · 🚫 ${counts.cant}\n` +
+        `ID: \`${e._id}\``,
+      inline: false,
+    });
+  }
+
+  await interaction.editReply({ embeds: [embed] });
+}
+
+async function handleCancel(
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  await interaction.deferReply({ ephemeral: true });
+  const id = interaction.options.getString("id", true).trim();
+  const service = EventService.getInstance(interaction.client);
+  const event = await service.cancelEvent(id, interaction.guildId as string);
+  if (!event) {
+    await interaction.editReply(`❌ Event \`${id}\` not found.`);
+    return;
+  }
+  await interaction.editReply(`✅ Cancelled **${event.title}**.`);
+}
+
+async function handleStart(
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  await interaction.deferReply({ ephemeral: true });
+  const id = interaction.options.getString("id", true).trim();
+  const service = EventService.getInstance(interaction.client);
+  const event = await service.startEventNow(id, interaction.guildId as string);
+  if (!event) {
+    await interaction.editReply(
+      `❌ Could not start event \`${id}\` (not found, or already ended/cancelled).`,
+    );
+    return;
+  }
+  const where = event.channelId ? ` Channel: <#${event.channelId}>` : "";
+  await interaction.editReply(`✅ Started **${event.title}**.${where}`);
+}

--- a/src/commands/event.ts
+++ b/src/commands/event.ts
@@ -91,11 +91,24 @@ export const data = new SlashCommandBuilder()
 
 function isAdmin(interaction: ChatInputCommandInteraction): boolean {
   const member = interaction.member;
-  if (!member || !("permissions" in member)) return false;
-  const perms = (member as GuildMember).permissions;
-  return (
-    typeof perms === "object" && perms.has(PermissionFlagsBits.Administrator)
-  );
+  if (!member) return false;
+  // Cached members are `GuildMember`; non-cached interactions surface an
+  // `APIInteractionGuildMember` whose `permissions` field is a string
+  // bitfield. Mirror the gating used by /config and /quote so real admins
+  // aren't blocked on the uncached path.
+  if (member instanceof GuildMember) {
+    return member.permissions.has(PermissionFlagsBits.Administrator);
+  }
+  const raw = (member as { permissions?: unknown }).permissions;
+  if (typeof raw !== "string") return false;
+  try {
+    return (
+      (BigInt(raw) & PermissionFlagsBits.Administrator) ===
+      PermissionFlagsBits.Administrator
+    );
+  } catch {
+    return false;
+  }
 }
 
 export async function execute(

--- a/src/handlers/event-rsvp-handler.ts
+++ b/src/handlers/event-rsvp-handler.ts
@@ -1,0 +1,79 @@
+import { ButtonInteraction } from "discord.js";
+import { EventService } from "../services/event-service.js";
+import type { RsvpStatus } from "../models/event.js";
+import logger from "../utils/logger.js";
+
+const RSVP_LABELS: Record<RsvpStatus, string> = {
+  going: "✅ Going",
+  maybe: "🤔 Maybe",
+  cant: "🚫 Can't make it",
+};
+
+function isRsvpStatus(value: string): value is RsvpStatus {
+  return value === "going" || value === "maybe" || value === "cant";
+}
+
+/**
+ * Handle a Going / Maybe / Can't RSVP button on an event announcement.
+ *
+ * customId format: `event_rsvp_{eventId}_{status}` — the eventId is a Mongo
+ * ObjectId (24 hex chars, no underscores) so a plain split is safe.
+ */
+export async function handleEventRsvpButton(
+  interaction: ButtonInteraction,
+): Promise<void> {
+  const parts = interaction.customId.split("_");
+  if (parts.length !== 4 || parts[0] !== "event" || parts[1] !== "rsvp") {
+    await interaction.reply({
+      content: "❌ Invalid RSVP button.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const [, , eventId, status] = parts;
+  if (!isRsvpStatus(status)) {
+    await interaction.reply({
+      content: "❌ Unknown RSVP option.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  try {
+    const service = EventService.getInstance(interaction.client);
+    const event = await service.setRsvp(eventId, interaction.user.id, status);
+    if (!event) {
+      await interaction.reply({
+        content:
+          "❌ This event is no longer accepting RSVPs (it may have ended or been cancelled).",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    // Refresh the announcement message in place with the new live counts.
+    await interaction.update(service.buildAnnouncementPayload(event));
+    await interaction.followUp({
+      content: `Your RSVP: **${RSVP_LABELS[status]}**`,
+      ephemeral: true,
+    });
+  } catch (error) {
+    logger.error("Error handling event RSVP button:", error);
+    if (interaction.replied || interaction.deferred) {
+      await interaction
+        .followUp({
+          content: "❌ There was an error recording your RSVP.",
+          ephemeral: true,
+        })
+        .catch(() => undefined);
+    } else {
+      await interaction
+        .reply({
+          content: "❌ There was an error recording your RSVP.",
+          ephemeral: true,
+        })
+        .catch(() => undefined);
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ import { LeaderboardRoleService } from "./services/leaderboard-role-service.js";
 import { DigestService } from "./services/digest-service.js";
 import { RewindNudgeService } from "./services/rewind-nudge-service.js";
 import { BirthdayService } from "./services/birthday-service.js";
+import { EventService } from "./services/event-service.js";
 import { WizardService } from "./services/wizard-service.js";
 import { MonitoringService } from "./services/monitoring-service.js";
 import {
@@ -496,6 +497,7 @@ async function gracefulShutdown(signal: string): Promise<void> {
         digestService.destroy();
         rewindNudgeService.destroy();
         birthdayService.destroy();
+        eventService.destroy();
         WizardService.getInstance().shutdown();
         // Persist any metrics still buffered in memory before the DB
         // connection closes below, then stop the flush/logging timers.
@@ -562,6 +564,7 @@ let leaderboardRoleService: LeaderboardRoleService;
 let digestService: DigestService;
 let rewindNudgeService: RewindNudgeService;
 let birthdayService: BirthdayService;
+let eventService: EventService;
 
 // Wrap service instantiation in try-catch to ensure errors are caught
 try {
@@ -589,6 +592,7 @@ try {
   digestService = DigestService.getInstance(client);
   rewindNudgeService = RewindNudgeService.getInstance(client);
   birthdayService = BirthdayService.getInstance(client);
+  eventService = EventService.getInstance(client);
 } catch (error) {
   logger.error("❌ Fatal error during service instantiation:", error);
   process.exit(1);
@@ -700,6 +704,7 @@ async function initializeServices(): Promise<void> {
     // date on /me/birthday; this schedules the recurring "is it anyone's
     // birthday today (in their timezone)?" check.
     await birthdayService.start();
+    await eventService.start();
 
     // Start the slash-command audit log cleanup cron (#459)
     CommandAuditCleanupService.getInstance().start();
@@ -786,6 +791,10 @@ client.on(Events.InteractionCreate, async (interaction) => {
         const { handleVCPresetButton } =
           await import("./handlers/vc-preset-handler.js");
         await handleVCPresetButton(interaction);
+      } else if (interaction.customId.startsWith("event_rsvp_")) {
+        const { handleEventRsvpButton } =
+          await import("./handlers/event-rsvp-handler.js");
+        await handleEventRsvpButton(interaction);
       } else {
         logger.debug(
           `Ignoring button interaction with unrecognized customId: ${interaction.customId}`,

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -15,6 +15,7 @@ export const CONFIG_CATEGORIES = [
   "birthdays",
   "core",
   "digest",
+  "events",
   "fun", // Kept for backward compatibility; key removed but legacy rows may exist
   "gamification", // Kept for backward compatibility during migration
   "help",

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -1,0 +1,105 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+/**
+ * A scheduled server event (#708).
+ *
+ * An event is a planned gathering with a start time and a *temporary*
+ * voice channel that the bot spins up shortly before the event begins and
+ * tears down once it ends and empties. Unlike the lobby-driven dynamic
+ * channels owned by `VoiceChannelManager`, an event channel's lifecycle is
+ * bound to the event's schedule rather than to someone joining a lobby.
+ *
+ * The whole lifecycle is driven by a single periodic scan in
+ * `EventService` (mirroring the birthday service's "scan and decide"
+ * cron), so progress is idempotent and survives a restart: the row's
+ * `state`, `reminderSent` and `channelId` fields are the source of truth,
+ * not any in-memory timer.
+ *
+ * Times are stored as absolute UTC instants (`startTime`); `timezone`
+ * records the IANA zone the organiser entered the wall-clock time in, for
+ * display only.
+ */
+
+/** Lifecycle states. `scheduled → active → ended`, or `cancelled` at any
+ * point before it ends. Terminal states are `ended` and `cancelled`. */
+export type EventState = "scheduled" | "active" | "ended" | "cancelled";
+
+/** RSVP responses surfaced by the Going / Maybe / Can't buttons. */
+export type RsvpStatus = "going" | "maybe" | "cant";
+
+export interface IEventRsvp {
+  userId: string;
+  status: RsvpStatus;
+  respondedAt: Date;
+}
+
+export interface IEvent extends Document {
+  guildId: string;
+  title: string;
+  description: string;
+  /** Absolute start instant (UTC). */
+  startTime: Date;
+  /** IANA zone the organiser entered the time in (display only). */
+  timezone: string;
+  durationMinutes: number;
+  /** Category the temp channel is created under; empty falls back to the
+   * `events.category_id` config value at creation time. */
+  categoryId: string;
+  /** Temp voice channel id, once created; null until then / after cleanup. */
+  channelId: string | null;
+  /** Channel the RSVP/announcement message was posted in. */
+  announcementChannelId: string | null;
+  /** Message id of the RSVP/announcement post, for live edits + reminders. */
+  announcementMessageId: string | null;
+  state: EventState;
+  reminderSent: boolean;
+  rsvps: IEventRsvp[];
+  createdBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const EventRsvpSchema = new Schema<IEventRsvp>(
+  {
+    userId: { type: String, required: true },
+    status: {
+      type: String,
+      required: true,
+      enum: ["going", "maybe", "cant"],
+    },
+    respondedAt: { type: Date, required: true },
+  },
+  { _id: false },
+);
+
+const EventSchema = new Schema<IEvent>(
+  {
+    guildId: { type: String, required: true, index: true },
+    // Discord channel-name cap is 100; the title also renders as an embed
+    // heading, so keep it comfortably short.
+    title: { type: String, required: true, maxlength: 100 },
+    description: { type: String, default: "", maxlength: 1000 },
+    startTime: { type: Date, required: true, index: true },
+    timezone: { type: String, default: "" },
+    durationMinutes: { type: Number, default: 120 },
+    categoryId: { type: String, default: "" },
+    channelId: { type: String, default: null },
+    announcementChannelId: { type: String, default: null },
+    announcementMessageId: { type: String, default: null },
+    state: {
+      type: String,
+      required: true,
+      enum: ["scheduled", "active", "ended", "cancelled"],
+      default: "scheduled",
+      index: true,
+    },
+    reminderSent: { type: Boolean, default: false },
+    rsvps: { type: [EventRsvpSchema], default: [] },
+    createdBy: { type: String, required: true },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+export const Event = mongoose.model<IEvent>("Event", EventSchema);

--- a/src/services/command-manager.ts
+++ b/src/services/command-manager.ts
@@ -90,6 +90,7 @@ export class CommandManager {
           file: "achievements",
         },
         { name: "quote", configKey: "quotes.enabled", file: "quote" },
+        { name: "event", configKey: "events.enabled", file: "event" },
         { name: "config", configKey: null, file: "config" }, // Always enabled - WebUI launcher
       ];
 
@@ -312,6 +313,7 @@ export class CommandManager {
           file: "achievements",
         },
         { name: "quote", configKey: "quotes.enabled", file: "quote" },
+        { name: "event", configKey: "events.enabled", file: "event" },
         { name: "config", configKey: null, file: "config" }, // Always enabled - WebUI launcher
       ];
 

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -94,6 +94,17 @@ export interface ConfigSchema {
   "birthdays.role_id": string; // Optional temporary "birthday" role
   "birthdays.role_duration_hours": number; // How long the temp role is held
 
+  // Events — scheduled/temporary voice channels (#708)
+  "events.enabled": boolean;
+  "events.category_id": string; // Category the temp event voice channels are created under
+  "events.announcement_channel_id": string; // Channel where RSVP + reminder messages post
+  "events.timezone": string; // IANA zone used to interpret event start times (empty → server tz)
+  "events.channel_prefix": string; // Prefix for auto-created event channel names
+  "events.reminder_minutes": number; // How long before start the reminder is posted
+  "events.create_lead_minutes": number; // How long before start the temp channel is created
+  "events.default_duration_minutes": number; // Default event length when none is given
+  "events.channel_grace_minutes": number; // How long after end an empty channel lingers before cleanup
+
   // Reaction Roles
   "reactionroles.enabled": boolean;
   "reactionroles.message_channel_id": string; // Channel for reaction role messages
@@ -278,6 +289,17 @@ export const defaultConfig: ConfigSchema = {
   "birthdays.mention": true,
   "birthdays.role_id": "", // Empty → no temporary role granted
   "birthdays.role_duration_hours": 24,
+
+  // Events (#708) — feature gate off by default (rule 1)
+  "events.enabled": false,
+  "events.category_id": "",
+  "events.announcement_channel_id": "",
+  "events.timezone": "", // Empty → host/server timezone
+  "events.channel_prefix": "📅",
+  "events.reminder_minutes": 30,
+  "events.create_lead_minutes": 15,
+  "events.default_duration_minutes": 120,
+  "events.channel_grace_minutes": 15,
 
   // Reaction Roles defaults
   "reactionroles.enabled": false,
@@ -665,6 +687,11 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
     title: "Birthdays",
     description:
       "Celebrate members' birthdays with a daily announcement in their own timezone, optionally granting a temporary birthday role. Members set their date on /me/birthday.",
+  },
+  events: {
+    title: "Events",
+    description:
+      "Schedule server events that spin up a temporary voice channel shortly before they start, let members RSVP with buttons, post a reminder beforehand, and tear the channel down once it ends. For servers without static voice channels. Manage from /admin/events or the /event command.",
   },
   reactionroles: {
     title: "Reaction Roles",
@@ -1172,6 +1199,69 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
     description:
       "How long the temporary birthday role is held before the daily sweep removes it.",
     category: "birthdays",
+    type: "number",
+  },
+  "events.enabled": {
+    label: "Events enabled",
+    description:
+      "Enable scheduled events, the /event command, and the /admin/events page. Events create a temporary voice channel shortly before they start and remove it once they end.",
+    category: "events",
+    type: "boolean",
+  },
+  "events.category_id": {
+    label: "Event channel category",
+    description:
+      "Category under which temporary event voice channels are created. Required for channels to spin up.",
+    category: "events",
+    type: "category",
+  },
+  "events.announcement_channel_id": {
+    label: "Event announcement channel",
+    description:
+      "Text channel where the RSVP message and the pre-start reminder are posted.",
+    category: "events",
+    type: "channel",
+  },
+  "events.timezone": {
+    label: "Event timezone (IANA)",
+    description:
+      "IANA timezone (e.g. Europe/London) used to interpret the wall-clock start time entered for an event. Empty falls back to the host/server timezone.",
+    category: "events",
+    type: "string",
+  },
+  "events.channel_prefix": {
+    label: "Event channel name prefix",
+    description:
+      "Prefix prepended to the event title when naming the temporary voice channel.",
+    category: "events",
+    type: "string",
+  },
+  "events.reminder_minutes": {
+    label: "Reminder lead time (minutes)",
+    description:
+      "How many minutes before an event starts the reminder is posted in the announcement channel. Set to 0 to disable reminders.",
+    category: "events",
+    type: "number",
+  },
+  "events.create_lead_minutes": {
+    label: "Channel creation lead time (minutes)",
+    description:
+      "How many minutes before an event starts its temporary voice channel is created.",
+    category: "events",
+    type: "number",
+  },
+  "events.default_duration_minutes": {
+    label: "Default event duration (minutes)",
+    description:
+      "Duration applied to an event when the organiser doesn't specify one.",
+    category: "events",
+    type: "number",
+  },
+  "events.channel_grace_minutes": {
+    label: "Channel cleanup grace (minutes)",
+    description:
+      "How long after an event ends the bot waits before deleting its (now empty) voice channel.",
+    category: "events",
     type: "number",
   },
   "reactionroles.enabled": {

--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -40,6 +40,10 @@ import { sanitizeForLog } from "../utils/log-sanitize.js";
 
 const TICK_CRON = "* * * * *"; // every minute
 const MS_PER_MINUTE = 60 * 1000;
+// Cap the reminder's inline pings: ~22 chars per `<@id>` keeps the body well
+// under Discord's 2000-char message limit, and Discord only pings up to 100
+// users per message anyway. Extra RSVPs are summarised as "…and N more".
+const MAX_REMINDER_MENTIONS = 50;
 const DISCORD_UNKNOWN_MESSAGE = 10008;
 const DISCORD_UNKNOWN_CHANNEL = 10003;
 
@@ -687,8 +691,16 @@ export class EventService {
     const interested = event.rsvps
       .filter((r) => r.status === "going" || r.status === "maybe")
       .map((r) => r.userId);
+    // Cap the ping list so the message body can't blow Discord's 2000-char
+    // limit (each `<@id>` is ~22 chars) and so the mention text matches the
+    // ids we actually allow to ping. Any overflow is summarised, not listed.
+    const pinged = interested.slice(0, MAX_REMINDER_MENTIONS);
+    const overflow = interested.length - pinged.length;
     const mentions =
-      interested.length > 0 ? interested.map((id) => `<@${id}>`).join(" ") : "";
+      pinged.length > 0
+        ? pinged.map((id) => `<@${id}>`).join(" ") +
+          (overflow > 0 ? ` …and ${overflow} more` : "")
+        : "";
     const where = event.channelId ? ` Join here: <#${event.channelId}>.` : "";
 
     const content =
@@ -697,7 +709,7 @@ export class EventService {
 
     await channel.send({
       content,
-      allowedMentions: { users: interested.slice(0, 100) },
+      allowedMentions: { users: pinged },
     });
   }
 

--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -1,0 +1,815 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  CategoryChannel,
+  ChannelType,
+  Client,
+  DiscordAPIError,
+  EmbedBuilder,
+  Guild,
+  TextChannel,
+  VoiceChannel,
+} from "discord.js";
+import { CronJob, CronTime } from "cron";
+import { fromZonedTime, formatInTimeZone } from "date-fns-tz";
+import { ConfigService } from "./config-service.js";
+import { DiscordLogger } from "./discord-logger.js";
+import { Event, type IEvent, type RsvpStatus } from "../models/event.js";
+import { resolveTimezone } from "../utils/timezone.js";
+import logger from "../utils/logger.js";
+import { sanitizeForLog } from "../utils/log-sanitize.js";
+
+/**
+ * Events feature (#708): scheduled gatherings backed by a *temporary*
+ * voice channel.
+ *
+ * Unlike the lobby-driven dynamic channels in `VoiceChannelManager`, an
+ * event's channel lifecycle is bound to its schedule: the channel is
+ * created shortly before the start time and removed once the event ends
+ * and empties past a grace period. A member RSVPs via Going / Maybe /
+ * Can't buttons on an announcement message that shows a live attendee
+ * count.
+ *
+ * The lifecycle is driven by a single periodic scan (a one-minute
+ * `CronJob`, mirroring `BirthdayService`'s "scan and decide" approach)
+ * rather than per-event timers, so every transition is idempotent and
+ * survives a restart — the Mongo row (`state`, `reminderSent`,
+ * `channelId`) is the source of truth.
+ */
+
+const TICK_CRON = "* * * * *"; // every minute
+const MS_PER_MINUTE = 60 * 1000;
+const DISCORD_UNKNOWN_MESSAGE = 10008;
+const DISCORD_UNKNOWN_CHANNEL = 10003;
+
+// Embed accent colours for the announcement message by lifecycle state.
+const COLOR_SCHEDULED = 0x5865f2; // blurple
+const COLOR_ACTIVE = 0x57f287; // green
+const COLOR_ENDED = 0x99aab5; // grey
+const COLOR_CANCELLED = 0xed4245; // red
+
+export interface RsvpCounts {
+  going: number;
+  maybe: number;
+  cant: number;
+}
+
+export interface CreateEventInput {
+  guildId: string;
+  title: string;
+  description: string;
+  startTime: Date;
+  timezone: string;
+  durationMinutes: number;
+  categoryId?: string;
+  createdBy: string;
+}
+
+// ---------------------------------------------------------------
+// Pure helpers (exported for unit testing)
+// ---------------------------------------------------------------
+
+/** The absolute end instant of an event. */
+export function computeEndTime(startTime: Date, durationMinutes: number): Date {
+  return new Date(
+    startTime.getTime() + Math.max(0, durationMinutes) * MS_PER_MINUTE,
+  );
+}
+
+/**
+ * Parse an organiser-entered wall-clock date + time (in `tz`) into an
+ * absolute UTC instant. Returns null on any malformed or impossible input
+ * (e.g. `2026-02-30`), verified by round-tripping the instant back through
+ * the same zone — `fromZonedTime` otherwise silently rolls invalid dates
+ * over.
+ */
+export function parseEventDateTime(
+  dateStr: string,
+  timeStr: string,
+  tz: string,
+): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return null;
+  if (!/^\d{2}:\d{2}$/.test(timeStr)) return null;
+  const zone = resolveTimezone(tz);
+  try {
+    const utc = fromZonedTime(`${dateStr}T${timeStr}:00`, zone);
+    if (Number.isNaN(utc.getTime())) return null;
+    const roundTrip = formatInTimeZone(utc, zone, "yyyy-MM-dd'T'HH:mm");
+    if (roundTrip !== `${dateStr}T${timeStr}`) return null;
+    return utc;
+  } catch {
+    return null;
+  }
+}
+
+/** Tally RSVPs by response. */
+export function countRsvps(rsvps: Array<{ status: RsvpStatus }>): RsvpCounts {
+  const counts: RsvpCounts = { going: 0, maybe: 0, cant: 0 };
+  for (const r of rsvps) {
+    if (r.status === "going") counts.going += 1;
+    else if (r.status === "maybe") counts.maybe += 1;
+    else if (r.status === "cant") counts.cant += 1;
+  }
+  return counts;
+}
+
+/**
+ * Set a member's RSVP, replacing any previous response. Pure — returns a
+ * new array and never mutates the input.
+ */
+export function upsertRsvp<
+  T extends { userId: string; status: RsvpStatus; respondedAt: Date },
+>(
+  rsvps: T[],
+  userId: string,
+  status: RsvpStatus,
+  now: Date,
+): Array<{ userId: string; status: RsvpStatus; respondedAt: Date }> {
+  const others = rsvps.filter((r) => r.userId !== userId);
+  return [...others, { userId, status, respondedAt: now }];
+}
+
+interface LifecycleView {
+  state: IEvent["state"];
+  startTime: Date;
+  durationMinutes: number;
+  channelId: string | null;
+  reminderSent: boolean;
+}
+
+/** Whether the temp channel should be created on this tick. */
+export function shouldCreateChannel(
+  event: LifecycleView,
+  now: Date,
+  leadMs: number,
+): boolean {
+  if (event.state === "cancelled" || event.state === "ended") return false;
+  if (event.channelId) return false;
+  const start = event.startTime.getTime();
+  const end = computeEndTime(event.startTime, event.durationMinutes).getTime();
+  const nowMs = now.getTime();
+  return nowMs >= start - leadMs && nowMs < end;
+}
+
+/** Whether the pre-start reminder should be posted on this tick. */
+export function shouldSendReminder(
+  event: LifecycleView,
+  now: Date,
+  reminderMs: number,
+): boolean {
+  if (reminderMs <= 0) return false;
+  if (event.reminderSent) return false;
+  if (event.state === "cancelled" || event.state === "ended") return false;
+  const start = event.startTime.getTime();
+  const nowMs = now.getTime();
+  return nowMs >= start - reminderMs && nowMs < start;
+}
+
+/** Whether the event has run past its end time and should be marked ended. */
+export function shouldEndEvent(event: LifecycleView, now: Date): boolean {
+  if (event.state === "cancelled" || event.state === "ended") return false;
+  return (
+    now.getTime() >=
+    computeEndTime(event.startTime, event.durationMinutes).getTime()
+  );
+}
+
+/** Whether an ended event's empty channel has aged past the grace period. */
+export function shouldCleanupChannel(
+  event: LifecycleView,
+  now: Date,
+  graceMs: number,
+  channelEmpty: boolean,
+): boolean {
+  if (!event.channelId) return false;
+  if (event.state !== "ended") return false;
+  if (!channelEmpty) return false;
+  const end = computeEndTime(event.startTime, event.durationMinutes).getTime();
+  return now.getTime() >= end + graceMs;
+}
+
+/** Human-readable start line, e.g. `2026-07-04 20:00 (Europe/London)`. */
+export function formatEventWhen(event: {
+  startTime: Date;
+  timezone: string;
+}): string {
+  const zone = resolveTimezone(event.timezone);
+  return `${formatInTimeZone(event.startTime, zone, "yyyy-MM-dd HH:mm")} (${zone})`;
+}
+
+function accentColor(state: IEvent["state"]): number {
+  switch (state) {
+    case "active":
+      return COLOR_ACTIVE;
+    case "ended":
+      return COLOR_ENDED;
+    case "cancelled":
+      return COLOR_CANCELLED;
+    default:
+      return COLOR_SCHEDULED;
+  }
+}
+
+export class EventService {
+  private static instance: EventService;
+  private client: Client;
+  private configService: ConfigService;
+  private job: CronJob | null = null;
+  private isInitialized = false;
+  private isRunning = false;
+  private inFlight: Promise<void> | null = null;
+
+  private constructor(client: Client) {
+    this.client = client;
+    this.configService = ConfigService.getInstance();
+
+    this.configService.registerReloadCallback(async () => {
+      try {
+        logger.info("Events configuration changed, reloading...");
+        const enabled = await this.configService.getBoolean(
+          "events.enabled",
+          false,
+        );
+        if (!enabled && this.isInitialized) {
+          logger.info("Events disabled, stopping scan job...");
+          this.destroy();
+        } else if (enabled) {
+          await this.reload();
+        }
+      } catch (error) {
+        logger.error(
+          "Error reloading event service after configuration change:",
+          error,
+        );
+      }
+    });
+  }
+
+  public static getInstance(client: Client): EventService {
+    if (!EventService.instance) {
+      EventService.instance = new EventService(client);
+    } else if (EventService.instance.client !== client) {
+      throw new Error(
+        "EventService already initialised with a different client",
+      );
+    }
+    return EventService.instance;
+  }
+
+  public static reset(): void {
+    if (EventService.instance) {
+      EventService.instance.destroy();
+    }
+    EventService.instance = undefined as unknown as EventService;
+  }
+
+  // ---------------------------------------------------------------
+  // Cron lifecycle
+  // ---------------------------------------------------------------
+
+  public async start(): Promise<void> {
+    if (this.isInitialized) {
+      logger.warn("Event service is already initialized, skipping...");
+      return;
+    }
+    try {
+      const enabled = await this.configService.getBoolean(
+        "events.enabled",
+        false,
+      );
+      if (!enabled) {
+        logger.info("Events are disabled");
+        this.isInitialized = true;
+        return;
+      }
+
+      if (!this.validateCronExpression(TICK_CRON)) {
+        logger.error("Event service not started: invalid tick cron");
+        this.isInitialized = true;
+        return;
+      }
+
+      this.job = new CronJob(TICK_CRON, async () => {
+        try {
+          await this.runNow();
+        } catch (error) {
+          logger.error("Error running event scan:", error);
+        }
+      });
+      this.job.start();
+      logger.info(`Event service started (scan cron: "${TICK_CRON}")`);
+      this.isInitialized = true;
+    } catch (error) {
+      logger.error("Error starting event service:", error);
+      throw error;
+    }
+  }
+
+  public async reload(): Promise<void> {
+    logger.info("Reloading event service...");
+    if (this.job) {
+      this.job.stop();
+      this.job = null;
+    }
+    this.isInitialized = false;
+    await this.start();
+  }
+
+  public destroy(): void {
+    if (this.job) {
+      this.job.stop();
+      this.job = null;
+    }
+    this.isInitialized = false;
+    logger.info("Event service destroyed");
+  }
+
+  private validateCronExpression(expression: string): boolean {
+    try {
+      new CronTime(expression);
+      return true;
+    } catch (error) {
+      logger.error(`Invalid cron expression for events: ${expression}`, error);
+      return false;
+    }
+  }
+
+  // ---------------------------------------------------------------
+  // Scan
+  // ---------------------------------------------------------------
+
+  /** Run the lifecycle scan immediately. Concurrent calls coalesce. */
+  public async runNow(): Promise<void> {
+    if (this.inFlight) return this.inFlight;
+    this.inFlight = this.runOnce();
+    try {
+      await this.inFlight;
+    } finally {
+      this.inFlight = null;
+    }
+  }
+
+  private async runOnce(): Promise<void> {
+    if (this.isRunning) {
+      logger.warn("Event scan already in progress, skipping");
+      return;
+    }
+    this.isRunning = true;
+    try {
+      const enabled = await this.configService.getBoolean(
+        "events.enabled",
+        false,
+      );
+      if (!enabled) return;
+
+      const guildId = await this.configService.getString("GUILD_ID", "");
+      if (!guildId) {
+        logger.error("Event scan aborted: GUILD_ID not configured");
+        return;
+      }
+
+      const guild = await this.client.guilds.fetch(guildId).catch(() => null);
+      if (!guild) {
+        logger.error(`Event scan aborted: guild ${guildId} not found`);
+        return;
+      }
+
+      // Everything not yet finished, plus ended events whose channel still
+      // needs sweeping.
+      const events = await Event.find({
+        guildId,
+        $or: [
+          { state: { $in: ["scheduled", "active"] } },
+          { state: "ended", channelId: { $ne: null } },
+        ],
+      });
+
+      const reminderMs =
+        (await this.configService.getNumber("events.reminder_minutes", 30)) *
+        MS_PER_MINUTE;
+      const leadMs =
+        (await this.configService.getNumber("events.create_lead_minutes", 15)) *
+        MS_PER_MINUTE;
+      const graceMs =
+        (await this.configService.getNumber(
+          "events.channel_grace_minutes",
+          15,
+        )) * MS_PER_MINUTE;
+
+      for (const event of events) {
+        try {
+          await this.processEvent(event, guild, new Date(), {
+            reminderMs,
+            leadMs,
+            graceMs,
+          });
+        } catch (error) {
+          logger.error(
+            `Error processing event ${sanitizeForLog(String(event._id))}:`,
+            error,
+          );
+        }
+      }
+    } finally {
+      this.isRunning = false;
+    }
+  }
+
+  private async processEvent(
+    event: IEvent,
+    guild: Guild,
+    now: Date,
+    windows: { reminderMs: number; leadMs: number; graceMs: number },
+  ): Promise<void> {
+    let changed = false;
+
+    // 1. Reminder (before start, once).
+    if (shouldSendReminder(event, now, windows.reminderMs)) {
+      await this.postReminder(event);
+      event.reminderSent = true;
+      changed = true;
+    }
+
+    // 2. Create the temp channel shortly before start.
+    if (shouldCreateChannel(event, now, windows.leadMs)) {
+      const channel = await this.createEventChannel(event, guild);
+      if (channel) {
+        event.channelId = channel.id;
+        if (event.state === "scheduled") event.state = "active";
+        changed = true;
+        await this.updateAnnouncement(event);
+      }
+    }
+
+    // 3. Mark ended once past the end time.
+    if (shouldEndEvent(event, now)) {
+      event.state = "ended";
+      changed = true;
+      await this.updateAnnouncement(event);
+    }
+
+    // 4. Sweep the empty channel after the grace period.
+    if (event.channelId && event.state === "ended") {
+      const empty = await this.isChannelEmpty(guild, event.channelId);
+      if (shouldCleanupChannel(event, now, windows.graceMs, empty)) {
+        await this.deleteEventChannel(guild, event.channelId);
+        event.channelId = null;
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      await event.save();
+      await this.logLifecycle(event);
+    }
+  }
+
+  // ---------------------------------------------------------------
+  // Public API (command + web + button handler)
+  // ---------------------------------------------------------------
+
+  public async createEvent(input: CreateEventInput): Promise<IEvent> {
+    const event = new Event({
+      guildId: input.guildId,
+      title: input.title,
+      description: input.description,
+      startTime: input.startTime,
+      timezone: input.timezone,
+      durationMinutes: input.durationMinutes,
+      categoryId: input.categoryId ?? "",
+      state: "scheduled",
+      reminderSent: false,
+      rsvps: [],
+      createdBy: input.createdBy,
+    });
+    await event.save();
+    await this.postAnnouncement(event).catch((error) =>
+      logger.error("Failed to post event announcement:", error),
+    );
+    logger.info(`Created event ${sanitizeForLog(String(event._id))}`);
+    return event;
+  }
+
+  public async listEvents(guildId: string): Promise<IEvent[]> {
+    return Event.find({ guildId }).sort({ startTime: 1 });
+  }
+
+  public async getEvent(eventId: string): Promise<IEvent | null> {
+    return Event.findById(eventId).catch(() => null);
+  }
+
+  /** Cancel an event: mark cancelled and tear down any live channel. */
+  public async cancelEvent(
+    eventId: string,
+    guildId?: string,
+  ): Promise<IEvent | null> {
+    const event = await this.getEvent(eventId);
+    if (!event) return null;
+    if (guildId && event.guildId !== guildId) return null;
+    if (event.state === "cancelled") return event;
+
+    if (event.channelId) {
+      const guild = await this.client.guilds
+        .fetch(event.guildId)
+        .catch(() => null);
+      if (guild) await this.deleteEventChannel(guild, event.channelId);
+      event.channelId = null;
+    }
+    event.state = "cancelled";
+    await event.save();
+    await this.updateAnnouncement(event);
+    logger.info(`Cancelled event ${sanitizeForLog(String(event._id))}`);
+    return event;
+  }
+
+  /** Force the temp channel to spin up now, ahead of its scheduled lead. */
+  public async startEventNow(
+    eventId: string,
+    guildId?: string,
+  ): Promise<IEvent | null> {
+    const event = await this.getEvent(eventId);
+    if (!event) return null;
+    if (guildId && event.guildId !== guildId) return null;
+    if (event.state === "cancelled" || event.state === "ended") return null;
+
+    if (!event.channelId) {
+      const guild = await this.client.guilds
+        .fetch(event.guildId)
+        .catch(() => null);
+      if (!guild) return null;
+      const channel = await this.createEventChannel(event, guild);
+      if (!channel) return null;
+      event.channelId = channel.id;
+      event.state = "active";
+      await event.save();
+      await this.updateAnnouncement(event);
+      logger.info(`Started event ${sanitizeForLog(String(event._id))} now`);
+    }
+    return event;
+  }
+
+  /** Record a member's RSVP. Returns the updated event, or null when the
+   * event is missing or already finished. */
+  public async setRsvp(
+    eventId: string,
+    userId: string,
+    status: RsvpStatus,
+  ): Promise<IEvent | null> {
+    const event = await this.getEvent(eventId);
+    if (!event) return null;
+    if (event.state === "cancelled" || event.state === "ended") return null;
+    event.rsvps = upsertRsvp(
+      event.rsvps,
+      userId,
+      status,
+      new Date(),
+    ) as IEvent["rsvps"];
+    await event.save();
+    return event;
+  }
+
+  // ---------------------------------------------------------------
+  // Announcement rendering
+  // ---------------------------------------------------------------
+
+  /** Build the RSVP embed + button row for an event. Synchronous so the
+   * button handler can refresh the message in a single interaction update. */
+  public buildAnnouncementPayload(event: IEvent): {
+    embeds: EmbedBuilder[];
+    components: ActionRowBuilder<ButtonBuilder>[];
+  } {
+    const counts = countRsvps(event.rsvps);
+    const finished = event.state === "cancelled" || event.state === "ended";
+
+    const embed = new EmbedBuilder()
+      .setColor(accentColor(event.state))
+      .setTitle(
+        event.state === "cancelled"
+          ? `❌ ${event.title} (cancelled)`
+          : `📅 ${event.title}`,
+      )
+      .addFields(
+        { name: "When", value: formatEventWhen(event), inline: false },
+        {
+          name: "✅ Going",
+          value: String(counts.going),
+          inline: true,
+        },
+        { name: "🤔 Maybe", value: String(counts.maybe), inline: true },
+        { name: "🚫 Can't", value: String(counts.cant), inline: true },
+      );
+
+    if (event.description) {
+      embed.setDescription(event.description);
+    }
+    if (event.channelId && !finished) {
+      embed.addFields({
+        name: "Voice channel",
+        value: `<#${event.channelId}>`,
+        inline: false,
+      });
+    }
+
+    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(`event_rsvp_${event._id}_going`)
+        .setLabel("Going")
+        .setEmoji("✅")
+        .setStyle(ButtonStyle.Success)
+        .setDisabled(finished),
+      new ButtonBuilder()
+        .setCustomId(`event_rsvp_${event._id}_maybe`)
+        .setLabel("Maybe")
+        .setEmoji("🤔")
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(finished),
+      new ButtonBuilder()
+        .setCustomId(`event_rsvp_${event._id}_cant`)
+        .setLabel("Can't")
+        .setEmoji("🚫")
+        .setStyle(ButtonStyle.Danger)
+        .setDisabled(finished),
+    );
+
+    return { embeds: [embed], components: [row] };
+  }
+
+  private async postAnnouncement(event: IEvent): Promise<void> {
+    const channelId = await this.configService.getString(
+      "events.announcement_channel_id",
+      "",
+    );
+    if (!channelId) {
+      logger.warn(
+        "events.announcement_channel_id not set — skipping event announcement",
+      );
+      return;
+    }
+    const channel = await this.fetchTextChannel(event.guildId, channelId);
+    if (!channel) return;
+
+    const message = await channel.send(this.buildAnnouncementPayload(event));
+    event.announcementChannelId = channelId;
+    event.announcementMessageId = message.id;
+    await event.save();
+  }
+
+  private async updateAnnouncement(event: IEvent): Promise<void> {
+    if (!event.announcementChannelId || !event.announcementMessageId) return;
+    const channel = await this.fetchTextChannel(
+      event.guildId,
+      event.announcementChannelId,
+    );
+    if (!channel) return;
+    try {
+      const message = await channel.messages.fetch(event.announcementMessageId);
+      await message.edit(this.buildAnnouncementPayload(event));
+    } catch (error) {
+      if (this.isDiscardableError(error, DISCORD_UNKNOWN_MESSAGE)) {
+        logger.warn(
+          `Event announcement message ${sanitizeForLog(event.announcementMessageId)} gone; skipping edit`,
+        );
+        return;
+      }
+      logger.error("Failed to update event announcement:", error);
+    }
+  }
+
+  private async postReminder(event: IEvent): Promise<void> {
+    if (!event.announcementChannelId) return;
+    const channel = await this.fetchTextChannel(
+      event.guildId,
+      event.announcementChannelId,
+    );
+    if (!channel) return;
+
+    const interested = event.rsvps
+      .filter((r) => r.status === "going" || r.status === "maybe")
+      .map((r) => r.userId);
+    const mentions =
+      interested.length > 0 ? interested.map((id) => `<@${id}>`).join(" ") : "";
+    const where = event.channelId ? ` Join here: <#${event.channelId}>.` : "";
+
+    const content =
+      `⏰ **${event.title}** starts at ${formatEventWhen(event)}.${where}` +
+      (mentions ? `\n${mentions}` : "");
+
+    await channel.send({
+      content,
+      allowedMentions: { users: interested.slice(0, 100) },
+    });
+  }
+
+  // ---------------------------------------------------------------
+  // Channel plumbing
+  // ---------------------------------------------------------------
+
+  private async createEventChannel(
+    event: IEvent,
+    guild: Guild,
+  ): Promise<VoiceChannel | null> {
+    const categoryId =
+      event.categoryId ||
+      (await this.configService.getString("events.category_id", ""));
+    if (!categoryId) {
+      logger.warn(
+        `events.category_id not set — cannot create channel for event ${sanitizeForLog(String(event._id))}`,
+      );
+      return null;
+    }
+    const category = guild.channels.cache.get(categoryId);
+    if (!category || category.type !== ChannelType.GuildCategory) {
+      logger.error(
+        `Event category ${sanitizeForLog(categoryId)} not found or not a category`,
+      );
+      return null;
+    }
+
+    const prefix = await this.configService.getString(
+      "events.channel_prefix",
+      "📅",
+    );
+    const rawName = `${prefix} ${event.title}`.trim();
+    const name = rawName.slice(0, 100);
+
+    try {
+      const channel = await guild.channels.create({
+        name,
+        type: ChannelType.GuildVoice,
+        parent: category as CategoryChannel,
+      });
+      logger.info(
+        `Created event channel ${sanitizeForLog(name)} for event ${sanitizeForLog(String(event._id))}`,
+      );
+      return channel;
+    } catch (error) {
+      logger.error("Error creating event channel:", error);
+      return null;
+    }
+  }
+
+  private async deleteEventChannel(
+    guild: Guild,
+    channelId: string,
+  ): Promise<void> {
+    try {
+      const channel =
+        guild.channels.cache.get(channelId) ??
+        (await guild.channels.fetch(channelId).catch(() => null));
+      if (channel) await channel.delete("Event ended");
+    } catch (error) {
+      if (this.isDiscardableError(error, DISCORD_UNKNOWN_CHANNEL)) return;
+      logger.error("Error deleting event channel:", error);
+    }
+  }
+
+  private async isChannelEmpty(
+    guild: Guild,
+    channelId: string,
+  ): Promise<boolean> {
+    const channel =
+      guild.channels.cache.get(channelId) ??
+      (await guild.channels.fetch(channelId).catch(() => null));
+    if (!channel || channel.type !== ChannelType.GuildVoice) {
+      // Gone already — treat as empty so the sweep clears the stale id.
+      return true;
+    }
+    return (channel as VoiceChannel).members.size === 0;
+  }
+
+  private async fetchTextChannel(
+    guildId: string,
+    channelId: string,
+  ): Promise<TextChannel | null> {
+    try {
+      const guild = await this.client.guilds.fetch(guildId);
+      const channel = await guild.channels.fetch(channelId);
+      if (channel instanceof TextChannel) return channel;
+      logger.warn(
+        `Event channel ${sanitizeForLog(channelId)} is not a text channel`,
+      );
+      return null;
+    } catch (error) {
+      logger.error("Failed to fetch event text channel:", error);
+      return null;
+    }
+  }
+
+  private isDiscardableError(error: unknown, code: number): boolean {
+    return error instanceof DiscordAPIError && error.code === code;
+  }
+
+  private async logLifecycle(event: IEvent): Promise<void> {
+    try {
+      const discordLogger = DiscordLogger.getInstance(this.client);
+      if (!discordLogger.isReady()) return;
+      await discordLogger.logCronSuccess(
+        "Events",
+        `${event.title}: ${event.state}`,
+      );
+    } catch (error) {
+      logger.error("Events: failed to post lifecycle log:", error);
+    }
+  }
+}

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -113,6 +113,12 @@ export const NAV_ITEMS: NavItem[] = [
     featureKey: "announcements.enabled",
   },
   {
+    href: "/admin/events",
+    label: "Events",
+    group: "Features",
+    featureKey: "events.enabled",
+  },
+  {
     href: "/admin/polls",
     label: "Polls",
     group: "Features",

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -1669,7 +1669,7 @@ export function renderEventsPage(props: EventsProps): string {
       const actions = finished
         ? '<span class="muted">—</span>'
         : `<form method="POST" action="/admin/events/${escapeHtml(e.id)}/start-now">${csrfInput}<button type="submit" class="btn">Start now</button></form>
-  <form method="POST" action="/admin/events/${escapeHtml(e.id)}/cancel" onsubmit="return confirm('Cancel event ${escapeHtml(e.title)}?');">${csrfInput}<button type="submit" class="btn btn-danger">Cancel</button></form>`;
+  <form method="POST" action="/admin/events/${escapeHtml(e.id)}/cancel" onsubmit="return confirm('Cancel event \\'${escapeJsInAttr(e.title)}\\'?');">${csrfInput}<button type="submit" class="btn btn-danger">Cancel</button></form>`;
       const channelCell = e.channelId
         ? `<span class="mono">${escapeHtml(e.channelId)}</span>`
         : '<span class="muted">—</span>';

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -1379,6 +1379,26 @@ export interface AnnouncementsProps extends CommonProps {
   flash?: FlashMessage | null;
 }
 
+export interface EventRow {
+  id: string;
+  title: string;
+  when: string;
+  state: string;
+  going: number;
+  maybe: number;
+  cant: number;
+  channelId: string | null;
+}
+
+export interface EventsProps extends CommonProps {
+  enabled: boolean;
+  categoryConfigured: boolean;
+  announcementConfigured: boolean;
+  timezone: string;
+  rows: EventRow[];
+  flash?: FlashMessage | null;
+}
+
 function renderFlash(flash?: FlashMessage | null): string {
   if (!flash) return "";
   const cls =
@@ -1619,6 +1639,123 @@ ${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Announcements", 
   return renderAdminPage({
     title: "Announcements",
     active: "/admin/announcements",
+    body,
+    csrfToken: props.csrfToken,
+    remainingMs: props.remainingMs,
+    navFeatureStatus: props.navFeatureStatus,
+  });
+}
+
+// ---------- Events ----------
+
+function eventStateTag(state: string): string {
+  const cls =
+    state === "active"
+      ? "tag-on"
+      : state === "cancelled"
+        ? "tag-off"
+        : state === "ended"
+          ? "tag-info"
+          : "tag-info";
+  return `<span class="tag ${cls}">${escapeHtml(state)}</span>`;
+}
+
+export function renderEventsPage(props: EventsProps): string {
+  const csrfInput = `<input type="hidden" name="_csrf" value="${escapeHtml(props.csrfToken)}">`;
+
+  const tableRows = props.rows
+    .map((e) => {
+      const finished = e.state === "cancelled" || e.state === "ended";
+      const actions = finished
+        ? '<span class="muted">—</span>'
+        : `<form method="POST" action="/admin/events/${escapeHtml(e.id)}/start-now">${csrfInput}<button type="submit" class="btn">Start now</button></form>
+  <form method="POST" action="/admin/events/${escapeHtml(e.id)}/cancel" onsubmit="return confirm('Cancel event ${escapeHtml(e.title)}?');">${csrfInput}<button type="submit" class="btn btn-danger">Cancel</button></form>`;
+      const channelCell = e.channelId
+        ? `<span class="mono">${escapeHtml(e.channelId)}</span>`
+        : '<span class="muted">—</span>';
+      return `<tr>
+<td>${escapeHtml(e.title)}</td>
+<td class="mono">${escapeHtml(e.when)}</td>
+<td>${eventStateTag(e.state)}</td>
+<td>✅ ${e.going} · 🤔 ${e.maybe} · 🚫 ${e.cant}</td>
+<td>${channelCell}</td>
+<td class="mono">${escapeHtml(e.id)}</td>
+<td class="actions">${actions}</td>
+</tr>`;
+    })
+    .join("");
+
+  const tableHtml =
+    props.rows.length > 0
+      ? `<table class="data">
+<thead><tr><th>Title</th><th>When</th><th>State</th><th>RSVPs</th><th>Channel</th><th>ID</th><th>Actions</th></tr></thead>
+<tbody>${tableRows}</tbody>
+</table>`
+      : '<p class="muted">No events scheduled yet.</p>';
+
+  const categoryWarn = props.categoryConfigured
+    ? ""
+    : `<div class="notice warn">No <code>events.category_id</code> is set — event channels won't be created until you pick a category in Settings.</div>`;
+  const announcementWarn = props.announcementConfigured
+    ? ""
+    : `<div class="notice warn">No <code>events.announcement_channel_id</code> is set — RSVP messages and reminders won't be posted until you pick a channel in Settings.</div>`;
+
+  const body = `
+<h1>Events</h1>
+<p class="subtitle">Schedule events that spin up a temporary voice channel shortly before they start, collect RSVPs, remind attendees, and clean themselves up afterward.</p>
+${renderFlash(props.flash)}
+${renderFeatureDisabledNotice({
+  enabled: props.enabled,
+  label: "Events",
+  featureKey: "events.enabled",
+  returnTo: "/admin/events",
+  csrfToken: props.csrfToken,
+})}
+<div class="card">
+  <h2>Status</h2>
+  <dl class="kv">
+    <dt>Feature</dt><dd>${tagOnOff(props.enabled, "enabled", "disabled")}</dd>
+    <dt>Channel category</dt><dd>${tagOnOff(props.categoryConfigured, "set", "not set")}</dd>
+    <dt>Announcement channel</dt><dd>${tagOnOff(props.announcementConfigured, "set", "not set")}</dd>
+    <dt>Timezone</dt><dd class="mono">${escapeHtml(props.timezone)}</dd>
+    <dt>Scheduled events</dt><dd>${props.rows.length}</dd>
+  </dl>
+  ${categoryWarn}
+  ${announcementWarn}
+</div>
+<div class="card">
+  <h2>Events</h2>${tableHtml}
+</div>
+<div class="card">
+  <h2>Schedule a new event</h2>
+  <form method="POST" action="/admin/events/create" class="stack">
+    ${csrfInput}
+    <label>Title
+      <input type="text" name="title" required maxlength="100" placeholder="Game Night">
+    </label>
+    <label>Description
+      <textarea name="description" rows="3" maxlength="1000" placeholder="What's happening?"></textarea>
+    </label>
+    <label>Date (YYYY-MM-DD)
+      <input type="text" name="date" required pattern="\\d{4}-\\d{2}-\\d{2}" placeholder="2026-07-04">
+    </label>
+    <label>Time (24h HH:MM)
+      <input type="text" name="time" required pattern="\\d{2}:\\d{2}" placeholder="20:00">
+    </label>
+    <label>Duration (minutes, optional)
+      <input type="number" name="duration" min="1" max="1440" placeholder="120">
+    </label>
+    <label>Timezone (IANA, optional — defaults to <code>${escapeHtml(props.timezone)}</code>)
+      <input type="text" name="timezone" placeholder="Europe/London">
+    </label>
+    <button type="submit" class="btn btn-primary">Schedule event</button>
+  </form>
+</div>
+`;
+
+  return renderAdminPage({
+    title: "Events",
+    active: "/admin/events",
     body,
     csrfToken: props.csrfToken,
     remainingMs: props.remainingMs,

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -49,7 +49,7 @@ import { WebAuditLog } from "../models/web-audit-log.js";
 import { DiscordCommandAuditLog } from "../models/discord-command-audit-log.js";
 import { getCommandMetricsSummary } from "../services/command-metrics-query.js";
 import { getGuildVoiceHeatmap } from "../services/voice-activity-analytics.js";
-import { getServerTimezone } from "../utils/timezone.js";
+import { getServerTimezone, resolveTimezone } from "../utils/timezone.js";
 import { BOOTSTRAP_VARS } from "./bootstrap-vars.js";
 import { getEnv } from "../config/env.js";
 import {
@@ -645,7 +645,9 @@ export function createReadOnlyRouter(
           enabled,
           categoryConfigured: categoryId.length > 0,
           announcementConfigured: announcementChannelId.length > 0,
-          timezone: tz || getServerTimezone(),
+          // Resolve to a usable zone (falls back to server tz on an invalid
+          // value) so the UI shows exactly what event parsing will use.
+          timezone: resolveTimezone(tz),
           rows,
           flash: readFlash(req),
         }),

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -20,6 +20,11 @@ import { defaultConfig, settingsMetadata } from "../services/config-schema.js";
 import { PermissionsService } from "../services/permissions-service.js";
 import { ScheduledAnnouncementService } from "../services/scheduled-announcement-service.js";
 import { ScheduledAnnouncement } from "../models/scheduled-announcement.js";
+import {
+  EventService,
+  formatEventWhen,
+  countRsvps,
+} from "../services/event-service.js";
 import { PollService } from "../services/poll-service.js";
 import { PollSchedule } from "../models/poll-schedule.js";
 import { PollItem } from "../models/poll-item.js";
@@ -67,6 +72,7 @@ import {
   renderDashboardPage,
   renderDatabasePage,
   renderDigestPage,
+  renderEventsPage,
   renderNoticesPage,
   renderPermissionsPage,
   renderPollsPage,
@@ -546,6 +552,50 @@ export function createReadOnlyRouter(
           enabled,
           rows,
           textChannels: channelData.textChannels,
+          flash: readFlash(req),
+        }),
+      );
+    }),
+  );
+
+  // ---------- Events ----------
+  router.get(
+    "/events",
+    asyncHandler(async (req, res) => {
+      const common = await commonFromReq(req);
+      const service = EventService.getInstance(client);
+      const config = ConfigService.getInstance();
+      const [enabled, categoryId, announcementChannelId, tz, events] =
+        await Promise.all([
+          config.getBoolean("events.enabled", false),
+          config.getString("events.category_id", ""),
+          config.getString("events.announcement_channel_id", ""),
+          config.getString("events.timezone", ""),
+          service.listEvents(common.guildId),
+        ]);
+
+      const rows = events.map((e) => {
+        const counts = countRsvps(e.rsvps);
+        return {
+          id: String(e._id),
+          title: e.title,
+          when: formatEventWhen(e),
+          state: e.state,
+          going: counts.going,
+          maybe: counts.maybe,
+          cant: counts.cant,
+          channelId: e.channelId,
+        };
+      });
+
+      res.type("text/html").send(
+        renderEventsPage({
+          ...common,
+          enabled,
+          categoryConfigured: categoryId.length > 0,
+          announcementConfigured: announcementChannelId.length > 0,
+          timezone: tz || getServerTimezone(),
+          rows,
           flash: readFlash(req),
         }),
       );

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -18,6 +18,8 @@ import { CronTime } from "cron";
 import * as yaml from "js-yaml";
 import logger from "../utils/logger.js";
 import { ScheduledAnnouncementService } from "../services/scheduled-announcement-service.js";
+import { EventService, parseEventDateTime } from "../services/event-service.js";
+import { isValidTimezone, resolveTimezone } from "../utils/timezone.js";
 import { PollService } from "../services/poll-service.js";
 import { VoiceChannelAnnouncer } from "../services/voice-channel-announcer.js";
 import { ReactionRoleService } from "../services/reaction-role-service.js";
@@ -2072,6 +2074,167 @@ export function createWriteRouter(
           text: `Failed to post: ${text}`,
         });
       }
+    }),
+  );
+
+  // ============================================================
+  // Events (#708)
+  // ============================================================
+
+  router.post(
+    "/events/create",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const title = getString(req, "title");
+      const description = getString(req, "description");
+      const date = getString(req, "date");
+      const time = getString(req, "time");
+      const durationRaw = getString(req, "duration");
+      const tzInput = getString(req, "timezone");
+
+      if (!title || !date || !time) {
+        flashRedirect(res, "/admin/events", {
+          type: "err",
+          text: "Title, date and time are all required.",
+        });
+        return;
+      }
+      const lengthError = firstLengthError([
+        { label: "Title", value: title, max: 100 },
+        { label: "Description", value: description, max: 1000 },
+      ]);
+      if (lengthError) {
+        flashRedirect(res, "/admin/events", { type: "err", text: lengthError });
+        return;
+      }
+      if (tzInput && !isValidTimezone(tzInput)) {
+        flashRedirect(res, "/admin/events", {
+          type: "err",
+          text: `Invalid timezone: ${tzInput}`,
+        });
+        return;
+      }
+
+      const config = ConfigService.getInstance();
+      const configuredTz = await config.getString("events.timezone", "");
+      const timezone = tzInput || configuredTz;
+
+      const startTime = parseEventDateTime(date, time, timezone);
+      if (!startTime) {
+        flashRedirect(res, "/admin/events", {
+          type: "err",
+          text: "Invalid date/time. Use YYYY-MM-DD and 24-hour HH:MM.",
+        });
+        return;
+      }
+      if (startTime.getTime() <= Date.now()) {
+        flashRedirect(res, "/admin/events", {
+          type: "err",
+          text: "The event start time must be in the future.",
+        });
+        return;
+      }
+
+      const defaultDuration = await config.getNumber(
+        "events.default_duration_minutes",
+        120,
+      );
+      let durationMinutes = defaultDuration;
+      if (durationRaw) {
+        const parsed = parseIntInRange(durationRaw, 1, 1440);
+        if (parsed === null) {
+          flashRedirect(res, "/admin/events", {
+            type: "err",
+            text: "Duration must be between 1 and 1440 minutes.",
+          });
+          return;
+        }
+        durationMinutes = parsed;
+      }
+
+      const service = EventService.getInstance(client);
+      try {
+        const event = await service.createEvent({
+          guildId: session.guildId,
+          title,
+          description,
+          startTime,
+          timezone: resolveTimezone(timezone),
+          durationMinutes,
+          createdBy: session.discordUserId,
+        });
+        await recordAudit(session, {
+          action: "event.create",
+          targetId: String(event._id),
+          details: {
+            title,
+            startTime: startTime.toISOString(),
+            durationMinutes,
+          },
+          result: "success",
+        });
+        flashRedirect(res, "/admin/events", {
+          type: "ok",
+          text: `Scheduled event "${title}".`,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Create event failed", err);
+        await recordAudit(session, {
+          action: "event.create",
+          details: { title },
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/events", {
+          type: "err",
+          text: `Failed to create event: ${text}`,
+        });
+      }
+    }),
+  );
+
+  router.post(
+    "/events/:id/cancel",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const id = String(req.params.id);
+      const service = EventService.getInstance(client);
+      const event = await service.cancelEvent(id, session.guildId);
+      const ok = event !== null;
+      await recordAudit(session, {
+        action: "event.cancel",
+        targetId: id,
+        result: ok ? "success" : "failure",
+        errorMessage: ok ? null : "not found or wrong guild",
+      });
+      flashRedirect(res, "/admin/events", {
+        type: ok ? "ok" : "err",
+        text: ok ? `Cancelled event ${id}.` : `Event ${id} not found.`,
+      });
+    }),
+  );
+
+  router.post(
+    "/events/:id/start-now",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const id = String(req.params.id);
+      const service = EventService.getInstance(client);
+      const event = await service.startEventNow(id, session.guildId);
+      const ok = event !== null;
+      await recordAudit(session, {
+        action: "event.start-now",
+        targetId: id,
+        result: ok ? "success" : "failure",
+        errorMessage: ok ? null : "not found, ended, or cancelled",
+      });
+      flashRedirect(res, "/admin/events", {
+        type: ok ? "ok" : "err",
+        text: ok
+          ? `Started event ${id}.`
+          : `Could not start event ${id} (not found, ended, or cancelled).`,
+      });
     }),
   );
 


### PR DESCRIPTION
## Description

Adds a gated **Events** feature for servers without static voice channels. An admin schedules an event; KoolBot spins up a **temporary voice channel** shortly before it starts, collects RSVPs via **Going / Maybe / Can't** buttons with a live attendee count, posts a reminder beforehand, and tears the channel down once the event ends and empties. This deliberately bypasses the lobby trigger — event channels are spawned by schedule/command rather than by someone joining a lobby.

Highlights:

- **`Event` Mongo model** (`src/models/event.ts`) — title, start time (UTC instant) + IANA timezone, duration, state (`scheduled → active → ended`, or `cancelled`), `channelId`, RSVPs, `reminderSent`.
- **`EventService`** (`src/services/event-service.ts`) — a once-a-minute "scan and decide" `CronJob` (mirroring `BirthdayService`) drives the entire lifecycle from the stored row rather than in-memory timers, so every transition is idempotent and **restart-safe**: create channel `events.create_lead_minutes` before start, post reminder `events.reminder_minutes` before, mark ended after the duration, delete the empty channel after `events.channel_grace_minutes`. Pure helpers are factored out and unit-tested.
- **`/event` command** (`src/commands/event.ts`) — `create` / `list` / `cancel` / `start`. `list` is open to everyone; the mutating subcommands are Administrator-gated.
- **RSVP buttons** (`src/handlers/event-rsvp-handler.ts`) — Going / Maybe / Can't refresh the announcement message in place with live counts.
- **`/admin/events` web page** — list, create, cancel, start-now, mirroring `/admin/announcements` (nav item, read-only GET route, write routes with audit logging, page renderer).
- **Config** — `events.*` keys added to `config-schema.ts` (interface, defaults, category + settings metadata) and the Config model category enum; feature-gated on `events.enabled` (off by default).

### Design decisions / open questions from the issue

- **Permissions**: Administrator-only for create/cancel/start in v1; `/event list` is open. A configurable creator role is a natural v2.
- **Recurring events**: out of scope for v1 (one-off events only).
- **Voice tracking**: an event channel is a plain managed voice channel — if voice tracking is enabled, time in it is tracked like any other channel; no special-casing.
- **Setup wizard**: not wired in, following the precedent of the recently-added Birthdays feature (also multi-setting, also not in the wizard); all keys are configurable via the Settings page and the dedicated `/admin/events` page.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update
- [x] 🧪 Test updates

## Related Issues

Closes #708

## How Has This Been Tested?

- [x] Existing tests pass (`npm run test:ci` — 121 suites, 1510 passing)
- [x] Added new tests for new functionality
- Added `__tests__/services/event-service.test.ts` (29 cases) covering the pure lifecycle/parse/RSVP helpers, plus `renderEventsPage` cases in `__tests__/web/admin-views.test.ts`.
- `npm run check` (build + lint + format:check) passes; `markdownlint` on the changed docs passes; coverage stays above the configured thresholds.

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format`
- [x] Self-review performed; no new warnings or errors

### Testing

- [x] Added tests that prove the feature works
- [x] New and existing unit tests pass locally

### Documentation

- [x] `COMMANDS.md` updated (new `/event` command + tables)
- [x] `SETTINGS.md` updated (new Events section + `events.*` keys)
- [x] Validated markdown with `markdownlint`

### Configuration

- [x] New feature is disabled by default and toggleable via `events.enabled`
- [x] Added configuration schema entries in `config-schema.ts`
- [x] Documented new configuration keys in `SETTINGS.md`

## Additional Notes

The lifecycle scan reads the guild from `GUILD_ID` and only acts when `events.enabled` is true; disabling the feature via `/config reload` stops the scan job. Channel creation requires `events.category_id`; the RSVP/reminder posts require `events.announcement_channel_id` — the `/admin/events` page surfaces a warning when either is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jnpFmCQhZkhKtdTLAyvWL

---
_Generated by [Claude Code](https://claude.ai/code/session_015jnpFmCQhZkhKtdTLAyvWL)_