### PR TITLE
fix(events): record RSVPs with an atomic update so concurrent clicks are not lost

### DIFF
--- a/__tests__/services/event-service.test.ts
+++ b/__tests__/services/event-service.test.ts
@@ -44,7 +44,6 @@ const {
   computeEndTime,
   parseEventDateTime,
   countRsvps,
-  upsertRsvp,
   shouldCreateChannel,
   shouldSendReminder,
   shouldEndEvent,
@@ -119,26 +118,6 @@ describe("countRsvps", () => {
   });
   it("returns zeros for an empty list", () => {
     expect(countRsvps([])).toEqual({ going: 0, maybe: 0, cant: 0 });
-  });
-});
-
-describe("upsertRsvp", () => {
-  const now = new Date("2026-07-01T00:00:00Z");
-  it("adds a new RSVP without mutating the input", () => {
-    const original = [
-      { userId: "a", status: "going" as const, respondedAt: now },
-    ];
-    const next = upsertRsvp(original, "b", "maybe", now);
-    expect(next).toHaveLength(2);
-    expect(original).toHaveLength(1);
-  });
-  it("replaces an existing member's response", () => {
-    const original = [
-      { userId: "a", status: "going" as const, respondedAt: now },
-    ];
-    const next = upsertRsvp(original, "a", "cant", now);
-    expect(next).toHaveLength(1);
-    expect(next[0]).toMatchObject({ userId: "a", status: "cant" });
   });
 });
 
@@ -237,6 +216,83 @@ describe("formatEventWhen", () => {
       timezone: "America/New_York",
     };
     expect(formatEventWhen(event)).toBe("2026-07-04 20:00 (America/New_York)");
+  });
+});
+
+// Regression tests for #768: an RSVP must be recorded as one atomic
+// server-side update, not a fetch/modify/save of the whole document —
+// two members clicking buttons in the same tick would otherwise clobber
+// each other's RSVP (lost update).
+describe("setRsvp", () => {
+  const EVENT_ID = "0123456789abcdef01234567"; // valid ObjectId shape
+
+  beforeEach(() => {
+    EventService.reset();
+  });
+
+  function buildService(): InstanceType<typeof EventService> {
+    return EventService.getInstance({} as never);
+  }
+
+  it("upserts via a single atomic findOneAndUpdate and returns the updated event", async () => {
+    const updated = {
+      _id: EVENT_ID,
+      rsvps: [{ userId: "user-1", status: "going" }],
+    };
+    EventMock.findOneAndUpdate = jest.fn(async () => updated);
+
+    const result = await buildService().setRsvp(EVENT_ID, "user-1", "going");
+
+    expect(result).toBe(updated);
+    expect(EventMock.findOneAndUpdate).toHaveBeenCalledTimes(1);
+    expect(EventMock.findOneAndUpdate).toHaveBeenCalledWith(
+      // The state filter doubles as the finished-event guard.
+      { _id: EVENT_ID, state: { $nin: ["cancelled", "ended"] } },
+      // Pipeline update: drop any previous entry for the user, append the
+      // new one — both inside one atomic document update.
+      [
+        {
+          $set: {
+            rsvps: {
+              $concatArrays: [
+                {
+                  $filter: {
+                    input: "$rsvps",
+                    as: "rsvp",
+                    cond: { $ne: ["$$rsvp.userId", "user-1"] },
+                  },
+                },
+                [
+                  {
+                    userId: "user-1",
+                    status: "going",
+                    respondedAt: expect.any(Date),
+                  },
+                ],
+              ],
+            },
+          },
+        },
+      ],
+      { new: true },
+    );
+  });
+
+  it("returns null when the event is missing, ended or cancelled", async () => {
+    EventMock.findOneAndUpdate = jest.fn(async () => null);
+
+    const result = await buildService().setRsvp(EVENT_ID, "user-1", "maybe");
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null for a malformed event id without touching the database", async () => {
+    EventMock.findOneAndUpdate = jest.fn(async () => null);
+
+    const result = await buildService().setRsvp("not-an-id", "user-1", "cant");
+
+    expect(result).toBeNull();
+    expect(EventMock.findOneAndUpdate).not.toHaveBeenCalled();
   });
 });
 

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -33,6 +33,11 @@ class MockSchema {
   }
 }
 
+// Pure helper, safe to mirror the real behaviour (24 hex chars or a
+// 12-char string), so id-validation guards work under the global mock.
+const mockIsValidObjectId = (id: unknown): boolean =>
+  typeof id === "string" && (/^[0-9a-fA-F]{24}$/.test(id) || id.length === 12);
+
 // Mock mongoose globally to prevent DB connections
 jest.mock("mongoose", () => ({
   default: {
@@ -42,6 +47,7 @@ jest.mock("mongoose", () => ({
       close: jest.fn().mockResolvedValue(undefined),
       readyState: 1,
     },
+    isValidObjectId: mockIsValidObjectId,
     Schema: MockSchema,
     model: jest.fn().mockReturnValue({
       find: jest.fn().mockResolvedValue([]),
@@ -59,6 +65,7 @@ jest.mock("mongoose", () => ({
     close: jest.fn().mockResolvedValue(undefined),
     readyState: 1,
   },
+  isValidObjectId: mockIsValidObjectId,
   Schema: MockSchema,
   model: jest.fn().mockReturnValue({
     find: jest.fn().mockResolvedValue([]),

--- a/src/services/event-service.ts
+++ b/src/services/event-service.ts
@@ -12,6 +12,7 @@ import {
   VoiceChannel,
 } from "discord.js";
 import { CronJob, CronTime } from "cron";
+import { isValidObjectId } from "mongoose";
 import { fromZonedTime, formatInTimeZone } from "date-fns-tz";
 import { ConfigService } from "./config-service.js";
 import { DiscordLogger } from "./discord-logger.js";
@@ -116,22 +117,6 @@ export function countRsvps(rsvps: Array<{ status: RsvpStatus }>): RsvpCounts {
     else if (r.status === "cant") counts.cant += 1;
   }
   return counts;
-}
-
-/**
- * Set a member's RSVP, replacing any previous response. Pure — returns a
- * new array and never mutates the input.
- */
-export function upsertRsvp<
-  T extends { userId: string; status: RsvpStatus; respondedAt: Date },
->(
-  rsvps: T[],
-  userId: string,
-  status: RsvpStatus,
-  now: Date,
-): Array<{ userId: string; status: RsvpStatus; respondedAt: Date }> {
-  const others = rsvps.filter((r) => r.userId !== userId);
-  return [...others, { userId, status, respondedAt: now }];
 }
 
 interface LifecycleView {
@@ -557,23 +542,45 @@ export class EventService {
   }
 
   /** Record a member's RSVP. Returns the updated event, or null when the
-   * event is missing or already finished. */
+   * event is missing or already finished.
+   *
+   * RSVP clicks are the highest-concurrency write in the feature — one
+   * announcement ping draws many button presses in the same tick, so a
+   * fetch/modify/save of the whole `rsvps` array would let the last save
+   * silently overwrite RSVPs recorded in between (lost update). Instead
+   * the upsert runs server-side as a single atomic `findOneAndUpdate`
+   * (the same lost-update defence as `claimEventChannel`'s
+   * compare-and-set): the pipeline drops any previous entry for this
+   * user and appends the new one in one document update, and the state
+   * filter doubles as the finished/missing guard. */
   public async setRsvp(
     eventId: string,
     userId: string,
     status: RsvpStatus,
   ): Promise<IEvent | null> {
-    const event = await this.getEvent(eventId);
-    if (!event) return null;
-    if (event.state === "cancelled" || event.state === "ended") return null;
-    event.rsvps = upsertRsvp(
-      event.rsvps,
-      userId,
-      status,
-      new Date(),
-    ) as IEvent["rsvps"];
-    await event.save();
-    return event;
+    if (!isValidObjectId(eventId)) return null;
+    return Event.findOneAndUpdate(
+      { _id: eventId, state: { $nin: ["cancelled", "ended"] } },
+      [
+        {
+          $set: {
+            rsvps: {
+              $concatArrays: [
+                {
+                  $filter: {
+                    input: "$rsvps",
+                    as: "rsvp",
+                    cond: { $ne: ["$$rsvp.userId", userId] },
+                  },
+                },
+                [{ userId, status, respondedAt: new Date() }],
+              ],
+            },
+          },
+        },
+      ],
+      { new: true },
+    );
   }
 
   // ---------------------------------------------------------------


### PR DESCRIPTION
## Description

`EventService.setRsvp` fetched the whole event document, rebuilt the `rsvps` array in memory via `upsertRsvp`, and saved the entire document back with no concurrency guard. Two members clicking Going/Maybe/Can't on the same announcement within the same tick would both start from the same snapshot, and whichever `.save()` landed second silently overwrote the other's RSVP — it disappeared from the stored array and from the counts on the announcement embed.

This PR replaces the read-modify-write with a single atomic `findOneAndUpdate` using an aggregation-pipeline update (`$concatArrays` of a `$filter` that drops the user's previous entry, plus the new entry), so the upsert happens server-side in one document update — the same lost-update defence `claimEventChannel` already uses in this file. Concurrent RSVPs from different users now each land independently instead of racing on the whole array.

Behaviour is otherwise preserved:

- The `state: { $nin: ["cancelled", "ended"] }` filter doubles as the existing finished-event guard — the method still returns `null` for missing/ended/cancelled events.
- An `isValidObjectId` pre-check keeps the old null-on-malformed-id behaviour (previously provided by `getEvent`'s catch).
- `{ new: true }` returns the updated document, so the button handler's live embed refresh keeps working unchanged.

The now-unused `upsertRsvp` helper is removed (its replace-previous-response semantics now live in the pipeline), and the global mongoose test mock in `__tests__/setup.ts` gains an `isValidObjectId` implementation.

Aggregation-pipeline updates require MongoDB 4.2+; the compose files use `mongo:latest`, so no compatibility concern.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #768

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality
- [ ] Manually tested in development environment
- [ ] Tested in Docker environment

New `setRsvp` regression tests in `__tests__/services/event-service.test.ts` verify the upsert is a single atomic `findOneAndUpdate` (asserting the filter, the full pipeline shape, and `{ new: true }`), that `null` is returned when no document matches (missing/ended/cancelled), and that a malformed event id returns `null` without touching the database. The `upsertRsvp` unit tests were removed along with the helper.

Note: `npm run check:all` passes except for one pre-existing, unrelated timing-sensitive failure in `__tests__/services/message-activity-cleanup.test.ts` (from #790), which fails identically on a clean checkout of current `main` in this environment.

**Test Configuration**:

- Node.js version: 22
- Discord.js version: 14
- Operating System: Linux

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes manually

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation where necessary (no command/config/user-facing changes)
- [ ] I have validated markdown (no markdown changes)

### Dependencies & Docker

- [ ] Not applicable — no dependency or build changes

### Configuration (if applicable)

- [ ] Not applicable — no configuration changes

## Additional Notes

RSVP clicks are the highest-concurrency write in the events feature (many members reacting to one announcement ping at roughly the same time), which is why this path in particular needed the same atomic treatment `claimEventChannel` already had.

## Pre-Submission Verification

- [x] I have rebased my branch on the latest main branch
- [x] I have resolved any merge conflicts
- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hhnoee7SAqCnjkrzj1oeZq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hhnoee7SAqCnjkrzj1oeZq)_