### PR TITLE
fix(ping): guard error handler against double-reply

### DIFF
--- a/__tests__/commands/ping.test.ts
+++ b/__tests__/commands/ping.test.ts
@@ -42,8 +42,11 @@ describe("Ping Command", () => {
       mockInteraction = {
         createdTimestamp: 900,
         client: mockClient as Client,
+        replied: false,
+        deferred: false,
         reply: jest.fn().mockResolvedValue(mockMessage),
         editReply: jest.fn().mockResolvedValue(undefined),
+        followUp: jest.fn().mockResolvedValue(undefined),
       };
     });
 
@@ -97,6 +100,39 @@ describe("Ping Command", () => {
       expect(mockInteraction.editReply).toHaveBeenCalledWith(
         expect.stringContaining("Bot Latency: 1ms"),
       );
+    });
+
+    it("should follow up with an error message when editReply fails after the reply succeeded", async () => {
+      (mockInteraction.reply as jest.Mock).mockImplementation(async () => {
+        (mockInteraction as any).replied = true;
+        return mockMessage;
+      });
+      (mockInteraction.editReply as jest.Mock).mockRejectedValue(
+        new Error("editReply failed") as never,
+      );
+
+      await execute(mockInteraction as ChatInputCommandInteraction);
+
+      expect(mockInteraction.followUp).toHaveBeenCalledWith({
+        content: "There was an error while executing this command!",
+        ephemeral: true,
+      });
+      expect(mockInteraction.reply).toHaveBeenCalledTimes(1);
+    });
+
+    it("should reply with an error message when the initial reply fails", async () => {
+      (mockInteraction.reply as jest.Mock)
+        .mockRejectedValueOnce(new Error("reply failed") as never)
+        .mockResolvedValueOnce(undefined as never);
+
+      await execute(mockInteraction as ChatInputCommandInteraction);
+
+      expect(mockInteraction.reply).toHaveBeenCalledTimes(2);
+      expect(mockInteraction.reply).toHaveBeenLastCalledWith({
+        content: "There was an error while executing this command!",
+        ephemeral: true,
+      });
+      expect(mockInteraction.followUp).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -21,9 +21,14 @@ export async function execute(
     );
   } catch (error) {
     logger.error("Error in ping command:", error);
-    await interaction.reply({
+    const payload = {
       content: "There was an error while executing this command!",
       ephemeral: true,
-    });
+    };
+    if (interaction.replied || interaction.deferred) {
+      await interaction.followUp(payload);
+    } else {
+      await interaction.reply(payload);
+    }
   }
 }


### PR DESCRIPTION
## Description

`ping` replies first and edits later, but its catch block unconditionally called `interaction.reply(...)` again. If `editReply` failed after the initial reply had already succeeded, that second `reply` threw `InteractionAlreadyReplied`, so the command's own error message was never delivered and a confusing second error was logged on top of the original one.

This mirrors the `interaction.replied || interaction.deferred` guard already used by every sibling command with the same reply-then-edit shape (`event.ts`, `modlog.ts`, `quote.ts`, `voicestats.ts`, `warn.ts`): when a reply already exists, the error message is sent via `followUp`; otherwise via `reply`. Two tests were added covering both catch-block paths.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] 🧪 Test updates
- [ ] 🔧 Build/tooling changes
- [ ] ⚡ Performance improvement

## Related Issues

Fixes #757

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality
- [ ] Manually tested in development environment
- [ ] Tested in Docker environment

**Test Configuration**:

- Node.js version: 22.22.2
- Discord.js version: 14.x
- Operating System: Linux

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes manually

### Documentation

- [ ] I have commented my code, particularly in hard-to-understand areas (not needed — the guard is the established idiom in sibling commands)
- [x] I have updated the documentation where necessary (no docs changes needed — no command/config/user-facing behavior change)
- [x] I have validated markdown with `npx markdownlint "**/*.md" --ignore node_modules --ignore dist` (no markdown changed)

### Dependencies & Docker

- [x] No dependency or Docker changes required

### Configuration (if applicable)

- [x] Not applicable — no configuration changes

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The failure path was previously caught by the global handler in `src/index.ts`, so the process never crashed — this change just makes `ping`'s own error handling actually deliver its message instead of throwing a second error.

## Pre-Submission Verification

- [x] I have rebased my branch on the latest main branch
- [x] I have resolved any merge conflicts
- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVGcyhpczH69agQ8sDqfDw)_