### PR TITLE
fix(events): atomically claim event channel to prevent duplicate/orphaned channels

### DIFF
--- a/__tests__/services/event-service.test.ts
+++ b/__tests__/services/event-service.test.ts
@@ -248,7 +248,8 @@ describe("claimEventChannel (start-now path)", () => {
   const CATEGORY_ID = "cat-1";
 
   function buildService(opts: {
-    findOneAndUpdate: unknown;
+    findOneAndUpdate?: unknown;
+    claimError?: Error;
     createdChannelId: string;
     deletableChannel?: { delete: jest.Mock };
     refreshedEvent?: unknown;
@@ -283,7 +284,10 @@ describe("claimEventChannel (start-now path)", () => {
       .fn()
       .mockReturnValueOnce(Promise.resolve(event))
       .mockReturnValue(Promise.resolve(opts.refreshedEvent ?? null));
-    EventMock.findOneAndUpdate = jest.fn(async () => opts.findOneAndUpdate);
+    EventMock.findOneAndUpdate = jest.fn(async () => {
+      if (opts.claimError) throw opts.claimError;
+      return opts.findOneAndUpdate;
+    });
 
     const createdChannel = { id: opts.createdChannelId };
     const createChannel = jest.fn(async () => createdChannel);
@@ -342,6 +346,27 @@ describe("claimEventChannel (start-now path)", () => {
     // The in-memory event adopts the winner's id and is not re-saved.
     expect(result?.channelId).toBe("chan-winner");
     expect(event.state).toBe("scheduled");
+    expect(event.save).not.toHaveBeenCalled();
+  });
+
+  it("tears down the channel when the claim write throws, leaking nothing", async () => {
+    const deletableChannel = { delete: jest.fn(async () => undefined) };
+    const { service, event, createChannel } = buildService({
+      // Transient DB error while claiming, after the channel already exists.
+      claimError: new Error("connection reset"),
+      createdChannelId: "chan-orphan",
+      deletableChannel,
+    });
+
+    const result = await service.startEventNow("evt-1");
+
+    expect(createChannel).toHaveBeenCalledTimes(1);
+    // The just-created channel is removed rather than left unreferenced...
+    expect(deletableChannel.delete).toHaveBeenCalledTimes(1);
+    // ...and the failure surfaces as a no-op (channelId still null) instead
+    // of crashing the caller, so the next scan can retry cleanly.
+    expect(result).toBeNull();
+    expect(event.channelId).toBeNull();
     expect(event.save).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/services/event-service.test.ts
+++ b/__tests__/services/event-service.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, jest } from "@jest/globals";
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { ChannelType } from "discord.js";
 
 // The event-service module registers a config reload callback and touches a
 // Mongoose model at import time. Mock the heavy dependencies so the pure
@@ -32,7 +33,14 @@ jest.unstable_mockModule("../../src/utils/logger.js", () => ({
   },
 }));
 
+const { Event } = await import("../../src/models/event.js");
+const EventMock = Event as unknown as jest.Mock & {
+  findById: jest.Mock;
+  findOneAndUpdate: jest.Mock;
+};
+
 const {
+  EventService,
   computeEndTime,
   parseEventDateTime,
   countRsvps,
@@ -229,5 +237,111 @@ describe("formatEventWhen", () => {
       timezone: "America/New_York",
     };
     expect(formatEventWhen(event)).toBe("2026-07-04 20:00 (America/New_York)");
+  });
+});
+
+// Regression tests for #730: cron and "start now" must not both create a
+// channel for the same event. Channel creation is guarded by an atomic
+// `findOneAndUpdate({ channelId: null })` claim, exercised here through
+// `startEventNow`.
+describe("claimEventChannel (start-now path)", () => {
+  const CATEGORY_ID = "cat-1";
+
+  function buildService(opts: {
+    findOneAndUpdate: unknown;
+    createdChannelId: string;
+    deletableChannel?: { delete: jest.Mock };
+    refreshedEvent?: unknown;
+  }): {
+    service: InstanceType<typeof EventService>;
+    event: {
+      _id: string;
+      guildId: string;
+      state: string;
+      channelId: string | null;
+      categoryId: string;
+      save: jest.Mock;
+      announcementChannelId: null;
+      announcementMessageId: null;
+      title: string;
+    };
+    createChannel: jest.Mock;
+  } {
+    const event = {
+      _id: "evt-1",
+      guildId: "guild-1",
+      state: "scheduled",
+      channelId: null as string | null,
+      categoryId: CATEGORY_ID,
+      title: "Game Night",
+      announcementChannelId: null,
+      announcementMessageId: null,
+      save: jest.fn(async () => undefined),
+    };
+
+    EventMock.findById = jest
+      .fn()
+      .mockReturnValueOnce(Promise.resolve(event))
+      .mockReturnValue(Promise.resolve(opts.refreshedEvent ?? null));
+    EventMock.findOneAndUpdate = jest.fn(async () => opts.findOneAndUpdate);
+
+    const createdChannel = { id: opts.createdChannelId };
+    const createChannel = jest.fn(async () => createdChannel);
+    const cache = new Map<string, unknown>();
+    cache.set(CATEGORY_ID, { type: ChannelType.GuildCategory });
+    if (opts.deletableChannel) {
+      cache.set(opts.createdChannelId, opts.deletableChannel);
+    }
+    const guild = { channels: { create: createChannel, cache } };
+    const client = {
+      guilds: { fetch: jest.fn(async () => guild) },
+    } as never;
+
+    const service = EventService.getInstance(client);
+    return { service, event, createChannel };
+  }
+
+  beforeEach(() => {
+    EventService.reset();
+  });
+
+  it("wins the claim, sets the channel and marks the event active", async () => {
+    const { service, event, createChannel } = buildService({
+      // Non-null pre-update doc => our compare-and-set matched.
+      findOneAndUpdate: { _id: "evt-1", channelId: null },
+      createdChannelId: "chan-win",
+    });
+
+    const result = await service.startEventNow("evt-1");
+
+    expect(createChannel).toHaveBeenCalledTimes(1);
+    expect(result?.channelId).toBe("chan-win");
+    expect(result?.state).toBe("active");
+    expect(event.save).toHaveBeenCalledTimes(1);
+    expect(EventMock.findOneAndUpdate).toHaveBeenCalledWith(
+      { _id: "evt-1", channelId: null },
+      { $set: { channelId: "chan-win" } },
+    );
+  });
+
+  it("loses the claim, deletes the redundant channel and adopts the winner's id", async () => {
+    const deletableChannel = { delete: jest.fn(async () => undefined) };
+    const { service, event, createChannel } = buildService({
+      // Null => no document matched; another path already claimed a channel.
+      findOneAndUpdate: null,
+      createdChannelId: "chan-loser",
+      deletableChannel,
+      refreshedEvent: { channelId: "chan-winner" },
+    });
+
+    const result = await service.startEventNow("evt-1");
+
+    expect(createChannel).toHaveBeenCalledTimes(1);
+    // The redundant channel is torn down, not left orphaned.
+    expect(deletableChannel.delete).toHaveBeenCalledTimes(1);
+    // The in-memory event adopts the winner's id and is not re-saved.
+    expect(result?.channelId).toBe("chan-winner");
+    expect(event.state).toBe("scheduled");
+    expect(event.save).not.toHaveBeenCalled();
   });
 });

--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -437,9 +437,8 @@ export class EventService {
 
     // 2. Create the temp channel shortly before start.
     if (shouldCreateChannel(event, now, windows.leadMs)) {
-      const channel = await this.createEventChannel(event, guild);
+      const channel = await this.claimEventChannel(event, guild);
       if (channel) {
-        event.channelId = channel.id;
         if (event.state === "scheduled") event.state = "active";
         changed = true;
         await this.updateAnnouncement(event);
@@ -542,13 +541,17 @@ export class EventService {
         .fetch(event.guildId)
         .catch(() => null);
       if (!guild) return null;
-      const channel = await this.createEventChannel(event, guild);
-      if (!channel) return null;
-      event.channelId = channel.id;
-      event.state = "active";
-      await event.save();
-      await this.updateAnnouncement(event);
-      logger.info(`Started event ${sanitizeForLog(String(event._id))} now`);
+      const channel = await this.claimEventChannel(event, guild);
+      if (channel) {
+        event.state = "active";
+        await event.save();
+        await this.updateAnnouncement(event);
+        logger.info(`Started event ${sanitizeForLog(String(event._id))} now`);
+      } else if (!event.channelId) {
+        // Channel creation genuinely failed (e.g. no category configured);
+        // a lost race instead leaves event.channelId set to the winner's id.
+        return null;
+      }
     }
     return event;
   }
@@ -716,6 +719,55 @@ export class EventService {
   // ---------------------------------------------------------------
   // Channel plumbing
   // ---------------------------------------------------------------
+
+  /**
+   * Create the temp channel and atomically claim it on the event row.
+   *
+   * Both the cron scan (`processEvent`) and the manual "start now" path
+   * (`startEventNow`) can decide to create a channel for the same event at
+   * the same moment. Without a claim they each gate on their own in-memory
+   * copy of `channelId` and both call `guild.channels.create()`, producing
+   * two channels while the row can only reference one — the loser's channel
+   * is orphaned forever (see #730).
+   *
+   * The `findOneAndUpdate` with a `channelId: null` filter is an atomic
+   * compare-and-set: only the first caller to land its write matches the
+   * document and wins the claim (this also holds across multiple
+   * processes/replicas). A caller that loses the race deletes the redundant
+   * channel it just created and adopts the winner's `channelId`, so no
+   * orphan is left behind.
+   *
+   * Returns the channel when THIS call won the claim, otherwise `null`. On a
+   * lost race `event.channelId` is refreshed to the winner's id; on an
+   * outright creation failure it stays `null`, so callers can tell the two
+   * apart.
+   */
+  private async claimEventChannel(
+    event: IEvent,
+    guild: Guild,
+  ): Promise<VoiceChannel | null> {
+    const channel = await this.createEventChannel(event, guild);
+    if (!channel) return null;
+
+    const claimed = await Event.findOneAndUpdate(
+      { _id: event._id, channelId: null },
+      { $set: { channelId: channel.id } },
+    );
+    if (!claimed) {
+      // Another path claimed the channel first — tear ours down and adopt
+      // the winner's id so we don't leak a channel.
+      logger.warn(
+        `Lost event-channel creation race for event ${sanitizeForLog(String(event._id))}; removing redundant channel`,
+      );
+      await this.deleteEventChannel(guild, channel.id);
+      const fresh = await Event.findById(event._id).catch(() => null);
+      event.channelId = fresh?.channelId ?? event.channelId;
+      return null;
+    }
+
+    event.channelId = channel.id;
+    return channel;
+  }
 
   private async createEventChannel(
     event: IEvent,

--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -735,12 +735,14 @@ export class EventService {
    * document and wins the claim (this also holds across multiple
    * processes/replicas). A caller that loses the race deletes the redundant
    * channel it just created and adopts the winner's `channelId`, so no
-   * orphan is left behind.
+   * orphan is left behind. If the claim write itself throws (transient
+   * DB/connectivity error) after the channel was created, the channel is
+   * likewise torn down so the failure can't leak one either.
    *
    * Returns the channel when THIS call won the claim, otherwise `null`. On a
    * lost race `event.channelId` is refreshed to the winner's id; on an
-   * outright creation failure it stays `null`, so callers can tell the two
-   * apart.
+   * outright creation failure or a failed claim it stays `null`, so callers
+   * can tell the two apart.
    */
   private async claimEventChannel(
     event: IEvent,
@@ -749,17 +751,39 @@ export class EventService {
     const channel = await this.createEventChannel(event, guild);
     if (!channel) return null;
 
-    const claimed = await Event.findOneAndUpdate(
-      { _id: event._id, channelId: null },
-      { $set: { channelId: channel.id } },
-    );
+    let claimed: IEvent | null;
+    try {
+      claimed = await Event.findOneAndUpdate(
+        { _id: event._id, channelId: null },
+        { $set: { channelId: channel.id } },
+      );
+    } catch (error) {
+      // The claim write failed after the channel was already created — tear
+      // it down so we don't leak an unreferenced channel, and let the next
+      // scan retry cleanly (channelId is still null in the row).
+      logger.error(
+        `Failed to claim event channel for event ${sanitizeForLog(String(event._id))}; removing unclaimed channel:`,
+        error,
+      );
+      await this.deleteEventChannel(
+        guild,
+        channel.id,
+        "Event channel claim failed",
+      );
+      return null;
+    }
+
     if (!claimed) {
       // Another path claimed the channel first — tear ours down and adopt
       // the winner's id so we don't leak a channel.
       logger.warn(
         `Lost event-channel creation race for event ${sanitizeForLog(String(event._id))}; removing redundant channel`,
       );
-      await this.deleteEventChannel(guild, channel.id);
+      await this.deleteEventChannel(
+        guild,
+        channel.id,
+        "Redundant event channel (creation race)",
+      );
       const fresh = await Event.findById(event._id).catch(() => null);
       event.channelId = fresh?.channelId ?? event.channelId;
       return null;
@@ -816,12 +840,13 @@ export class EventService {
   private async deleteEventChannel(
     guild: Guild,
     channelId: string,
+    reason = "Event ended",
   ): Promise<void> {
     try {
       const channel =
         guild.channels.cache.get(channelId) ??
         (await guild.channels.fetch(channelId).catch(() => null));
-      if (channel) await channel.delete("Event ended");
+      if (channel) await channel.delete(reason);
     } catch (error) {
       if (this.isDiscardableError(error, DISCORD_UNKNOWN_CHANNEL)) return;
       logger.error("Error deleting event channel:", error);


### PR DESCRIPTION
## Description

`event-service.ts` had two independent code paths that could both decide to create a Discord voice channel for the same event at the same time:

- the cron scan (`processEvent` → `shouldCreateChannel`), and
- the manual "start now" path (`startEventNow`, reachable from `/admin/events/:id/start-now` and the `/event start` command).

Each gated channel creation purely on its own in-memory copy of `Event.channelId` and then persisted with a plain `await event.save()`. When both fired for the same event within its create-lead window they each called `guild.channels.create()`, producing **two** voice channels while the row can only reference one. Whichever `.save()` lost the race left its channel orphaned with no `channelId` anywhere in the DB, so the grace-period cleanup sweep (keyed off `event.channelId`) never found it and it sat in the guild indefinitely.

Both paths now route through a new `claimEventChannel()` helper that creates the channel and then performs an atomic compare-and-set:

```ts
Event.findOneAndUpdate({ _id: event._id, channelId: null }, { $set: { channelId: channel.id } })
```

Only the first caller to land its write matches the document and wins the claim — this holds across multiple processes/replicas, not just within one process. A caller that loses the race tears down the redundant channel it just created and adopts the winner's `channelId`, so no orphan is left behind. On an outright creation failure `channelId` stays `null`, so callers can still distinguish a genuine failure from a lost race.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #730

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality

Added two regression tests that drive `startEventNow` through both branches of the claim:
- **wins the claim** — creates the channel exactly once, sets `channelId`, marks the event `active`, and issues the `findOneAndUpdate` with the `channelId: null` filter;
- **loses the claim** — deletes the redundant channel it created, adopts the winner's `channelId`, and does not re-save the row.

`npm run build`, `npm run lint`, and `npm run format:check` all pass.

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas

No configuration keys, commands, or dependencies changed, so `SETTINGS.md`, `COMMANDS.md`, and the Dockerfiles are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFH36tmAaMWy6FNd7onS49)_