### PR TITLE
fix(setup-wizard): make wizard apply atomic and report exact per-key outcome

### DIFF
--- a/__tests__/services/wizard-service.test.ts
+++ b/__tests__/services/wizard-service.test.ts
@@ -181,13 +181,22 @@ describe("WizardService", () => {
     const mockGuildId = "guild-456";
 
     let mockConfigService: any;
+    // Simulates the ConfigService cache: set/delete keep it in step, and
+    // get reads it, matching how the real service behaves in-process.
+    let cache: Map<string, unknown>;
 
     beforeEach(() => {
+      cache = new Map();
       mockConfigService = {
         findDependencyIssues: jest.fn(async () => [] as any[]),
         getAll: jest.fn(async () => [] as any[]),
-        set: jest.fn(async () => undefined),
-        delete: jest.fn(async () => undefined),
+        get: jest.fn(async (key: string) => cache.get(key)),
+        set: jest.fn(async (key: string, value: unknown) => {
+          cache.set(key, value);
+        }),
+        delete: jest.fn(async (key: string) => {
+          cache.delete(key);
+        }),
         triggerReload: jest.fn(async () => undefined),
       };
       // The ConfigService module is auto-mocked, so inject a controllable
@@ -244,11 +253,14 @@ describe("WizardService", () => {
           category: "quotes",
         },
       ] as any);
-      mockConfigService.set.mockImplementation(async (key: string) => {
-        if (key === "quotes.delete_roles") {
-          throw new Error("mongo write failed");
-        }
-      });
+      mockConfigService.set.mockImplementation(
+        async (key: string, value: unknown) => {
+          if (key === "quotes.delete_roles") {
+            throw new Error("mongo write failed");
+          }
+          cache.set(key, value);
+        },
+      );
 
       const result = await service.applyConfiguration(mockUserId, mockGuildId);
 
@@ -281,11 +293,14 @@ describe("WizardService", () => {
     });
 
     it("reloads and reports keys whose rollback failed", async () => {
-      mockConfigService.set.mockImplementation(async (key: string) => {
-        if (key === "quotes.channel_id") {
-          throw new Error("write failed");
-        }
-      });
+      mockConfigService.set.mockImplementation(
+        async (key: string, value: unknown) => {
+          if (key === "quotes.channel_id") {
+            throw new Error("write failed");
+          }
+          cache.set(key, value);
+        },
+      );
       mockConfigService.delete.mockRejectedValue(new Error("delete failed"));
 
       const result = await service.applyConfiguration(mockUserId, mockGuildId);
@@ -296,7 +311,81 @@ describe("WizardService", () => {
       expect(result.rolledBackKeys).toEqual([]);
       expect(result.revertFailedKeys).toEqual(["quotes.enabled"]);
       // A key stayed persisted, so the reload must run to keep services in
-      // sync with the DB.
+      // sync with the DB — and it succeeded here.
+      expect(mockConfigService.triggerReload).toHaveBeenCalledTimes(1);
+      expect(result.reloadFailed).toBeUndefined();
+    });
+
+    it("flags reloadFailed when rollback failure is followed by a reload failure", async () => {
+      mockConfigService.set.mockImplementation(
+        async (key: string, value: unknown) => {
+          if (key === "quotes.channel_id") {
+            throw new Error("write failed");
+          }
+          cache.set(key, value);
+        },
+      );
+      mockConfigService.delete.mockRejectedValue(new Error("delete failed"));
+      mockConfigService.triggerReload.mockRejectedValue(
+        new Error("reload failed"),
+      );
+
+      const result = await service.applyConfiguration(mockUserId, mockGuildId);
+
+      expect(result.success).toBe(false);
+      expect(result.revertFailedKeys).toEqual(["quotes.enabled"]);
+      // The persisted key has NOT taken effect for callback-driven services;
+      // the result must say so rather than only logging it.
+      expect(result.reloadFailed).toBe(true);
+      expect(result.errorMessage).toBe("write failed");
+    });
+
+    it("skips rolling back a key changed concurrently after the wizard wrote it", async () => {
+      mockConfigService.getAll.mockResolvedValue([
+        {
+          key: "quotes.enabled",
+          value: false,
+          description: "old description",
+          category: "quotes",
+        },
+      ] as any);
+      mockConfigService.set.mockImplementation(
+        async (key: string, value: unknown) => {
+          if (key === "quotes.delete_roles") {
+            throw new Error("mongo write failed");
+          }
+          cache.set(key, value);
+        },
+      );
+      // Simulate another writer updating quotes.enabled between this apply's
+      // write and its rollback.
+      mockConfigService.get.mockImplementation(async (key: string) =>
+        key === "quotes.enabled" ? "someone-elses-value" : cache.get(key),
+      );
+
+      const result = await service.applyConfiguration(mockUserId, mockGuildId);
+
+      expect(result.success).toBe(false);
+      // quotes.channel_id still held our value → rolled back (deleted);
+      // quotes.enabled was changed concurrently → left alone, reported.
+      expect(result.rolledBackKeys).toEqual(["quotes.channel_id"]);
+      expect(result.revertFailedKeys).toEqual(["quotes.enabled"]);
+      expect(mockConfigService.delete).toHaveBeenCalledWith(
+        "quotes.channel_id",
+      );
+      expect(mockConfigService.delete).not.toHaveBeenCalledWith(
+        "quotes.enabled",
+      );
+      // The snapshot restore for quotes.enabled must NOT have run — that
+      // would clobber the concurrent writer's newer value.
+      expect(mockConfigService.set).not.toHaveBeenCalledWith(
+        "quotes.enabled",
+        false,
+        "old description",
+        "quotes",
+        { skipDependencyCheck: true },
+      );
+      // A key stayed persisted → reload runs.
       expect(mockConfigService.triggerReload).toHaveBeenCalledTimes(1);
     });
 
@@ -312,6 +401,7 @@ describe("WizardService", () => {
       expect(result.appliedKeys).toHaveLength(3);
       expect(result.rolledBackKeys).toEqual([]);
       expect(result.revertFailedKeys).toEqual([]);
+      expect(result.reloadFailed).toBe(true);
       expect(result.errorMessage).toContain("/config reload");
       // Nothing is rolled back — the writes themselves all succeeded.
       expect(mockConfigService.delete).not.toHaveBeenCalled();

--- a/__tests__/services/wizard-service.test.ts
+++ b/__tests__/services/wizard-service.test.ts
@@ -176,6 +176,165 @@ describe("WizardService", () => {
     });
   });
 
+  describe("applyConfiguration", () => {
+    const mockUserId = "user-123";
+    const mockGuildId = "guild-456";
+
+    let mockConfigService: any;
+
+    beforeEach(() => {
+      mockConfigService = {
+        findDependencyIssues: jest.fn(async () => [] as any[]),
+        getAll: jest.fn(async () => [] as any[]),
+        set: jest.fn(async () => undefined),
+        delete: jest.fn(async () => undefined),
+        triggerReload: jest.fn(async () => undefined),
+      };
+      // The ConfigService module is auto-mocked, so inject a controllable
+      // instance directly.
+      (service as any).configService = mockConfigService;
+
+      service.createSession(mockUserId, mockGuildId);
+      service.addConfiguration(mockUserId, mockGuildId, "quotes.enabled", true);
+      service.addConfiguration(
+        mockUserId,
+        mockGuildId,
+        "quotes.channel_id",
+        "123",
+      );
+      service.addConfiguration(
+        mockUserId,
+        mockGuildId,
+        "quotes.delete_roles",
+        "role-1",
+      );
+    });
+
+    it("applies every key and reloads on success", async () => {
+      const result = await service.applyConfiguration(mockUserId, mockGuildId);
+
+      expect(result.success).toBe(true);
+      expect(result.appliedKeys).toEqual([
+        "quotes.enabled",
+        "quotes.channel_id",
+        "quotes.delete_roles",
+      ]);
+      expect(result.rolledBackKeys).toEqual([]);
+      expect(result.revertFailedKeys).toEqual([]);
+      expect(mockConfigService.set).toHaveBeenCalledTimes(3);
+      expect(mockConfigService.triggerReload).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns a failure result when no session exists", async () => {
+      const result = await service.applyConfiguration("nobody", "nowhere");
+
+      expect(result.success).toBe(false);
+      expect(result.appliedKeys).toEqual([]);
+      expect(result.errorMessage).toContain("No active wizard session");
+      expect(mockConfigService.set).not.toHaveBeenCalled();
+    });
+
+    it("rolls back already-written keys when a mid-batch write fails", async () => {
+      // quotes.enabled had a stored row; quotes.channel_id did not.
+      mockConfigService.getAll.mockResolvedValue([
+        {
+          key: "quotes.enabled",
+          value: false,
+          description: "old description",
+          category: "quotes",
+        },
+      ] as any);
+      mockConfigService.set.mockImplementation(async (key: string) => {
+        if (key === "quotes.delete_roles") {
+          throw new Error("mongo write failed");
+        }
+      });
+
+      const result = await service.applyConfiguration(mockUserId, mockGuildId);
+
+      expect(result.success).toBe(false);
+      expect(result.failedKey).toBe("quotes.delete_roles");
+      expect(result.errorMessage).toBe("mongo write failed");
+      expect(result.appliedKeys).toEqual([
+        "quotes.enabled",
+        "quotes.channel_id",
+      ]);
+      // Rolled back newest-first: the unsaved key is deleted, the
+      // previously-stored key is restored with its prior row verbatim.
+      expect(result.rolledBackKeys).toEqual([
+        "quotes.channel_id",
+        "quotes.enabled",
+      ]);
+      expect(result.revertFailedKeys).toEqual([]);
+      expect(mockConfigService.delete).toHaveBeenCalledWith(
+        "quotes.channel_id",
+      );
+      expect(mockConfigService.set).toHaveBeenCalledWith(
+        "quotes.enabled",
+        false,
+        "old description",
+        "quotes",
+        { skipDependencyCheck: true },
+      );
+      // Full rollback → nothing changed → no reload.
+      expect(mockConfigService.triggerReload).not.toHaveBeenCalled();
+    });
+
+    it("reloads and reports keys whose rollback failed", async () => {
+      mockConfigService.set.mockImplementation(async (key: string) => {
+        if (key === "quotes.channel_id") {
+          throw new Error("write failed");
+        }
+      });
+      mockConfigService.delete.mockRejectedValue(new Error("delete failed"));
+
+      const result = await service.applyConfiguration(mockUserId, mockGuildId);
+
+      expect(result.success).toBe(false);
+      expect(result.failedKey).toBe("quotes.channel_id");
+      expect(result.appliedKeys).toEqual(["quotes.enabled"]);
+      expect(result.rolledBackKeys).toEqual([]);
+      expect(result.revertFailedKeys).toEqual(["quotes.enabled"]);
+      // A key stayed persisted, so the reload must run to keep services in
+      // sync with the DB.
+      expect(mockConfigService.triggerReload).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports a reload failure after all keys persisted", async () => {
+      mockConfigService.triggerReload.mockRejectedValue(
+        new Error("reload broke"),
+      );
+
+      const result = await service.applyConfiguration(mockUserId, mockGuildId);
+
+      expect(result.success).toBe(false);
+      expect(result.failedKey).toBeUndefined();
+      expect(result.appliedKeys).toHaveLength(3);
+      expect(result.rolledBackKeys).toEqual([]);
+      expect(result.revertFailedKeys).toEqual([]);
+      expect(result.errorMessage).toContain("/config reload");
+      // Nothing is rolled back — the writes themselves all succeeded.
+      expect(mockConfigService.delete).not.toHaveBeenCalled();
+    });
+
+    it("throws DependencyError before writing anything when the batch is inconsistent", async () => {
+      mockConfigService.findDependencyIssues.mockResolvedValue([
+        {
+          key: "quotes.channel_id",
+          dependency: "quotes.enabled",
+          kind: "missing-dependency",
+          message: "quotes.channel_id requires quotes.enabled",
+        },
+      ] as any);
+
+      await expect(
+        service.applyConfiguration(mockUserId, mockGuildId),
+      ).rejects.toThrow();
+      expect(mockConfigService.set).not.toHaveBeenCalled();
+      expect(mockConfigService.triggerReload).not.toHaveBeenCalled();
+    });
+  });
+
   describe("shutdown", () => {
     it("should shutdown without errors", () => {
       service.shutdown();

--- a/__tests__/web/write-routes.test.ts
+++ b/__tests__/web/write-routes.test.ts
@@ -14,9 +14,11 @@ import {
   safeAdminRedirect,
   truncateFlash,
   wantsJson,
+  wizardApplyFailureMessage,
   TEXT_LIMITS,
   type ResetConfigStore,
 } from "../../src/web/write-routes.js";
+import type { WizardApplyResult } from "../../src/services/wizard-service.js";
 import {
   BOOTSTRAP_VARS,
   PROTECTED_KEYS,
@@ -493,6 +495,87 @@ describe("safeAdminRedirect (#610)", () => {
     expect(safeAdminRedirect("https://evil.example/")).toBe("/admin/settings");
     expect(safeAdminRedirect("//evil.example")).toBe("/admin/settings");
     expect(safeAdminRedirect("/etc/passwd")).toBe("/admin/settings");
+  });
+});
+
+describe("wizardApplyFailureMessage (#780)", () => {
+  const base: WizardApplyResult = {
+    success: false,
+    appliedKeys: [],
+    rolledBackKeys: [],
+    revertFailedKeys: [],
+  };
+
+  it("reports a fully rolled-back batch as no changes applied", () => {
+    const msg = wizardApplyFailureMessage({
+      ...base,
+      failedKey: "quotes.delete_roles",
+      errorMessage: "mongo write failed",
+      appliedKeys: ["quotes.enabled", "quotes.channel_id"],
+      rolledBackKeys: ["quotes.channel_id", "quotes.enabled"],
+    });
+    expect(msg).toContain("quotes.delete_roles failed (mongo write failed)");
+    expect(msg).toContain("2 settings written before the failure were rolled back");
+    expect(msg).toContain("no changes were applied");
+  });
+
+  it("uses singular wording for a single rolled-back key", () => {
+    const msg = wizardApplyFailureMessage({
+      ...base,
+      failedKey: "quotes.channel_id",
+      errorMessage: "boom",
+      appliedKeys: ["quotes.enabled"],
+      rolledBackKeys: ["quotes.enabled"],
+    });
+    expect(msg).toContain("1 setting written before the failure was rolled back");
+  });
+
+  it("names keys that could not be rolled back and says they are in effect", () => {
+    const msg = wizardApplyFailureMessage({
+      ...base,
+      failedKey: "quotes.channel_id",
+      errorMessage: "boom",
+      appliedKeys: ["quotes.enabled"],
+      revertFailedKeys: ["quotes.enabled"],
+    });
+    expect(msg).toContain("Could not roll back quotes.enabled");
+    expect(msg).toContain("saved and now in effect");
+  });
+
+  it("does not claim un-reverted keys are in effect when the reload also failed", () => {
+    const msg = wizardApplyFailureMessage({
+      ...base,
+      failedKey: "quotes.channel_id",
+      errorMessage: "boom",
+      appliedKeys: ["quotes.enabled"],
+      revertFailedKeys: ["quotes.enabled"],
+      reloadFailed: true,
+    });
+    expect(msg).toContain("Could not roll back quotes.enabled");
+    expect(msg).not.toContain("now in effect");
+    expect(msg).toContain("run /config reload");
+  });
+
+  it("reports a failure before any write as safe to retry", () => {
+    const msg = wizardApplyFailureMessage({
+      ...base,
+      failedKey: "quotes.enabled",
+      errorMessage: "boom",
+    });
+    expect(msg).toContain("No changes were applied");
+    expect(msg).toContain("You can retry");
+  });
+
+  it("passes through the reload-failure explanation after a fully persisted batch", () => {
+    const msg = wizardApplyFailureMessage({
+      ...base,
+      appliedKeys: ["quotes.enabled", "quotes.channel_id"],
+      errorMessage:
+        "All settings were saved, but the configuration reload failed — run /config reload to apply them",
+    });
+    expect(msg).toContain("All settings were saved");
+    expect(msg).toContain("run /config reload");
+    expect(msg).not.toContain("rolled back");
   });
 });
 

--- a/src/services/wizard-service.ts
+++ b/src/services/wizard-service.ts
@@ -1,10 +1,32 @@
 import { TextChannel, VoiceChannel, CategoryChannel } from "discord.js";
 import logger from "../utils/logger.js";
 import { ConfigService } from "./config-service.js";
-import { DependencyError } from "./config-schema.js";
+import { DependencyError, hasOwn } from "./config-schema.js";
+import type { IConfig } from "../models/config.js";
 
 export interface WizardConfiguration {
   [key: string]: string | number | boolean;
+}
+
+/**
+ * Outcome of a wizard apply (#780). A plain boolean can't describe a batch
+ * that failed partway through, so the result reports exactly which keys were
+ * written, which were restored to their prior state, and which (if any) could
+ * not be restored and are therefore live in the config store.
+ */
+export interface WizardApplyResult {
+  /** True when every setting persisted and the config reload ran. */
+  success: boolean;
+  /** Keys persisted by this call, in apply order (includes keys that were later rolled back). */
+  appliedKeys: string[];
+  /** The key whose write failed, when a per-key write threw. */
+  failedKey?: string;
+  /** Human-readable reason for a failure (per-key write, reload, or missing session). */
+  errorMessage?: string;
+  /** Keys that were persisted and then successfully restored to their prior state. */
+  rolledBackKeys: string[];
+  /** Keys that were persisted but could not be restored — they remain in effect. */
+  revertFailedKeys: string[];
 }
 
 export interface DetectedResources {
@@ -247,13 +269,29 @@ export class WizardService {
   }
 
   /**
-   * Apply all configuration changes from wizard
+   * Apply all configuration changes from wizard.
+   *
+   * The batch is atomic in effect (#780): prior values are snapshotted before
+   * anything is written, and a mid-batch write failure triggers a best-effort
+   * rollback of the keys already persisted. If any rollback itself fails, the
+   * config reload still runs so services on registered reload callbacks pick
+   * up what actually persisted rather than silently lagging behind the DB,
+   * and the returned result names the keys left in effect.
    */
-  async applyConfiguration(userId: string, guildId: string): Promise<boolean> {
+  async applyConfiguration(
+    userId: string,
+    guildId: string,
+  ): Promise<WizardApplyResult> {
     const state = this.getSession(userId, guildId);
     if (!state) {
       logger.error(`No wizard session found for user ${userId}`);
-      return false;
+      return {
+        success: false,
+        appliedKeys: [],
+        rolledBackKeys: [],
+        revertFailedKeys: [],
+        errorMessage: "No active wizard session",
+      };
     }
 
     // Validate the whole proposed batch against the feature dependency graph
@@ -269,34 +307,123 @@ export class WizardService {
       throw new DependencyError(issues);
     }
 
-    try {
-      logger.info(
-        `Applying wizard configuration for user ${userId}: ${Object.keys(state.configuration).length} settings`,
-      );
+    const entries = Object.entries(state.configuration);
+    logger.info(
+      `Applying wizard configuration for user ${userId}: ${entries.length} settings`,
+    );
 
-      // Apply each configuration setting. The batch was already validated
-      // above, so per-key dependency checks are skipped to avoid spurious
-      // ordering-dependent rejections within the batch.
-      for (const [key, value] of Object.entries(state.configuration)) {
-        const category = key.split(".")[0];
-        const description = this.getSettingDescription(key);
+    // Snapshot the stored rows for the batch's keys before writing anything,
+    // so a mid-batch failure can restore each written key to its exact prior
+    // state — a key with no stored row is deleted on rollback rather than
+    // left behind with a wizard-supplied value.
+    const priorRows = new Map<string, IConfig>();
+    for (const row of await this.configService.getAll()) {
+      if (hasOwn(state.configuration, row.key)) {
+        priorRows.set(row.key, row);
+      }
+    }
+
+    // Apply each configuration setting. The batch was already validated
+    // above, so per-key dependency checks are skipped to avoid spurious
+    // ordering-dependent rejections within the batch.
+    const appliedKeys: string[] = [];
+    let failedKey: string | undefined;
+    let errorMessage: string | undefined;
+    for (const [key, value] of entries) {
+      const category = key.split(".")[0];
+      const description = this.getSettingDescription(key);
+      try {
         await this.configService.set(key, value, description, category, {
           skipDependencyCheck: true,
         });
+        appliedKeys.push(key);
         logger.debug(`Set ${key} = ${value}`);
+      } catch (error) {
+        failedKey = key;
+        errorMessage = error instanceof Error ? error.message : String(error);
+        logger.error(`Error applying wizard configuration at ${key}:`, error);
+        break;
       }
+    }
 
-      // Trigger reload to apply changes
-      await this.configService.triggerReload();
+    if (failedKey === undefined) {
+      try {
+        await this.configService.triggerReload();
+      } catch (error) {
+        // Every key persisted (and is cached), but the reload didn't run, so
+        // callback-driven services are still on their old config. Surface
+        // that precisely instead of pretending nothing was written.
+        logger.error(
+          "Error reloading configuration after wizard apply:",
+          error,
+        );
+        return {
+          success: false,
+          appliedKeys,
+          rolledBackKeys: [],
+          revertFailedKeys: [],
+          errorMessage:
+            "All settings were saved, but the configuration reload failed — run /config reload to apply them",
+        };
+      }
       logger.info(
         `Successfully applied wizard configuration for user ${userId}`,
       );
-
-      return true;
-    } catch (error) {
-      logger.error("Error applying wizard configuration:", error);
-      return false;
+      return {
+        success: true,
+        appliedKeys,
+        rolledBackKeys: [],
+        revertFailedKeys: [],
+      };
     }
+
+    // A write failed partway through the batch: best-effort revert of the
+    // keys persisted before the failure, newest first.
+    const rolledBackKeys: string[] = [];
+    const revertFailedKeys: string[] = [];
+    for (const key of [...appliedKeys].reverse()) {
+      try {
+        const prior = priorRows.get(key);
+        if (prior) {
+          await this.configService.set(
+            key,
+            prior.value,
+            prior.description,
+            prior.category,
+            { skipDependencyCheck: true },
+          );
+        } else {
+          await this.configService.delete(key);
+        }
+        rolledBackKeys.push(key);
+      } catch (error) {
+        revertFailedKeys.push(key);
+        logger.error(`Failed to roll back wizard setting ${key}:`, error);
+      }
+    }
+
+    if (revertFailedKeys.length > 0) {
+      // Some writes could not be undone, so the DB has changed. Reload so
+      // services pick those values up immediately instead of diverging from
+      // the store until the next /config reload or restart.
+      try {
+        await this.configService.triggerReload();
+      } catch (reloadError) {
+        logger.error(
+          "Error reloading configuration after partial wizard apply:",
+          reloadError,
+        );
+      }
+    }
+
+    return {
+      success: false,
+      appliedKeys,
+      failedKey,
+      errorMessage,
+      rolledBackKeys,
+      revertFailedKeys,
+    };
   }
 
   /**

--- a/src/services/wizard-service.ts
+++ b/src/services/wizard-service.ts
@@ -25,8 +25,15 @@ export interface WizardApplyResult {
   errorMessage?: string;
   /** Keys that were persisted and then successfully restored to their prior state. */
   rolledBackKeys: string[];
-  /** Keys that were persisted but could not be restored — they remain in effect. */
+  /**
+   * Keys that were persisted but could not be restored — they remain in the
+   * store. Includes keys skipped because a concurrent writer changed them
+   * after this apply wrote them (rolling those back would clobber the newer
+   * value).
+   */
   revertFailedKeys: string[];
+  /** True when a config reload was needed (keys remain persisted) but failed to run. */
+  reloadFailed?: boolean;
 }
 
 export interface DetectedResources {
@@ -362,6 +369,7 @@ export class WizardService {
           appliedKeys,
           rolledBackKeys: [],
           revertFailedKeys: [],
+          reloadFailed: true,
           errorMessage:
             "All settings were saved, but the configuration reload failed — run /config reload to apply them",
         };
@@ -383,6 +391,19 @@ export class WizardService {
     const revertFailedKeys: string[] = [];
     for (const key of [...appliedKeys].reverse()) {
       try {
+        // Only restore a key that still holds the value this apply wrote.
+        // Another writer (settings page, /config set — all in-process, so
+        // the ConfigService cache reflects the latest write) may have
+        // updated it after the snapshot; rolling back would clobber their
+        // newer value, so leave it and report the key as not reverted.
+        const current = await this.configService.get(key);
+        if (current !== state.configuration[key]) {
+          revertFailedKeys.push(key);
+          logger.warn(
+            `Skipping rollback of wizard setting ${key}: it was changed concurrently after this apply wrote it`,
+          );
+          continue;
+        }
         const prior = priorRows.get(key);
         if (prior) {
           await this.configService.set(
@@ -402,6 +423,7 @@ export class WizardService {
       }
     }
 
+    let reloadFailed = false;
     if (revertFailedKeys.length > 0) {
       // Some writes could not be undone, so the DB has changed. Reload so
       // services pick those values up immediately instead of diverging from
@@ -409,6 +431,7 @@ export class WizardService {
       try {
         await this.configService.triggerReload();
       } catch (reloadError) {
+        reloadFailed = true;
         logger.error(
           "Error reloading configuration after partial wizard apply:",
           reloadError,
@@ -423,6 +446,7 @@ export class WizardService {
       errorMessage,
       rolledBackKeys,
       revertFailedKeys,
+      ...(reloadFailed ? { reloadFailed } : {}),
     };
   }
 

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -29,7 +29,10 @@ import { VoiceChannelManager } from "../services/voice-channel-manager.js";
 import { DigestService } from "../services/digest-service.js";
 import { ConfigService } from "../services/config-service.js";
 import { PermissionsService } from "../services/permissions-service.js";
-import { WizardService } from "../services/wizard-service.js";
+import {
+  WizardService,
+  type WizardApplyResult,
+} from "../services/wizard-service.js";
 import { BotStatusService } from "../services/bot-status-service.js";
 import { CommandManager } from "../services/command-manager.js";
 import {
@@ -130,6 +133,36 @@ export function firstLengthError(
     }
   }
   return null;
+}
+
+/**
+ * Build the operator-facing flash message for a failed wizard apply (#780).
+ * Pure and exported so each wording branch — full rollback, keys left in
+ * effect, reload failure — can be unit-tested without Express or Mongo.
+ */
+export function wizardApplyFailureMessage(result: WizardApplyResult): string {
+  const reason = result.failedKey
+    ? `${result.failedKey} failed (${result.errorMessage ?? "unknown error"})`
+    : (result.errorMessage ?? "unknown error");
+  if (result.revertFailedKeys.length > 0) {
+    const kept = `Wizard apply failed: ${reason}. Could not roll back ${result.revertFailedKeys.join(", ")} — these settings are saved`;
+    // When the follow-up reload also failed, the persisted keys have NOT
+    // taken effect for callback-driven services yet — say so instead of
+    // claiming they're live.
+    return result.reloadFailed
+      ? `${kept}, and the configuration reload failed — run /config reload to apply them.`
+      : `${kept} and now in effect.`;
+  }
+  if (result.rolledBackKeys.length > 0) {
+    const n = result.rolledBackKeys.length;
+    return `Wizard apply failed: ${reason}. The ${n} setting${n === 1 ? "" : "s"} written before the failure ${n === 1 ? "was" : "were"} rolled back — no changes were applied. You can retry.`;
+  }
+  if (result.appliedKeys.length === 0) {
+    return `Wizard apply failed: ${reason}. No changes were applied. You can retry.`;
+  }
+  // Every write persisted but the reload failed; the reason already says
+  // what to do (/config reload).
+  return `Wizard apply failed: ${reason}.`;
 }
 
 function flashRedirect(res: Response, path: string, flash: Flash): void {
@@ -1757,6 +1790,7 @@ export function createWriteRouter(
             failedKey: result.failedKey ?? null,
             rolledBackKeys: result.rolledBackKeys,
             revertFailedKeys: result.revertFailedKeys,
+            reloadFailed: result.reloadFailed ?? false,
           },
           result: result.success ? "success" : "failure",
           errorMessage: result.success
@@ -1776,25 +1810,10 @@ export function createWriteRouter(
         // keys (if any) could not be reverted and are therefore live — and
         // keep the session so they can retry from the confirm step instead
         // of losing their input.
-        const reason = result.failedKey
-          ? `${result.failedKey} failed (${result.errorMessage ?? "unknown error"})`
-          : (result.errorMessage ?? "unknown error");
-        let text: string;
-        if (result.revertFailedKeys.length > 0) {
-          text = `Wizard apply failed: ${reason}. Could not roll back ${result.revertFailedKeys.join(", ")} — these settings are saved and now in effect.`;
-        } else if (result.rolledBackKeys.length > 0) {
-          text = `Wizard apply failed: ${reason}. The ${result.rolledBackKeys.length} setting${result.rolledBackKeys.length === 1 ? "" : "s"} written before the failure ${result.rolledBackKeys.length === 1 ? "was" : "were"} rolled back — no changes were applied. You can retry.`;
-        } else if (result.appliedKeys.length === 0) {
-          text = `Wizard apply failed: ${reason}. No changes were applied. You can retry.`;
-        } else {
-          // Every write persisted but the reload failed; the reason already
-          // says what to do (/config reload).
-          text = `Wizard apply failed: ${reason}.`;
-        }
         const qs = new globalThis.URLSearchParams({
           step: "confirm",
           flash: "err",
-          msg: truncateFlash(text),
+          msg: truncateFlash(wizardApplyFailureMessage(result)),
         }).toString();
         res.redirect(303, `/admin/wizard?${qs}`);
       } catch (err) {

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -1744,23 +1744,59 @@ export function createWriteRouter(
 
       const pendingKeys = Object.keys(state.configuration);
       try {
-        const applied = await wizard.applyConfiguration(
+        const result = await wizard.applyConfiguration(
           session.discordUserId,
           session.guildId,
         );
         await recordAudit(session, {
           action: "wizard.apply",
-          details: { keys: pendingKeys, count: pendingKeys.length },
-          result: applied ? "success" : "failure",
-          errorMessage: applied ? null : "applyConfiguration returned false",
+          details: {
+            keys: pendingKeys,
+            count: pendingKeys.length,
+            appliedKeys: result.appliedKeys,
+            failedKey: result.failedKey ?? null,
+            rolledBackKeys: result.rolledBackKeys,
+            revertFailedKeys: result.revertFailedKeys,
+          },
+          result: result.success ? "success" : "failure",
+          errorMessage: result.success
+            ? null
+            : (result.errorMessage ?? "applyConfiguration failed"),
         });
-        wizard.endSession(session.discordUserId, session.guildId);
-        flashRedirect(res, "/admin/settings", {
-          type: applied ? "ok" : "err",
-          text: applied
-            ? `Wizard applied ${pendingKeys.length} setting${pendingKeys.length === 1 ? "" : "s"}.`
-            : "Wizard failed to apply some settings. Check the bot logs.",
-        });
+        if (result.success) {
+          wizard.endSession(session.discordUserId, session.guildId);
+          flashRedirect(res, "/admin/settings", {
+            type: "ok",
+            text: `Wizard applied ${pendingKeys.length} setting${pendingKeys.length === 1 ? "" : "s"}.`,
+          });
+          return;
+        }
+        // The apply failed. Tell the operator exactly what state the config
+        // is in (#780) — which write failed, what was rolled back, and which
+        // keys (if any) could not be reverted and are therefore live — and
+        // keep the session so they can retry from the confirm step instead
+        // of losing their input.
+        const reason = result.failedKey
+          ? `${result.failedKey} failed (${result.errorMessage ?? "unknown error"})`
+          : (result.errorMessage ?? "unknown error");
+        let text: string;
+        if (result.revertFailedKeys.length > 0) {
+          text = `Wizard apply failed: ${reason}. Could not roll back ${result.revertFailedKeys.join(", ")} — these settings are saved and now in effect.`;
+        } else if (result.rolledBackKeys.length > 0) {
+          text = `Wizard apply failed: ${reason}. The ${result.rolledBackKeys.length} setting${result.rolledBackKeys.length === 1 ? "" : "s"} written before the failure ${result.rolledBackKeys.length === 1 ? "was" : "were"} rolled back — no changes were applied. You can retry.`;
+        } else if (result.appliedKeys.length === 0) {
+          text = `Wizard apply failed: ${reason}. No changes were applied. You can retry.`;
+        } else {
+          // Every write persisted but the reload failed; the reason already
+          // says what to do (/config reload).
+          text = `Wizard apply failed: ${reason}.`;
+        }
+        const qs = new globalThis.URLSearchParams({
+          step: "confirm",
+          flash: "err",
+          msg: truncateFlash(text),
+        }).toString();
+        res.redirect(303, `/admin/wizard?${qs}`);
       } catch (err) {
         const text = err instanceof Error ? err.message : "Unknown error";
         logger.error("Wizard apply failed", err);


### PR DESCRIPTION
## Description

`WizardService.applyConfiguration` wrote each key of a wizard batch to the config store one at a time with no rollback, and only called `triggerReload()` after the whole loop. If a per-key write threw partway through, the earlier keys were already persisted to Mongo, but the method returned `false` as if nothing had happened — so the DB and the bot's running config silently diverged (reload-callback services kept their old in-memory config until the next `/config reload` or restart), and the admin got a generic "check the bot logs" message with no way to tell which keys landed.

This PR makes the batch atomic in effect and the outcome fully reported:

- **Snapshot before writing:** the stored rows for the batch's keys are read up front, so a mid-batch failure can restore each already-written key to its exact prior state (restore the old row verbatim, or delete keys that previously had no row).
- **Best-effort rollback on mid-batch failure**, newest-first. If every rollback succeeds, the DB (and the `ConfigService` cache, which `set`/`delete` keep in step) is back to its prior state and no reload is needed.
- **Reload whenever the DB actually changed:** if any rollback itself fails, `triggerReload()` still runs so callback-driven services immediately pick up what actually persisted instead of silently lagging — per the issue's suggested fix.
- **Structured result instead of a bare boolean:** `applyConfiguration` now returns a `WizardApplyResult` (`success`, `appliedKeys`, `failedKey`, `errorMessage`, `rolledBackKeys`, `revertFailedKeys`). A reload failure after a fully-persisted batch is reported distinctly ("run /config reload") instead of masquerading as a total failure.
- **`/wizard/apply` route** records the per-key outcome in the audit log, shows the operator exactly what state the config is in (what failed, what was rolled back, which keys are now live), and keeps the wizard session alive on failure so they can retry from the confirm step instead of losing their input. The pre-write `DependencyError` path is unchanged.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] 🧪 Test updates
- [ ] 🔧 Build/tooling changes
- [ ] ⚡ Performance improvement

## Related Issues

Fixes #780

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality
- [ ] Manually tested in development environment
- [ ] Tested in Docker environment

Added six `applyConfiguration` unit tests covering: full success (all keys set + one reload), missing session, mid-batch failure with full rollback (prior row restored verbatim, unstored key deleted, no reload), rollback failure (key reported in `revertFailedKeys` and reload triggered), reload failure after a fully-persisted batch, and the pre-write `DependencyError` path writing nothing.

**Test Configuration**:

- Node.js version: 22
- Discord.js version: v14
- Operating System: Linux

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes manually

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary:
  - [ ] `COMMANDS.md` (if adding/modifying commands)
  - [ ] `SETTINGS.md` (if adding/modifying configuration)
  - [ ] `README.md` (if adding user-facing features)
  - [x] Inline code comments for complex logic
- [ ] I have validated markdown with `npx markdownlint "**/*.md" --ignore node_modules --ignore dist` (no markdown changed)

### Dependencies & Docker

- [ ] I have updated `Dockerfile` if dependencies changed (no dependency changes)
- [ ] I have updated `Dockerfile.dev` if dev dependencies changed (no dependency changes)
- [ ] I have tested the Docker build (`docker-compose build`)
- [ ] I have run security checks if adding new dependencies (no new dependencies)

### Configuration (if applicable)

- [ ] New features are disabled by default and toggleable via configuration (no new config keys)
- [ ] I have added configuration schema entries in `config-schema.ts` (no new config keys)
- [ ] I have documented new configuration keys in `SETTINGS.md` (no new config keys)
- [x] I have tested configuration reload (`/config reload`) — reload behavior is covered by the new unit tests

## Screenshots (if applicable)

N/A

## Additional Notes

The issue offered two fix directions (best-effort revert, or reload-in-finally + precise reporting); this implements both — rollback for atomicity, with the reload-plus-report path as the safety net for the case where a rollback write itself fails.

## Pre-Submission Verification

- [x] I have rebased my branch on the latest main branch
- [x] I have resolved any merge conflicts
- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PeRCoApNpwpmkxJrCML9hD

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeRCoApNpwpmkxJrCML9hD)_