### PR TITLE
fix(webui): treat malformed ids as not-found in announcement/poll-schedule lookups

### DIFF
--- a/__tests__/services/poll-service.test.ts
+++ b/__tests__/services/poll-service.test.ts
@@ -444,16 +444,30 @@ describe("PollService", () => {
   });
 
   describe("getSchedule", () => {
-    it("returns null instead of throwing when findById rejects on a malformed id", async () => {
+    it("returns null instead of throwing when findById rejects with a CastError (malformed id)", async () => {
       // Mongoose throws a CastError for a non-ObjectId id; the web toggle/test
       // routes rely on null to take their audited "not found" path (#758).
+      const castError = new Error("Cast to ObjectId failed");
+      castError.name = "CastError";
       mockPollScheduleFindById.mockImplementation(() =>
-        Promise.reject(new Error("Cast to ObjectId failed")),
+        Promise.reject(castError),
       );
 
       const service = PollService.getInstance({} as never);
 
       await expect(service.getSchedule("not-an-id")).resolves.toBeNull();
+    });
+
+    it("propagates non-CastError failures instead of masking them as not-found", async () => {
+      mockPollScheduleFindById.mockImplementation(() =>
+        Promise.reject(new Error("connection timed out")),
+      );
+
+      const service = PollService.getInstance({} as never);
+
+      await expect(service.getSchedule("sched-1")).rejects.toThrow(
+        "connection timed out",
+      );
     });
   });
 

--- a/__tests__/services/poll-service.test.ts
+++ b/__tests__/services/poll-service.test.ts
@@ -443,6 +443,20 @@ describe("PollService", () => {
     });
   });
 
+  describe("getSchedule", () => {
+    it("returns null instead of throwing when findById rejects on a malformed id", async () => {
+      // Mongoose throws a CastError for a non-ObjectId id; the web toggle/test
+      // routes rely on null to take their audited "not found" path (#758).
+      mockPollScheduleFindById.mockImplementation(() =>
+        Promise.reject(new Error("Cast to ObjectId failed")),
+      );
+
+      const service = PollService.getInstance({} as never);
+
+      await expect(service.getSchedule("not-an-id")).resolves.toBeNull();
+    });
+  });
+
   describe("deleteSchedule", () => {
     it("stops the job keyed by the canonical _id even when called with a non-canonical id", async () => {
       const schedule = {

--- a/__tests__/services/scheduled-announcement-service.test.ts
+++ b/__tests__/services/scheduled-announcement-service.test.ts
@@ -1,7 +1,75 @@
-import { describe, it, expect } from "@jest/globals";
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import type { Client } from "discord.js";
 
-describe("ScheduledAnnouncementService", () => {
-  it("placeholder test", () => {
-    expect(true).toBe(true);
+// ESM-safe module mocks (jest.unstable_mockModule + dynamic import).
+jest.unstable_mockModule("../../src/services/config-service.js", () => ({
+  ConfigService: {
+    getInstance: () => ({
+      registerReloadCallback: jest.fn(),
+      getBoolean: jest.fn().mockResolvedValue(false),
+      getString: jest.fn().mockResolvedValue(""),
+    }),
+  },
+}));
+jest.unstable_mockModule("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const findById = jest.fn();
+jest.unstable_mockModule("../../src/models/scheduled-announcement.js", () => ({
+  ScheduledAnnouncement: {
+    find: jest.fn().mockResolvedValue([]),
+    findById,
+  },
+}));
+
+describe("ScheduledAnnouncementService.getAnnouncement", () => {
+  let mockClient: Partial<Client>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const { ScheduledAnnouncementService } = await import(
+      "../../src/services/scheduled-announcement-service.js"
+    );
+    ScheduledAnnouncementService.reset();
+
+    mockClient = {
+      isReady: jest.fn().mockReturnValue(true),
+      guilds: { fetch: jest.fn() } as any,
+    } as Client;
+  });
+
+  it("returns the announcement when findById resolves", async () => {
+    const announcement = { _id: "a1", guildId: "g1" };
+    findById.mockResolvedValue(announcement);
+    const { ScheduledAnnouncementService } = await import(
+      "../../src/services/scheduled-announcement-service.js"
+    );
+    const service = ScheduledAnnouncementService.getInstance(
+      mockClient as Client,
+    );
+
+    await expect(service.getAnnouncement("a1")).resolves.toBe(announcement);
+  });
+
+  it("returns null instead of throwing when findById rejects on a malformed id", async () => {
+    // Mongoose throws a CastError for a non-ObjectId id; the web toggle route
+    // relies on null to take its audited "not found" path (#758).
+    findById.mockImplementation(() =>
+      Promise.reject(new Error("Cast to ObjectId failed")),
+    );
+    const { ScheduledAnnouncementService } = await import(
+      "../../src/services/scheduled-announcement-service.js"
+    );
+    const service = ScheduledAnnouncementService.getInstance(
+      mockClient as Client,
+    );
+
+    await expect(service.getAnnouncement("not-an-id")).resolves.toBeNull();
   });
 });

--- a/__tests__/services/scheduled-announcement-service.test.ts
+++ b/__tests__/services/scheduled-announcement-service.test.ts
@@ -57,12 +57,12 @@ describe("ScheduledAnnouncementService.getAnnouncement", () => {
     await expect(service.getAnnouncement("a1")).resolves.toBe(announcement);
   });
 
-  it("returns null instead of throwing when findById rejects on a malformed id", async () => {
+  it("returns null instead of throwing when findById rejects with a CastError (malformed id)", async () => {
     // Mongoose throws a CastError for a non-ObjectId id; the web toggle route
     // relies on null to take its audited "not found" path (#758).
-    findById.mockImplementation(() =>
-      Promise.reject(new Error("Cast to ObjectId failed")),
-    );
+    const castError = new Error("Cast to ObjectId failed");
+    castError.name = "CastError";
+    findById.mockImplementation(() => Promise.reject(castError));
     const { ScheduledAnnouncementService } = await import(
       "../../src/services/scheduled-announcement-service.js"
     );
@@ -71,5 +71,21 @@ describe("ScheduledAnnouncementService.getAnnouncement", () => {
     );
 
     await expect(service.getAnnouncement("not-an-id")).resolves.toBeNull();
+  });
+
+  it("propagates non-CastError failures instead of masking them as not-found", async () => {
+    findById.mockImplementation(() =>
+      Promise.reject(new Error("connection timed out")),
+    );
+    const { ScheduledAnnouncementService } = await import(
+      "../../src/services/scheduled-announcement-service.js"
+    );
+    const service = ScheduledAnnouncementService.getInstance(
+      mockClient as Client,
+    );
+
+    await expect(service.getAnnouncement("a1")).rejects.toThrow(
+      "connection timed out",
+    );
   });
 });

--- a/src/services/poll-service.ts
+++ b/src/services/poll-service.ts
@@ -714,7 +714,9 @@ export class PollService {
    * Get a specific poll schedule
    */
   public async getSchedule(scheduleId: string): Promise<IPollSchedule | null> {
-    return await PollSchedule.findById(scheduleId);
+    // A malformed (non-ObjectId) id makes Mongoose throw a CastError —
+    // treat it as "not found" so callers get their audited failure path.
+    return await PollSchedule.findById(scheduleId).catch(() => null);
   }
 
   /**

--- a/src/services/poll-service.ts
+++ b/src/services/poll-service.ts
@@ -714,9 +714,17 @@ export class PollService {
    * Get a specific poll schedule
    */
   public async getSchedule(scheduleId: string): Promise<IPollSchedule | null> {
-    // A malformed (non-ObjectId) id makes Mongoose throw a CastError —
-    // treat it as "not found" so callers get their audited failure path.
-    return await PollSchedule.findById(scheduleId).catch(() => null);
+    try {
+      return await PollSchedule.findById(scheduleId);
+    } catch (error) {
+      // A malformed (non-ObjectId) id makes Mongoose throw a CastError —
+      // treat it as "not found" so callers get their audited failure path.
+      // Other failures (connection loss, timeouts) still propagate.
+      if (error instanceof Error && error.name === "CastError") {
+        return null;
+      }
+      throw error;
+    }
   }
 
   /**

--- a/src/services/scheduled-announcement-service.ts
+++ b/src/services/scheduled-announcement-service.ts
@@ -589,7 +589,11 @@ export class ScheduledAnnouncementService {
   public async getAnnouncement(
     announcementId: string,
   ): Promise<IScheduledAnnouncement | null> {
-    return await ScheduledAnnouncement.findById(announcementId);
+    // A malformed (non-ObjectId) id makes Mongoose throw a CastError —
+    // treat it as "not found" so callers get their audited failure path.
+    return await ScheduledAnnouncement.findById(announcementId).catch(
+      () => null,
+    );
   }
 
   public async reload(): Promise<void> {

--- a/src/services/scheduled-announcement-service.ts
+++ b/src/services/scheduled-announcement-service.ts
@@ -589,11 +589,17 @@ export class ScheduledAnnouncementService {
   public async getAnnouncement(
     announcementId: string,
   ): Promise<IScheduledAnnouncement | null> {
-    // A malformed (non-ObjectId) id makes Mongoose throw a CastError —
-    // treat it as "not found" so callers get their audited failure path.
-    return await ScheduledAnnouncement.findById(announcementId).catch(
-      () => null,
-    );
+    try {
+      return await ScheduledAnnouncement.findById(announcementId);
+    } catch (error) {
+      // A malformed (non-ObjectId) id makes Mongoose throw a CastError —
+      // treat it as "not found" so callers get their audited failure path.
+      // Other failures (connection loss, timeouts) still propagate.
+      if (error instanceof Error && error.name === "CastError") {
+        return null;
+      }
+      throw error;
+    }
   }
 
   public async reload(): Promise<void> {


### PR DESCRIPTION
## Description

`ScheduledAnnouncementService.getAnnouncement` and `PollService.getSchedule` were bare `Model.findById(id)` calls with no `CastError` guard. A non-ObjectId `:id` (stale bookmark, hand-edited URL, or crafted request) made Mongoose reject inside the `await`, which the `POST /announcements/:id/toggle` and `POST /polls/schedules/:id/toggle` routes (and also `POST /polls/schedules/:id/test`, which shares the same lookup) did not catch — the request fell through to the generic 500 handler and **skipped the `recordAudit` call**, breaking the write-routes file's "every write records exactly one audit entry" invariant.

This PR fixes it at the service layer by appending `.catch(() => null)` to both lookups, exactly matching the existing `EventService.getEvent` pattern (`event-service.ts:501-502`). A malformed id now takes the same audited "not found" flash + redirect path as every other rejected write in the file, and the fix covers all three affected routes with one change per service.

Also adds unit tests for both services covering the rejecting-`findById` case (and replaces the placeholder scheduled-announcement-service test file with real tests).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #758

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality
- [ ] Manually tested in development environment
- [ ] Tested in Docker environment

**Test Configuration**:

- Node.js version: 22.22.2
- Discord.js version: 14 (as pinned in package.json)
- Operating System: Linux

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes manually

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary (no doc changes needed — no command/config/user-facing changes)
- [x] I have validated markdown with `npx markdownlint "**/*.md" --ignore node_modules --ignore dist` (no markdown changed)

### Dependencies & Docker

- [x] No dependency or Docker changes required

### Configuration (if applicable)

- [x] Not applicable — no configuration changes

## Additional Notes

The issue suggested either per-route try/catch or the service-layer `.catch(() => null)`; the service-layer option was chosen because it matches the established `EventService.getEvent` precedent and also fixes the `/polls/schedules/:id/test` route, which has the identical unguarded lookup but wasn't listed in the issue.

## Pre-Submission Verification

- [x] I have rebased my branch on the latest main branch
- [x] I have resolved any merge conflicts
- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NKJPGCZwaG4SG3oxWgCe4

---
_Generated by [Claude Code](https://claude.ai/code/session_016NKJPGCZwaG4SG3oxWgCe4)_