### PR TITLE
fix(webui): require CSRF token on magic-link redemption to stop login CSRF

### DIFF
--- a/__tests__/web/redeem-csrf.test.ts
+++ b/__tests__/web/redeem-csrf.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Integration tests for login-CSRF protection on the magic-link redemption
+ * route `POST /admin/s/:token` (issue #771).
+ *
+ * The URL-bound token gates access to *a* valid identity, but on its own it
+ * does nothing against login CSRF: an attacker auto-submitting a cross-site
+ * POST that carries *their own* valid token from the victim's browser would
+ * plant the attacker's session in that browser. The double-submit CSRF token
+ * blocks that — a cross-site page can't read the victim's `koolbot_csrf`
+ * cookie to forge a matching `_csrf`.
+ *
+ * We spin up the real router on an ephemeral port and drive it with `fetch`,
+ * managing cookies by hand so both the same-site (legitimate) and cross-site
+ * (forged) shapes are exercised end-to-end. `WebSessionService.peek/redeem`
+ * are stubbed so no Mongo connection is needed.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import express from "express";
+import type { AddressInfo } from "net";
+import { createServer, type Server } from "http";
+import { createWebRouter } from "../../src/web/index.js";
+import { WebSessionService } from "../../src/services/web-session-service.js";
+
+const ORIGINAL_ENV = { ...process.env };
+const SECRET = "test-secret-for-redeem-csrf-tests-0123456789";
+
+let server: Server;
+let baseUrl: string;
+
+function startServer(): Promise<void> {
+  const app = express();
+  // Mounted at /admin to match production so the consent form's action and
+  // the CSRF cookie path (`/`) line up with the routes under test.
+  app.use("/admin", createWebRouter({} as never));
+  return new Promise((resolve) => {
+    server = createServer(app);
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      baseUrl = `http://127.0.0.1:${port}`;
+      resolve();
+    });
+  });
+}
+
+function stopServer(): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+/** Pull a cookie's value out of a Set-Cookie header list. */
+function readCookie(setCookies: string[], name: string): string | undefined {
+  for (const line of setCookies) {
+    const match = line.match(new RegExp(`^${name}=([^;]*)`));
+    if (match) return decodeURIComponent(match[1]);
+  }
+  return undefined;
+}
+
+describe("POST /admin/s/:token login-CSRF protection (#771)", () => {
+  beforeEach(async () => {
+    process.env.WEBUI_SESSION_SECRET = SECRET;
+    process.env.WEBUI_BASE_URL = "http://127.0.0.1";
+    (WebSessionService as unknown as { instance: unknown }).instance = null;
+
+    const svc = WebSessionService.getInstance();
+    jest.spyOn(svc, "peek").mockResolvedValue({
+      sessionId: "s1",
+      discordUserId: "attacker-1",
+      guildId: "g1",
+      role: "user",
+      scopes: [],
+    } as unknown as never);
+    jest.spyOn(svc, "redeem").mockResolvedValue({
+      sessionId: "s1",
+      discordUserId: "attacker-1",
+      guildId: "g1",
+      role: "user",
+      scopes: [],
+    } as unknown as never);
+
+    await startServer();
+  });
+
+  afterEach(async () => {
+    await stopServer();
+    jest.restoreAllMocks();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("GET consent page sets a CSRF cookie and mirrors it into the form", async () => {
+    const res = await fetch(`${baseUrl}/admin/s/tok`, { redirect: "manual" });
+    expect(res.status).toBe(200);
+    const setCookies = res.headers.getSetCookie();
+    const csrf = readCookie(setCookies, "koolbot_csrf");
+    expect(csrf).toBeTruthy();
+    const html = await res.text();
+    expect(html).toContain(
+      `<input type="hidden" name="_csrf" value="${csrf}">`,
+    );
+  });
+
+  it("rejects a cross-site POST with no CSRF token (403, no session cookie)", async () => {
+    const res = await fetch(`${baseUrl}/admin/s/tok`, {
+      method: "POST",
+      redirect: "manual",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "",
+    });
+    expect(res.status).toBe(403);
+    // The attacker's identity must NOT be planted into the browser.
+    const setCookies = res.headers.getSetCookie();
+    expect(readCookie(setCookies, "koolbot_session")).toBeUndefined();
+  });
+
+  it("rejects a forged POST whose _csrf doesn't match the cookie (login CSRF)", async () => {
+    // Attacker knows *a* koolbot_csrf value is required but can't read the
+    // victim's cookie, so the mirrored token can't match.
+    const res = await fetch(`${baseUrl}/admin/s/tok`, {
+      method: "POST",
+      redirect: "manual",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        cookie: "koolbot_csrf=victim-cookie-value",
+      },
+      body: "_csrf=attacker-guessed-value",
+    });
+    expect(res.status).toBe(403);
+    const setCookies = res.headers.getSetCookie();
+    expect(readCookie(setCookies, "koolbot_session")).toBeUndefined();
+  });
+
+  it("accepts the legitimate same-site POST (matching cookie + _csrf) and writes the session", async () => {
+    // Step 1: GET the consent page to obtain the CSRF cookie + form token.
+    const getRes = await fetch(`${baseUrl}/admin/s/tok`, {
+      redirect: "manual",
+    });
+    const csrf = readCookie(getRes.headers.getSetCookie(), "koolbot_csrf")!;
+    expect(csrf).toBeTruthy();
+
+    // Step 2: submit the form same-site, echoing the cookie + hidden field.
+    const postRes = await fetch(`${baseUrl}/admin/s/tok`, {
+      method: "POST",
+      redirect: "manual",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        cookie: `koolbot_csrf=${encodeURIComponent(csrf)}`,
+      },
+      body: `_csrf=${encodeURIComponent(csrf)}`,
+    });
+    expect(postRes.status).toBe(302);
+    expect(postRes.headers.get("location")).toBe("/me/");
+    const session = readCookie(
+      postRes.headers.getSetCookie(),
+      "koolbot_session",
+    );
+    expect(session).toBeTruthy();
+  });
+});

--- a/__tests__/web/views.test.ts
+++ b/__tests__/web/views.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Unit tests for the pre-auth WebUI scaffold views (`src/web/views.ts`).
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import { renderConsent } from "../../src/web/views.js";
+
+describe("renderConsent", () => {
+  it("posts to the token-bound redemption route with the token URL-encoded", () => {
+    const html = renderConsent({ token: "a b/c", csrfToken: "csrf-1" });
+    expect(html).toContain('action="/admin/s/a%20b%2Fc"');
+    expect(html).toContain('<button type="submit">Continue</button>');
+  });
+
+  it("embeds the double-submit CSRF token so the redemption POST can pass requireCsrf (#771)", () => {
+    const html = renderConsent({ token: "tok", csrfToken: "csrf-123" });
+    expect(html).toContain(
+      '<input type="hidden" name="_csrf" value="csrf-123">',
+    );
+  });
+
+  it("HTML-escapes the CSRF token value", () => {
+    const html = renderConsent({
+      token: "tok",
+      csrfToken: '"><script>x</script>',
+    });
+    expect(html).not.toContain("<script>x</script>");
+    expect(html).toContain("&quot;&gt;&lt;script&gt;x&lt;/script&gt;");
+  });
+});

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -60,7 +60,12 @@ export function createWebRouter(client: Client): Router {
           res.status(404).type("text/html").send(renderInvalidLink());
           return;
         }
-        res.status(200).type("text/html").send(renderConsent({ token }));
+        const csrfToken =
+          (req as Request & { csrfToken?: string }).csrfToken ?? "";
+        res
+          .status(200)
+          .type("text/html")
+          .send(renderConsent({ token, csrfToken }));
       } catch (err) {
         logger.error("Error peeking web session token", err);
         res.status(500).type("text/plain").send("Internal Server Error");
@@ -71,16 +76,23 @@ export function createWebRouter(client: Client): Router {
   // POST consumes the token, marks it used, writes the session cookie,
   // and redirects into the admin app.
   //
-  // No CSRF check here: the URL-bound token IS the credential, exactly
-  // like an OAuth authorization-code redemption. An attacker who has the
-  // token can already consume it directly; an attacker without it can't
-  // construct a meaningful POST (path won't match any session). The
-  // attacker also has no pre-existing session at this point to leverage.
-  // CSRF on /finish and write routes still applies because those run
-  // against an already-authenticated cookie.
+  // CSRF is required here even though the URL-bound token already gates
+  // access to *a* valid identity. The token check defends against an
+  // attacker *stealing/replaying a victim's* token; it does nothing against
+  // the inverse — login CSRF (#771) — where an attacker auto-submits a
+  // cross-site POST carrying *their own* valid token from the victim's
+  // browser, coercing the browser into adopting the attacker-chosen
+  // session (and silently writing the victim's `/me/*` edits to the
+  // attacker's account, or laundering admin actions through the attacker's
+  // audit identity). The double-submit token stops that: a cross-site
+  // auto-submit can't read the victim's koolbot_csrf cookie to forge a
+  // matching `_csrf`, and SameSite=Lax withholds that cookie from a
+  // cross-site POST entirely. The consent page (rendered on GET above)
+  // mirrors the token into the form, so the same-site sign-in click passes.
   router.post(
     "/s/:token",
     redeemLimiter,
+    requireCsrf,
     async (req: Request, res: Response): Promise<void> => {
       try {
         const token = String(req.params.token || "");

--- a/src/web/views.ts
+++ b/src/web/views.ts
@@ -53,12 +53,19 @@ export function renderSignedOut(): string {
   );
 }
 
-export function renderConsent(opts: { token: string }): string {
+export function renderConsent(opts: {
+  token: string;
+  csrfToken: string;
+}): string {
   const action = `/admin/s/${encodeURIComponent(opts.token)}`;
   const body = [
     "<h1>Sign in to Koolbot Admin</h1>",
     "<p>Click <strong>Continue</strong> to start your admin session in this browser. Your single-use sign-in link will be consumed when you do.</p>",
     `<form method="POST" action="${escapeHtml(action)}">`,
+    // Double-submit CSRF token: mirrors the koolbot_csrf cookie so the POST
+    // redemption can reject a cross-site login-CSRF forgery (issue #771). A
+    // cross-site auto-submit can't read the victim's cookie to forge a match.
+    `<input type="hidden" name="_csrf" value="${escapeHtml(opts.csrfToken)}">`,
     '<button type="submit">Continue</button>',
     "</form>",
   ].join("");


### PR DESCRIPTION
## Description

`POST /admin/s/:token` redeemed a magic-link token and wrote the `koolbot_session` cookie with **no CSRF check** and no `Origin`/`Referer` verification. The URL-bound token defends against an attacker *stealing/replaying a victim's* token, but not against the inverse — **login CSRF**: an attacker auto-submitting a cross-site POST that carries *their own* valid token from the victim's browser, so the victim's browser silently adopts the attacker's session. The victim's subsequent `/me/*` edits (birthday, timezone, VC presets, …) then write to the *attacker's* account, and any admin actions get attributed to the attacker's identity in `WebAuditLog`.

This PR enforces the existing double-submit CSRF token on the redemption POST:

- **`src/web/index.ts`** — add `requireCsrf` to `POST /s/:token`, and pass the request's CSRF token into the consent page rendered on `GET /s/:token`. The stale "no CSRF here" comment is replaced with the login-CSRF rationale.
- **`src/web/views.ts`** — `renderConsent` now embeds the token as a hidden `_csrf` field (HTML-escaped), mirroring the `koolbot_csrf` cookie.

A cross-site auto-submit can't read the victim's `koolbot_csrf` cookie to forge a matching `_csrf`, and `SameSite=Lax` withholds that cookie from a cross-site POST entirely, so the forged navigation is rejected (403). The legitimate same-site sign-in click still passes because the consent page mirrors the token into the form. No config keys or user-facing commands changed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #771

## How Has This Been Tested?

- [x] Existing tests pass (`npm run test:ci` — 1618 passed, coverage gates hold)
- [x] Added new tests for new functionality

New tests:

- `__tests__/web/redeem-csrf.test.ts` — spins up the real router on an ephemeral port and drives it with `fetch`: GET sets the CSRF cookie and mirrors it into the form; a no-token cross-site POST → 403 (no session cookie planted); a forged POST whose `_csrf` doesn't match the cookie → 403; the legitimate same-site POST (matching cookie + `_csrf`) → 302 + session cookie written.
- `__tests__/web/views.test.ts` — `renderConsent` embeds and HTML-escapes the `_csrf` field.

## Checklist

### Code Quality

- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- No `COMMANDS.md` / `SETTINGS.md` / `README.md` changes needed (no command or config-key changes)

## Additional Notes

The fix reuses the already-tested `requireCsrf` double-submit middleware and the CSRF cookie whose path was broadened to `/` in #481, so it applies cleanly to the redemption route without new machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5kCJCHPhp5SmSqmUr7Ze2)_