### PR TITLE
fix(webui): do not revoke sessions when the permission re-check fails transiently

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -104,7 +104,10 @@ is never created and `/admin/*` returns 404.
      their existing session — the magic-link gate at `/admin/s/<token>`
      is the primary defense, not this revalidation. If you want demotions
      to log existing sessions out, configure Permissions → `config` to
-     an admin-only role.
+     an admin-only role. A transient failure of the check itself (Discord
+     API hiccup, rate limit) is not a denial: the middleware responds 503
+     without revoking the session or clearing the cookie, so the next
+     request succeeds once the blip clears.
 4. `POST /admin/finish` revokes the session in MongoDB, clears the cookie.
 
 The cookie value carries `sid`, `uid`, `gid`, `iat`, `act` — all

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -169,6 +169,9 @@ Key properties:
   no longer matches the user's roles. With no explicit gating configured,
   a re-check after demotion still passes — the magic-link gate at
   `/admin/s/<token>` is the primary defense, not this revalidation.
+  If the check itself cannot be performed (Discord API hiccup, rate
+  limit), the request fails with a 503 and the session is left intact —
+  only a definitive denial revokes it.
 - **No persistent OAuth.** The bot is the trust anchor. If you can run
   `/config` in Discord, you can configure the bot — no separate login.
 

--- a/__tests__/services/permissions-service.test.ts
+++ b/__tests__/services/permissions-service.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
-import { PermissionsService } from "../../src/services/permissions-service.js";
+import {
+  PermissionsService,
+  PermissionCheckError,
+} from "../../src/services/permissions-service.js";
 import { CommandPermission } from "../../src/models/command-permissions.js";
 
 // Mock dependencies
@@ -476,6 +479,91 @@ describe("PermissionsService", () => {
       );
 
       expect(result).toBe(true);
+    });
+
+    // #781 — transient internal failures must be distinguishable from a
+    // genuine denial when the caller opts in via onUnavailable: "throw".
+    describe("internal failure handling (#781)", () => {
+      function makeServiceWithFailingFetch(
+        fetchError: unknown,
+      ): PermissionsService {
+        const mockGuild = {
+          members: {
+            fetch: jest.fn().mockRejectedValue(fetchError as never),
+          },
+        };
+        mockClient.guilds.fetch = jest.fn().mockResolvedValue(mockGuild);
+
+        const mockConfigService = {
+          getString: jest.fn().mockResolvedValue("guild123" as never),
+        };
+
+        (PermissionsService as unknown as { instance: unknown }).instance =
+          undefined;
+        const serviceWithMocks = PermissionsService.getInstance(
+          mockClient as never,
+        );
+        (serviceWithMocks as never)["configService"] = mockConfigService;
+        return serviceWithMocks;
+      }
+
+      it("returns false on a transient error by default (legacy behavior)", async () => {
+        const serviceWithMocks = makeServiceWithFailingFetch(
+          new Error("Discord API timeout"),
+        );
+
+        const result = await serviceWithMocks.checkCommandPermission(
+          "user123",
+          "guild123",
+          "quote",
+        );
+
+        expect(result).toBe(false);
+      });
+
+      it("throws PermissionCheckError on a transient error when onUnavailable is 'throw'", async () => {
+        const underlying = new Error("Discord API timeout");
+        const serviceWithMocks = makeServiceWithFailingFetch(underlying);
+
+        await expect(
+          serviceWithMocks.checkCommandPermission(
+            "user123",
+            "guild123",
+            "quote",
+            { onUnavailable: "throw" },
+          ),
+        ).rejects.toThrow(PermissionCheckError);
+
+        try {
+          await serviceWithMocks.checkCommandPermission(
+            "user123",
+            "guild123",
+            "quote",
+            { onUnavailable: "throw" },
+          );
+          throw new Error("expected checkCommandPermission to throw");
+        } catch (err) {
+          expect(err).toBeInstanceOf(PermissionCheckError);
+          expect((err as PermissionCheckError).cause).toBe(underlying);
+        }
+      });
+
+      it("returns false (genuine denial) for Unknown Member even when onUnavailable is 'throw'", async () => {
+        // Shaped like a DiscordAPIError: 10007 = Unknown Member.
+        const unknownMember = Object.assign(new Error("Unknown Member"), {
+          code: 10007,
+        });
+        const serviceWithMocks = makeServiceWithFailingFetch(unknownMember);
+
+        const result = await serviceWithMocks.checkCommandPermission(
+          "user123",
+          "guild123",
+          "quote",
+          { onUnavailable: "throw" },
+        );
+
+        expect(result).toBe(false);
+      });
     });
   });
 });

--- a/__tests__/services/permissions-service.test.ts
+++ b/__tests__/services/permissions-service.test.ts
@@ -548,6 +548,85 @@ describe("PermissionsService", () => {
         }
       });
 
+      function makeServiceWithFailingCacheLoad(
+        isAdmin: boolean,
+      ): PermissionsService {
+        const mockGuild = {
+          members: {
+            fetch: jest.fn().mockResolvedValue({
+              id: "user123",
+              permissions: {
+                has: jest.fn().mockReturnValue(isAdmin),
+              },
+              roles: {
+                cache: new Map(),
+              },
+            } as never),
+          },
+        };
+        mockClient.guilds.fetch = jest.fn().mockResolvedValue(mockGuild);
+
+        const mockConfigService = {
+          getString: jest.fn().mockResolvedValue("guild123" as never),
+        };
+
+        // The cache load itself fails (e.g. Mongo outage) — initializeCache
+        // swallows this and leaves the cache empty and uninitialized.
+        (CommandPermission.find as jest.Mock) = jest
+          .fn()
+          .mockRejectedValue(new Error("Mongo connection lost") as never);
+
+        (PermissionsService as unknown as { instance: unknown }).instance =
+          undefined;
+        const serviceWithMocks = PermissionsService.getInstance(
+          mockClient as never,
+        );
+        (serviceWithMocks as never)["configService"] = mockConfigService;
+        return serviceWithMocks;
+      }
+
+      it("throws in 'throw' mode when the permission cache failed to load (non-admin)", async () => {
+        const serviceWithMocks = makeServiceWithFailingCacheLoad(false);
+
+        // Without this guard the empty cache would fall through to the
+        // default-open branch and authorize the user despite the outage.
+        await expect(
+          serviceWithMocks.checkCommandPermission(
+            "user123",
+            "guild123",
+            "quote",
+            { onUnavailable: "throw" },
+          ),
+        ).rejects.toThrow(PermissionCheckError);
+      });
+
+      it("still allows Administrators in 'throw' mode when the cache failed to load", async () => {
+        const serviceWithMocks = makeServiceWithFailingCacheLoad(true);
+
+        // The admin short-circuit rests on live Discord data, not the
+        // cache, so a cache outage must not lock admins out.
+        const result = await serviceWithMocks.checkCommandPermission(
+          "user123",
+          "guild123",
+          "quote",
+          { onUnavailable: "throw" },
+        );
+
+        expect(result).toBe(true);
+      });
+
+      it("keeps legacy default-open behavior on cache load failure in default mode", async () => {
+        const serviceWithMocks = makeServiceWithFailingCacheLoad(false);
+
+        const result = await serviceWithMocks.checkCommandPermission(
+          "user123",
+          "guild123",
+          "quote",
+        );
+
+        expect(result).toBe(true);
+      });
+
       it("returns false (genuine denial) for Unknown Member even when onUnavailable is 'throw'", async () => {
         // Shaped like a DiscordAPIError: 10007 = Unknown Member.
         const unknownMember = Object.assign(new Error("Unknown Member"), {

--- a/__tests__/web/session-permission-unavailable.test.ts
+++ b/__tests__/web/session-permission-unavailable.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Regression test for #781 — a transient Discord API error during the
+ * per-request permission re-check must NOT be treated as "access denied"
+ * and must NOT permanently revoke the user's session.
+ *
+ * Before the fix, `checkCommandPermission` swallowed every internal
+ * error into the same `false` as a genuine denial, and the session
+ * middleware reacted to any `false` by clearing the cookie and calling
+ * `revokeSession` — so a brief Discord outage logged every active WebUI
+ * user out for good. Now the middleware asks for `onUnavailable:
+ * "throw"`, and a thrown `PermissionCheckError` fails only the current
+ * request (503) while leaving the cookie and the DB session intact.
+ */
+
+import { Buffer } from "buffer";
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import { Client } from "discord.js";
+import {
+  createSessionMiddleware,
+  type AuthenticatedRequest,
+} from "../../src/web/session.js";
+import { signValue } from "../../src/web/cookies.js";
+import { WebSessionService } from "../../src/services/web-session-service.js";
+import {
+  PermissionsService,
+  PermissionCheckError,
+} from "../../src/services/permissions-service.js";
+import type { Response, NextFunction } from "express";
+
+const SECRET = "test-secret-for-permission-unavailable";
+const ORIGINAL_ENV = { ...process.env };
+
+interface CookiePayload {
+  sid: string;
+  uid: string;
+  gid: string;
+  rol?: "admin" | "user";
+  iat: number;
+  act: number;
+}
+
+function buildCookie(payload: CookiePayload): string {
+  const encoded = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return signValue(encoded, SECRET);
+}
+
+interface FakeRes {
+  statusCode: number;
+  headers: Record<string, unknown>;
+  status: jest.Mock;
+  type: jest.Mock;
+  send: jest.Mock;
+  setHeader: jest.Mock;
+  getHeader: jest.Mock;
+}
+
+function makeRes(): FakeRes {
+  const headers: Record<string, unknown> = {};
+  const res: FakeRes = {
+    statusCode: 200,
+    headers,
+    status: jest.fn(),
+    type: jest.fn(),
+    send: jest.fn(),
+    setHeader: jest.fn(),
+    getHeader: jest.fn(),
+  };
+  res.status.mockImplementation((code: number) => {
+    res.statusCode = code;
+    return res;
+  });
+  res.type.mockImplementation(() => res);
+  res.send.mockImplementation(() => res);
+  res.setHeader.mockImplementation((name: string, value: unknown) => {
+    headers[name.toLowerCase()] = value;
+    return res;
+  });
+  res.getHeader.mockImplementation(
+    (name: string) => headers[name.toLowerCase()],
+  );
+  return res;
+}
+
+function makeReq(cookieValue: string): AuthenticatedRequest {
+  return {
+    headers: { cookie: `koolbot_session=${cookieValue}` },
+    method: "GET",
+  } as unknown as AuthenticatedRequest;
+}
+
+function sessionCookieHeaders(res: FakeRes): string[] {
+  const raw = res.headers["set-cookie"];
+  const list = Array.isArray(raw) ? raw : raw ? [String(raw)] : [];
+  return list
+    .map((h) => String(h))
+    .filter((h) => h.startsWith("koolbot_session="));
+}
+
+describe("createSessionMiddleware permission re-check failures (#781)", () => {
+  const now = Date.UTC(2026, 0, 1, 12, 0, 0);
+  let revokeSession: jest.Mock;
+
+  beforeEach(() => {
+    process.env.WEBUI_SESSION_SECRET = SECRET;
+    process.env.WEBUI_INACTIVITY_TIMEOUT_MINUTES = "30";
+    (WebSessionService as unknown as { instance: unknown }).instance = null;
+
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+
+    const svc = WebSessionService.getInstance();
+    jest.spyOn(svc, "findById").mockResolvedValue({
+      discordUserId: "u-1",
+      guildId: "g-1",
+      role: "admin",
+      scopes: [],
+      revokedAt: null,
+      expiresAt: new Date(now + 24 * 60 * 60 * 1000),
+    } as never);
+    revokeSession = jest.fn(async () => true);
+    (svc as unknown as { revokeSession: unknown }).revokeSession =
+      revokeSession;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    jest.restoreAllMocks();
+    (WebSessionService as unknown as { instance: unknown }).instance = null;
+  });
+
+  function freshCookie(): string {
+    return buildCookie({
+      sid: "session-id",
+      uid: "u-1",
+      gid: "g-1",
+      rol: "admin",
+      iat: now,
+      act: now,
+    });
+  }
+
+  it("asks checkCommandPermission to throw instead of masking failures as denial", async () => {
+    const check = jest.fn(async () => true);
+    jest.spyOn(PermissionsService, "getInstance").mockReturnValue({
+      checkCommandPermission: check,
+    } as never);
+
+    const middleware = createSessionMiddleware({} as Client);
+    const res = makeRes();
+    const next = jest.fn() as unknown as NextFunction;
+    await middleware(makeReq(freshCookie()), res as unknown as Response, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(check).toHaveBeenCalledWith("u-1", "g-1", "config", {
+      onUnavailable: "throw",
+    });
+  });
+
+  it("responds 503 and keeps the session when the check fails transiently", async () => {
+    jest.spyOn(PermissionsService, "getInstance").mockReturnValue({
+      checkCommandPermission: async () => {
+        throw new PermissionCheckError(
+          "Permission check could not be completed",
+          new Error("Discord API timeout"),
+        );
+      },
+    } as never);
+
+    const middleware = createSessionMiddleware({} as Client);
+    const res = makeRes();
+    const next = jest.fn() as unknown as NextFunction;
+    await middleware(makeReq(freshCookie()), res as unknown as Response, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(503);
+    expect(res.headers["retry-after"]).toBe("10");
+    // The session must survive: no DB revocation and no cookie clearing,
+    // so the very next request succeeds once the transient error clears.
+    expect(revokeSession).not.toHaveBeenCalled();
+    expect(sessionCookieHeaders(res)).toHaveLength(0);
+  });
+
+  it("still revokes the session on a genuine denial", async () => {
+    jest.spyOn(PermissionsService, "getInstance").mockReturnValue({
+      checkCommandPermission: async () => false,
+    } as never);
+
+    const middleware = createSessionMiddleware({} as Client);
+    const res = makeRes();
+    const next = jest.fn() as unknown as NextFunction;
+    await middleware(makeReq(freshCookie()), res as unknown as Response, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(revokeSession).toHaveBeenCalledWith("session-id");
+    // Denial clears the cookie (Max-Age=0 / empty value).
+    const cleared = sessionCookieHeaders(res);
+    expect(cleared.length).toBeGreaterThan(0);
+    expect(cleared[0]).toMatch(/^koolbot_session=;/);
+  });
+});

--- a/src/services/permissions-service.ts
+++ b/src/services/permissions-service.ts
@@ -7,6 +7,40 @@ import { ConfigService } from "./config-service.js";
 import logger from "../utils/logger.js";
 import { sanitizeForLog } from "../utils/log-sanitize.js";
 
+/**
+ * Thrown by `checkCommandPermission` (only with `onUnavailable: "throw"`)
+ * when the check could not be completed — a Discord API hiccup, rate
+ * limit, or network blip. Distinct from a `false` result so callers can
+ * tell "checked and denied" apart from "couldn't check" (#781).
+ */
+export class PermissionCheckError extends Error {
+  public readonly cause?: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = "PermissionCheckError";
+    this.cause = cause;
+  }
+}
+
+/**
+ * Discord API error codes that are a definitive "the target doesn't
+ * exist" answer rather than a transient failure: 10004 Unknown Guild,
+ * 10007 Unknown Member, 10013 Unknown User. A permission check that hits
+ * one of these is a genuine denial (the user/guild is gone), never an
+ * outage.
+ */
+const UNKNOWN_TARGET_ERROR_CODES = new Set<unknown>([10004, 10007, 10013]);
+
+function isUnknownTargetError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    UNKNOWN_TARGET_ERROR_CODES.has((error as { code: unknown }).code)
+  );
+}
+
 export class PermissionsService {
   private static instance: PermissionsService;
   private client: Client;
@@ -89,12 +123,20 @@ export class PermissionsService {
    * @param userId - Discord user ID
    * @param guildId - Discord guild ID
    * @param commandName - Name of the command
+   * @param options - `onUnavailable` controls what an *internal* failure
+   *   (Discord API hiccup, rate limit, network blip) maps to: `"deny"`
+   *   (default) keeps the legacy behavior of returning `false`, while
+   *   `"throw"` raises a `PermissionCheckError` so the caller can react
+   *   differently to "couldn't check" than to a genuine denial. A
+   *   definitive Unknown Guild/Member answer from Discord is a real
+   *   denial and returns `false` in both modes.
    * @returns True if user has permission, false otherwise
    */
   public async checkCommandPermission(
     userId: string,
     guildId: string,
     commandName: string,
+    options: { onUnavailable?: "deny" | "throw" } = {},
   ): Promise<boolean> {
     try {
       // Ensure cache is initialized
@@ -136,7 +178,19 @@ export class PermissionsService {
 
       return hasPermission;
     } catch (error) {
+      if (isUnknownTargetError(error)) {
+        logger.warn(
+          `Permission check for ${sanitizeForLog(commandName)}: guild ${guildId} or member ${userId} not found`,
+        );
+        return false;
+      }
       logger.error("Error checking command permission:", error);
+      if (options.onUnavailable === "throw") {
+        throw new PermissionCheckError(
+          `Permission check for ${commandName} could not be completed`,
+          error,
+        );
+      }
       return false;
     }
   }

--- a/src/services/permissions-service.ts
+++ b/src/services/permissions-service.ts
@@ -48,6 +48,14 @@ export class PermissionsService {
   private permissionsCache: Map<string, string[]> = new Map();
   private cacheInitialized = false;
   private cacheInitializing: Promise<void> | null = null;
+  /**
+   * Error from the most recent failed cache load, cleared on success.
+   * Lets `checkCommandPermission` (in `onUnavailable: "throw"` mode) tell
+   * "cache empty because nothing is configured" apart from "cache empty
+   * because loading it failed" — the latter must not fall through to the
+   * default-open branch and silently authorize (#795 review).
+   */
+  private cacheLoadError: unknown = null;
 
   private constructor(client: Client) {
     this.client = client;
@@ -97,10 +105,12 @@ export class PermissionsService {
         }
 
         this.cacheInitialized = true;
+        this.cacheLoadError = null;
         logger.info(
           `Permissions cache initialized with ${permissions.length} entries`,
         );
       } catch (error) {
+        this.cacheLoadError = error;
         logger.error("Error initializing permissions cache:", error);
       } finally {
         this.cacheInitializing = null;
@@ -161,6 +171,23 @@ export class PermissionsService {
         return true;
       }
 
+      // Everything below depends on the permissions cache. If the cache
+      // failed to load (e.g. a Mongo blip) we cannot know whether role
+      // gating is configured, so in throw mode surface "couldn't check"
+      // instead of falling through to the default-open branch and
+      // silently authorizing. Admins are unaffected: their short-circuit
+      // above rests on live Discord data, not the cache.
+      if (
+        options.onUnavailable === "throw" &&
+        !this.cacheInitialized &&
+        this.cacheLoadError !== null
+      ) {
+        throw new PermissionCheckError(
+          `Permission check for ${commandName} could not be completed: permissions cache failed to load`,
+          this.cacheLoadError,
+        );
+      }
+
       // Check if there are any permissions set for this command
       const cacheKey = `${guildId}:${commandName}`;
       const allowedRoleIds = this.permissionsCache.get(cacheKey);
@@ -178,6 +205,9 @@ export class PermissionsService {
 
       return hasPermission;
     } catch (error) {
+      if (error instanceof PermissionCheckError) {
+        throw error;
+      }
       if (isUnknownTargetError(error)) {
         logger.warn(
           `Permission check for ${sanitizeForLog(commandName)}: guild ${guildId} or member ${userId} not found`,

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -2,7 +2,10 @@ import { Buffer } from "buffer";
 import { Client } from "discord.js";
 import { Request, RequestHandler, Response, NextFunction } from "express";
 import logger from "../utils/logger.js";
-import { PermissionsService } from "../services/permissions-service.js";
+import {
+  PermissionsService,
+  PermissionCheckError,
+} from "../services/permissions-service.js";
 import { WebSessionService } from "../services/web-session-service.js";
 import type { IWebSession, WebSessionRole } from "../models/web-session.js";
 import {
@@ -180,7 +183,9 @@ function readSessionCookie(req: Request): CookiePayload | null {
  * inactivity window, hard-caps the session to its server-side expiresAt,
  * and re-checks the user's command permission on every request via
  * PermissionsService (admins always pass; otherwise the configured roles
- * for "config" must allow the user).
+ * for "config" must allow the user). Only a definitive denial revokes
+ * the session; if the check itself fails transiently the request gets a
+ * 503 and the session survives (#781).
  */
 export function createSessionMiddleware(
   client: Client,
@@ -209,11 +214,16 @@ export function createSessionMiddleware(
       const permissions = PermissionsService.getInstance(client);
       // checkCommandPermission already short-circuits to true for
       // Administrators and to true when no role gating is configured for
-      // the command, so we can rely on its boolean directly.
+      // the command, so we can rely on its boolean directly. With
+      // `onUnavailable: "throw"` a transient internal failure (Discord
+      // API hiccup, rate limit, network blip) surfaces as a
+      // PermissionCheckError instead of being conflated with a `false`
+      // denial — only a genuine denial may revoke the session (#781).
       const allowed = await permissions.checkCommandPermission(
         payload.uid,
         payload.gid,
         "config",
+        { onUnavailable: "throw" },
       );
       if (!allowed) {
         clearSessionCookie(res);
@@ -222,9 +232,20 @@ export function createSessionMiddleware(
         return;
       }
     } catch (err) {
-      logger.warn("Failed to revalidate web session permissions", err);
-      clearSessionCookie(res);
-      respondUnauthorized(res);
+      // The permission could not be *checked* — that is not a denial.
+      // Fail only this request, leaving the cookie and the DB session
+      // untouched, so the very next request succeeds once the transient
+      // condition clears. Revoking here would force every active user to
+      // redeem a brand-new magic link after any brief Discord outage.
+      if (err instanceof PermissionCheckError) {
+        logger.warn(
+          "Web session permission re-check unavailable, failing request softly",
+          err,
+        );
+      } else {
+        logger.warn("Failed to revalidate web session permissions", err);
+      }
+      respondServiceUnavailable(res);
       return;
     }
 
@@ -345,6 +366,27 @@ export function createSessionPingHandler(): RequestHandler {
 
 function respondPingUnauthorized(res: Response): void {
   res.status(401).json({ error: "unauthorized" });
+}
+
+/**
+ * 503 used when the per-request permission re-check could not be
+ * performed (e.g. Discord API outage or rate limit). Deliberately does
+ * NOT clear the session cookie or revoke the DB session — the session is
+ * still valid, we just couldn't verify it right now (#781).
+ */
+function respondServiceUnavailable(res: Response): void {
+  res.setHeader("Retry-After", "10");
+  res
+    .status(503)
+    .type("text/html")
+    .send(
+      `<!doctype html><html><head><meta charset="utf-8"><title>Temporarily unavailable</title></head>` +
+        `<body style="font-family:system-ui,sans-serif;padding:2rem;max-width:32rem;margin:0 auto;">` +
+        `<h1>Temporarily unavailable</h1>` +
+        `<p>Your sign-in could not be verified because Discord did not respond. ` +
+        `Your session is still valid &mdash; refresh the page to try again.</p>` +
+        `</body></html>`,
+    );
 }
 
 function respondUnauthorized(res: Response): void {


### PR DESCRIPTION
## Description

`PermissionsService.checkCommandPermission` swallowed every internal error — including transient ones like `guild.members.fetch()` failing on a Discord API hiccup or rate limit — into the same `false` as a genuine "user lacks permission" result. `createSessionMiddleware` reacted to any `false` by clearing the session cookie **and permanently revoking the session in the database**, so every WebUI user who loaded a page during a brief Discord outage was forced to redeem a brand-new magic link.

This PR distinguishes "checked and denied" from "couldn't check":

- `checkCommandPermission` gains an `onUnavailable` option: `"deny"` (default, legacy behavior — the Discord command path in `CommandManager` is unchanged) or `"throw"`, which raises a new exported `PermissionCheckError` carrying the underlying cause.
- Definitive Unknown Guild/Member/User answers from Discord (API error codes 10004, 10007, 10013) still return `false` in both modes — the user or guild really is gone, so revocation on that path remains correct.
- `createSessionMiddleware` opts into `"throw"`. On a thrown error it now responds **503 with `Retry-After`** without clearing the cookie or revoking the DB session, so the very next request succeeds once the transient condition clears. Only a checked-and-denied `false` clears the cookie and revokes.
- `WEBUI.md` and `DEVELOPER_GUIDE.md` sections describing the per-request re-check are updated to document the new soft-failure behavior.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #781

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`) — 127 suites, 1564 tests passing
- [x] Added new tests for new functionality
  - `__tests__/services/permissions-service.test.ts`: transient error returns `false` by default; throws `PermissionCheckError` (with `cause`) under `onUnavailable: "throw"`; Unknown Member (10007) still returns `false` even in throw mode
  - `__tests__/web/session-permission-unavailable.test.ts` (new): middleware passes `{ onUnavailable: "throw" }`; a thrown `PermissionCheckError` yields 503 + `Retry-After` with no `revokeSession` call and no cookie clearing; a genuine `false` denial still returns 401, revokes the session, and clears the cookie
- [ ] Manually tested in development environment
- [ ] Tested in Docker environment

**Test Configuration**:

- Node.js version: 22
- Discord.js version: 14
- Operating System: Linux

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes manually

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary:
  - [ ] `COMMANDS.md` (no command changes)
  - [ ] `SETTINGS.md` (no configuration changes)
  - [ ] `README.md` (no user-facing feature additions)
  - [x] Inline code comments for complex logic (`WEBUI.md` / `DEVELOPER_GUIDE.md` updated for the new middleware behavior)
- [x] I have validated markdown with `npx markdownlint "**/*.md" --ignore node_modules --ignore dist`

### Dependencies & Docker

- [ ] No dependency changes — `Dockerfile` / `Dockerfile.dev` untouched

### Configuration (if applicable)

- [ ] Not applicable — no new configuration keys

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The `onUnavailable` default of `"deny"` keeps the Discord slash-command permission gate in `CommandManager.executeCommand` byte-for-byte identical in behavior; only the WebUI session middleware opts into the throwing mode. The 503 page tells the user their session is still valid and to refresh.

## Pre-Submission Verification

- [x] I have rebased my branch on the latest main branch
- [x] I have resolved any merge conflicts
- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfyTFXxdESsngEgzYZK6KM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfyTFXxdESsngEgzYZK6KM)_