### PR TITLE
feat(moderation): add lightweight moderation log with /warn, /modlog, and admin page

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -36,6 +36,9 @@ See [WEBUI.md](WEBUI.md) for the full surface breakdown.
   - [/achievements](#achievements)
   - [/quote](#quote)
   - [/event](#event)
+- [Moderation commands](#-moderation-commands)
+  - [/warn](#warn)
+  - [/modlog](#modlog)
 - [Web UI launcher](#-web-ui-launcher)
   - [/config](#config)
 - [Voice Channel Control Panel](#voice-channel-control-panel)
@@ -544,6 +547,55 @@ restart-safe — progress is tracked on the stored event, not in memory.
 
 ---
 
+## 🚨 Moderation commands
+
+A lightweight, queryable **moderation log**. KoolBot records warnings issued
+with `/warn` and mirrors native kick / ban / unban / timeout actions from the
+guild audit log into one place, so you can answer "has this person been
+warned before / what's their history?" without scrolling Discord's native
+audit log (which only retains ~45 days and has no per-user warn concept).
+
+Gated by the `moderation.enabled` feature flag. Both commands default to
+members with the **Moderate Members** permission (and administrators);
+additional roles can be granted from the Web UI's **Permissions** page.
+Server-wide history is also viewable on the `/admin/moderation` page.
+
+Capturing native actions requires the bot to have the **View Audit Log**
+permission. See [SETTINGS.md](SETTINGS.md#moderation).
+
+### `/warn`
+
+Record a warning against a member. Warnings are KoolBot's own record —
+Discord has no native warning action — so this is the only place they exist.
+The confirmation is shown only to you (ephemeral); the warned member is not
+DM'd.
+
+```text
+/warn user:@SomeMember reason:"Spamming in #general"
+```
+
+**Options:**
+
+- `user` (required) — the member to warn
+- `reason` (required) — why the member is being warned (up to 512 characters)
+
+### `/modlog`
+
+View a member's moderation history (warnings plus mirrored native actions),
+newest first, paginated 10 per page. The reply is ephemeral.
+
+```text
+/modlog user:@SomeMember
+/modlog user:@SomeMember page:2
+```
+
+**Options:**
+
+- `user` (required) — the member whose history to view
+- `page` (optional) — page of history to view (10 per page; defaults to 1)
+
+---
+
 ## 🔧 Web UI launcher
 
 KoolBot has exactly one Web UI slash command. It does one thing: mint a
@@ -793,8 +845,12 @@ button to admit them. **🗑️ Remove Waiting Room** deletes it.
 | `/quote`                       | Everyone\*       | Quotes enabled                |
 | `/event list`                  | Everyone\*       | Events enabled                |
 | `/event` create/cancel/start   | Administrator    | Events enabled                |
+| `/warn`                        | Moderate Members | Moderation log enabled        |
+| `/modlog`                      | Moderate Members | Moderation log enabled        |
 
 \* Per-command role gating can be added in the Web UI's **Permissions** page.
+`/warn` and `/modlog` default to members with the **Moderate Members**
+permission (and administrators); grant additional roles from the same page.
 
 ### Web UI launcher permissions
 
@@ -837,6 +893,11 @@ The bot needs these Discord permissions:
 
 - Manage Roles (same hierarchy rule as above)
 
+**For the moderation log:**
+
+- View Audit Log (so native kick / ban / timeout actions can be mirrored
+  into the log; `/warn` works without it)
+
 ---
 
 ## 📚 Quick Command Reference
@@ -854,6 +915,8 @@ The bot needs these Discord permissions:
 /quote edit id:"..." [text:"..."] [author:@User]
 /event list                         # List upcoming events
 /event create title:"..." date:YYYY-MM-DD time:HH:MM  # (admin) schedule an event
+/warn user:@User reason:"..."       # (mod) record a warning
+/modlog user:@User [page:N]         # (mod) view a member's moderation history
 ```
 
 ### Web UI launcher

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -41,6 +41,7 @@ Complete configuration reference for all KoolBot settings.
 - [Rewind (Year-in-Review)](#-rewind-year-in-review)
 - [Birthdays](#-birthdays)
 - [Events](#-events)
+- [Moderation](#-moderation)
 - [Reaction Roles](#-reaction-roles)
 - [Leaderboard Role Rewards](#-leaderboard-role-rewards)
 - [Rate Limiting](#-rate-limiting)
@@ -704,6 +705,38 @@ command (see [COMMANDS.md](COMMANDS.md#event)).
 
 ---
 
+## 🚨 Moderation
+
+A lightweight, queryable **moderation log**. Records warnings issued with
+`/warn` and mirrors native kick / ban / unban / timeout actions from the
+guild audit log into one place, so moderators can answer "has this person
+been warned before / what's their history?" without scrolling Discord's
+native audit log (which only retains ~45 days and has no per-user warn
+concept).
+
+Query per-member history in Discord with **`/modlog`**, or browse
+server-wide history on the **`/admin/moderation`** page. Both `/warn` and
+`/modlog` default to members with the **Moderate Members** permission (and
+administrators); grant additional roles from the **Permissions** page. See
+[COMMANDS.md](COMMANDS.md#-moderation-commands).
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `moderation.enabled` | `false` | Master switch — enables the `/warn` and `/modlog` commands, mirroring of native kick/ban/timeout actions from the guild audit log, and the `/admin/moderation` page |
+
+**Notes:**
+
+- Warnings are KoolBot's own record — Discord has no native warning action,
+  so `/warn` is the only place they exist. The warned member is **not** DM'd
+  (consistent with the opt-in-only DM posture).
+- Mirroring native actions requires the bot to have the **View Audit Log**
+  permission and the `GuildModeration` gateway intent (enabled by default in
+  the bot). `/warn` works without View Audit Log.
+- The log is an append-only history, not a case-management system: there are
+  no appeals, expiring warnings, or auto-moderation thresholds.
+
+---
+
 ## 🎭 Reaction Roles
 
 Self-assignable roles via message reactions. Users react to a message
@@ -1181,6 +1214,10 @@ leave the graph in a broken state.
 - `birthdays.mention` (bool, default: true)
 - `birthdays.role_id` (string, default: "")
 - `birthdays.role_duration_hours` (number, default: 24)
+
+#### Moderation
+
+- `moderation.enabled` (bool, default: false)
 
 #### Cleanup
 

--- a/__tests__/commands/modlog.test.ts
+++ b/__tests__/commands/modlog.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "@jest/globals";
+import { data, actionLabel } from "../../src/commands/modlog.js";
+
+describe("Modlog Command", () => {
+  it("has the correct command name", () => {
+    expect(data.name).toBe("modlog");
+  });
+
+  it("has a description", () => {
+    expect(data.description.length).toBeGreaterThan(0);
+  });
+
+  it("requires a user option and an optional page option", () => {
+    const json = data.toJSON();
+    expect(json.options?.[0]).toMatchObject({
+      name: "user",
+      type: 6, // User
+      required: true,
+    });
+    expect(json.options?.[1]).toMatchObject({
+      name: "page",
+      type: 4, // Integer
+    });
+    expect(json.options?.[1]?.required ?? false).toBe(false);
+  });
+
+  it("defaults to the Moderate Members permission", () => {
+    const json = data.toJSON();
+    expect(json.default_member_permissions).toBe((1n << 40n).toString());
+  });
+
+  describe("actionLabel", () => {
+    it("renders a label for every action", () => {
+      expect(actionLabel("warn")).toContain("Warn");
+      expect(actionLabel("kick")).toContain("Kick");
+      expect(actionLabel("ban")).toContain("Ban");
+      expect(actionLabel("unban")).toContain("Unban");
+      expect(actionLabel("timeout")).toContain("Timeout");
+      expect(actionLabel("untimeout")).toContain("lifted");
+    });
+  });
+});

--- a/__tests__/commands/warn.test.ts
+++ b/__tests__/commands/warn.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "@jest/globals";
+import { data } from "../../src/commands/warn.js";
+
+describe("Warn Command", () => {
+  it("has the correct command name", () => {
+    expect(data.name).toBe("warn");
+  });
+
+  it("has a description", () => {
+    expect(data.description.length).toBeGreaterThan(0);
+  });
+
+  it("requires a user and a reason option", () => {
+    const json = data.toJSON();
+    expect(json.options?.[0]).toMatchObject({
+      name: "user",
+      type: 6, // User
+      required: true,
+    });
+    expect(json.options?.[1]).toMatchObject({
+      name: "reason",
+      type: 3, // String
+      required: true,
+    });
+  });
+
+  it("defaults to the Moderate Members permission", () => {
+    const json = data.toJSON();
+    // ModerateMembers = 1 << 40. default_member_permissions is the decimal
+    // string of the permission bitfield.
+    expect(json.default_member_permissions).toBe((1n << 40n).toString());
+  });
+});

--- a/__tests__/models/moderation-log.test.ts
+++ b/__tests__/models/moderation-log.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "@jest/globals";
+
+describe("ModerationLog model", () => {
+  it("loads without throwing under the global mongoose mock", async () => {
+    const mod = await import("../../src/models/moderation-log.js");
+    expect(mod.ModerationLog).toBeDefined();
+  });
+
+  it("accepts the canonical entry shape", () => {
+    // Type-only check that the interface compiles with the documented action
+    // enum, source enum, and nullable moderator/reason fields — matching what
+    // ModerationService writes on both the /warn and audit-mirror paths.
+    const sample = {
+      guildId: "g1",
+      userId: "u1",
+      moderatorId: "m1" as string | null,
+      action: "warn" as
+        | "warn"
+        | "kick"
+        | "ban"
+        | "unban"
+        | "timeout"
+        | "untimeout",
+      reason: "spamming" as string | null,
+      source: "command" as "command" | "audit",
+      createdAt: new Date(),
+    };
+    expect(sample.action).toBe("warn");
+    expect(sample.source).toBe("command");
+    expect(sample.guildId).toBe("g1");
+  });
+});

--- a/__tests__/services/config-schema.test.ts
+++ b/__tests__/services/config-schema.test.ts
@@ -425,6 +425,7 @@ describe("Config Schema", () => {
       "leaderboard_roles.enabled": false,
       "messagetracking.enabled": false,
       "reactiontracking.enabled": false,
+      "moderation.enabled": false,
 
       // ─── Sub-features that default off (auxiliary opt-ins) ──────────
       "voicechannels.presets.enabled": false,

--- a/__tests__/services/moderation-service.test.ts
+++ b/__tests__/services/moderation-service.test.ts
@@ -130,6 +130,16 @@ describe("mapAuditLogEntry", () => {
   });
 });
 
+describe("ModerationService.isEnabled", () => {
+  it("reads the moderation.enabled config key", async () => {
+    getBooleanMock.mockResolvedValueOnce(true);
+    const service = freshService();
+
+    await expect(service.isEnabled()).resolves.toBe(true);
+    expect(getBooleanMock).toHaveBeenCalledWith("moderation.enabled", false);
+  });
+});
+
 describe("ModerationService.logWarn", () => {
   it("writes a warn row with source=command", async () => {
     createMock.mockResolvedValueOnce({ id: "row1" });

--- a/__tests__/services/moderation-service.test.ts
+++ b/__tests__/services/moderation-service.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { AuditLogEvent } from "discord.js";
+
+// The moderation-service touches a Mongoose model and ConfigService at
+// runtime. Mock both so the pure mapper and the service's gating/write logic
+// can be exercised without a DB (mirrors the event-service test).
+const getBooleanMock = jest.fn<() => Promise<boolean>>();
+
+jest.unstable_mockModule("../../src/services/config-service.js", () => ({
+  ConfigService: {
+    getInstance: jest.fn(() => ({
+      getBoolean: getBooleanMock,
+      getString: jest.fn(),
+      getNumber: jest.fn(),
+      registerReloadCallback: jest.fn(),
+    })),
+  },
+}));
+
+const createMock = jest.fn<(doc: unknown) => Promise<unknown>>();
+const findMock = jest.fn();
+const countExecMock = jest.fn<() => Promise<number>>();
+const countDocumentsMock = jest.fn(() => ({ exec: countExecMock }));
+
+function makeQuery(result: unknown[]): Record<string, unknown> {
+  const q: Record<string, unknown> = {};
+  q.sort = jest.fn(() => q);
+  q.skip = jest.fn(() => q);
+  q.limit = jest.fn(() => q);
+  q.lean = jest.fn(() => q);
+  q.exec = jest.fn(async () => result);
+  return q;
+}
+
+jest.unstable_mockModule("../../src/models/moderation-log.js", () => ({
+  ModerationLog: {
+    create: createMock,
+    find: findMock,
+    countDocuments: countDocumentsMock,
+  },
+}));
+
+jest.unstable_mockModule("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.unstable_mockModule("../../src/utils/log-sanitize.js", () => ({
+  sanitizeForLog: (v: unknown) => String(v),
+}));
+
+const { ModerationService, mapAuditLogEntry } = await import(
+  "../../src/services/moderation-service.js"
+);
+
+// A distinct fake client per test keeps the getInstance singleton from
+// leaking a stale client across the suite.
+function freshService(): InstanceType<typeof ModerationService> {
+  ModerationService.reset();
+  const client = { tag: "fake-client" } as never;
+  return ModerationService.getInstance(client);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  findMock.mockImplementation(() => makeQuery([]));
+});
+
+describe("mapAuditLogEntry", () => {
+  const base = { reason: "spam", changes: [] as never[] };
+
+  it("maps kick / ban / unban actions", () => {
+    expect(mapAuditLogEntry({ ...base, action: AuditLogEvent.MemberKick })).toEqual({
+      action: "kick",
+      reason: "spam",
+    });
+    expect(
+      mapAuditLogEntry({ ...base, action: AuditLogEvent.MemberBanAdd }),
+    ).toEqual({ action: "ban", reason: "spam" });
+    expect(
+      mapAuditLogEntry({ ...base, action: AuditLogEvent.MemberBanRemove }),
+    ).toEqual({ action: "unban", reason: "spam" });
+  });
+
+  it("treats a MemberUpdate that sets communication_disabled_until as a timeout", () => {
+    const result = mapAuditLogEntry({
+      action: AuditLogEvent.MemberUpdate,
+      reason: null,
+      changes: [
+        {
+          key: "communication_disabled_until",
+          new: "2999-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+    expect(result).toEqual({ action: "timeout", reason: null });
+  });
+
+  it("treats a cleared communication_disabled_until as untimeout", () => {
+    const result = mapAuditLogEntry({
+      action: AuditLogEvent.MemberUpdate,
+      reason: null,
+      changes: [{ key: "communication_disabled_until", new: undefined }],
+    });
+    expect(result).toEqual({ action: "untimeout", reason: null });
+  });
+
+  it("ignores a MemberUpdate without a timeout change (e.g. nickname edit)", () => {
+    expect(
+      mapAuditLogEntry({
+        action: AuditLogEvent.MemberUpdate,
+        reason: null,
+        changes: [{ key: "nick", new: "New Nick" }],
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores unrelated audit-log actions", () => {
+    expect(
+      mapAuditLogEntry({
+        action: AuditLogEvent.ChannelCreate,
+        reason: null,
+        changes: [],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("ModerationService.logWarn", () => {
+  it("writes a warn row with source=command", async () => {
+    createMock.mockResolvedValueOnce({ id: "row1" });
+    const service = freshService();
+
+    const result = await service.logWarn({
+      guildId: "g1",
+      userId: "u1",
+      moderatorId: "m1",
+      reason: "being rude",
+    });
+
+    expect(createMock).toHaveBeenCalledWith({
+      guildId: "g1",
+      userId: "u1",
+      moderatorId: "m1",
+      action: "warn",
+      reason: "being rude",
+      source: "command",
+    });
+    expect(result).toEqual({ id: "row1" });
+  });
+});
+
+describe("ModerationService.handleAuditLogEntry", () => {
+  const guild = { id: "g1" } as never;
+
+  it("does nothing when the feature is disabled", async () => {
+    getBooleanMock.mockResolvedValue(false);
+    const service = freshService();
+
+    await service.handleAuditLogEntry(
+      {
+        action: AuditLogEvent.MemberKick,
+        reason: "x",
+        changes: [],
+        targetId: "u1",
+        executorId: "m1",
+      } as never,
+      guild,
+    );
+
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("mirrors a native kick as an audit-sourced row", async () => {
+    getBooleanMock.mockResolvedValue(true);
+    const service = freshService();
+
+    await service.handleAuditLogEntry(
+      {
+        action: AuditLogEvent.MemberBanAdd,
+        reason: "raiding",
+        changes: [],
+        targetId: "u9",
+        executorId: "m9",
+      } as never,
+      guild,
+    );
+
+    expect(createMock).toHaveBeenCalledWith({
+      guildId: "g1",
+      userId: "u9",
+      moderatorId: "m9",
+      action: "ban",
+      reason: "raiding",
+      source: "audit",
+    });
+  });
+
+  it("skips entries with no target", async () => {
+    getBooleanMock.mockResolvedValue(true);
+    const service = freshService();
+
+    await service.handleAuditLogEntry(
+      {
+        action: AuditLogEvent.MemberKick,
+        reason: null,
+        changes: [],
+        targetId: null,
+        executorId: "m1",
+      } as never,
+      guild,
+    );
+
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("never throws when the write fails", async () => {
+    getBooleanMock.mockResolvedValue(true);
+    createMock.mockRejectedValueOnce(new Error("db down"));
+    const service = freshService();
+
+    await expect(
+      service.handleAuditLogEntry(
+        {
+          action: AuditLogEvent.MemberKick,
+          reason: null,
+          changes: [],
+          targetId: "u1",
+          executorId: "m1",
+        } as never,
+        guild,
+      ),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("ModerationService query helpers", () => {
+  it("getHistory filters by guild + user and paginates", async () => {
+    const query = makeQuery([{ id: "h1" }]);
+    findMock.mockReturnValueOnce(query);
+    const service = freshService();
+
+    const rows = await service.getHistory("g1", "u1", { limit: 10, skip: 20 });
+
+    expect(findMock).toHaveBeenCalledWith({ guildId: "g1", userId: "u1" });
+    expect(query.skip).toHaveBeenCalledWith(20);
+    expect(query.limit).toHaveBeenCalledWith(10);
+    expect(rows).toEqual([{ id: "h1" }]);
+  });
+
+  it("getRecent applies action + user filters when provided", async () => {
+    const query = makeQuery([]);
+    findMock.mockReturnValueOnce(query);
+    const service = freshService();
+
+    await service.getRecent("g1", {
+      action: "ban",
+      userId: "u1",
+      limit: 50,
+      skip: 0,
+    });
+
+    expect(findMock).toHaveBeenCalledWith({
+      guildId: "g1",
+      action: "ban",
+      userId: "u1",
+    });
+  });
+
+  it("countRecent omits absent filters", async () => {
+    countExecMock.mockResolvedValueOnce(7);
+    const service = freshService();
+
+    const total = await service.countRecent("g1", {});
+
+    expect(countDocumentsMock).toHaveBeenCalledWith({ guildId: "g1" });
+    expect(total).toBe(7);
+  });
+});

--- a/__tests__/services/settings-metadata.test.ts
+++ b/__tests__/services/settings-metadata.test.ts
@@ -58,6 +58,7 @@ describe("settingsMetadata", () => {
       "leaderboard_roles",
       "messagetracking",
       "reactiontracking",
+      "moderation",
     ]);
     const violations: string[] = [];
     for (const [key, meta] of Object.entries(settingsMetadata)) {

--- a/src/commands/modlog.ts
+++ b/src/commands/modlog.ts
@@ -1,0 +1,124 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  PermissionFlagsBits,
+} from "discord.js";
+import { ModerationService } from "../services/moderation-service.js";
+import type { ModerationAction } from "../models/moderation-log.js";
+import logger from "../utils/logger.js";
+
+const PAGE_SIZE = 10;
+
+/** Emoji + label shown for each action in the history embed. */
+export function actionLabel(action: ModerationAction): string {
+  switch (action) {
+    case "warn":
+      return "⚠️ Warn";
+    case "kick":
+      return "👢 Kick";
+    case "ban":
+      return "🔨 Ban";
+    case "unban":
+      return "🕊️ Unban";
+    case "timeout":
+      return "⏳ Timeout";
+    case "untimeout":
+      return "✅ Timeout lifted";
+    default:
+      return action;
+  }
+}
+
+export const data = new SlashCommandBuilder()
+  .setName("modlog")
+  .setDescription("View a member's moderation history")
+  .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
+  .addUserOption((option) =>
+    option
+      .setName("user")
+      .setDescription("The member whose history to view")
+      .setRequired(true),
+  )
+  .addIntegerOption((option) =>
+    option
+      .setName("page")
+      .setDescription("Page of history to view (10 per page)")
+      .setMinValue(1),
+  );
+
+export async function execute(
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  try {
+    if (!interaction.guildId) {
+      await interaction.reply({
+        content: "This command can only be used in a server.",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const targetUser = interaction.options.getUser("user", true);
+    const requestedPage = interaction.options.getInteger("page") ?? 1;
+
+    const moderationService = ModerationService.getInstance(interaction.client);
+    const total = await moderationService.countHistory(
+      interaction.guildId,
+      targetUser.id,
+    );
+
+    if (total === 0) {
+      await interaction.reply({
+        content: `**${targetUser.tag}** has no moderation history.`,
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+    const page = Math.min(Math.max(1, requestedPage), totalPages);
+    const skip = (page - 1) * PAGE_SIZE;
+
+    const entries = await moderationService.getHistory(
+      interaction.guildId,
+      targetUser.id,
+      { limit: PAGE_SIZE, skip },
+    );
+
+    const lines = entries.map((entry) => {
+      const when = `<t:${Math.floor(entry.createdAt.getTime() / 1000)}:f>`;
+      const moderator = entry.moderatorId
+        ? `<@${entry.moderatorId}>`
+        : "Unknown";
+      const reason = entry.reason ? `\n> ${entry.reason}` : "";
+      return `**${actionLabel(entry.action)}** · ${when} · by ${moderator}${reason}`;
+    });
+
+    const embed = new EmbedBuilder()
+      .setColor(0x6366f1)
+      .setTitle(`🛡️ Moderation history — ${targetUser.tag}`)
+      .setThumbnail(targetUser.displayAvatarURL())
+      .setDescription(lines.join("\n\n"))
+      .setFooter({
+        text: `Page ${page}/${totalPages} · ${total} total entr${
+          total === 1 ? "y" : "ies"
+        }`,
+      })
+      .setTimestamp();
+
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+  } catch (error) {
+    logger.error("Error in modlog command:", error);
+    if (interaction.replied || interaction.deferred) {
+      await interaction.editReply({
+        content: "There was an error fetching the moderation history.",
+      });
+    } else {
+      await interaction.reply({
+        content: "There was an error fetching the moderation history.",
+        ephemeral: true,
+      });
+    }
+  }
+}

--- a/src/commands/modlog.ts
+++ b/src/commands/modlog.ts
@@ -63,6 +63,18 @@ export async function execute(
     const requestedPage = interaction.options.getInteger("page") ?? 1;
 
     const moderationService = ModerationService.getInstance(interaction.client);
+
+    // Runtime gate: moderation.enabled is the documented master switch, so a
+    // stale command registration must not keep serving history after the
+    // feature is turned off.
+    if (!(await moderationService.isEnabled())) {
+      await interaction.reply({
+        content: "The moderation log is currently disabled.",
+        ephemeral: true,
+      });
+      return;
+    }
+
     const total = await moderationService.countHistory(
       interaction.guildId,
       targetUser.id,

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -62,6 +62,19 @@ export async function execute(
     }
 
     const moderationService = ModerationService.getInstance(interaction.client);
+
+    // Runtime gate: the command is only registered while moderation.enabled is
+    // true, but Discord keeps a stale registration until the next reload, so an
+    // operator who toggles the feature off expects new writes to stop
+    // immediately. Return a clear message instead of recording a warning.
+    if (!(await moderationService.isEnabled())) {
+      await interaction.reply({
+        content: "The moderation log is currently disabled.",
+        ephemeral: true,
+      });
+      return;
+    }
+
     await moderationService.logWarn({
       guildId: interaction.guildId,
       userId: targetUser.id,

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -1,0 +1,105 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  PermissionFlagsBits,
+} from "discord.js";
+import { ModerationService } from "../services/moderation-service.js";
+import logger from "../utils/logger.js";
+
+const MAX_REASON_LENGTH = 512;
+
+export const data = new SlashCommandBuilder()
+  .setName("warn")
+  .setDescription("Record a warning against a member (moderation log)")
+  // Hide the command from members without the Moderate Members permission by
+  // default. The bot's own PermissionsService still gates execution and lets
+  // admins configure additional roles.
+  .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
+  .addUserOption((option) =>
+    option
+      .setName("user")
+      .setDescription("The member to warn")
+      .setRequired(true),
+  )
+  .addStringOption((option) =>
+    option
+      .setName("reason")
+      .setDescription("Why the member is being warned")
+      .setRequired(true)
+      .setMaxLength(MAX_REASON_LENGTH),
+  );
+
+export async function execute(
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  try {
+    if (!interaction.guildId) {
+      await interaction.reply({
+        content: "This command can only be used in a server.",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const targetUser = interaction.options.getUser("user", true);
+    const reason = interaction.options.getString("reason", true).trim();
+
+    if (targetUser.bot) {
+      await interaction.reply({
+        content: "You can't warn a bot.",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    if (targetUser.id === interaction.user.id) {
+      await interaction.reply({
+        content: "You can't warn yourself.",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const moderationService = ModerationService.getInstance(interaction.client);
+    await moderationService.logWarn({
+      guildId: interaction.guildId,
+      userId: targetUser.id,
+      moderatorId: interaction.user.id,
+      reason,
+    });
+
+    const total = await moderationService.countHistory(
+      interaction.guildId,
+      targetUser.id,
+    );
+
+    const embed = new EmbedBuilder()
+      .setColor(0xf59e0b)
+      .setTitle("⚠️ Warning recorded")
+      .setDescription(
+        `**${targetUser.tag}** has been warned.\nThey now have **${total}** entr${
+          total === 1 ? "y" : "ies"
+        } in the moderation log.`,
+      )
+      .addFields({ name: "Reason", value: reason })
+      .setFooter({ text: `Use /modlog to view history` })
+      .setTimestamp();
+
+    // Ephemeral so the moderator gets a clear confirmation without posting a
+    // public call-out; the durable record lives in the moderation log.
+    await interaction.reply({ embeds: [embed], ephemeral: true });
+  } catch (error) {
+    logger.error("Error in warn command:", error);
+    if (interaction.replied || interaction.deferred) {
+      await interaction.editReply({
+        content: "There was an error recording the warning.",
+      });
+    } else {
+      await interaction.reply({
+        content: "There was an error recording the warning.",
+        ephemeral: true,
+      });
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import { DigestService } from "./services/digest-service.js";
 import { RewindNudgeService } from "./services/rewind-nudge-service.js";
 import { BirthdayService } from "./services/birthday-service.js";
 import { EventService } from "./services/event-service.js";
+import { ModerationService } from "./services/moderation-service.js";
 import { WizardService } from "./services/wizard-service.js";
 import { MonitoringService } from "./services/monitoring-service.js";
 import {
@@ -107,6 +108,9 @@ const client = new Client({
     GatewayIntentBits.GuildVoiceStates,
     GatewayIntentBits.MessageContent,
     GatewayIntentBits.GuildMessageReactions,
+    // Required to receive guildAuditLogEntryCreate events for the moderation
+    // log (#728) — mirrors native kick/ban/timeout actions into the log.
+    GatewayIntentBits.GuildModeration,
     // Required to receive messagePollVoteAdd events for poll-participation
     // tracking (#570). The events still only fire for guild polls.
     GatewayIntentBits.GuildMessagePolls,
@@ -565,6 +569,7 @@ let digestService: DigestService;
 let rewindNudgeService: RewindNudgeService;
 let birthdayService: BirthdayService;
 let eventService: EventService;
+let moderationService: ModerationService;
 
 // Wrap service instantiation in try-catch to ensure errors are caught
 try {
@@ -593,6 +598,7 @@ try {
   rewindNudgeService = RewindNudgeService.getInstance(client);
   birthdayService = BirthdayService.getInstance(client);
   eventService = EventService.getInstance(client);
+  moderationService = ModerationService.getInstance(client);
 } catch (error) {
   logger.error("❌ Fatal error during service instantiation:", error);
   process.exit(1);
@@ -705,6 +711,11 @@ async function initializeServices(): Promise<void> {
     // birthday today (in their timezone)?" check.
     await birthdayService.start();
     await eventService.start();
+
+    // Initialize the moderation log (#728). No timers to own — this just logs
+    // its enabled state; the /warn write path and the audit-log mirroring
+    // below both gate on `moderation.enabled` at call time.
+    await moderationService.initialize();
 
     // Start the slash-command audit log cleanup cron (#459)
     CommandAuditCleanupService.getInstance().start();
@@ -959,6 +970,19 @@ client.on(Events.MessagePollVoteAdd, async (pollAnswer, userId) => {
     await pollParticipationTracker.handlePollVoteAdd(pollAnswer, userId);
   } catch (error) {
     logger.error("Error handling messagePollVoteAdd:", error);
+  }
+});
+
+// Mirror native moderation actions (kick/ban/unban/timeout) into the
+// moderation log (#728). Gating (enabled, action type, target present) lives
+// in the service. Requires the GuildModeration intent and the bot's View
+// Audit Log permission.
+client.on(Events.GuildAuditLogEntryCreate, async (auditLogEntry, guild) => {
+  recordDiscordEvent("guildAuditLogEntryCreate");
+  try {
+    await moderationService.handleAuditLogEntry(auditLogEntry, guild);
+  } catch (error) {
+    logger.error("Error handling guildAuditLogEntryCreate:", error);
   }
 });
 

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -21,6 +21,7 @@ export const CONFIG_CATEGORIES = [
   "help",
   "leaderboard_roles",
   "messagetracking",
+  "moderation",
   "notices",
   "ping",
   "polls",

--- a/src/models/moderation-log.ts
+++ b/src/models/moderation-log.ts
@@ -1,0 +1,75 @@
+import mongoose, { Document, Schema } from "mongoose";
+
+/**
+ * Moderation-log entry (issue #728). One append-only row per moderation
+ * action taken against a member, keyed by the target user so a moderator can
+ * ask "what's this person's history?" without scrolling Discord's native
+ * audit log (which only retains ~45 days and has no per-user warn concept).
+ *
+ * Two write paths feed the same collection:
+ *   - `warn` rows are KoolBot's own record, written by the `/warn` command —
+ *     Discord has no native warning action, so this is the only place a warn
+ *     exists.
+ *   - every other action (`kick` / `ban` / `unban` / `timeout` / `untimeout`)
+ *     is mirrored from a `GuildAuditLogEntryCreate` gateway event, so actions
+ *     taken through Discord's native UI or another bot still land in one
+ *     place. `source` records which path produced the row.
+ *
+ * Deliberately kept simple (an append-only history, not a case-management
+ * system): no appeals, expiry, or edit workflow. Indexed on
+ * `(guildId, userId, createdAt)` so the per-user `/modlog` lookup and the
+ * server-wide admin listing are both covered.
+ */
+export type ModerationAction =
+  "warn" | "kick" | "ban" | "unban" | "timeout" | "untimeout";
+
+export type ModerationSource = "command" | "audit";
+
+export interface IModerationLog extends Document {
+  guildId: string;
+  /** The member the action was taken against. */
+  userId: string;
+  /** The moderator who took the action. Null when Discord hid the executor. */
+  moderatorId: string | null;
+  action: ModerationAction;
+  reason: string | null;
+  /**
+   * `"command"` for KoolBot-issued warns via `/warn`; `"audit"` for actions
+   * mirrored from the guild audit log.
+   */
+  source: ModerationSource;
+  createdAt: Date;
+}
+
+const ModerationLogSchema = new Schema<IModerationLog>(
+  {
+    guildId: { type: String, required: true, index: true },
+    userId: { type: String, required: true, index: true },
+    moderatorId: { type: String, default: null },
+    action: {
+      type: String,
+      enum: ["warn", "kick", "ban", "unban", "timeout", "untimeout"],
+      required: true,
+    },
+    reason: { type: String, default: null },
+    source: {
+      type: String,
+      enum: ["command", "audit"],
+      required: true,
+      default: "command",
+    },
+    createdAt: { type: Date, required: true, default: Date.now, index: true },
+  },
+  { timestamps: false },
+);
+
+// Per-user history lookup (`/modlog <user>`) is the hot path: filter by
+// (guildId, userId) and sort by newest first.
+ModerationLogSchema.index({ guildId: 1, userId: 1, createdAt: -1 });
+// Server-wide admin listing filters by guild and sorts by newest first.
+ModerationLogSchema.index({ guildId: 1, createdAt: -1 });
+
+export const ModerationLog = mongoose.model<IModerationLog>(
+  "ModerationLog",
+  ModerationLogSchema,
+);

--- a/src/services/command-manager.ts
+++ b/src/services/command-manager.ts
@@ -91,6 +91,8 @@ export class CommandManager {
         },
         { name: "quote", configKey: "quotes.enabled", file: "quote" },
         { name: "event", configKey: "events.enabled", file: "event" },
+        { name: "warn", configKey: "moderation.enabled", file: "warn" },
+        { name: "modlog", configKey: "moderation.enabled", file: "modlog" },
         { name: "config", configKey: null, file: "config" }, // Always enabled - WebUI launcher
       ];
 
@@ -314,6 +316,8 @@ export class CommandManager {
         },
         { name: "quote", configKey: "quotes.enabled", file: "quote" },
         { name: "event", configKey: "events.enabled", file: "event" },
+        { name: "warn", configKey: "moderation.enabled", file: "warn" },
+        { name: "modlog", configKey: "moderation.enabled", file: "modlog" },
         { name: "config", configKey: null, file: "config" }, // Always enabled - WebUI launcher
       ];
 

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -136,6 +136,9 @@ export interface ConfigSchema {
   // Persisted command metrics (issue #648)
   "monitoring.metrics_persistence.enabled": boolean;
   "monitoring.metrics_retention_days": number;
+
+  // Moderation log (issue #728)
+  "moderation.enabled": boolean;
 }
 
 /**
@@ -339,6 +342,11 @@ export const defaultConfig: ConfigSchema = {
   // Metrics dashboard out of the box; 30-day window matches the issue.
   "monitoring.metrics_persistence.enabled": true,
   "monitoring.metrics_retention_days": 30,
+
+  // Moderation log defaults (#728). Master gate off, follows rule 1 — the
+  // /warn + /modlog commands, the GuildAuditLogEntryCreate mirroring, and the
+  // /admin/moderation page are all inert until an operator opts in.
+  "moderation.enabled": false,
 };
 
 /**
@@ -717,6 +725,11 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
     title: "Core",
     description:
       "Core bot infrastructure: audit logging, retention, and other cross-cutting concerns.",
+  },
+  moderation: {
+    title: "Moderation",
+    description:
+      "Lightweight moderation log: record warnings via /warn, mirror native kick/ban/timeout actions from the guild audit log, and query per-member history with /modlog or the admin page.",
   },
   other: {
     title: "Other",
@@ -1409,5 +1422,14 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
       "Days to keep persisted command-metric buckets before MongoDB's TTL index prunes them.",
     category: "core",
     type: "number",
+  },
+
+  // Moderation log (#728)
+  "moderation.enabled": {
+    label: "Moderation log enabled",
+    description:
+      "Enable the moderation log: the /warn and /modlog commands, mirroring of native kick/ban/timeout actions from the guild audit log, and the /admin/moderation page. Requires the bot to have the View Audit Log permission for native actions to be captured.",
+    category: "moderation",
+    type: "boolean",
   },
 };

--- a/src/services/moderation-service.ts
+++ b/src/services/moderation-service.ts
@@ -1,0 +1,248 @@
+import {
+  AuditLogEvent,
+  Client,
+  Guild,
+  type GuildAuditLogsEntry,
+} from "discord.js";
+import logger from "../utils/logger.js";
+import { sanitizeForLog } from "../utils/log-sanitize.js";
+import { ConfigService } from "./config-service.js";
+import {
+  ModerationLog,
+  type IModerationLog,
+  type ModerationAction,
+} from "../models/moderation-log.js";
+
+export interface WarnInput {
+  guildId: string;
+  userId: string;
+  moderatorId: string;
+  reason: string | null;
+}
+
+export interface ModerationHistoryQuery {
+  limit: number;
+  skip: number;
+}
+
+export interface RecentQuery extends ModerationHistoryQuery {
+  action?: ModerationAction;
+  userId?: string;
+}
+
+/**
+ * The result of interpreting a guild audit-log entry as a moderation action.
+ * `null` when the entry is not a moderation action we mirror (e.g. a
+ * `MemberUpdate` that only changed a nickname).
+ */
+export interface MappedAuditEntry {
+  action: ModerationAction;
+  reason: string | null;
+}
+
+/**
+ * Interpret a `GuildAuditLogEntryCreate` entry as a moderation action, or
+ * return `null` when it isn't one we mirror. Pure and exported so the mapping
+ * (especially the timeout add/remove disambiguation) is unit-testable without
+ * a live gateway.
+ *
+ * Timeouts have no dedicated audit-log action: Discord records them as a
+ * `MemberUpdate` carrying a `communication_disabled_until` change. A non-empty
+ * new value is a timeout being applied; an empty/absent new value is a timeout
+ * being lifted. A `MemberUpdate` without that change key (a plain nickname or
+ * role edit) is not a moderation action.
+ */
+export function mapAuditLogEntry(entry: {
+  action: number;
+  reason: string | null;
+  changes: ReadonlyArray<{ key: string; old?: unknown; new?: unknown }>;
+}): MappedAuditEntry | null {
+  const reason = entry.reason ?? null;
+  switch (entry.action) {
+    case AuditLogEvent.MemberKick:
+      return { action: "kick", reason };
+    case AuditLogEvent.MemberBanAdd:
+      return { action: "ban", reason };
+    case AuditLogEvent.MemberBanRemove:
+      return { action: "unban", reason };
+    case AuditLogEvent.MemberUpdate: {
+      const change = entry.changes.find(
+        (c) => c.key === "communication_disabled_until",
+      );
+      if (!change) return null;
+      // A future timestamp string in `new` means a timeout was applied; a
+      // cleared value (undefined / null / empty) means it was lifted.
+      const applied =
+        change.new !== undefined && change.new !== null && change.new !== "";
+      return { action: applied ? "timeout" : "untimeout", reason };
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Moderation log (issue #728). Owns two write paths into the shared
+ * `ModerationLog` collection and the read paths that `/modlog` and the admin
+ * `/admin/moderation` page consume:
+ *
+ *   - `/warn` calls {@link logWarn} directly — bot-issued warnings are not a
+ *     native Discord action, so KoolBot is the only place they exist.
+ *   - {@link handleAuditLogEntry} mirrors native kick/ban/unban/timeout
+ *     actions from `GuildAuditLogEntryCreate`, following the same "aggregate
+ *     what already happens" pattern the activity trackers use.
+ *
+ * The whole feature is gated behind `moderation.enabled` (default off). There
+ * are no timers to own, so the service needs no start/destroy — it is a thin
+ * façade over the model plus the config gate, constructed with the standard
+ * `getInstance(client)` singleton pattern.
+ */
+export class ModerationService {
+  private static instance: ModerationService;
+  private client: Client;
+  private configService: ConfigService;
+
+  private constructor(client: Client) {
+    this.client = client;
+    this.configService = ConfigService.getInstance();
+  }
+
+  public static getInstance(client: Client): ModerationService {
+    if (!ModerationService.instance) {
+      ModerationService.instance = new ModerationService(client);
+    } else if (ModerationService.instance.client !== client) {
+      throw new Error(
+        "ModerationService already initialised with a different client",
+      );
+    }
+    return ModerationService.instance;
+  }
+
+  public static reset(): void {
+    ModerationService.instance = undefined as unknown as ModerationService;
+  }
+
+  public async isEnabled(): Promise<boolean> {
+    return this.configService.getBoolean("moderation.enabled", false);
+  }
+
+  public async initialize(): Promise<void> {
+    const enabled = await this.isEnabled();
+    logger.info(
+      `ModerationService initialized (moderation.enabled=${enabled})`,
+    );
+  }
+
+  /**
+   * Record a bot-issued warning. Called by the `/warn` command. Returns the
+   * persisted row so the caller can surface a confirmation.
+   */
+  public async logWarn(input: WarnInput): Promise<IModerationLog> {
+    const entry = await ModerationLog.create({
+      guildId: input.guildId,
+      userId: input.userId,
+      moderatorId: input.moderatorId,
+      action: "warn",
+      reason: input.reason,
+      source: "command",
+    });
+    logger.info(
+      `Moderation: warn recorded for user ${sanitizeForLog(
+        input.userId,
+      )} by ${sanitizeForLog(input.moderatorId)} in guild ${sanitizeForLog(
+        input.guildId,
+      )}`,
+    );
+    return entry;
+  }
+
+  /**
+   * Mirror a native moderation action from a `GuildAuditLogEntryCreate`
+   * event. No-op when the feature is disabled, when the entry is not a
+   * moderation action, or when the target is unknown. Never throws — a
+   * failure here must not crash the gateway event handler.
+   */
+  public async handleAuditLogEntry(
+    entry: GuildAuditLogsEntry,
+    guild: Guild,
+  ): Promise<void> {
+    try {
+      if (!(await this.isEnabled())) return;
+
+      const mapped = mapAuditLogEntry({
+        action: entry.action,
+        reason: entry.reason,
+        changes: entry.changes,
+      });
+      if (!mapped) return;
+
+      const targetId = entry.targetId;
+      if (!targetId) {
+        logger.debug(
+          `Moderation: skipping ${mapped.action} audit entry with no target`,
+        );
+        return;
+      }
+
+      await ModerationLog.create({
+        guildId: guild.id,
+        userId: targetId,
+        moderatorId: entry.executorId ?? null,
+        action: mapped.action,
+        reason: mapped.reason,
+        source: "audit",
+      });
+      logger.info(
+        `Moderation: mirrored ${mapped.action} for user ${sanitizeForLog(
+          targetId,
+        )} from audit log in guild ${sanitizeForLog(guild.id)}`,
+      );
+    } catch (error) {
+      logger.error("Error mirroring moderation audit-log entry:", error);
+    }
+  }
+
+  /** Per-user history, newest first. Backs `/modlog <user>`. */
+  public async getHistory(
+    guildId: string,
+    userId: string,
+    query: ModerationHistoryQuery,
+  ): Promise<IModerationLog[]> {
+    return ModerationLog.find({ guildId, userId })
+      .sort({ createdAt: -1 })
+      .skip(query.skip)
+      .limit(query.limit)
+      .lean<IModerationLog[]>()
+      .exec();
+  }
+
+  public async countHistory(guildId: string, userId: string): Promise<number> {
+    return ModerationLog.countDocuments({ guildId, userId }).exec();
+  }
+
+  /** Server-wide recent actions, newest first. Backs the admin page. */
+  public async getRecent(
+    guildId: string,
+    query: RecentQuery,
+  ): Promise<IModerationLog[]> {
+    const filter: Record<string, unknown> = { guildId };
+    if (query.action) filter.action = query.action;
+    if (query.userId) filter.userId = query.userId;
+    return ModerationLog.find(filter)
+      .sort({ createdAt: -1 })
+      .skip(query.skip)
+      .limit(query.limit)
+      .lean<IModerationLog[]>()
+      .exec();
+  }
+
+  public async countRecent(
+    guildId: string,
+    query: Pick<RecentQuery, "action" | "userId">,
+  ): Promise<number> {
+    const filter: Record<string, unknown> = { guildId };
+    if (query.action) filter.action = query.action;
+    if (query.userId) filter.userId = query.userId;
+    return ModerationLog.countDocuments(filter).exec();
+  }
+}

--- a/src/web/admin-layout.ts
+++ b/src/web/admin-layout.ts
@@ -100,6 +100,12 @@ export const NAV_ITEMS: NavItem[] = [
   { href: "/admin/database", label: "Database", group: "Info" },
   { href: "/admin/audit/commands", label: "Command Audit", group: "Info" },
   { href: "/admin/metrics", label: "Command Metrics", group: "Info" },
+  {
+    href: "/admin/moderation",
+    label: "Moderation",
+    group: "Info",
+    featureKey: "moderation.enabled",
+  },
   { href: "/admin/bootstrap", label: "Bootstrap", group: "Info" },
   // Settings — configuration & setup surfaces.
   { href: "/admin/settings", label: "Settings", group: "Settings" },

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -22,6 +22,7 @@ import {
 import { DAY_NAMES, formatHourLabel } from "../services/rewind-service.js";
 import type { BotStatusPool } from "../content/statuses.js";
 import type { GuildVoiceHeatmap } from "../services/voice-activity-analytics.js";
+import type { ModerationAction } from "../models/moderation-log.js";
 
 interface CommonProps {
   csrfToken: string;
@@ -3065,6 +3066,178 @@ export function renderCommandAuditPage(props: CommandAuditProps): string {
   return renderAdminPage({
     title: "Command audit",
     active: "/admin/audit/commands",
+    body,
+    csrfToken: props.csrfToken,
+    remainingMs: props.remainingMs,
+    navFeatureStatus: props.navFeatureStatus,
+  });
+}
+
+// ---------- Moderation log (issue #728) ----------
+
+export interface ModerationRow {
+  createdAt: string;
+  userId: string;
+  userLabel: string;
+  moderatorId: string | null;
+  moderatorLabel: string | null;
+  action: ModerationAction;
+  reason: string | null;
+  source: "command" | "audit";
+}
+
+export interface ModerationProps extends CommonProps {
+  enabled: boolean;
+  /** All action types — populates the filter dropdown. */
+  actionOptions: ModerationAction[];
+  /** Distinct target user IDs on the current page — populates the user filter. */
+  userOptions: Array<{ id: string; label: string }>;
+  filters: {
+    action: string;
+    userId: string;
+  };
+  rows: ModerationRow[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+const MODERATION_ACTION_LABELS: Record<ModerationAction, string> = {
+  warn: "warn",
+  kick: "kick",
+  ban: "ban",
+  unban: "unban",
+  timeout: "timeout",
+  untimeout: "untimeout",
+};
+
+function moderationActionTag(action: ModerationAction): string {
+  const label = MODERATION_ACTION_LABELS[action] ?? action;
+  // Warns/timeouts are cautionary (amber), kicks/bans are severe (red), and the
+  // "undo" actions (unban / untimeout) read as positive (green).
+  const cls =
+    action === "unban" || action === "untimeout"
+      ? "tag-on"
+      : action === "ban" || action === "kick"
+        ? "tag-off"
+        : "tag-warn";
+  return `<span class="tag ${cls}">${escapeHtml(label)}</span>`;
+}
+
+function buildModerationQueryString(
+  filters: ModerationProps["filters"],
+  page: number,
+): string {
+  const parts: string[] = [];
+  if (filters.action)
+    parts.push(`action=${encodeURIComponent(filters.action)}`);
+  if (filters.userId) parts.push(`user=${encodeURIComponent(filters.userId)}`);
+  if (page > 1) parts.push(`page=${page}`);
+  return parts.length === 0 ? "" : `?${parts.join("&")}`;
+}
+
+export function renderModerationPage(props: ModerationProps): string {
+  const totalPages = Math.max(1, Math.ceil(props.total / props.pageSize));
+  const page = Math.min(Math.max(1, props.page), totalPages);
+
+  const actionOptionsHtml = props.actionOptions
+    .map((a) => {
+      const sel = a === props.filters.action ? " selected" : "";
+      return `<option value="${escapeHtml(a)}"${sel}>${escapeHtml(
+        MODERATION_ACTION_LABELS[a] ?? a,
+      )}</option>`;
+    })
+    .join("");
+  const userOptionsHtml = props.userOptions
+    .map((u) => {
+      const sel = u.id === props.filters.userId ? " selected" : "";
+      return `<option value="${escapeHtml(u.id)}"${sel}>${escapeHtml(u.label)}</option>`;
+    })
+    .join("");
+
+  const rowsHtml =
+    props.rows.length === 0
+      ? `<div class="empty">No moderation actions match the current filters.</div>`
+      : `<table>
+<thead><tr>
+<th>When</th><th>User</th><th>Action</th><th>Moderator</th>
+<th>Reason</th><th>Source</th>
+</tr></thead>
+<tbody>${props.rows
+          .map((r) => {
+            const moderator = r.moderatorId
+              ? `<span title="${escapeHtml(r.moderatorId)}">${escapeHtml(
+                  r.moderatorLabel ?? r.moderatorId,
+                )}</span>`
+              : '<span class="muted">Unknown</span>';
+            return `<tr>
+<td class="muted mono">${escapeHtml(r.createdAt)}</td>
+<td title="${escapeHtml(r.userId)}">${escapeHtml(r.userLabel)}</td>
+<td>${moderationActionTag(r.action)}</td>
+<td>${moderator}</td>
+<td class="muted">${r.reason ? escapeHtml(r.reason.slice(0, 200)) : "—"}</td>
+<td class="muted">${escapeHtml(r.source)}</td>
+</tr>`;
+          })
+          .join("")}</tbody></table>`;
+
+  const prevLink =
+    page > 1
+      ? `<a class="btn btn-sm" href="/admin/moderation${buildModerationQueryString(props.filters, page - 1)}">← Prev</a>`
+      : `<button class="btn btn-sm" disabled>← Prev</button>`;
+  const nextLink =
+    page < totalPages
+      ? `<a class="btn btn-sm" href="/admin/moderation${buildModerationQueryString(props.filters, page + 1)}">Next →</a>`
+      : `<button class="btn btn-sm" disabled>Next →</button>`;
+
+  const body = `
+<h1>Moderation log</h1>
+<p class="subtitle">Warnings recorded via <code>/warn</code> plus native kick/ban/timeout actions mirrored from the guild audit log. Query per-member history in Discord with <code>/modlog</code>.</p>
+
+${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Moderation", featureKey: "moderation.enabled", returnTo: "/admin/moderation", csrfToken: props.csrfToken })}
+
+<div class="card">
+  <h2>Status</h2>
+  <dl class="kv">
+    <dt>Moderation log</dt><dd>${props.enabled ? '<span class="tag tag-on">enabled</span>' : '<span class="tag tag-off">disabled</span>'}</dd>
+    <dt>Actions matched</dt><dd>${props.total}</dd>
+  </dl>
+  <p class="muted">Native actions require the bot to have the <strong>View Audit Log</strong> permission.</p>
+</div>
+
+<div class="card">
+  <h2>Filters</h2>
+  <form method="GET" action="/admin/moderation" class="inline-form">
+    <label>Action
+      <select name="action">
+        <option value="">— any —</option>
+        ${actionOptionsHtml}
+      </select>
+    </label>
+    <label>User
+      <select name="user">
+        <option value="">— any —</option>
+        ${userOptionsHtml}
+      </select>
+    </label>
+    <button type="submit" class="btn btn-primary btn-sm">Apply</button>
+    <a class="btn btn-sm" href="/admin/moderation">Reset</a>
+  </form>
+</div>
+
+<div class="card">
+  <h2>Actions (page ${page} of ${totalPages})</h2>
+  ${rowsHtml}
+  <div class="inline-form" style="margin-top:.75rem">
+    ${prevLink}
+    ${nextLink}
+    <span class="muted">${props.pageSize} per page</span>
+  </div>
+</div>
+`;
+  return renderAdminPage({
+    title: "Moderation log",
+    active: "/admin/moderation",
     body,
     csrfToken: props.csrfToken,
     remainingMs: props.remainingMs,

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -47,6 +47,8 @@ import {
 } from "../services/voice-channel-manager.js";
 import { WebAuditLog } from "../models/web-audit-log.js";
 import { DiscordCommandAuditLog } from "../models/discord-command-audit-log.js";
+import { ModerationService } from "../services/moderation-service.js";
+import type { ModerationAction } from "../models/moderation-log.js";
 import { getCommandMetricsSummary } from "../services/command-metrics-query.js";
 import { getGuildVoiceHeatmap } from "../services/voice-activity-analytics.js";
 import { getServerTimezone, resolveTimezone } from "../utils/timezone.js";
@@ -76,11 +78,13 @@ import {
   renderNoticesPage,
   renderPermissionsPage,
   renderPollsPage,
+  renderModerationPage,
   renderReactionRolesPage,
   renderSettingsPage,
   renderVoiceChannelsPage,
   type ChannelOption,
   type CommandAuditRow,
+  type ModerationRow,
   type DbTrunkHistoryRow,
   type DigestPreviewView,
   type FlashMessage,
@@ -1380,6 +1384,113 @@ export function createReadOnlyRouter(
             result: resultFilter,
             from: fromFilter,
             to: toFilter,
+          },
+          rows,
+          total,
+          page,
+          pageSize,
+        }),
+      );
+    }),
+  );
+
+  // ---------- Moderation log (#728) ----------
+  const MODERATION_ACTIONS: ModerationAction[] = [
+    "warn",
+    "kick",
+    "ban",
+    "unban",
+    "timeout",
+    "untimeout",
+  ];
+
+  router.get(
+    "/moderation",
+    asyncHandler(async (req, res) => {
+      const common = await commonFromReq(req);
+      const config = ConfigService.getInstance();
+      const moderationService = ModerationService.getInstance(client);
+
+      const pageSize = 50;
+      const pageRaw = Number.parseInt(String(req.query.page ?? "1"), 10);
+      const page = Number.isFinite(pageRaw) && pageRaw > 0 ? pageRaw : 1;
+
+      const actionRaw = String(req.query.action ?? "").trim();
+      const actionFilter = (MODERATION_ACTIONS as string[]).includes(actionRaw)
+        ? (actionRaw as ModerationAction)
+        : undefined;
+      const userFilter = String(req.query.user ?? "").trim() || undefined;
+
+      const [enabled, total, docs] = await Promise.all([
+        config.getBoolean("moderation.enabled", false),
+        moderationService
+          .countRecent(common.guildId, {
+            action: actionFilter,
+            userId: userFilter,
+          })
+          .catch(() => 0),
+        moderationService
+          .getRecent(common.guildId, {
+            action: actionFilter,
+            userId: userFilter,
+            limit: pageSize,
+            skip: (page - 1) * pageSize,
+          })
+          .catch(() => []),
+      ]);
+
+      // Resolve user + moderator labels from the guild member cache so the
+      // table shows names rather than raw snowflakes.
+      const idsOnPage = new Set<string>();
+      for (const d of docs) {
+        idsOnPage.add(d.userId);
+        if (d.moderatorId) idsOnPage.add(d.moderatorId);
+      }
+      const labels = new Map<string, string>();
+      try {
+        const guild = await client.guilds.fetch(common.guildId);
+        for (const id of idsOnPage) {
+          try {
+            const member = await guild.members.fetch(id);
+            labels.set(id, member.displayName ?? member.user.username);
+          } catch {
+            // Member left the guild or fetch failed; fall back to ID.
+          }
+        }
+      } catch (err) {
+        logger.debug("moderation page member-label fetch failed", err);
+      }
+
+      const rows: ModerationRow[] = docs.map((d) => ({
+        createdAt:
+          d.createdAt instanceof Date
+            ? d.createdAt.toISOString()
+            : String(d.createdAt ?? ""),
+        userId: d.userId,
+        userLabel: labels.get(d.userId) ?? d.userId,
+        moderatorId: d.moderatorId ?? null,
+        moderatorLabel: d.moderatorId
+          ? (labels.get(d.moderatorId) ?? d.moderatorId)
+          : null,
+        action: d.action,
+        reason: d.reason ?? null,
+        source: d.source,
+      }));
+
+      // The user filter dropdown is seeded from the target users on this page.
+      const userOptions = Array.from(new Set(docs.map((d) => d.userId)))
+        .sort()
+        .map((id) => ({ id, label: labels.get(id) ?? id }));
+
+      res.type("text/html").send(
+        renderModerationPage({
+          ...common,
+          enabled,
+          actionOptions: MODERATION_ACTIONS,
+          userOptions,
+          filters: {
+            action: actionFilter ?? "",
+            userId: userFilter ?? "",
           },
           rows,
           total,

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -1421,44 +1421,66 @@ export function createReadOnlyRouter(
         : undefined;
       const userFilter = String(req.query.user ?? "").trim() || undefined;
 
-      const [enabled, total, docs] = await Promise.all([
-        config.getBoolean("moderation.enabled", false),
-        moderationService
-          .countRecent(common.guildId, {
-            action: actionFilter,
-            userId: userFilter,
-          })
-          .catch(() => 0),
-        moderationService
-          .getRecent(common.guildId, {
-            action: actionFilter,
-            userId: userFilter,
-            limit: pageSize,
-            skip: (page - 1) * pageSize,
-          })
-          .catch(() => []),
-      ]);
+      // moderation.enabled is the master gate: when off, the page renders the
+      // disabled banner and an empty table without touching the DB, matching
+      // the "inert until opted in" contract in defaultConfig.
+      const enabled = await config.getBoolean("moderation.enabled", false);
+      const [total, docs] = enabled
+        ? await Promise.all([
+            moderationService
+              .countRecent(common.guildId, {
+                action: actionFilter,
+                userId: userFilter,
+              })
+              .catch(() => 0),
+            moderationService
+              .getRecent(common.guildId, {
+                action: actionFilter,
+                userId: userFilter,
+                limit: pageSize,
+                skip: (page - 1) * pageSize,
+              })
+              .catch(() => []),
+          ])
+        : [0, []];
 
-      // Resolve user + moderator labels from the guild member cache so the
-      // table shows names rather than raw snowflakes.
+      // Resolve user + moderator labels to display names. Look in the member
+      // cache first and batch the misses into a single `fetch({ user: [...] })`
+      // request rather than one awaited fetch per id — a page of 50 rows can
+      // reference up to ~100 distinct ids, and per-id fetches would be slow and
+      // rate-limit-prone. Ids that stay unresolved (member left the guild) fall
+      // back to the raw snowflake at render time.
       const idsOnPage = new Set<string>();
       for (const d of docs) {
         idsOnPage.add(d.userId);
         if (d.moderatorId) idsOnPage.add(d.moderatorId);
       }
       const labels = new Map<string, string>();
-      try {
-        const guild = await client.guilds.fetch(common.guildId);
-        for (const id of idsOnPage) {
-          try {
-            const member = await guild.members.fetch(id);
-            labels.set(id, member.displayName ?? member.user.username);
-          } catch {
-            // Member left the guild or fetch failed; fall back to ID.
+      if (idsOnPage.size > 0) {
+        try {
+          const guild = await client.guilds.fetch(common.guildId);
+          const missing: string[] = [];
+          for (const id of idsOnPage) {
+            const cached = guild.members.cache.get(id);
+            if (cached) {
+              labels.set(id, cached.displayName ?? cached.user.username);
+            } else {
+              missing.push(id);
+            }
           }
+          if (missing.length > 0) {
+            const fetched = await guild.members
+              .fetch({ user: missing })
+              .catch(() => null);
+            if (fetched) {
+              for (const [id, member] of fetched) {
+                labels.set(id, member.displayName ?? member.user.username);
+              }
+            }
+          }
+        } catch (err) {
+          logger.debug("moderation page member-label fetch failed", err);
         }
-      } catch (err) {
-        logger.debug("moderation page member-label fetch failed", err);
       }
 
       const rows: ModerationRow[] = docs.map((d) => ({


### PR DESCRIPTION
## Description

Adds a lightweight, queryable **moderation log** (issue #728). KoolBot has deep per-user engagement tracking but no concept of moderation history — this fills that gap without a full mod-bot.

Two write paths feed one append-only collection:

- **`/warn`** records KoolBot's own warnings (Discord has no native warning action).
- **`GuildAuditLogEntryCreate`** mirroring captures native kick / ban / unban / timeout (and timeout-lifted) actions taken via Discord's UI or another bot, so everything lands in one place — the same "aggregate what already happens" pattern the activity trackers use.

Surfaced three ways: `/modlog <user>` (paginated per-member history in Discord), and a server-wide `/admin/moderation` page with action/user filters. Architecturally a close cousin of `web-audit-log` (append-only log + admin listing) plus the existing `permissions-service` gating.

Highlights:

- **Model** `models/moderation-log.ts` — `{ guildId, userId, moderatorId, action, reason, source, createdAt }`, indexed on `(guildId, userId, createdAt)`.
- **Service** `moderation-service.ts` — singleton `getInstance(client)`; `logWarn` write path, `handleAuditLogEntry` mirroring with a pure, unit-tested `mapAuditLogEntry` (incl. timeout add/remove disambiguation), and history/recent read paths.
- **Commands** `/warn` and `/modlog` — wired into both `CommandManager` arrays, default to the **Moderate Members** permission (still subject to `PermissionsService`).
- **Web** — new `/admin/moderation` Info-nav page (feature-gated) with filters + pagination.
- **Config** — `moderation.enabled` (default `false`) added to the schema, `Config` category enum, and settings metadata.
- **Wiring** — `GuildModeration` intent + `GuildAuditLogEntryCreate` handler in `src/index.ts`.

Out of scope (per the issue): auto-moderation, DM-ing warned users, and case-management workflows (appeals/expiry).

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update
- [x] 🧪 Test updates

## Related Issues

Closes #728

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality

New tests: `__tests__/models/moderation-log.test.ts`, `__tests__/services/moderation-service.test.ts` (pure mapper + gating/write/query paths), `__tests__/commands/warn.test.ts`, `__tests__/commands/modlog.test.ts`. Invariant audits in `config-schema.test.ts` / `settings-metadata.test.ts` updated for the new key. Full suite: **125 suites / 1544 passing** under `npm run test:ci`.

**Test Configuration**:

- Node.js version: 22
- Discord.js version: ^14.26.4
- Operating System: Linux

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary:
  - [x] `COMMANDS.md` (added `/warn` and `/modlog`)
  - [x] `SETTINGS.md` (added the Moderation section + `moderation.enabled`)
  - [x] Inline code comments for complex logic
- [x] I have validated markdown with `npx markdownlint`

### Configuration

- [x] New features are disabled by default and toggleable via configuration
- [x] I have added configuration schema entries in `config-schema.ts`
- [x] I have documented new configuration keys in `SETTINGS.md`

## Additional Notes

Native-action mirroring requires the bot to have the **View Audit Log** permission (documented in both COMMANDS.md and SETTINGS.md); `/warn` works without it. The warned member is intentionally not DM'd, consistent with the opt-in-only DM posture.

## Pre-Submission Verification

- [x] I have rebased my branch on the latest main branch
- [x] I have resolved any merge conflicts
- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMopNVkBW3ENHqccADyDmH

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMopNVkBW3ENHqccADyDmH)_