### PR TITLE
fix(voice-cleanup): register config-reload callback so /config reload reschedules or stops the cleanup cron

### DIFF
--- a/__tests__/services/voice-channel-truncation.test.ts
+++ b/__tests__/services/voice-channel-truncation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 import { VoiceChannelTruncationService } from "../../src/services/voice-channel-truncation.js";
+import { ConfigService } from "../../src/services/config-service.js";
 
 // Mock dependencies
 jest.mock("../../src/services/config-service.js");
@@ -45,6 +46,64 @@ describe("VoiceChannelTruncationService", () => {
 
     it("should have getStatus method", () => {
       expect(typeof service.getStatus).toBe("function");
+    });
+  });
+
+  describe("config reload", () => {
+    function createServiceWithCapturedReload(enabled: boolean) {
+      let reloadCallback: (() => Promise<void>) | undefined;
+      const mockConfigService = {
+        getString: jest.fn<() => Promise<string>>().mockResolvedValue(""),
+        getBoolean: jest.fn<() => Promise<boolean>>().mockResolvedValue(
+          enabled,
+        ),
+        getNumber: jest.fn<() => Promise<number>>().mockResolvedValue(400),
+        get: jest.fn<() => Promise<unknown>>().mockResolvedValue(null),
+        registerReloadCallback: jest.fn((cb: () => Promise<void>) => {
+          reloadCallback = cb;
+        }),
+      };
+      jest
+        .spyOn(ConfigService, "getInstance")
+        .mockReturnValueOnce(mockConfigService as unknown as ConfigService);
+      (
+        VoiceChannelTruncationService as unknown as { instance: unknown }
+      ).instance = undefined;
+      const svc = VoiceChannelTruncationService.getInstance(mockClient);
+      return { svc, mockConfigService, getReloadCallback: () => reloadCallback };
+    }
+
+    it("registers a reload callback that rebuilds the cleanup schedule", async () => {
+      const { svc, mockConfigService, getReloadCallback } =
+        createServiceWithCapturedReload(true);
+
+      expect(mockConfigService.registerReloadCallback).toHaveBeenCalledTimes(1);
+      const reloadCallback = getReloadCallback();
+      expect(reloadCallback).toBeDefined();
+
+      await reloadCallback!();
+
+      expect(svc.getStatus().isScheduled).toBe(true);
+      svc.destroy();
+    });
+
+    it("stops the cron job when the feature is disabled at reload time", async () => {
+      const { svc, getReloadCallback } = createServiceWithCapturedReload(true);
+      const configService = (
+        svc as unknown as {
+          configService: { getBoolean: jest.Mock };
+        }
+      ).configService;
+
+      await getReloadCallback()!();
+      expect(svc.getStatus().isScheduled).toBe(true);
+
+      // Admin disables the feature, then runs /config reload.
+      configService.getBoolean.mockResolvedValue(false as never);
+      await getReloadCallback()!();
+
+      expect(svc.getStatus().isScheduled).toBe(false);
+      svc.destroy();
     });
   });
 });

--- a/__tests__/services/voice-channel-truncation.test.ts
+++ b/__tests__/services/voice-channel-truncation.test.ts
@@ -73,7 +73,17 @@ describe("VoiceChannelTruncationService", () => {
       return { svc, mockConfigService, getReloadCallback: () => reloadCallback };
     }
 
-    it("registers a reload callback that rebuilds the cleanup schedule", async () => {
+    function getCleanupJob(
+      svc: VoiceChannelTruncationService,
+    ): { isActive: boolean; cronTime: { source: unknown } } | null {
+      return (
+        svc as unknown as {
+          cleanupJob: { isActive: boolean; cronTime: { source: unknown } } | null;
+        }
+      ).cleanupJob;
+    }
+
+    it("registers a reload callback that replaces the old cron job with the new schedule", async () => {
       const { svc, mockConfigService, getReloadCallback } =
         createServiceWithCapturedReload(true);
 
@@ -81,8 +91,35 @@ describe("VoiceChannelTruncationService", () => {
       const reloadCallback = getReloadCallback();
       expect(reloadCallback).toBeDefined();
 
+      // First reload schedules with cron expression A.
+      mockConfigService.getString.mockResolvedValue("0 1 * * *");
       await reloadCallback!();
 
+      const oldJob = getCleanupJob(svc);
+      expect(svc.getStatus().isScheduled).toBe(true);
+      expect(oldJob?.isActive).toBe(true);
+      expect(oldJob?.cronTime.source).toBe("0 1 * * *");
+
+      // Admin changes the schedule to B, then runs /config reload.
+      mockConfigService.getString.mockResolvedValue("0 2 * * *");
+      await reloadCallback!();
+
+      const newJob = getCleanupJob(svc);
+      expect(oldJob?.isActive).toBe(false);
+      expect(newJob).not.toBe(oldJob);
+      expect(newJob?.isActive).toBe(true);
+      expect(newJob?.cronTime.source).toBe("0 2 * * *");
+      expect(svc.getStatus().isScheduled).toBe(true);
+      svc.destroy();
+    });
+
+    it("does not clear the overlap guard of an in-flight cleanup when reloading", async () => {
+      const { svc, getReloadCallback } = createServiceWithCapturedReload(true);
+
+      (svc as unknown as { isRunning: boolean }).isRunning = true;
+      await getReloadCallback()!();
+
+      expect(svc.getStatus().isRunning).toBe(true);
       expect(svc.getStatus().isScheduled).toBe(true);
       svc.destroy();
     });

--- a/src/services/voice-channel-truncation.ts
+++ b/src/services/voice-channel-truncation.ts
@@ -48,9 +48,11 @@ export class VoiceChannelTruncationService {
     this.configService.registerReloadCallback(async () => {
       try {
         logger.info("Voice cleanup configuration changed, reloading...");
-        // Tear down any existing schedule, then re-evaluate from config.
-        // startScheduledCleanup() is a no-op when the feature is disabled.
-        this.destroy();
+        // Tear down only the schedule (not the run state — an in-flight
+        // cleanup must keep runCleanup()'s overlap guard armed), then
+        // re-evaluate from config. startScheduledCleanup() is a no-op when
+        // the feature is disabled.
+        this.stopScheduledCleanup();
         await this.startScheduledCleanup();
       } catch (error) {
         logger.error(
@@ -459,15 +461,23 @@ export class VoiceChannelTruncationService {
   }
 
   /**
-   * Destroy the cleanup service and stop the cron job
+   * Stop the scheduled cron job without touching the run state, so a
+   * cleanup already in progress keeps runCleanup()'s overlap guard armed.
    */
-  public destroy(): void {
+  private stopScheduledCleanup(): void {
     if (this.cleanupJob) {
       this.cleanupJob.stop();
       this.cleanupJob = null;
     }
-    this.isRunning = false;
     this.isScheduled = false;
+  }
+
+  /**
+   * Destroy the cleanup service and stop the cron job
+   */
+  public destroy(): void {
+    this.stopScheduledCleanup();
+    this.isRunning = false;
     this.isConnected = false;
   }
 }

--- a/src/services/voice-channel-truncation.ts
+++ b/src/services/voice-channel-truncation.ts
@@ -41,6 +41,24 @@ export class VoiceChannelTruncationService {
     this.client = client;
     this.configService = ConfigService.getInstance();
     this.discordLogger = DiscordLogger.getInstance(client);
+
+    // Apply config changes at runtime (e.g. after /config reload) so the
+    // cron is (re)started, rescheduled, or stopped without a bot restart —
+    // matching message-activity-cleanup-service and digest-service.
+    this.configService.registerReloadCallback(async () => {
+      try {
+        logger.info("Voice cleanup configuration changed, reloading...");
+        // Tear down any existing schedule, then re-evaluate from config.
+        // startScheduledCleanup() is a no-op when the feature is disabled.
+        this.destroy();
+        await this.startScheduledCleanup();
+      } catch (error) {
+        logger.error(
+          "Error reloading voice cleanup service after configuration change:",
+          error,
+        );
+      }
+    });
   }
 
   public static getInstance(client: Client): VoiceChannelTruncationService {


### PR DESCRIPTION
## Description

`VoiceChannelTruncationService` never registered a reload callback with `ConfigService`, so its `voicetracking.cleanup.*` cron job was only ever built once at startup. Changing `voicetracking.cleanup.schedule` or disabling `voicetracking.cleanup.enabled` followed by `/config reload` had no effect: the old cron kept firing (and, when disabled, kept erroring with "Cleanup service is disabled") until the bot process was restarted.

This PR mirrors `MessageActivityCleanupService`'s constructor: it registers a reload callback that tears down the existing cron job (`destroy()`) and re-evaluates the schedule from config (`startScheduledCleanup()`, which is already a no-op when the feature is disabled). Errors inside the callback are caught and logged so a reload can never crash the process.

Also adds two tests covering the reload path: the callback rebuilds the schedule when the feature is enabled, and stops the cron job when the feature has been disabled at reload time.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #778

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality
- [ ] Manually tested in development environment
- [ ] Tested in Docker environment

**Test Configuration**:

- Node.js version: 22.22.2
- Discord.js version: 14 (mocked in tests)
- Operating System: Linux

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes manually

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary (no command/config keys added or changed, so `COMMANDS.md`/`SETTINGS.md`/`README.md` are unaffected)
- [x] I have validated markdown (no markdown files changed)

### Dependencies & Docker

- [x] No dependency or Docker changes required

### Configuration (if applicable)

- [x] No new configuration keys; this change makes the existing `voicetracking.cleanup.*` keys honor `/config reload`
- [x] I have tested configuration reload (`/config reload`) — via the new unit tests exercising the reload callback

## Additional Notes

Every comparable scheduling service (message cleanup, digest, scheduled announcements) already honors the config-reload contract documented in `CLAUDE.md`; this brings the voice cleanup service in line with them.

## Pre-Submission Verification

- [x] I have rebased my branch on the latest main branch
- [x] I have resolved any merge conflicts
- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

---
_Generated by [Claude Code](https://claude.ai/code/session_01N87ZQ8tsfsyFLSMbwzHC2u)_