### PR TITLE
fix(quotes): normalize addedById before /quote edit ownership check

### DIFF
--- a/src/commands/quote.ts
+++ b/src/commands/quote.ts
@@ -243,18 +243,18 @@ async function handleEdit(
     return;
   }
 
+  // Normalize IDs from existing quote (handles legacy mention formats)
+  const normalizedExistingAuthorId = normalizeUserId(existingQuote.authorId);
+  const normalizedAddedById = normalizeUserId(existingQuote.addedById);
+
   // Check if user has permission to edit (only the person who added it can edit)
-  if (existingQuote.addedById !== interaction.user.id) {
+  if (normalizedAddedById !== interaction.user.id) {
     await interaction.reply({
       content: "❌ You can only edit quotes that you added.",
       ephemeral: true,
     });
     return;
   }
-
-  // Normalize authorId from existing quote (handles legacy formats)
-  const normalizedExistingAuthorId = normalizeUserId(existingQuote.authorId);
-  const normalizedAddedById = normalizeUserId(existingQuote.addedById);
 
   const finalContent = newText ?? existingQuote.content;
   const finalAuthorId = newAuthor?.id ?? normalizedExistingAuthorId;


### PR DESCRIPTION
## Description

`/quote edit`'s ownership check in `handleEdit` compared the raw, un-normalized `existingQuote.addedById` against `interaction.user.id`. When `addedById` was persisted in a legacy Discord mention format (e.g. `<@123>`, `<@!123>`, `@123`) — exactly the formats the file's own `normalizeUserId()` helper exists to handle — the strict `!==` comparison rejected the legitimate owner with "You can only edit quotes that you added," even though the normalized value (computed two lines below, but only for display use) would have matched.

The fix moves the `normalizeUserId(existingQuote.addedById)` computation above the permission check and compares against the normalized value instead. No behavior change for quotes stored with a plain numeric `addedById`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #775

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Manually verified `npm run build` (typecheck) and `npm run lint` pass

The repository's command test suite (`__tests__/commands/quote.test.ts`) covers slash-command metadata only and does not invoke `execute`/`handleEdit`, so no execute-level test harness exists to extend for this path; the change is a focused one-line correction that reuses the existing, already-tested `normalizeUserId()` helper.

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` (Prettier) — no changes needed
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Documentation

- No documentation changes required — no command surface, config key, or user-facing behavior contract changes (only a bug fix restoring the documented behavior).

## Additional Notes

The issue also mentions a related, currently-dead-code inversion in `QuoteService.deleteQuote`. That is intentionally **not** part of this change, per the issue ("not part of this fix").

## Pre-Submission Verification

- [x] I have rebased my branch on the latest main branch
- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

---
_Generated by [Claude Code](https://claude.ai/code/session_013uDUk5wiidSKjeD76mSU7Y)_