### PR TITLE
fix(quotes): keep posted quote id when reaction step fails

### DIFF
--- a/__tests__/services/quote-channel-manager-post.test.ts
+++ b/__tests__/services/quote-channel-manager-post.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+const mockRegisterReloadCallback = jest.fn();
+const mockGetBoolean = jest.fn();
+const mockGetString = jest.fn();
+const mockSet = jest.fn();
+
+jest.mock("../../src/utils/logger.js");
+jest.mock("cron");
+
+jest.unstable_mockModule("../../src/services/config-service.js", () => ({
+  ConfigService: {
+    getInstance: jest.fn(() => ({
+      registerReloadCallback: mockRegisterReloadCallback,
+      getBoolean: mockGetBoolean,
+      getString: mockGetString,
+      set: mockSet,
+    })),
+  },
+}));
+
+jest.unstable_mockModule("../../src/services/quote-service.js", () => ({
+  quoteService: {},
+}));
+
+function makeChannel(message: any) {
+  return {
+    isTextBased: jest.fn().mockReturnValue(true),
+    isDMBased: jest.fn().mockReturnValue(false),
+    send: jest.fn().mockResolvedValue(message),
+  };
+}
+
+const mockClient: any = {
+  isReady: jest.fn().mockReturnValue(true),
+  user: { id: "bot123" },
+  channels: { fetch: jest.fn() },
+  on: jest.fn(),
+  removeListener: jest.fn(),
+};
+
+async function loadManager() {
+  const { QuoteChannelManager } =
+    await import("../../src/services/quote-channel-manager.js");
+  return QuoteChannelManager.getInstance(mockClient);
+}
+
+describe("QuoteChannelManager.postQuote - reaction failure handling", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetString.mockResolvedValue("channel123");
+  });
+
+  it("returns the message id when the message posts successfully", async () => {
+    const message = {
+      id: "msg123",
+      react: jest.fn().mockResolvedValue(undefined),
+    };
+    const channel = makeChannel(message);
+    mockClient.channels.fetch.mockResolvedValue(channel);
+
+    const manager = await loadManager();
+    const result = await manager.postQuote("q1", "hello", "author1", "adder1");
+
+    expect(result).toBe("msg123");
+    expect(channel.send).toHaveBeenCalledTimes(1);
+    expect(message.react).toHaveBeenCalledWith("👍");
+    expect(message.react).toHaveBeenCalledWith("👎");
+  });
+
+  it("still returns the message id when adding reactions fails", async () => {
+    const message = {
+      id: "msg456",
+      react: jest.fn().mockRejectedValue(new Error("Missing Permissions")),
+    };
+    const channel = makeChannel(message);
+    mockClient.channels.fetch.mockResolvedValue(channel);
+
+    const manager = await loadManager();
+    const result = await manager.postQuote("q2", "world", "author2", "adder2");
+
+    // The message was posted; a reaction hiccup must not orphan it (issue #776).
+    expect(result).toBe("msg456");
+    expect(channel.send).toHaveBeenCalledTimes(1);
+    expect(message.react).toHaveBeenCalled();
+  });
+
+  it("returns null when the message genuinely fails to send", async () => {
+    const channel = {
+      isTextBased: jest.fn().mockReturnValue(true),
+      isDMBased: jest.fn().mockReturnValue(false),
+      send: jest.fn().mockRejectedValue(new Error("Cannot send messages")),
+    };
+    mockClient.channels.fetch.mockResolvedValue(channel);
+
+    const manager = await loadManager();
+    const result = await manager.postQuote("q3", "nope", "author3", "adder3");
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/services/quote-channel-manager.ts
+++ b/src/services/quote-channel-manager.ts
@@ -628,9 +628,18 @@ export class QuoteChannelManager {
 
       const message = await channel.send({ embeds: [embed] });
 
-      // Add reaction buttons
-      await message.react("👍");
-      await message.react("👎");
+      // Add reaction buttons. A failure here must not discard the
+      // successfully-posted message id — otherwise the message is orphaned in
+      // the channel and its messageId is never persisted (see issue #776).
+      try {
+        await message.react("👍");
+        await message.react("👎");
+      } catch (reactionError) {
+        logger.error(
+          `Posted quote ${quoteId} as message ${message.id} but failed to add reactions:`,
+          reactionError,
+        );
+      }
 
       logger.info(
         `Posted quote ${quoteId} to channel as message ${message.id}`,


### PR DESCRIPTION
## Description

`QuoteChannelManager.postQuote` wrapped `channel.send()` and the two follow-up `message.react()` calls in a single `try`/`catch`. A reaction failure was therefore indistinguishable from a failed send — both returned `null`. When the embed posted but a `react()` call threw (transient Discord API error, reaction rate limit, or a briefly-missing `Add Reactions` permission), the message was left orphaned in the channel and its `messageId` was never persisted to Mongo, so its votes could never be tracked and a rebuild could post a duplicate.

This change wraps **only** the `react()` calls in their own `try`/`catch`. A reaction hiccup is now logged with the message id but the successfully-posted message id is still returned and persisted. `postQuote` returns `null` only when the send itself genuinely fails.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #776

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality

Added `__tests__/services/quote-channel-manager-post.test.ts` covering three cases:

- message posts and reactions succeed → returns the message id
- message posts but `react()` rejects → still returns the message id (regression guard for #776)
- `channel.send()` rejects → returns `null`

`npm run build`, `npm run lint`, and the quote-channel-manager test suite all pass.

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

### Documentation

- [x] No documentation changes required (no command or config keys added/changed)

### Dependencies & Docker

- [x] No dependency or Docker changes

## Additional Notes

The fix mirrors the approach suggested in the issue: separate the "send" and "react" steps so a reaction failure doesn't discard a successfully-posted message id.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VygVEwK44xJc6pLd9mMfX2)_