### PR TITLE
fix(polls): key jobs map by canonical _id in setScheduleEnabled/deleteSchedule

### DIFF
--- a/__tests__/services/poll-service.test.ts
+++ b/__tests__/services/poll-service.test.ts
@@ -5,6 +5,7 @@ const mockPollItemFindOne = jest.fn();
 const mockPollItemCreate = jest.fn();
 const mockPollItemFindById = jest.fn();
 const mockPollScheduleFindById = jest.fn();
+const mockPollScheduleFindByIdAndDelete = jest.fn();
 const mockRegisterReloadCallback = jest.fn();
 const mockConfigGetBoolean = jest.fn();
 const mockConfigGetNumber = jest.fn();
@@ -30,6 +31,7 @@ jest.unstable_mockModule("../../src/models/poll-item.js", () => ({
 jest.unstable_mockModule("../../src/models/poll-schedule.js", () => ({
   PollSchedule: {
     findById: mockPollScheduleFindById,
+    findByIdAndDelete: mockPollScheduleFindByIdAndDelete,
   },
 }));
 
@@ -54,6 +56,7 @@ describe("PollService", () => {
     mockPollItemCreate.mockResolvedValue({});
     mockPollItemFindById.mockResolvedValue(null);
     mockPollScheduleFindById.mockResolvedValue(null);
+    mockPollScheduleFindByIdAndDelete.mockResolvedValue(null);
     // Imports never touch the network (#646); a stub lets the paste-path tests
     // assert fetch is never called.
     global.fetch = mockFetch as unknown as typeof fetch;
@@ -369,6 +372,117 @@ describe("PollService", () => {
 
       expect(result).toBeNull();
       expect(save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("setScheduleEnabled", () => {
+    it("stops the job keyed by the canonical _id even when called with a non-canonical id", async () => {
+      const save = jest.fn<() => Promise<void>>().mockResolvedValue();
+      const schedule = {
+        _id: { toString: () => "sched-1" },
+        guildId: "guild-1",
+        enabled: true,
+        save,
+      };
+      // findById resolves via Mongo's ObjectId comparison, so a non-canonical
+      // id string still finds the row.
+      mockPollScheduleFindById.mockResolvedValue(schedule);
+
+      const service = PollService.getInstance({} as never);
+      const stop = jest.fn();
+      const internals = service as unknown as {
+        jobs: Map<string, { schedule: unknown; job: { stop: () => void } }>;
+      };
+      internals.jobs.set("sched-1", { schedule, job: { stop } });
+
+      const result = await service.setScheduleEnabled(
+        "SCHED-1",
+        false,
+        "guild-1",
+      );
+
+      expect(result).toBe(schedule);
+      expect(save).toHaveBeenCalledTimes(1);
+      expect(schedule.enabled).toBe(false);
+      // The canonically-keyed job must be found, stopped, and removed.
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(internals.jobs.has("sched-1")).toBe(false);
+    });
+
+    it("re-arms the job under the canonical _id when enabling with a non-canonical id", async () => {
+      const save = jest.fn<() => Promise<void>>().mockResolvedValue();
+      const schedule = {
+        _id: { toString: () => "sched-1" },
+        guildId: "guild-1",
+        channelId: "chan-1",
+        cronSchedule: "0 9 * * *",
+        enabled: false,
+        save,
+      };
+      mockPollScheduleFindById.mockResolvedValue(schedule);
+
+      const service = PollService.getInstance({} as never);
+      const internals = service as unknown as {
+        isInitialized: boolean;
+        jobs: Map<string, { schedule: unknown; job: { stop: () => void } }>;
+      };
+      internals.isInitialized = true;
+
+      const result = await service.setScheduleEnabled(
+        "SCHED-1",
+        true,
+        "guild-1",
+      );
+
+      expect(result).toBe(schedule);
+      expect(schedule.enabled).toBe(true);
+      expect(internals.jobs.has("sched-1")).toBe(true);
+
+      // Stop the real CronJob so it does not leak a live timer.
+      service.destroy();
+    });
+  });
+
+  describe("deleteSchedule", () => {
+    it("stops the job keyed by the canonical _id even when called with a non-canonical id", async () => {
+      const schedule = {
+        _id: { toString: () => "sched-1" },
+        guildId: "guild-1",
+      };
+      mockPollScheduleFindById.mockResolvedValue(schedule);
+
+      const service = PollService.getInstance({} as never);
+      const stop = jest.fn();
+      const internals = service as unknown as {
+        jobs: Map<string, { schedule: unknown; job: { stop: () => void } }>;
+      };
+      internals.jobs.set("sched-1", { schedule, job: { stop } });
+
+      const result = await service.deleteSchedule("SCHED-1", "guild-1");
+
+      expect(result).toBe(true);
+      // The canonically-keyed job must be found, stopped, and removed —
+      // otherwise the deleted schedule keeps posting from its stale in-memory
+      // copy (findById returns null after deletion and the cron closure falls
+      // back to the captured schedule object).
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(internals.jobs.has("sched-1")).toBe(false);
+      expect(mockPollScheduleFindByIdAndDelete).toHaveBeenCalledWith("sched-1");
+    });
+
+    it("refuses to delete a schedule belonging to another guild", async () => {
+      const schedule = {
+        _id: { toString: () => "sched-1" },
+        guildId: "other-guild",
+      };
+      mockPollScheduleFindById.mockResolvedValue(schedule);
+
+      const service = PollService.getInstance({} as never);
+
+      const result = await service.deleteSchedule("sched-1", "guild-1");
+
+      expect(result).toBe(false);
+      expect(mockPollScheduleFindByIdAndDelete).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/services/poll-service.ts
+++ b/src/services/poll-service.ts
@@ -613,21 +613,25 @@ export class PollService {
     schedule.enabled = enabled;
     await schedule.save();
 
-    const existing = this.jobs.get(scheduleId);
+    // Key off the canonical `_id` (not the raw `scheduleId` argument) for both
+    // the lookup and the re-insert so a non-canonical id can't leave the old
+    // job running while a second one is scheduled for the same row.
+    const canonicalId = schedule._id.toString();
+    const existing = this.jobs.get(canonicalId);
     if (existing) {
       existing.job.stop();
-      this.jobs.delete(scheduleId);
+      this.jobs.delete(canonicalId);
     }
 
     if (this.isInitialized && enabled) {
       const job = this.schedulePoll(schedule);
       if (job) {
-        this.jobs.set(schedule._id.toString(), { schedule, job });
+        this.jobs.set(canonicalId, { schedule, job });
       }
     }
 
     logger.info(
-      `${enabled ? "Enabled" : "Disabled"} poll schedule: ${sanitizeForLog(schedule._id.toString())}`,
+      `${enabled ? "Enabled" : "Disabled"} poll schedule: ${sanitizeForLog(canonicalId)}`,
     );
     return schedule;
   }
@@ -683,15 +687,19 @@ export class PollService {
       return false;
     }
 
-    // Stop the job if it's running
-    const scheduledJob = this.jobs.get(scheduleId);
+    // Stop the job if it's running. Key off the canonical `_id` (not the raw
+    // `scheduleId` argument) so a non-canonical id can't miss the entry and
+    // leave the job posting from its stale in-memory schedule after the row
+    // is deleted.
+    const canonicalId = schedule._id.toString();
+    const scheduledJob = this.jobs.get(canonicalId);
     if (scheduledJob) {
       scheduledJob.job.stop();
-      this.jobs.delete(scheduleId);
+      this.jobs.delete(canonicalId);
     }
 
-    await PollSchedule.findByIdAndDelete(scheduleId);
-    logger.info(`Deleted poll schedule: ${sanitizeForLog(scheduleId)}`);
+    await PollSchedule.findByIdAndDelete(canonicalId);
+    logger.info(`Deleted poll schedule: ${sanitizeForLog(canonicalId)}`);
     return true;
   }
 


### PR DESCRIPTION
## Description

`PollService.jobs` entries are always inserted under the canonical `schedule._id.toString()`, but `setScheduleEnabled` and `deleteSchedule` still looked up and deleted entries using the raw `scheduleId` argument (which reaches these methods straight from an Express route param with no normalization). If the caller's id string differs in form from the canonical one — while `PollSchedule.findById()` still resolves it via Mongo's ObjectId comparison — the `Map` lookup misses:

- **Toggle-off**: the row is saved `enabled: false`, but the live `CronJob` is never stopped and keeps posting polls.
- **Delete**: worse — the cron closure's `(await PollSchedule.findById(schedule._id)) ?? schedule` fallback means the orphaned job keeps posting indefinitely from its stale in-memory schedule after the row is gone, until the process restarts.

This mirrors the fix already applied in `updateSchedule`: resolve `schedule._id.toString()` once after `findById` succeeds and use that canonical id for the `jobs.get(...)` lookup, `.delete(...)`, and re-`.set(...)`. Regression tests cover both non-canonical-id paths plus the cross-guild delete guard.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] 🧪 Test updates
- [ ] 🔧 Build/tooling changes
- [ ] ⚡ Performance improvement

## Related Issues

Fixes #770

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality
- [ ] Manually tested in development environment
- [ ] Tested in Docker environment

**Test Configuration**:

- Node.js version: 22
- Discord.js version: 14
- Operating System: Linux

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes manually

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary:
  - [ ] `COMMANDS.md` (if adding/modifying commands)
  - [ ] `SETTINGS.md` (if adding/modifying configuration)
  - [ ] `README.md` (if adding user-facing features)
  - [x] Inline code comments for complex logic
- [ ] I have validated markdown with `npx markdownlint "**/*.md" --ignore node_modules --ignore dist`

### Dependencies & Docker

- [ ] I have updated `Dockerfile` if dependencies changed (no dependency changes)
- [ ] I have updated `Dockerfile.dev` if dev dependencies changed (no dependency changes)
- [ ] I have tested the Docker build (`docker-compose build`)
- [ ] I have run security checks if adding new dependencies (no new dependencies)

### Configuration (if applicable)

- [ ] New features are disabled by default and toggleable via configuration (no config changes)
- [ ] I have added configuration schema entries in `config-schema.ts` (no config changes)
- [ ] I have documented new configuration keys in `SETTINGS.md` (no config changes)
- [ ] I have tested configuration reload (`/config reload`) (no config changes)

## Screenshots (if applicable)

N/A — backend fix, no UI changes.

## Additional Notes

The fix is intentionally minimal and mirrors the existing pattern from `updateSchedule` (`src/services/poll-service.ts:567-580`), including the explanatory comment style, so all three schedule-mutating methods now handle ids consistently.

## Pre-Submission Verification

- [x] I have rebased my branch on the latest main branch
- [x] I have resolved any merge conflicts
- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPCFnShe8syBhqQnVvyvG2

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPCFnShe8syBhqQnVvyvG2)_