### PR TITLE
fix(leaderboard-roles): fetch full ranking so wide tiers are not truncated

### DIFF
--- a/__tests__/services/leaderboard-role-service.test.ts
+++ b/__tests__/services/leaderboard-role-service.test.ts
@@ -249,7 +249,6 @@ describe("LeaderboardRoleService", () => {
         return "";
       });
 
-      // Largest tier (5) drives how many top users to fetch
       mockGetTopUsers.mockResolvedValue([
         { userId: "u1", username: "u1", totalTime: 100 },
         { userId: "u2", username: "u2", totalTime: 90 },
@@ -271,8 +270,43 @@ describe("LeaderboardRoleService", () => {
       expect(result).not.toBeNull();
       // Only "1:111" and "5:222" parse successfully → 2 tiers reconciled
       expect(result!.tiers.map((t) => t.topN).sort()).toEqual([1, 5]);
-      // getTopUsers should be called with the widest tier (5)
-      expect(mockGetTopUsers).toHaveBeenCalledWith(5, "alltime");
+      // Full ranking is fetched with the "all ranked users" sentinel (0);
+      // per-tier cutoffs happen in reconcileTier.
+      expect(mockGetTopUsers).toHaveBeenCalledWith(0, "alltime");
+    });
+  });
+
+  describe("ranking fetch", () => {
+    it("fetches all ranked users so tiers wider than leaderboard_max_results are not truncated", async () => {
+      mockConfigGetString.mockImplementation(async (key: unknown) => {
+        const k = key as string;
+        if (k === "GUILD_ID") return "guild-1";
+        // Tier wider than the default leaderboard_max_results cap (50).
+        if (k === "leaderboard_roles.tiers") return "100:99999100";
+        if (k === "leaderboard_roles.period") return "week";
+        return "";
+      });
+      // With the sentinel, the tracker returns every ranked user (60 > 50).
+      const allRanked = Array.from({ length: 60 }, (_, i) => ({
+        userId: `u${i + 1}`,
+        username: `u${i + 1}`,
+        totalTime: 1000 - i,
+      }));
+      mockGetTopUsers.mockResolvedValue(allRanked);
+      mockClientGuildsFetch.mockResolvedValue(
+        makeGuildWithRole({ roleId: "99999100", roleName: "Top 100" }),
+      );
+
+      const svc: ServiceInstance =
+        LeaderboardRoleService.getInstance(makeClient());
+      const result = await svc.runNow();
+
+      expect(result).not.toBeNull();
+      // Never passes a positive limit that would be clamped server-side.
+      expect(mockGetTopUsers).toHaveBeenCalledWith(0, "week");
+      // All 60 ranked users fall within the top-100 tier and get the role.
+      expect(result!.tiers[0].added).toHaveLength(60);
+      expect(result!.tiers[0].added).toContain("u60");
     });
   });
 

--- a/src/services/leaderboard-role-service.ts
+++ b/src/services/leaderboard-role-service.ts
@@ -272,10 +272,13 @@ export class LeaderboardRoleService {
         return null;
       }
 
-      // The widest tier (largest topN) defines how many top users we need to fetch.
-      const maxTopN = Math.max(...tiers.map((t) => t.topN));
+      // Fetch the full ranking with the documented "all ranked users"
+      // sentinel (0). A positive limit would be clamped to
+      // voicetracking.stats.leaderboard_max_results, silently truncating
+      // tiers wider than that cap; the per-tier cutoff happens in
+      // reconcileTier via rankedUserIds.slice(0, tier.topN).
       const tracker = VoiceChannelTracker.getInstance(this.client);
-      const topUsers = await tracker.getTopUsers(maxTopN, period);
+      const topUsers = await tracker.getTopUsers(0, period);
       const rankedUserIds: string[] = topUsers.map((u) => u.userId);
 
       const summary: LeaderboardRoleRunSummary = {


### PR DESCRIPTION
## Summary

Fixes #754.

`LeaderboardRoleService.runNow()` passed the widest tier's `topN` to `VoiceChannelTracker.getTopUsers`. That method clamps any positive `limit` to `voicetracking.stats.leaderboard_max_results` (default **50**), so a tier wider than the cap (e.g. `100:<roleId>`) silently never fetched users ranked beyond 50 — those users never received the role, with no warning.

`getTopUsers`'s own contract documents a non-positive `limit` as the "all ranked users" sentinel for internal aggregation consumers, and explicitly names leaderboard-role reconcile as one of them; `digest-service.ts` already calls it that way.

## Changes

- `src/services/leaderboard-role-service.ts`: call `tracker.getTopUsers(0, period)` (the documented sentinel) instead of `maxTopN`. The per-tier cutoff continues to happen in `reconcileTier` via the existing `rankedUserIds.slice(0, tier.topN)`, so behavior for tiers narrower than the cap is unchanged.
- `__tests__/services/leaderboard-role-service.test.ts`: updated the existing assertion to expect the sentinel, and added a regression test where a `100:` tier with 60 ranked users (more than the default cap of 50) assigns the role to all 60.

The issue's optional suggestion of warning when a tier's `topN` exceeds `leaderboard_max_results` was intentionally not implemented: with the sentinel, that cap no longer applies to reconciliation, so such a warning would be misleading.

## Testing

- `npm run check:all` — build, ESLint, Prettier check, and full Jest suite (127 suites, 1585 tests) all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxnQ8D1fQkyUdGN15emdgV)_