### PR TITLE
fix: adopt Prettier 3.9 cast formatting in voice-channel-manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "eslint": "^10.5.0",
         "jest": "^30.4.2",
         "markdownlint-cli": "^0.49.0",
-        "prettier": "^3.8.4",
+        "prettier": "^3.9.5",
         "ts-jest": "^29.4.11",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.3",
@@ -7108,9 +7108,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint": "^10.5.0",
     "jest": "^30.4.2",
     "markdownlint-cli": "^0.49.0",
-    "prettier": "^3.8.4",
+    "prettier": "^3.9.5",
     "ts-jest": "^29.4.11",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3",

--- a/src/services/voice-channel-manager.ts
+++ b/src/services/voice-channel-manager.ts
@@ -413,15 +413,13 @@ export class VoiceChannelManager {
       if (!waitingRoomId) return;
 
       const waitingRoom = this.client.channels.cache.get(waitingRoomId) as
-        | VoiceChannel
-        | undefined;
+        VoiceChannel | undefined;
 
       if (waitingRoom) {
         // Move waiting users to main channel or disconnect them
         if (waitingRoom.members.size > 0) {
           const mainChannel = this.client.channels.cache.get(channelId) as
-            | VoiceChannel
-            | undefined;
+            VoiceChannel | undefined;
 
           if (mainChannel) {
             for (const member of waitingRoom.members.values()) {
@@ -1014,8 +1012,7 @@ export class VoiceChannelManager {
   ): Promise<void> {
     try {
       const mainChannel = this.client.channels.cache.get(mainChannelId) as
-        | VoiceChannel
-        | undefined;
+        VoiceChannel | undefined;
       if (!mainChannel) return;
 
       // Find the owner


### PR DESCRIPTION
## Description

Prettier 3.9 changed how `as A | B` type-assertion casts wrap — from the broken-out
leading-pipe style to a single line. This blocked the dev-dependency group bump
(Prettier 3.8.4 → 3.9.x, dependabot PR #720) because the `Lint` job's `format:check`
step reformats the three `as VoiceChannel | undefined` casts in
`src/services/voice-channel-manager.ts`.

The reformat and the Prettier version are coupled: 3.9's single-line style is rejected
by 3.8.x and vice-versa. A reformat-only change would therefore fail its own CI (which
resolves `^3.8.4` to a 3.8.x). This PR bumps `prettier` to `^3.9.x` **and** reformats the
affected casts so the version and formatting agree, unblocking the dependency-group bump.

```diff
       const waitingRoom = this.client.channels.cache.get(waitingRoomId) as
-        | VoiceChannel
-        | undefined;
+        VoiceChannel | undefined;
```

No logic changes — three mechanical cast reformats plus the `prettier` version bump in
`package.json` / `package-lock.json`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Build/tooling changes

## Related Issues

Fixes #727

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Manually tested in development environment

Verified locally against the branch:

- `npm run build` — exit 0
- `npm run lint` — clean
- `npm run format:check` — "All matched files use Prettier code style!" (now on Prettier 3.9.x)

**Test Configuration**:

- Node.js version: 22
- Discord.js version: v14
- Operating System: Linux

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Dependencies & Docker

- [x] I have run security checks if adding new dependencies (`npm audit` — 0 vulnerabilities)

## Additional Notes

Once merged, dependabot PR #720 can be rebased/re-run; its Prettier bump becomes a no-op
and the `Lint` job will go green.

## Pre-Submission Verification

- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011t8yj9KEDjNjGEHn81cg65)_