### PR TITLE
feat(moderation): add moderation-log retention config and daily cleanup job

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -736,10 +736,9 @@ administrators); grant additional roles from the **Permissions** page. See
 - The log is an append-only history, not a case-management system: there are
   no appeals, expiring warnings, or auto-moderation thresholds.
 - Retention: a daily cleanup job (03:30 server time) prunes rows older than
-  `moderation.retention_days`. The default of one year deliberately keeps
-  moderation history longer than the voice/message activity trackers keep
-  their detail data; set it to `0` if the log should never be pruned. The
-  job only runs while `moderation.enabled` is on.
+  `moderation.retention_days` (default: one year). Set it to `0` if the log
+  should never be pruned. The job only runs while `moderation.enabled` is
+  on.
 
 ---
 

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -723,6 +723,7 @@ administrators); grant additional roles from the **Permissions** page. See
 | Setting | Default | Description |
 | --- | --- | --- |
 | `moderation.enabled` | `false` | Master switch — enables the `/warn` and `/modlog` commands, mirroring of native kick/ban/timeout actions from the guild audit log, and the `/admin/moderation` page |
+| `moderation.retention_days` | `365` | Days to keep moderation-log rows before the daily cleanup prunes them. Set to `0` to keep history forever |
 
 **Notes:**
 
@@ -734,6 +735,11 @@ administrators); grant additional roles from the **Permissions** page. See
   the bot). `/warn` works without View Audit Log.
 - The log is an append-only history, not a case-management system: there are
   no appeals, expiring warnings, or auto-moderation thresholds.
+- Retention: a daily cleanup job (03:30 server time) prunes rows older than
+  `moderation.retention_days`. The default of one year deliberately keeps
+  moderation history longer than the voice/message activity trackers keep
+  their detail data; set it to `0` if the log should never be pruned. The
+  job only runs while `moderation.enabled` is on.
 
 ---
 
@@ -1218,6 +1224,7 @@ leave the graph in a broken state.
 #### Moderation
 
 - `moderation.enabled` (bool, default: false)
+- `moderation.retention_days` (number, default: 365)
 
 #### Cleanup
 

--- a/__tests__/services/moderation-log-cleanup.test.ts
+++ b/__tests__/services/moderation-log-cleanup.test.ts
@@ -28,16 +28,35 @@ jest.unstable_mockModule("../../src/utils/logger.js", () => ({
   },
 }));
 
+// Observable CronJob mock: records every constructed job so the tests can
+// assert on the schedule expression and start/stop lifecycle.
+interface MockCronJob {
+  expression: string;
+  started: boolean;
+  stopped: boolean;
+}
+const cronInstances: MockCronJob[] = [];
+
 jest.unstable_mockModule("cron", () => ({
-  CronJob: class {
-    start(): void {}
-    stop(): void {}
+  CronJob: class implements MockCronJob {
+    expression: string;
+    started = false;
+    stopped = false;
+    constructor(expression: string) {
+      this.expression = expression;
+      cronInstances.push(this);
+    }
+    start(): void {
+      this.started = true;
+    }
+    stop(): void {
+      this.stopped = true;
+    }
   },
 }));
 
-const { ModerationLogCleanupService } = await import(
-  "../../src/services/moderation-log-cleanup.js"
-);
+const { ModerationLogCleanupService } =
+  await import("../../src/services/moderation-log-cleanup.js");
 
 describe("ModerationLogCleanupService", () => {
   beforeEach(() => {
@@ -45,6 +64,28 @@ describe("ModerationLogCleanupService", () => {
     mockGetBoolean.mockReset();
     mockGetNumber.mockReset();
     mockDeleteMany.mockReset();
+    cronInstances.length = 0;
+  });
+
+  it("schedules a daily job at 03:30 and start() is idempotent", () => {
+    const service = ModerationLogCleanupService.getInstance();
+    service.start();
+    expect(cronInstances).toHaveLength(1);
+    expect(cronInstances[0]?.expression).toBe("30 3 * * *");
+    expect(cronInstances[0]?.started).toBe(true);
+    // A second start() while a job exists must not schedule a duplicate.
+    service.start();
+    expect(cronInstances).toHaveLength(1);
+  });
+
+  it("destroy() stops the scheduled job and allows a later restart", () => {
+    const service = ModerationLogCleanupService.getInstance();
+    service.start();
+    service.destroy();
+    expect(cronInstances[0]?.stopped).toBe(true);
+    service.start();
+    expect(cronInstances).toHaveLength(2);
+    expect(cronInstances[1]?.started).toBe(true);
   });
 
   it("is a no-op when the moderation feature is disabled", async () => {

--- a/__tests__/services/moderation-log-cleanup.test.ts
+++ b/__tests__/services/moderation-log-cleanup.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+
+const mockGetBoolean =
+  jest.fn<(key: string, def: boolean) => Promise<boolean>>();
+const mockGetNumber = jest.fn<(key: string, def: number) => Promise<number>>();
+
+jest.unstable_mockModule("../../src/services/config-service.js", () => ({
+  ConfigService: {
+    getInstance: jest.fn(() => ({
+      getBoolean: mockGetBoolean,
+      getNumber: mockGetNumber,
+    })),
+  },
+}));
+
+const mockDeleteMany = jest.fn<() => Promise<{ deletedCount: number }>>();
+
+jest.unstable_mockModule("../../src/models/moderation-log.js", () => ({
+  ModerationLog: { deleteMany: mockDeleteMany },
+}));
+
+jest.unstable_mockModule("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.unstable_mockModule("cron", () => ({
+  CronJob: class {
+    start(): void {}
+    stop(): void {}
+  },
+}));
+
+const { ModerationLogCleanupService } = await import(
+  "../../src/services/moderation-log-cleanup.js"
+);
+
+describe("ModerationLogCleanupService", () => {
+  beforeEach(() => {
+    ModerationLogCleanupService.reset();
+    mockGetBoolean.mockReset();
+    mockGetNumber.mockReset();
+    mockDeleteMany.mockReset();
+  });
+
+  it("is a no-op when the moderation feature is disabled", async () => {
+    mockGetBoolean.mockResolvedValue(false);
+    const service = ModerationLogCleanupService.getInstance();
+    const result = await service.runCleanup();
+    expect(result).toBeNull();
+    expect(mockDeleteMany).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when retention is non-positive (keep forever)", async () => {
+    mockGetBoolean.mockResolvedValue(true);
+    mockGetNumber.mockResolvedValue(0);
+    const result = await ModerationLogCleanupService.getInstance().runCleanup();
+    expect(result).toBeNull();
+    expect(mockDeleteMany).not.toHaveBeenCalled();
+  });
+
+  it("deletes rows older than the configured retention window", async () => {
+    mockGetBoolean.mockResolvedValue(true);
+    mockGetNumber.mockResolvedValue(365);
+    mockDeleteMany.mockResolvedValue({ deletedCount: 12 });
+
+    const before = Date.now();
+    const result = await ModerationLogCleanupService.getInstance().runCleanup();
+    const after = Date.now();
+
+    expect(result).toEqual({ deleted: 12 });
+    expect(mockDeleteMany).toHaveBeenCalledTimes(1);
+    const arg = mockDeleteMany.mock.calls[0]?.[0] as {
+      createdAt: { $lt: Date };
+    };
+    const cutoff = arg.createdAt.$lt.getTime();
+    const retentionMs = 365 * 24 * 60 * 60 * 1000;
+    // Cutoff is "now - 365d" computed inside the service; allow for the
+    // tiny wall-clock drift between the test's bounds and the service call.
+    expect(cutoff).toBeGreaterThanOrEqual(before - retentionMs);
+    expect(cutoff).toBeLessThanOrEqual(after - retentionMs);
+  });
+
+  it("returns null and swallows DB errors", async () => {
+    mockGetBoolean.mockResolvedValue(true);
+    mockGetNumber.mockResolvedValue(30);
+    mockDeleteMany.mockRejectedValueOnce(new Error("mongo down"));
+    const result = await ModerationLogCleanupService.getInstance().runCleanup();
+    expect(result).toBeNull();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { MessageActivityCleanupService } from "./services/message-activity-clean
 import { ReactionActivityTracker } from "./services/reaction-activity-tracker.js";
 import { PollParticipationTracker } from "./services/poll-participation-tracker.js";
 import { CommandAuditCleanupService } from "./services/command-audit-cleanup.js";
+import { ModerationLogCleanupService } from "./services/moderation-log-cleanup.js";
 import { ScheduledAnnouncementService } from "./services/scheduled-announcement-service.js";
 import { ChannelInitializer } from "./services/channel-initializer.js";
 import { StartupMigrator } from "./services/startup-migrator.js";
@@ -495,6 +496,7 @@ async function gracefulShutdown(signal: string): Promise<void> {
         voiceChannelTruncation.destroy();
         messageActivityCleanup.destroy();
         CommandAuditCleanupService.getInstance().destroy();
+        ModerationLogCleanupService.getInstance().destroy();
         await noticesChannelManager.stop();
         pollService.destroy();
         leaderboardRoleService.destroy();
@@ -719,6 +721,10 @@ async function initializeServices(): Promise<void> {
 
     // Start the slash-command audit log cleanup cron (#459)
     CommandAuditCleanupService.getInstance().start();
+
+    // Start the moderation-log retention cleanup cron (#742). Gates on
+    // `moderation.enabled` and `moderation.retention_days` at run time.
+    ModerationLogCleanupService.getInstance().start();
 
     // Initialize permissions service and set up default permissions
     const permissionsService = PermissionsService.getInstance(client);

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -347,10 +347,8 @@ export const defaultConfig: ConfigSchema = {
   // Moderation log defaults (#728). Master gate off, follows rule 1 — the
   // /warn + /modlog commands, the GuildAuditLogEntryCreate mirroring, and the
   // /admin/moderation page are all inert until an operator opts in.
-  // Retention (#742) defaults to a year — moderation history plausibly wants
-  // to outlive routine activity data (voice/message detail defaults to 400
-  // days) — and 0 disables pruning entirely for operators who want the log
-  // kept forever.
+  // Retention (#742) defaults to a year, the value proposed in the issue;
+  // 0 disables pruning entirely for operators who want the log kept forever.
   "moderation.enabled": false,
   "moderation.retention_days": 365,
 };

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -139,6 +139,7 @@ export interface ConfigSchema {
 
   // Moderation log (issue #728)
   "moderation.enabled": boolean;
+  "moderation.retention_days": number; // 0 = keep history forever (issue #742)
 }
 
 /**
@@ -346,7 +347,12 @@ export const defaultConfig: ConfigSchema = {
   // Moderation log defaults (#728). Master gate off, follows rule 1 — the
   // /warn + /modlog commands, the GuildAuditLogEntryCreate mirroring, and the
   // /admin/moderation page are all inert until an operator opts in.
+  // Retention (#742) defaults to a year — moderation history plausibly wants
+  // to outlive routine activity data (voice/message detail defaults to 400
+  // days) — and 0 disables pruning entirely for operators who want the log
+  // kept forever.
   "moderation.enabled": false,
+  "moderation.retention_days": 365,
 };
 
 /**
@@ -1431,5 +1437,12 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
       "Enable the moderation log: the /warn and /modlog commands, mirroring of native kick/ban/timeout actions from the guild audit log, and the /admin/moderation page. Requires the bot to have the View Audit Log permission for native actions to be captured.",
     category: "moderation",
     type: "boolean",
+  },
+  "moderation.retention_days": {
+    label: "Moderation log retention (days)",
+    description:
+      "Days to keep moderation-log rows before the daily cleanup job prunes them. Set to 0 to keep moderation history forever.",
+    category: "moderation",
+    type: "number",
   },
 };

--- a/src/services/moderation-log-cleanup.ts
+++ b/src/services/moderation-log-cleanup.ts
@@ -1,0 +1,84 @@
+import { CronJob } from "cron";
+import logger from "../utils/logger.js";
+import { ModerationLog } from "../models/moderation-log.js";
+import { ConfigService } from "./config-service.js";
+
+/**
+ * Periodically prune moderation-log rows older than
+ * `moderation.retention_days` (issue #742). Runs once a day at 03:30 server
+ * time — offset from the command-audit cleanup at 03:00 and the
+ * voice/message cleanups that default to 00:00 / 03:00.
+ *
+ * No-op when `moderation.enabled` is false (a disabled feature shouldn't
+ * keep pruning a static table) and when retention is zero or negative —
+ * the documented "keep history forever" setting, since moderation history
+ * plausibly wants to outlive routine activity data.
+ */
+export class ModerationLogCleanupService {
+  private static instance: ModerationLogCleanupService;
+  private configService: ConfigService;
+  private job: CronJob | null = null;
+
+  private constructor() {
+    this.configService = ConfigService.getInstance();
+  }
+
+  public static getInstance(): ModerationLogCleanupService {
+    if (!ModerationLogCleanupService.instance) {
+      ModerationLogCleanupService.instance = new ModerationLogCleanupService();
+    }
+    return ModerationLogCleanupService.instance;
+  }
+
+  public static reset(): void {
+    ModerationLogCleanupService.instance =
+      undefined as unknown as ModerationLogCleanupService;
+  }
+
+  public start(): void {
+    if (this.job) return;
+    this.job = new CronJob("30 3 * * *", () => {
+      this.runCleanup().catch((err) => {
+        logger.error("Moderation log cleanup failed:", err);
+      });
+    });
+    this.job.start();
+    logger.info("Moderation log cleanup scheduled (daily at 03:30)");
+  }
+
+  public destroy(): void {
+    if (this.job) {
+      this.job.stop();
+      this.job = null;
+    }
+  }
+
+  public async runCleanup(): Promise<{ deleted: number } | null> {
+    const enabled = await this.configService
+      .getBoolean("moderation.enabled", false)
+      .catch(() => false);
+    if (!enabled) return null;
+
+    const retentionDays = await this.configService
+      .getNumber("moderation.retention_days", 365)
+      .catch(() => 365);
+    if (!Number.isFinite(retentionDays) || retentionDays <= 0) return null;
+
+    const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+    try {
+      const result = await ModerationLog.deleteMany({
+        createdAt: { $lt: cutoff },
+      });
+      const deleted = result.deletedCount ?? 0;
+      if (deleted > 0) {
+        logger.info(
+          `Moderation log cleanup removed ${deleted} rows older than ${retentionDays}d`,
+        );
+      }
+      return { deleted };
+    } catch (err) {
+      logger.error("Moderation log deleteMany failed:", err);
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
## Description

The moderation log (#728) captured `/warn` entries and mirrored native kick/ban/unban/timeout actions with no retention story, unlike every other append-only capture feature (voice tracking, message tracking, command audit, command metrics). A busy guild's moderation log grew unbounded for the lifetime of the bot.

This PR implements option 1 from the issue:

- **New config key `moderation.retention_days`** (default **365**, the value proposed in the issue; `0` disables pruning entirely for operators who want the log kept forever). Declared in `config-schema.ts` with a default and settings metadata, so it appears on the WebUI Settings page under the existing Moderation category.
- **New `ModerationLogCleanupService`** (`src/services/moderation-log-cleanup.ts`) mirroring the existing `CommandAuditCleanupService` pattern: a daily cron (03:30 server time, offset from the command-audit cleanup at 03:00 and the voice/message cleanups at 00:00/03:00) that runs `deleteMany({ createdAt: { $lt: cutoff } })` on `ModerationLog`. It no-ops while `moderation.enabled` is off (a disabled feature shouldn't keep pruning a static table) or when retention is zero/negative, and swallows DB errors so the cron never crashes the process.
- **Wiring in `src/index.ts`**: started alongside the command-audit cleanup cron, destroyed on shutdown.
- **`SETTINGS.md`** documents the new key in the Moderation table, a retention note in the section body, and the all-settings listing.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Related Issues

Fixes #742

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality
- [ ] Manually tested in development environment
- [ ] Tested in Docker environment

New suite `__tests__/services/moderation-log-cleanup.test.ts` covers: the scheduling contract (03:30 cron expression, idempotent `start()`, `destroy()` stopping the job) via an observable `CronJob` mock, no-op when the feature is disabled, no-op when retention is non-positive (keep-forever), correct cutoff computation for the delete query, and DB errors being swallowed. Full `npm run check:all` (build + lint + format:check + tests with coverage thresholds) passes, plus `npx markdownlint SETTINGS.md`.

**Test Configuration**:

- Node.js version: 22
- Discord.js version: 14
- Operating System: Linux

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes manually

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary:
  - [ ] `COMMANDS.md` (if adding/modifying commands) — no command changes
  - [x] `SETTINGS.md` (if adding/modifying configuration)
  - [ ] `README.md` (if adding user-facing features) — operator-facing config only
  - [x] Inline code comments for complex logic
- [x] I have validated markdown with `npx markdownlint "**/*.md" --ignore node_modules --ignore dist`

### Dependencies & Docker

- [ ] I have updated `Dockerfile` if dependencies changed — no dependency changes
- [ ] I have updated `Dockerfile.dev` if dev dependencies changed — no dependency changes
- [ ] I have tested the Docker build (`docker-compose build`)
- [ ] I have run security checks if adding new dependencies — no new dependencies

### Configuration (if applicable)

- [x] New features are disabled by default and toggleable via configuration — the cleanup gates on the existing `moderation.enabled` (default off)
- [x] I have added configuration schema entries in `config-schema.ts`
- [x] I have documented new configuration keys in `SETTINGS.md`
- [ ] I have tested configuration reload (`/config reload`)

## Screenshots (if applicable)

N/A — no UI changes.

## Additional Notes

The cleanup deliberately follows the `CommandAuditCleanupService` shape (fixed daily cron, config read at run time) rather than the heavier `messagetracking.cleanup` service, because `ModerationLog` is a flat, `createdAt`-indexed collection where a single `deleteMany` suffices — no per-document array trimming, no configurable schedule needed. Reading config at run time also means `/config reload` changes take effect on the next run without restarting the cron.

## Pre-Submission Verification

- [x] I have rebased my branch on the latest main branch
- [x] I have resolved any merge conflicts
- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdDGbQpPKLvJDnd9dNg99N