### PR TITLE
fix(voice-presets): guard Discord preset actions against stale panel indexes

### DIFF
--- a/__tests__/handlers/vc-modal-handler.test.ts
+++ b/__tests__/handlers/vc-modal-handler.test.ts
@@ -13,6 +13,9 @@ jest.mock("../../src/services/voice-channel-manager.js");
 
 // Import after mocks
 import { VoiceChannelManager } from "../../src/services/voice-channel-manager.js";
+import { ConfigService } from "../../src/services/config-service.js";
+import { UserVoicePrefsService } from "../../src/services/user-voice-prefs-service.js";
+import { presetNameTag } from "../../src/handlers/vc-preset-handler.js";
 import { handleVCModal } from "../../src/handlers/vc-modal-handler.js";
 
 const mockVoiceChannelManager = VoiceChannelManager as jest.Mocked<
@@ -126,6 +129,104 @@ describe("VCModalHandler - Custom Name Tracking", () => {
         content: "❌ Channel name cannot be empty.",
         ephemeral: true,
       });
+    });
+  });
+
+  describe("Rename preset staleness guard", () => {
+    let mockService: { getPrefs: jest.Mock; renamePreset: jest.Mock };
+
+    beforeEach(() => {
+      // The feature gate reads real ConfigService (backed by mocked mongoose,
+      // whose schema default disables presets) — force it on for these tests.
+      jest
+        .spyOn(ConfigService.prototype, "getBoolean")
+        .mockResolvedValue(true);
+      mockService = {
+        getPrefs: jest.fn(),
+        renamePreset: jest.fn(),
+      };
+      jest
+        .spyOn(UserVoicePrefsService, "getInstance")
+        .mockReturnValue(mockService as unknown as UserVoicePrefsService);
+      mockInteraction.fields = {
+        getTextInputValue: jest.fn().mockReturnValue("Renamed Preset"),
+      } as any;
+    });
+
+    it("renames and passes the verified name as expectedName when the tag matches", async () => {
+      mockService.getPrefs.mockResolvedValue({
+        presets: [{ name: "Squad Night", isDefault: false }],
+      } as never);
+      mockService.renamePreset.mockResolvedValue({
+        oldName: "Squad Night",
+        newName: "Renamed Preset",
+      } as never);
+      mockInteraction.customId = `vc_modal_renamepreset_0_${presetNameTag("Squad Night")}_test-channel-id_test-user-id`;
+
+      await handleVCModal(mockInteraction as ModalSubmitInteraction);
+
+      expect(mockService.renamePreset).toHaveBeenCalledWith(
+        "test-user-id",
+        0,
+        "Renamed Preset",
+        "Squad Night",
+      );
+      expect(mockInteraction.reply).toHaveBeenCalledWith({
+        content: "✏️ Preset **Squad Night** renamed to **Renamed Preset**.",
+        ephemeral: true,
+      });
+    });
+
+    it("refuses when the preset at the index changed since the modal opened", async () => {
+      mockService.getPrefs.mockResolvedValue({
+        presets: [{ name: "Other Preset", isDefault: false }],
+      } as never);
+      mockInteraction.customId = `vc_modal_renamepreset_0_${presetNameTag("Squad Night")}_test-channel-id_test-user-id`;
+
+      await handleVCModal(mockInteraction as ModalSubmitInteraction);
+
+      expect(mockService.renamePreset).not.toHaveBeenCalled();
+      expect(mockInteraction.reply).toHaveBeenCalledWith({
+        content:
+          "❌ Your presets changed since this dialog was opened — reopen the panel and try again.",
+        ephemeral: true,
+      });
+    });
+
+    it("refuses when the preset index no longer exists", async () => {
+      mockService.getPrefs.mockResolvedValue({ presets: [] } as never);
+      mockInteraction.customId = `vc_modal_renamepreset_0_${presetNameTag("Squad Night")}_test-channel-id_test-user-id`;
+
+      await handleVCModal(mockInteraction as ModalSubmitInteraction);
+
+      expect(mockService.renamePreset).not.toHaveBeenCalled();
+      expect(mockInteraction.reply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content:
+            "❌ Your presets changed since this dialog was opened — reopen the panel and try again.",
+        }),
+      );
+    });
+
+    it("still renames via legacy tag-less modal IDs, guarded by the current name", async () => {
+      mockService.getPrefs.mockResolvedValue({
+        presets: [{ name: "Squad Night", isDefault: false }],
+      } as never);
+      mockService.renamePreset.mockResolvedValue({
+        oldName: "Squad Night",
+        newName: "Renamed Preset",
+      } as never);
+      mockInteraction.customId =
+        "vc_modal_renamepreset_0_test-channel-id_test-user-id";
+
+      await handleVCModal(mockInteraction as ModalSubmitInteraction);
+
+      expect(mockService.renamePreset).toHaveBeenCalledWith(
+        "test-user-id",
+        0,
+        "Renamed Preset",
+        "Squad Night",
+      );
     });
   });
 });

--- a/__tests__/handlers/vc-preset-handler.test.ts
+++ b/__tests__/handlers/vc-preset-handler.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import {
+  ChannelType,
+  type ButtonInteraction,
+  type Guild,
+  type VoiceChannel,
+} from "discord.js";
+
+// Mock dependencies before importing
+jest.mock("../../src/utils/logger.js");
+jest.mock("../../src/models/user-voice-preferences.js", () => ({
+  UserVoicePreferences: {
+    findOne: jest.fn(),
+    create: jest.fn(),
+  },
+}));
+
+// Import after mocks
+import { ConfigService } from "../../src/services/config-service.js";
+import { UserVoicePreferences } from "../../src/models/user-voice-preferences.js";
+import { UserVoicePrefsService } from "../../src/services/user-voice-prefs-service.js";
+import {
+  handleVCPresetButton,
+  presetNameTag,
+} from "../../src/handlers/vc-preset-handler.js";
+
+const mockFindOne = UserVoicePreferences.findOne as unknown as jest.Mock;
+
+describe("VCPresetHandler - staleness guard on preset actions", () => {
+  let mockInteraction: Partial<ButtonInteraction>;
+  let mockGuild: Partial<Guild>;
+  let mockChannel: Partial<VoiceChannel>;
+  let mockService: {
+    setDefault: jest.Mock;
+    deletePreset: jest.Mock;
+    renamePreset: jest.Mock;
+  };
+
+  const squadNight = { name: "Squad Night", isDefault: false };
+  const other = { name: "Other Preset", isDefault: false };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // The feature gate reads real ConfigService (backed by mocked mongoose,
+    // whose schema default disables presets) — force it on for these tests.
+    jest.spyOn(ConfigService.prototype, "getBoolean").mockResolvedValue(true);
+    jest.spyOn(ConfigService.prototype, "getNumber").mockResolvedValue(3);
+
+    mockService = {
+      setDefault: jest.fn(),
+      deletePreset: jest.fn(),
+      renamePreset: jest.fn(),
+    };
+    jest
+      .spyOn(UserVoicePrefsService, "getInstance")
+      .mockReturnValue(mockService as unknown as UserVoicePrefsService);
+
+    mockChannel = {
+      id: "chan1",
+      name: "Test Channel",
+      type: ChannelType.GuildVoice,
+    } as any;
+
+    mockGuild = {
+      channels: {
+        fetch: jest.fn().mockResolvedValue(mockChannel),
+      } as any,
+    } as any;
+
+    mockInteraction = {
+      user: { id: "user1" } as any,
+      guild: mockGuild as Guild,
+      reply: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn().mockResolvedValue(undefined),
+      followUp: jest.fn().mockResolvedValue(undefined),
+      showModal: jest.fn().mockResolvedValue(undefined),
+    } as any;
+  });
+
+  const setPresets = (presets: Array<{ name: string; isDefault: boolean }>) =>
+    mockFindOne.mockResolvedValue({ presets } as never);
+
+  describe("delete button", () => {
+    it("passes the verified preset name through as expectedName", async () => {
+      setPresets([squadNight, other]);
+      mockService.deletePreset.mockResolvedValue({
+        name: "Squad Night",
+        remaining: 1,
+      } as never);
+      mockInteraction.customId = `vc_preset_delete_0_${presetNameTag("Squad Night")}_chan1_user1`;
+
+      await handleVCPresetButton(mockInteraction as ButtonInteraction);
+
+      expect(mockService.deletePreset).toHaveBeenCalledWith(
+        "user1",
+        0,
+        "Squad Night",
+      );
+      expect(mockInteraction.followUp).toHaveBeenCalledWith({
+        content: "🗑️ Deleted preset **Squad Night**.",
+        flags: expect.anything(),
+      });
+    });
+
+    it("refuses when the preset at the index no longer matches the tag", async () => {
+      // Panel rendered "Squad Night" at index 0, but the list shifted and
+      // "Other Preset" now sits there.
+      setPresets([other]);
+      mockInteraction.customId = `vc_preset_delete_0_${presetNameTag("Squad Night")}_chan1_user1`;
+
+      await handleVCPresetButton(mockInteraction as ButtonInteraction);
+
+      expect(mockService.deletePreset).not.toHaveBeenCalled();
+      expect(mockInteraction.reply).toHaveBeenCalledWith({
+        content:
+          "❌ Your presets changed since this panel was opened — reopen it and try again.",
+        flags: expect.anything(),
+      });
+    });
+
+    it("refuses when the preset index no longer exists", async () => {
+      setPresets([]);
+      mockInteraction.customId = `vc_preset_delete_0_${presetNameTag("Squad Night")}_chan1_user1`;
+
+      await handleVCPresetButton(mockInteraction as ButtonInteraction);
+
+      expect(mockService.deletePreset).not.toHaveBeenCalled();
+      expect(mockInteraction.reply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content:
+            "❌ Your presets changed since this panel was opened — reopen it and try again.",
+        }),
+      );
+    });
+
+    it("still guards legacy tag-less custom IDs with the current name", async () => {
+      setPresets([squadNight]);
+      mockService.deletePreset.mockResolvedValue({
+        name: "Squad Night",
+        remaining: 0,
+      } as never);
+      mockInteraction.customId = "vc_preset_delete_0_chan1_user1";
+
+      await handleVCPresetButton(mockInteraction as ButtonInteraction);
+
+      expect(mockService.deletePreset).toHaveBeenCalledWith(
+        "user1",
+        0,
+        "Squad Night",
+      );
+    });
+  });
+
+  describe("set-default button", () => {
+    it("passes the verified preset name through as expectedName", async () => {
+      setPresets([squadNight, other]);
+      mockService.setDefault.mockResolvedValue({
+        name: "Squad Night",
+        isDefault: true,
+      } as never);
+      mockInteraction.customId = `vc_preset_default_0_${presetNameTag("Squad Night")}_chan1_user1`;
+
+      await handleVCPresetButton(mockInteraction as ButtonInteraction);
+
+      expect(mockService.setDefault).toHaveBeenCalledWith(
+        "user1",
+        0,
+        "Squad Night",
+      );
+    });
+
+    it("refuses when the preset at the index no longer matches the tag", async () => {
+      setPresets([other, squadNight]);
+      mockInteraction.customId = `vc_preset_default_0_${presetNameTag("Squad Night")}_chan1_user1`;
+
+      await handleVCPresetButton(mockInteraction as ButtonInteraction);
+
+      expect(mockService.setDefault).not.toHaveBeenCalled();
+      expect(mockInteraction.reply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content:
+            "❌ Your presets changed since this panel was opened — reopen it and try again.",
+        }),
+      );
+    });
+  });
+
+  describe("rename button", () => {
+    it("embeds the name fingerprint in the rename modal custom ID", async () => {
+      setPresets([squadNight]);
+      mockInteraction.customId = `vc_preset_rename_0_${presetNameTag("Squad Night")}_chan1_user1`;
+
+      await handleVCPresetButton(mockInteraction as ButtonInteraction);
+
+      expect(mockInteraction.showModal).toHaveBeenCalledTimes(1);
+      const modal = (mockInteraction.showModal as jest.Mock).mock
+        .calls[0][0] as { data: { custom_id?: string } };
+      expect(modal.data.custom_id).toBe(
+        `vc_modal_renamepreset_0_${presetNameTag("Squad Night")}_chan1_user1`,
+      );
+    });
+
+    it("refuses to open the modal from a stale rename button", async () => {
+      setPresets([other]);
+      mockInteraction.customId = `vc_preset_rename_0_${presetNameTag("Squad Night")}_chan1_user1`;
+
+      await handleVCPresetButton(mockInteraction as ButtonInteraction);
+
+      expect(mockInteraction.showModal).not.toHaveBeenCalled();
+      expect(mockInteraction.reply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content:
+            "❌ Your presets changed since this panel was opened — reopen it and try again.",
+        }),
+      );
+    });
+  });
+
+  describe("presetNameTag", () => {
+    it("is deterministic and safe for the underscore-delimited custom ID", () => {
+      const tag = presetNameTag("Squad_Night with_underscores");
+      expect(tag).toBe(presetNameTag("Squad_Night with_underscores"));
+      expect(tag).toMatch(/^[0-9a-f]{8}$/);
+      expect(presetNameTag("Other")).not.toBe(tag);
+    });
+  });
+});

--- a/src/handlers/vc-modal-handler.ts
+++ b/src/handlers/vc-modal-handler.ts
@@ -6,6 +6,7 @@ import {
   UserVoicePrefsService,
   VoicePrefsValidationError,
 } from "../services/user-voice-prefs-service.js";
+import { presetNameTag } from "./vc-preset-handler.js";
 
 const configService = ConfigService.getInstance();
 
@@ -15,8 +16,9 @@ export async function handleVCModal(
   const customId = interaction.customId;
 
   // Forms:
-  //   vc_modal_{action}_{channelId}_{userId}              (5 parts)
-  //   vc_modal_{action}_{presetIndex}_{channelId}_{userId} (6 parts, preset-targeting actions)
+  //   vc_modal_{action}_{channelId}_{userId}                          (5 parts)
+  //   vc_modal_{action}_{presetIndex}_{channelId}_{userId}            (6 parts, legacy in-flight modals)
+  //   vc_modal_{action}_{presetIndex}_{nameTag}_{channelId}_{userId}  (7 parts, preset-targeting actions)
   const parts = customId.split("_");
   if (parts.length < 5 || parts[0] !== "vc" || parts[1] !== "modal") {
     await interaction.reply({
@@ -27,10 +29,16 @@ export async function handleVCModal(
   }
 
   const action = parts[2];
-  const usesPresetIndex = parts.length === 6;
+  const usesPresetIndex = parts.length >= 6;
+  const hasNameTag = parts.length === 7;
   const presetIndex = usesPresetIndex ? Number(parts[3]) : null;
-  const channelId = usesPresetIndex ? parts[4] : parts[3];
-  const userId = usesPresetIndex ? parts[5] : parts[4];
+  const nameTag = hasNameTag ? parts[4] : null;
+  const channelId = hasNameTag
+    ? parts[5]
+    : usesPresetIndex
+      ? parts[4]
+      : parts[3];
+  const userId = hasNameTag ? parts[6] : usesPresetIndex ? parts[5] : parts[4];
 
   // Verify user
   if (userId !== interaction.user.id) {
@@ -67,7 +75,12 @@ export async function handleVCModal(
           });
           return;
         }
-        await handleRenamePresetModal(interaction, presetIndex, userId);
+        await handleRenamePresetModal(
+          interaction,
+          presetIndex,
+          nameTag,
+          userId,
+        );
         break;
       default:
         await interaction.reply({
@@ -214,6 +227,7 @@ async function handleSavePresetModal(
 async function handleRenamePresetModal(
   interaction: ModalSubmitInteraction,
   presetIndex: number,
+  nameTag: string | null,
   userId: string,
 ): Promise<void> {
   const enabled = await configService.getBoolean(
@@ -229,14 +243,31 @@ async function handleRenamePresetModal(
   }
 
   const newName = interaction.fields.getTextInputValue("name");
+  const service = UserVoicePrefsService.getInstance();
+
+  // Staleness guard: the modal's custom ID carries a fingerprint of the
+  // preset name shown when the modal opened. If the list shifted before
+  // submit (delete/rename from another panel, device, or the web UI), the
+  // index would now point at a different preset — refuse instead of
+  // renaming the wrong one.
+  const prefs = await service.getPrefs(userId);
+  const target = prefs.presets[presetIndex];
+  if (!target || (nameTag !== null && presetNameTag(target.name) !== nameTag)) {
+    await interaction.reply({
+      content:
+        "❌ Your presets changed since this dialog was opened — reopen the panel and try again.",
+      ephemeral: true,
+    });
+    return;
+  }
 
   try {
-    const { oldName, newName: savedName } =
-      await UserVoicePrefsService.getInstance().renamePreset(
-        userId,
-        presetIndex,
-        newName,
-      );
+    const { oldName, newName: savedName } = await service.renamePreset(
+      userId,
+      presetIndex,
+      newName,
+      target.name,
+    );
 
     await interaction.reply({
       content: `✏️ Preset **${oldName}** renamed to **${savedName}**.`,

--- a/src/handlers/vc-preset-handler.ts
+++ b/src/handlers/vc-preset-handler.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   ButtonInteraction,
   StringSelectMenuInteraction,
@@ -27,17 +28,32 @@ import {
 
 const configService = ConfigService.getInstance();
 
+/**
+ * Short fingerprint of a preset name, embedded in preset-targeting custom
+ * IDs. The full name can't ride in the ID itself — it may contain the `_`
+ * delimiter, and 50 name chars next to two snowflakes would overflow
+ * Discord's 100-char custom-ID limit — so panels embed this tag at render
+ * time and action handlers verify it against the preset currently at the
+ * index. This is the Discord-surface counterpart of the `expectedName`
+ * guard the web forms thread through `UserVoicePrefsService`.
+ */
+export function presetNameTag(name: string): string {
+  return createHash("sha256").update(name).digest("hex").slice(0, 8);
+}
+
 type ParsedId = {
   action: string;
   presetIndex: number | null;
+  nameTag: string | null;
   channelId: string;
   ownerId: string;
 };
 
 function parseCustomId(customId: string): ParsedId | null {
   // Forms:
-  //   vc_preset_{action}_{channelId}_{ownerId}                    (5 parts)
-  //   vc_preset_{action}_{presetIndex}_{channelId}_{ownerId}      (6 parts)
+  //   vc_preset_{action}_{channelId}_{ownerId}                            (5 parts)
+  //   vc_preset_{action}_{presetIndex}_{channelId}_{ownerId}              (6 parts, legacy in-flight panels)
+  //   vc_preset_{action}_{presetIndex}_{nameTag}_{channelId}_{ownerId}    (7 parts)
   const parts = customId.split("_");
   if (parts[0] !== "vc" || parts[1] !== "preset") return null;
 
@@ -48,18 +64,21 @@ function parseCustomId(customId: string): ParsedId | null {
     return {
       action,
       presetIndex: null,
+      nameTag: null,
       channelId: parts[3],
       ownerId: parts[4],
     };
   }
-  if (parts.length === 6) {
+  if (parts.length === 6 || parts.length === 7) {
     const idx = Number(parts[3]);
     if (!Number.isInteger(idx) || idx < 0) return null;
+    const hasTag = parts.length === 7;
     return {
       action,
       presetIndex: idx,
-      channelId: parts[4],
-      ownerId: parts[5],
+      nameTag: hasTag ? parts[4] : null,
+      channelId: parts[hasTag ? 5 : 4],
+      ownerId: parts[hasTag ? 6 : 5],
     };
   }
   return null;
@@ -191,22 +210,26 @@ function buildManagePanel(
 
   const idx = selectedIndex ?? 0;
   const disabled = selected === null;
+  // The tag pins each action button to the preset name shown when this
+  // panel rendered; "0" is a placeholder for the disabled (no selection)
+  // state and never reaches an action handler.
+  const tag = selected ? presetNameTag(selected.name) : "0";
   rows.push(
     new ActionRowBuilder<ButtonBuilder>().addComponents(
       new ButtonBuilder()
-        .setCustomId(`vc_preset_default_${idx}_${channelId}_${ownerId}`)
+        .setCustomId(`vc_preset_default_${idx}_${tag}_${channelId}_${ownerId}`)
         .setLabel(selected?.isDefault ? "Unset default" : "Set as default")
         .setStyle(ButtonStyle.Primary)
         .setEmoji("⭐")
         .setDisabled(disabled),
       new ButtonBuilder()
-        .setCustomId(`vc_preset_rename_${idx}_${channelId}_${ownerId}`)
+        .setCustomId(`vc_preset_rename_${idx}_${tag}_${channelId}_${ownerId}`)
         .setLabel("Rename")
         .setStyle(ButtonStyle.Secondary)
         .setEmoji("✏️")
         .setDisabled(disabled),
       new ButtonBuilder()
-        .setCustomId(`vc_preset_delete_${idx}_${channelId}_${ownerId}`)
+        .setCustomId(`vc_preset_delete_${idx}_${tag}_${channelId}_${ownerId}`)
         .setLabel("Delete")
         .setStyle(ButtonStyle.Danger)
         .setEmoji("🗑️")
@@ -440,6 +463,34 @@ async function openSaveModal(
   await interaction.showModal(modal);
 }
 
+/**
+ * Re-load the preset a preset-targeting component points at and verify its
+ * name still matches the fingerprint captured when the panel rendered.
+ * Replies with a staleness error and returns null when the list shifted
+ * underneath the panel (preset deleted/renamed via another panel, device,
+ * or the web UI) so the action can't silently hit the wrong preset.
+ */
+async function resolveTargetPreset(
+  interaction: ButtonInteraction,
+  parsed: ParsedId,
+): Promise<IChannelPreset | null> {
+  const prefs = await loadPrefs(parsed.ownerId);
+  const preset =
+    parsed.presetIndex !== null ? prefs.presets[parsed.presetIndex] : undefined;
+  if (
+    !preset ||
+    (parsed.nameTag !== null && presetNameTag(preset.name) !== parsed.nameTag)
+  ) {
+    await interaction.reply({
+      content:
+        "❌ Your presets changed since this panel was opened — reopen it and try again.",
+      flags: MessageFlags.Ephemeral,
+    });
+    return null;
+  }
+  return preset;
+}
+
 async function openRenameModal(
   interaction: ButtonInteraction,
   parsed: ParsedId,
@@ -451,19 +502,12 @@ async function openRenameModal(
     });
     return;
   }
-  const prefs = await loadPrefs(parsed.ownerId);
-  const preset = prefs.presets[parsed.presetIndex];
-  if (!preset) {
-    await interaction.reply({
-      content: "❌ Preset no longer exists.",
-      flags: MessageFlags.Ephemeral,
-    });
-    return;
-  }
+  const preset = await resolveTargetPreset(interaction, parsed);
+  if (!preset) return;
 
   const modal = new ModalBuilder()
     .setCustomId(
-      `vc_modal_renamepreset_${parsed.presetIndex}_${parsed.channelId}_${parsed.ownerId}`,
+      `vc_modal_renamepreset_${parsed.presetIndex}_${presetNameTag(preset.name)}_${parsed.channelId}_${parsed.ownerId}`,
     )
     .setTitle("Rename preset");
   const nameInput = new TextInputBuilder()
@@ -485,11 +529,16 @@ async function toggleDefault(
   parsed: ParsedId,
 ): Promise<void> {
   if (parsed.presetIndex === null) return;
+  const target = await resolveTargetPreset(interaction, parsed);
+  if (!target) return;
   let result: { name: string; isDefault: boolean };
   try {
+    // Passing the just-verified name as expectedName lets the service
+    // re-check it at write time, closing the read→write race window.
     result = await UserVoicePrefsService.getInstance().setDefault(
       parsed.ownerId,
       parsed.presetIndex,
+      target.name,
     );
   } catch (error) {
     // Only the known "missing preset" validation case becomes a friendly
@@ -519,11 +568,14 @@ async function deletePreset(
   parsed: ParsedId,
 ): Promise<void> {
   if (parsed.presetIndex === null) return;
+  const target = await resolveTargetPreset(interaction, parsed);
+  if (!target) return;
   let removed: { name: string; remaining: number };
   try {
     removed = await UserVoicePrefsService.getInstance().deletePreset(
       parsed.ownerId,
       parsed.presetIndex,
+      target.name,
     );
   } catch (error) {
     // As in toggleDefault: translate only the known validation/missing case;


### PR DESCRIPTION
## Description

The Discord preset surface acted purely on a numeric `presetIndex` baked into the button/modal `customId` at panel-render time: `toggleDefault` and `deletePreset` in `vc-preset-handler.ts` and the rename modal in `vc-modal-handler.ts` all called `UserVoicePrefsService` without the optional `expectedName` argument, so the staleness guard the web surface already threads through (`user-routes.ts`) was silently disabled on Discord. If the preset list shifted between panel render and click/submit (a second open panel, another device, or the web UI), the action "succeeded" against whichever preset now sat at that index.

The full preset name can't ride in the `customId` itself — names may contain the `_` delimiter, and 50 name chars next to two ~19-char snowflakes would overflow Discord's 100-char `customId` limit. Instead:

- `buildManagePanel` and the rename-modal opener now embed an 8-hex sha256 fingerprint of the preset's name (`presetNameTag`) in preset-targeting `customId`s (new 7-part form; legacy 6-part IDs from in-flight panels are still parsed).
- On click/submit, the handlers re-load the preset at the index and refuse with a clear ephemeral error ("Your presets changed since this panel was opened — reopen it and try again.") when the fingerprint no longer matches.
- The verified name is then passed through as `expectedName`, so the service re-checks it at write time — closing the read→write race the same way the web surface does.
- The stale-check also applies when opening the rename modal, and the modal's `customId` carries a fresh fingerprint so the submit is guarded against shifts that happen while the dialog is open.

Fixes the exact failure scenario from the issue: clicking "Set default"/"Delete" or submitting a rename against an index that now points at a different preset is rejected instead of silently acting on the wrong one.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] 🧪 Test updates
- [ ] 🔧 Build/tooling changes
- [ ] ⚡ Performance improvement

## Related Issues

Fixes #759

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality
- [ ] Manually tested in development environment
- [ ] Tested in Docker environment

New coverage: `__tests__/handlers/vc-preset-handler.test.ts` (delete/set-default/rename-open with matching, mismatched, and missing presets; legacy tag-less IDs; `presetNameTag` determinism and underscore safety) and a "Rename preset staleness guard" block in `__tests__/handlers/vc-modal-handler.test.ts` (matching tag, shifted list, missing index, legacy tag-less modal IDs).

One pre-existing failure in `__tests__/services/message-activity-cleanup.test.ts` ("keeps the mutual-exclusion guard intact when destroy() fires mid-run") reproduces identically on this environment with the changes stashed — unrelated to this PR.

**Test Configuration**:

- Node.js version: 22.22.2
- Discord.js version: 14 (repo pin)
- Operating System: Linux

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested my changes manually

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary:
  - [ ] `COMMANDS.md` (if adding/modifying commands) — no command changes
  - [ ] `SETTINGS.md` (if adding/modifying configuration) — no config changes
  - [ ] `README.md` (if adding user-facing features) — no new features
  - [x] Inline code comments for complex logic
- [x] I have validated markdown with `npx markdownlint "**/*.md" --ignore node_modules --ignore dist` — no markdown changed

### Dependencies & Docker

- [ ] I have updated `Dockerfile` if dependencies changed — no dependency changes
- [ ] I have updated `Dockerfile.dev` if dev dependencies changed — no dependency changes
- [ ] I have tested the Docker build (`docker-compose build`)
- [ ] I have run security checks if adding new dependencies — no new dependencies

### Configuration (if applicable)

- [ ] New features are disabled by default and toggleable via configuration — no new config keys; existing `voicechannels.presets.enabled` gate unchanged
- [ ] I have added configuration schema entries in `config-schema.ts` — not applicable
- [ ] I have documented new configuration keys in `SETTINGS.md` — not applicable
- [ ] I have tested configuration reload (`/config reload`) — not applicable

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Backward compatibility: buttons/modals rendered before this deploys carry the old 6-part `customId`s. They are still parsed (`nameTag` is `null`, so the fingerprint check is skipped), and they still gain the write-time `expectedName` check from the handler's fresh read — strictly better than before, and fully guarded panels take over as soon as they're re-rendered.

## Pre-Submission Verification

- [x] I have rebased my branch on the latest main branch
- [x] I have resolved any merge conflicts
- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NvknA2jswVwiq6X3W64jz4

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvknA2jswVwiq6X3W64jz4)_