### PR TITLE
fix(birthdays): log save errors when clearing roleAssignedAt in sweep

### DIFF
--- a/__tests__/services/birthday-service.test.ts
+++ b/__tests__/services/birthday-service.test.ts
@@ -54,10 +54,12 @@ jest.unstable_mockModule("../../src/models/user-birthday.js", () => ({
   },
 }));
 
+const mockLoggerWarn = jest.fn();
+
 jest.unstable_mockModule("../../src/utils/logger.js", () => ({
   default: {
     info: jest.fn(),
-    warn: jest.fn(),
+    warn: mockLoggerWarn,
     error: jest.fn(),
     debug: jest.fn(),
   },
@@ -362,6 +364,123 @@ describe("BirthdayService", () => {
         svc.setBirthday("u1", "g1", { month: 6, day: 16, year: 1800 }),
       ).rejects.toThrow(/valid birth year/);
       expect(mockBirthdayFindOneAndUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("sweepExpiredRoles", () => {
+    const MS_PER_HOUR = 60 * 60 * 1000;
+    const now = new Date("2026-06-16T12:00:00Z");
+    const expiredAt = new Date(now.getTime() - 48 * MS_PER_HOUR);
+
+    type SweepFn = (
+      guild: unknown,
+      guildId: string,
+      roleId: string,
+      durationMs: number,
+      now: Date,
+    ) => Promise<number>;
+
+    function sweep(svc: ServiceInstance): SweepFn {
+      return (
+        svc as unknown as { sweepExpiredRoles: SweepFn }
+      ).sweepExpiredRoles.bind(svc);
+    }
+
+    function makeGuild(member: unknown): unknown {
+      return { members: { fetch: jest.fn().mockResolvedValue(member) } };
+    }
+
+    function makeMember(): unknown {
+      return {
+        roles: {
+          cache: { has: jest.fn(() => true) },
+          remove: jest.fn().mockResolvedValue(undefined),
+        },
+      };
+    }
+
+    it("logs a warning with the sanitized user id when clearing roleAssignedAt fails to save", async () => {
+      const saveError = new Error("mongo down");
+      const row = {
+        userId: "user-1\nforged log line",
+        roleAssignedAt: expiredAt as Date | undefined,
+        save: jest.fn().mockRejectedValue(saveError),
+      };
+      mockBirthdayFind.mockResolvedValue([row]);
+
+      const svc: ServiceInstance = BirthdayService.getInstance(makeClient());
+      const removed = await sweep(svc)(
+        makeGuild(makeMember()),
+        "guild-1",
+        "role-1",
+        24 * MS_PER_HOUR,
+        now,
+      );
+
+      // The role removal itself still counts and the marker is cleared
+      // in memory; only the persistence failed.
+      expect(removed).toBe(1);
+      expect(row.roleAssignedAt).toBeUndefined();
+
+      // The save failure must be logged (regression: it used to be
+      // swallowed by a bare `.catch(() => undefined)`), with the user id
+      // sanitized so it cannot forge log lines.
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to clear roleAssignedAt"),
+        saveError,
+      );
+      const [message] = mockLoggerWarn.mock.calls.find(
+        ([msg]) => typeof msg === "string" && msg.includes("roleAssignedAt"),
+      ) as [string, unknown];
+      expect(message).toContain("user-1 forged log line");
+      expect(message).not.toContain("\n");
+    });
+
+    it("does not warn when the save succeeds", async () => {
+      const row = {
+        userId: "user-2",
+        roleAssignedAt: expiredAt as Date | undefined,
+        save: jest.fn().mockResolvedValue(undefined),
+      };
+      mockBirthdayFind.mockResolvedValue([row]);
+
+      const svc: ServiceInstance = BirthdayService.getInstance(makeClient());
+      const removed = await sweep(svc)(
+        makeGuild(makeMember()),
+        "guild-1",
+        "role-1",
+        24 * MS_PER_HOUR,
+        now,
+      );
+
+      expect(removed).toBe(1);
+      expect(row.roleAssignedAt).toBeUndefined();
+      expect(row.save).toHaveBeenCalledTimes(1);
+      expect(mockLoggerWarn).not.toHaveBeenCalled();
+    });
+
+    it("leaves unexpired grants untouched", async () => {
+      const row = {
+        userId: "user-3",
+        roleAssignedAt: new Date(now.getTime() - 1 * MS_PER_HOUR) as
+          | Date
+          | undefined,
+        save: jest.fn().mockResolvedValue(undefined),
+      };
+      mockBirthdayFind.mockResolvedValue([row]);
+
+      const svc: ServiceInstance = BirthdayService.getInstance(makeClient());
+      const removed = await sweep(svc)(
+        makeGuild(makeMember()),
+        "guild-1",
+        "role-1",
+        24 * MS_PER_HOUR,
+        now,
+      );
+
+      expect(removed).toBe(0);
+      expect(row.roleAssignedAt).toBeDefined();
+      expect(row.save).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/services/birthday-service.ts
+++ b/src/services/birthday-service.ts
@@ -573,7 +573,14 @@ export class BirthdayService {
         // Clear the marker regardless: if the role is already gone or the
         // member left, there's nothing more to sweep.
         row.roleAssignedAt = undefined;
-        await row.save().catch(() => undefined);
+        await row
+          .save()
+          .catch((error) =>
+            logger.warn(
+              `Failed to clear roleAssignedAt for ${sanitizeForLog(row.userId)}:`,
+              error,
+            ),
+          );
       }
     }
     return removed;


### PR DESCRIPTION
## Description

`sweepExpiredRoles` in `src/services/birthday-service.ts` cleared the `roleAssignedAt` marker with `await row.save().catch(() => undefined)`, silently discarding any save failure. If the write failed (e.g. MongoDB briefly unreachable), the marker was never cleared, the sweep re-attempted the same member on every run, and operators had no log signal at all.

This change replaces the bare `.catch(() => undefined)` with a `logger.warn` that includes the sanitized user id and the error, mirroring the error-handling pattern used for the role-removal failure directly above it in the same function.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] 🧪 Test updates
- [ ] 🔧 Build/tooling changes
- [ ] ⚡ Performance improvement

## Related Issues

Fixes #741

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [ ] Added new tests for new functionality
- [ ] Manually tested in development environment
- [ ] Tested in Docker environment

Ran `npm run check:all` (build + lint + format check + tests): all 126 suites / 1572 tests pass.

**Test Configuration**:

- Node.js version: 22
- Discord.js version: 14
- Operating System: Linux

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes manually

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation where necessary (not needed — logging-only change, no commands or config keys touched)
- [ ] I have validated markdown with `npx markdownlint` (no markdown changed)

### Dependencies & Docker

- [ ] N/A — no dependency or Docker changes

### Configuration (if applicable)

- [ ] N/A — no configuration changes

## Additional Notes

Found during a routine automated code-quality scan (see issue #741). The fix is a single logging addition; behavior of the sweep itself is unchanged.

## Pre-Submission Verification

- [x] I have rebased my branch on the latest main branch
- [x] I have resolved any merge conflicts
- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArkugQcNRPPoW1533RK81r

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArkugQcNRPPoW1533RK81r)_