### PR TITLE
fix(message-cleanup): stop destroy() from clearing the in-flight run guard

### DIFF
--- a/__tests__/services/message-activity-cleanup.test.ts
+++ b/__tests__/services/message-activity-cleanup.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { setImmediate } from "node:timers";
 import type { Client } from "discord.js";
 
 jest.mock("../../src/utils/logger.js", () => ({
@@ -161,6 +162,49 @@ describe("MessageActivityCleanupService", () => {
     expect(find).toHaveBeenCalledTimes(1);
     expect(cursor).toHaveBeenCalledTimes(1);
     expect(find.mock.results[0].value).not.toHaveProperty("exec");
+  });
+
+  it("keeps the mutual-exclusion guard intact when destroy() fires mid-run (issue #779)", async () => {
+    const { service } = createService();
+
+    let releaseCursor!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseCursor = resolve;
+    });
+
+    // A cursor whose iteration blocks until the test releases it, holding
+    // performCleanup() in flight.
+    find.mockReturnValue({
+      lean: () => ({
+        cursor: () => ({
+          async *[Symbol.asyncIterator]() {
+            await gate;
+            yield* [];
+          },
+        }),
+      }),
+    });
+
+    const firstRun = service.runCleanup();
+    // Let runCleanup() pass its guard and enter performCleanup().
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(service.getStatus().isRunning).toBe(true);
+
+    // The config-reload callback tears the schedule down while the pass is
+    // still executing — it must not reset the in-flight flag.
+    service.destroy();
+    expect(service.getStatus().isRunning).toBe(true);
+    expect(service.getStatus().isScheduled).toBe(false);
+
+    // A second run (next cron tick, or a web UI "run now") stays blocked.
+    await expect(service.runCleanup()).rejects.toThrow(
+      "Message cleanup is already running",
+    );
+
+    releaseCursor();
+    await firstRun;
+    // The finally block in runCleanup() — not destroy() — clears the flag.
+    expect(service.getStatus().isRunning).toBe(false);
   });
 
   it("skips when the cleanup job is disabled", async () => {

--- a/src/services/message-activity-cleanup.ts
+++ b/src/services/message-activity-cleanup.ts
@@ -355,7 +355,11 @@ export class MessageActivityCleanupService {
       this.cleanupJob.stop();
       this.cleanupJob = null;
     }
-    this.isRunning = false;
+    // Deliberately leave `isRunning` alone: it mirrors whether a cleanup
+    // pass is actually in flight and is owned by runCleanup()'s finally
+    // block. destroy() runs on every /config reload (see the constructor
+    // callback), and clearing the flag there would let a second pass start
+    // while performCleanup() is still iterating the collection.
     this.isScheduled = false;
   }
 }


### PR DESCRIPTION
## Description

`MessageActivityCleanupService`'s config-reload callback unconditionally calls `destroy()`, which reset `this.isRunning = false` even while a `performCleanup()` pass was still iterating the collection. Since `runCleanup()`'s mutual-exclusion guard relies on that flag, any `/config reload` during an in-flight pass silently disarmed the guard — the next cron tick (or a manual "run now") could then start a second concurrent pass against the same collection, racing `updateOne` writes on the same user documents.

The fix splits the two responsibilities the issue identified:

- `destroy()` still unconditionally stops scheduling (`cleanupJob.stop()`, `isScheduled = false`) — safe at any time.
- `isRunning` is no longer touched by `destroy()`; it is owned exclusively by `runCleanup()`'s `finally` block, so it always reflects whether a pass is genuinely in flight. A comment in `destroy()` documents why, to prevent the line from being reintroduced.

A regression test holds `performCleanup()` in flight behind a gated cursor, calls `destroy()` mid-run, and verifies the guard still rejects a second run while the schedule is torn down.

**Audit of the sibling services flagged in the issue:** `digest-service.ts` and `scheduled-announcement-service.ts` are not affected — their `destroy()` only clears `isInitialized`/jobs and never touches their in-flight guards (`isRunning` / `inFlight`). `voice-channel-truncation.ts` has the identical `isRunning = false` line in its `destroy()`, but that `destroy()` is only invoked from the process-shutdown path in `src/index.ts` (no reload callback), so the hazard is not reachable there; left as-is to keep this change scoped.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] 🧪 Test updates
- [ ] 🔧 Build/tooling changes
- [ ] ⚡ Performance improvement

## Related Issues

Fixes #779

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`) — 125 suites, 1549 tests passing
- [x] Added new tests for new functionality — regression test simulating `destroy()` firing mid-run
- [ ] Manually tested in development environment
- [ ] Tested in Docker environment

**Test Configuration**:

- Node.js version: 22
- Discord.js version: v14
- Operating System: Linux

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes manually

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary (no user-facing command/config changes — `COMMANDS.md`/`SETTINGS.md`/`README.md` not applicable)
- [x] I have validated markdown with `npx markdownlint "**/*.md" --ignore node_modules --ignore dist` (no markdown changed)

### Dependencies & Docker

- [x] No dependency changes — `Dockerfile`/`Dockerfile.dev` untouched

### Configuration (if applicable)

- [x] Not applicable — no new configuration keys; the fix hardens the existing `/config reload` path

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The reload callback's behavior is otherwise unchanged: it still tears down and rebuilds the cron on every reload, so schedule/enable changes keep applying without a restart. If a pass is in flight during a reload, the rebuilt cron simply finds the guard still armed on its next tick, exactly as if the reload had not happened.

## Pre-Submission Verification

- [x] I have rebased my branch on the latest main branch
- [x] I have resolved any merge conflicts
- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpkqSuwkX7aC5RzCgaTHhE)_