### PR TITLE
fix(cleanup): prune detail arrays with atomic $pull instead of read-filter-$set

### DIFF
--- a/__tests__/services/message-activity-cleanup.test.ts
+++ b/__tests__/services/message-activity-cleanup.test.ts
@@ -24,24 +24,8 @@ import { MessageActivityTracking } from "../../src/models/message-activity-track
 
 // Attach methods the global mongoose mock doesn't provide.
 (MessageActivityTracking as unknown as { find: jest.Mock }).find = jest.fn();
-(MessageActivityTracking as unknown as { updateOne: jest.Mock }).updateOne =
+(MessageActivityTracking as unknown as { updateMany: jest.Mock }).updateMany =
   jest.fn();
-
-// Mimics the streaming `find({}).lean(false).cursor()` chain the cleanup
-// service uses, yielding each doc one at a time.
-function findCursor(docs: unknown[]) {
-  return {
-    lean: () => ({
-      cursor: () => ({
-        async *[Symbol.asyncIterator]() {
-          for (const doc of docs) {
-            yield doc;
-          }
-        },
-      }),
-    }),
-  };
-}
 
 function createService() {
   const service = MessageActivityCleanupService.getInstance({} as Client);
@@ -64,14 +48,19 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 
 describe("MessageActivityCleanupService", () => {
   let find: jest.Mock;
-  let updateOne: jest.Mock;
+  let updateMany: jest.Mock;
+  let aggregate: jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
     find = (MessageActivityTracking as unknown as { find: jest.Mock }).find;
-    updateOne = (MessageActivityTracking as unknown as { updateOne: jest.Mock })
-      .updateOne;
-    updateOne.mockResolvedValue({ matchedCount: 1 });
+    updateMany = (
+      MessageActivityTracking as unknown as { updateMany: jest.Mock }
+    ).updateMany;
+    aggregate = (MessageActivityTracking as unknown as { aggregate: jest.Mock })
+      .aggregate;
+    aggregate.mockResolvedValue([]);
+    updateMany.mockResolvedValue({ matchedCount: 0, modifiedCount: 0 });
     (
       MessageActivityCleanupService as unknown as { instance: unknown }
     ).instance = undefined;
@@ -83,84 +72,58 @@ describe("MessageActivityCleanupService", () => {
     expect(a).toBe(b);
   });
 
-  it("prunes recentMessages older than retention and preserves totals", async () => {
+  it("prunes old recentMessages with a scoped atomic $pull and preserves totals", async () => {
     const { service } = createService();
 
-    const now = Date.now();
-    const oldEntry = { sentAt: new Date(now - 500 * DAY_MS), channelId: "c1" };
-    const recentEntry = {
-      sentAt: new Date(now - 10 * DAY_MS),
-      channelId: "c1",
-    };
-
-    const userDoc = {
-      _id: "id1",
-      username: "User1",
-      totalCount: 42,
-      channels: [{ channelId: "c1", count: 42 }],
-      recentMessages: [oldEntry, recentEntry],
-    };
-
-    find.mockReturnValue(findCursor([userDoc]));
+    aggregate.mockResolvedValue([{ _id: null, messages: 3 }]);
+    updateMany.mockResolvedValue({ matchedCount: 2, modifiedCount: 2 });
 
     const stats = await service.runCleanup();
 
-    expect(stats.messagesPruned).toBe(1);
-    expect(stats.usersProcessed).toBe(1);
+    expect(stats.messagesPruned).toBe(3);
+    expect(stats.usersProcessed).toBe(2);
 
-    // The update only rewrites recentMessages — it must not touch
-    // channels[] or totalCount.
-    expect(updateOne).toHaveBeenCalledTimes(1);
-    const [filter, update] = updateOne.mock.calls[0];
-    expect(filter).toEqual({ _id: "id1" });
-    expect(update.$set.recentMessages).toEqual([recentEntry]);
-    expect(update.$set.recentMessages).toHaveLength(1);
-    expect(update.$set).not.toHaveProperty("channels");
-    expect(update.$set).not.toHaveProperty("totalCount");
+    // A single collection-wide update, scoped to expired entries. Rewriting
+    // the whole array from an in-memory snapshot would race with the
+    // tracker's concurrent $push appends (#755).
+    expect(updateMany).toHaveBeenCalledTimes(1);
+    const [filter, update] = updateMany.mock.calls[0] as [
+      Record<string, unknown>,
+      { $pull: Record<string, unknown>; $set: Record<string, unknown> },
+    ];
+    expect(filter).toEqual({
+      "recentMessages.sentAt": { $lt: expect.any(Date) },
+    });
+    expect(update.$pull).toEqual({
+      recentMessages: { sentAt: { $lt: expect.any(Date) } },
+    });
+    // The update must only pull expired entries and stamp the cleanup date —
+    // it must not rewrite recentMessages wholesale or touch the all-time
+    // channels[] / totalCount fields.
+    expect(update.$set).toEqual({ lastCleanupDate: expect.any(Date) });
+
+    // The cutoff honours the configured retention window (400 days).
+    const cutoff = (
+      update.$pull.recentMessages as { sentAt: { $lt: Date } }
+    ).sentAt.$lt;
+    const expectedCutoff = Date.now() - 400 * DAY_MS;
+    expect(Math.abs(cutoff.getTime() - expectedCutoff)).toBeLessThan(60_000);
+
+    // No read-then-write snapshot of user documents.
+    expect(find).not.toHaveBeenCalled();
   });
 
-  it("does not write when nothing is beyond retention", async () => {
+  it("reports zeros when nothing is beyond retention", async () => {
     const { service } = createService();
 
-    const recentEntry = {
-      sentAt: new Date(Date.now() - 5 * DAY_MS),
-      channelId: "c1",
-    };
-    find.mockReturnValue(
-      findCursor([
-        {
-          _id: "id1",
-          username: "User1",
-          totalCount: 1,
-          channels: [{ channelId: "c1", count: 1 }],
-          recentMessages: [recentEntry],
-        },
-      ]),
-    );
+    aggregate.mockResolvedValue([]);
+    updateMany.mockResolvedValue({ matchedCount: 0, modifiedCount: 0 });
 
     const stats = await service.runCleanup();
 
     expect(stats.messagesPruned).toBe(0);
     expect(stats.usersProcessed).toBe(0);
-    expect(updateOne).not.toHaveBeenCalled();
-  });
-
-  it("streams via a cursor and never materialises the whole collection", async () => {
-    const { service } = createService();
-
-    const cursor = jest.fn(() => ({
-      async *[Symbol.asyncIterator]() {},
-    }));
-    const lean = jest.fn(() => ({ cursor }));
-    find.mockReturnValue({ lean });
-
-    await service.runCleanup();
-
-    // The cleanup must page through the collection with a cursor rather than
-    // awaiting an unbounded `.find({}).exec()` that loads every document.
-    expect(find).toHaveBeenCalledTimes(1);
-    expect(cursor).toHaveBeenCalledTimes(1);
-    expect(find.mock.results[0].value).not.toHaveProperty("exec");
+    expect(stats.errors).toEqual([]);
   });
 
   it("skips when the cleanup job is disabled", async () => {
@@ -169,6 +132,6 @@ describe("MessageActivityCleanupService", () => {
 
     const stats = await service.runCleanup();
     expect(stats.errors.length).toBeGreaterThan(0);
-    expect(find).not.toHaveBeenCalled();
+    expect(updateMany).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/services/voice-channel-truncation-methods.test.ts
+++ b/__tests__/services/voice-channel-truncation-methods.test.ts
@@ -14,6 +14,10 @@ jest.mock("../../src/models/voice-channel-tracking.js", () => ({
 
 import { VoiceChannelTracking } from "../../src/models/voice-channel-tracking.js";
 
+// Attach methods the global mongoose mock doesn't provide.
+(VoiceChannelTracking as unknown as { updateMany: jest.Mock }).updateMany =
+  jest.fn();
+
 describe("VoiceChannelTruncationService Methods", () => {
   let mockClient: Partial<Client>;
 
@@ -70,28 +74,51 @@ describe("VoiceChannelTruncationService Methods", () => {
     expect(typeof instance.getStatus).toBe("function");
   });
 
-  it("streams the tracking collection via a cursor, not an unbounded find", async () => {
+  it("prunes expired sessions with a scoped atomic $pull, not a read-filter-$set sweep", async () => {
     const { VoiceChannelTruncationService } =
       await import("../../src/services/voice-channel-truncation.js");
     const instance = VoiceChannelTruncationService.getInstance(
       mockClient as Client,
     );
 
-    const cursor = jest.fn(() => ({
-      async *[Symbol.asyncIterator]() {},
-    }));
-    const lean = jest.fn(() => ({ cursor }));
     const find = VoiceChannelTracking.find as jest.Mock;
-    find.mockReturnValue({ lean });
+    const updateMany = VoiceChannelTracking.updateMany as jest.Mock;
+    const aggregate = VoiceChannelTracking.aggregate as jest.Mock;
+    aggregate.mockResolvedValue([{ _id: null, sessions: 5 }]);
+    updateMany.mockResolvedValue({ matchedCount: 2, modifiedCount: 2 });
 
     // performCleanup is the private worker that the cron tick invokes.
-    await (
-      instance as unknown as { performCleanup: () => Promise<unknown> }
+    const stats = await (
+      instance as unknown as {
+        performCleanup: () => Promise<{
+          sessionsRemoved: number;
+          dataAggregated: number;
+        }>;
+      }
     ).performCleanup();
 
-    expect(find).toHaveBeenCalledTimes(1);
-    expect(cursor).toHaveBeenCalledTimes(1);
-    // The unbounded materialisation path (.exec()) must never be used.
-    expect(find.mock.results[0].value).not.toHaveProperty("exec");
+    expect(stats.sessionsRemoved).toBe(5);
+    expect(stats.dataAggregated).toBe(2);
+
+    // A single collection-wide update, scoped to expired sessions. Rewriting
+    // the whole array from an in-memory snapshot would race with the
+    // tracker's concurrent $push appends (#755).
+    expect(updateMany).toHaveBeenCalledTimes(1);
+    const [filter, update] = updateMany.mock.calls[0] as [
+      Record<string, unknown>,
+      { $pull: Record<string, unknown>; $set: Record<string, unknown> },
+    ];
+    expect(filter).toEqual({
+      "sessions.startTime": { $lt: expect.any(Date) },
+    });
+    expect(update.$pull).toEqual({
+      sessions: { startTime: { $lt: expect.any(Date) } },
+    });
+    // Only expired entries are pulled and the cleanup date stamped — the
+    // sessions array itself must never be rewritten wholesale.
+    expect(update.$set).toEqual({ lastCleanupDate: expect.any(Date) });
+
+    // No read-then-write snapshot of user documents.
+    expect(find).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/services/voice-channel-truncation-methods.test.ts
+++ b/__tests__/services/voice-channel-truncation-methods.test.ts
@@ -14,8 +14,14 @@ jest.mock("../../src/models/voice-channel-tracking.js", () => ({
 
 import { VoiceChannelTracking } from "../../src/models/voice-channel-tracking.js";
 
-// Attach methods the global mongoose mock doesn't provide.
+// Under ESM the jest.mock factory above is not hoisted, so the import
+// actually resolves to the global mongoose mock from __tests__/setup.ts.
+// Attach the methods that mock doesn't provide, and pin `aggregate`
+// explicitly so this file doesn't silently depend on the global mock's
+// method set.
 (VoiceChannelTracking as unknown as { updateMany: jest.Mock }).updateMany =
+  jest.fn();
+(VoiceChannelTracking as unknown as { aggregate: jest.Mock }).aggregate =
   jest.fn();
 
 describe("VoiceChannelTruncationService Methods", () => {

--- a/src/services/message-activity-cleanup.ts
+++ b/src/services/message-activity-cleanup.ts
@@ -300,41 +300,47 @@ export class MessageActivityCleanupService {
       const cutoffDate = new Date();
       cutoffDate.setDate(cutoffDate.getDate() - retentionDays);
 
-      // Stream users one at a time via a cursor instead of loading the whole
-      // (append-heavy) collection into memory. The loop only reads fields and
-      // writes back via `updateOne`, so `.lean()` avoids hydration overhead.
-      const cursor = MessageActivityTracking.find({}).lean().cursor();
-
-      for await (const user of cursor) {
-        try {
-          if (user.recentMessages && user.recentMessages.length > 0) {
-            const recent = user.recentMessages.filter(
-              (entry) => entry.sentAt >= cutoffDate,
-            );
-            const prunedCount = user.recentMessages.length - recent.length;
-
-            if (prunedCount > 0) {
-              // Only touch recentMessages — channels[] and totalCount are
-              // all-time and intentionally preserved.
-              await MessageActivityTracking.updateOne(
-                { _id: user._id },
-                {
-                  $set: {
-                    recentMessages: recent,
-                    lastCleanupDate: new Date(),
+      // Count the entries about to be pruned, for reporting only. The
+      // deletion below is keyed on the same criterion — not on this count —
+      // so a write landing between the two just makes the stats off by one.
+      const [pruneCounts] = await MessageActivityTracking.aggregate<{
+        messages: number;
+      }>([
+        { $match: { "recentMessages.sentAt": { $lt: cutoffDate } } },
+        {
+          $group: {
+            _id: null,
+            messages: {
+              $sum: {
+                $size: {
+                  $filter: {
+                    input: "$recentMessages",
+                    cond: { $lt: ["$$this.sentAt", cutoffDate] },
                   },
                 },
-              );
-              messagesPruned += prunedCount;
-              usersProcessed += 1;
-            }
-          }
-        } catch (userError) {
-          const errorMessage = `Error processing user ${user.username}: ${userError instanceof Error ? userError.message : String(userError)}`;
-          errors.push(errorMessage);
-          logger.error(errorMessage, userError);
-        }
-      }
+              },
+            },
+          },
+        },
+      ]);
+
+      // Prune expired entries with a scoped, atomic $pull. Reading a
+      // snapshot, filtering in memory, and $set-ing the whole array back
+      // races with the tracker's concurrent `$push` appends — a message
+      // recorded mid-sweep would be silently overwritten (#755). `$pull`
+      // is applied atomically per document, so concurrent appends survive.
+      // Only recentMessages is touched — channels[] and totalCount are
+      // all-time and intentionally preserved.
+      const result = await MessageActivityTracking.updateMany(
+        { "recentMessages.sentAt": { $lt: cutoffDate } },
+        {
+          $pull: { recentMessages: { sentAt: { $lt: cutoffDate } } },
+          $set: { lastCleanupDate: new Date() },
+        },
+      );
+
+      messagesPruned = pruneCounts?.messages ?? 0;
+      usersProcessed = result.modifiedCount;
     } catch (error) {
       const errorMessage = `General message cleanup error: ${error instanceof Error ? error.message : String(error)}`;
       errors.push(errorMessage);

--- a/src/services/voice-channel-truncation.ts
+++ b/src/services/voice-channel-truncation.ts
@@ -361,53 +361,50 @@ export class VoiceChannelTruncationService {
       // Get retention configuration
       const retentionConfig = await this.getRetentionConfig();
 
-      // Stream users one at a time via a cursor instead of loading the whole
-      // (append-heavy) collection into memory. The loop only reads fields and
-      // writes back via `updateOne`, so `.lean()` avoids hydration overhead.
-      const cursor = VoiceChannelTracking.find({}).lean().cursor();
+      const cutoffDate = new Date();
+      cutoffDate.setDate(
+        cutoffDate.getDate() - retentionConfig.detailedSessionsDays,
+      );
 
-      for await (const user of cursor) {
-        try {
-          if (user.sessions && user.sessions.length > 0) {
-            const cutoffDate = new Date();
-            cutoffDate.setDate(
-              cutoffDate.getDate() - retentionConfig.detailedSessionsDays,
-            );
-
-            // Separate recent and old sessions
-            const recentSessions = user.sessions.filter(
-              (session) => session.startTime >= cutoffDate,
-            );
-            const oldSessions = user.sessions.filter(
-              (session) => session.startTime < cutoffDate,
-            );
-
-            if (oldSessions.length > 0) {
-              // Update user document: remove old sessions, keep recent ones
-              await VoiceChannelTracking.updateOne(
-                { _id: user._id },
-                {
-                  $set: {
-                    sessions: recentSessions,
-                    lastCleanupDate: new Date(),
+      // Count the sessions about to be pruned, for reporting only. The
+      // deletion below is keyed on the same criterion — not on this count —
+      // so a write landing between the two just makes the stats off by one.
+      const [pruneCounts] = await VoiceChannelTracking.aggregate<{
+        sessions: number;
+      }>([
+        { $match: { "sessions.startTime": { $lt: cutoffDate } } },
+        {
+          $group: {
+            _id: null,
+            sessions: {
+              $sum: {
+                $size: {
+                  $filter: {
+                    input: "$sessions",
+                    cond: { $lt: ["$$this.startTime", cutoffDate] },
                   },
                 },
-              );
+              },
+            },
+          },
+        },
+      ]);
 
-              sessionsRemoved += oldSessions.length;
-              dataAggregated += 1;
+      // Prune expired sessions with a scoped, atomic $pull. Reading a
+      // snapshot, filtering in memory, and $set-ing the whole array back
+      // races with the tracker's concurrent `$push` appends — a session
+      // recorded mid-sweep would be silently overwritten (#755). `$pull`
+      // is applied atomically per document, so concurrent appends survive.
+      const result = await VoiceChannelTracking.updateMany(
+        { "sessions.startTime": { $lt: cutoffDate } },
+        {
+          $pull: { sessions: { startTime: { $lt: cutoffDate } } },
+          $set: { lastCleanupDate: new Date() },
+        },
+      );
 
-              logger.debug(
-                `Cleaned up ${oldSessions.length} old sessions for user ${user.username}, kept ${recentSessions.length} recent sessions`,
-              );
-            }
-          }
-        } catch (userError) {
-          const errorMessage = `Error processing user ${user.username}: ${userError instanceof Error ? userError.message : String(userError)}`;
-          errors.push(errorMessage);
-          logger.error(errorMessage, userError);
-        }
-      }
+      sessionsRemoved = pruneCounts?.sessions ?? 0;
+      dataAggregated = result.modifiedCount;
 
       logger.info(
         `Cleanup completed: ${sessionsRemoved} sessions removed, ${dataAggregated} users processed`,


### PR DESCRIPTION
## Description

The voice-session and message-activity cleanup jobs streamed every tracking document with a `.lean()` cursor, filtered the `sessions` / `recentMessages` array in application memory, and wrote the **whole array** back with `$set`. Meanwhile the live trackers append to those same arrays with atomic `$push` (`voice-channel-tracker.ts`, `message-activity-tracker.ts`). A session or message recorded between the cursor snapshot and the write-back was silently overwritten by the stale snapshot — a real race window on any active server whose collection is large enough for the sweep to take noticeable time.

This PR removes the read-then-write window entirely:

- `VoiceChannelTruncationService.performCleanup()` and `MessageActivityCleanupService.performCleanup()` now issue a single scoped `updateMany` with `$pull: { sessions: { startTime: { $lt: cutoffDate } } }` (resp. `recentMessages` / `sentAt`), plus `$set: { lastCleanupDate }`. MongoDB applies `$pull` atomically per document, so a concurrent `$push` can no longer be clobbered.
- Run statistics (`sessionsRemoved` / `messagesPruned`) are kept via a best-effort aggregation (`$size` of a `$filter` over the same cutoff criterion) executed before the pull; the deletion itself is keyed only on the cutoff, never on the counted snapshot. `usersProcessed` / `dataAggregated` come from `updateMany`'s `modifiedCount`.
- The message cleanup still only touches `recentMessages` — the all-time `channels[]` totals and `totalCount` are untouched, and the update no longer rewrites the array at all.
- Tests updated to assert the scoped `$pull` shape (no wholesale `$set` of the array, no `find()` snapshot sweep, cutoff honours the configured retention window).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #755

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality
- [ ] Manually tested in development environment
- [ ] Tested in Docker environment

**Test Configuration**:

- Node.js version: 22
- Discord.js version: 14
- Operating System: Linux

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes manually

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary (no user-facing command/config changes)
- [x] I have validated markdown with `npx markdownlint "**/*.md" --ignore node_modules --ignore dist`

### Dependencies & Docker

- [x] No dependency or Docker changes required

### Configuration (if applicable)

- [x] No configuration changes — existing `*.cleanup.*` keys are unchanged

## Screenshots (if applicable)

N/A

## Additional Notes

The pruned-entry counts reported to the log/Discord are now computed by an aggregation immediately before the atomic pull, so under heavy concurrent writes they can be off by the handful of entries written in between — the data itself is always pruned strictly by the cutoff criterion.

## Pre-Submission Verification

- [x] I have rebased my branch on the latest main branch
- [x] I have resolved any merge conflicts
- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ac8CjGsvfsvrLc9MgRQ3dn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ac8CjGsvfsvrLc9MgRQ3dn)_