### PR TITLE
docs(webui): document /admin/moderation and /admin/events pages

### DIFF
--- a/WEBUI.md
+++ b/WEBUI.md
@@ -751,6 +751,7 @@ No dashboard JSON ships with the bot — wire these up to taste:
 | **Permissions**    | `/permissions set`, `add`, `remove`, `clear`, `list`, `view`                                        |
 | **Setup Wizard**   | `/setup wizard`                                                                                     |
 | **Announcements**  | `/announce create`, `list`, `delete`                                                                |
+| **Events**         | `/event create`, `list`, `cancel`, `start`                                                          |
 | **Polls**          | `/poll create`, `list`, `add-item`, `delete`, `delete-item`, `test`, `list-items`                   |
 | **Reaction Roles** | `/reactrole create`, `archive`, `unarchive`, `delete`, `list`, `status`                             |
 | **Notices**        | `/notice add`, `edit`, `delete`, `sync`                                                             |
@@ -760,6 +761,7 @@ No dashboard JSON ships with the bot — wire these up to taste:
 | **Database**       | `/dbtrunk status`, `/dbtrunk run`                                                                   |
 | **Command Audit**  | (new — read-only Discord slash-command audit log)                                                   |
 | **Command Metrics**| (new — historical per-command usage / error-rate / latency dashboard)                               |
+| **Moderation**     | `/modlog` (read-only, server-wide; also surfaces `/warn` entries)                                   |
 | **Bootstrap**      | (new — read-only env diagnostics)                                                                   |
 
 Feature pages (Announcements, Polls, Reaction Roles, Notices, Voice
@@ -855,6 +857,39 @@ cheap across every member's full history.) The page is gated by
 `voicetracking.enabled` (the #610 disabled-feature pattern): when tracking is
 off the page still renders but shows a notice and only whatever was captured
 before it was disabled.
+
+The **Events** page (`/admin/events`) is the Web UI surface for the event
+scheduler (`/event create`, `list`, `cancel`, `start`) — events that spin up a
+temporary voice channel shortly before they start, collect RSVPs, remind
+attendees, and clean themselves up afterward. A status card shows whether the
+feature, the `events.category_id` channel category, and the
+`events.announcement_channel_id` are configured (with inline warnings when a
+category or announcement channel is missing, since event channels and RSVP
+messages won't be created without them) plus the resolved event timezone. The
+events table lists each event's title, start time, lifecycle state
+(*scheduled* / *active* / *ended* / *cancelled*), live RSVP tallies (✅ going ·
+🤔 maybe · 🚫 can't), channel, and id. Events that are still open get two
+lifecycle controls — **Start now** (spin the event up immediately) and
+**Cancel** (a confirm-guarded stop) — while finished events show no actions. A
+**Schedule a new event** form creates events without leaving the page. The page
+is gated by `events.enabled` (the #610 disabled-feature pattern), and the
+category / announcement channel / timezone themselves live under **Settings**
+(`events.*`).
+
+The **Moderation** page (`/admin/moderation`) is a read-only, server-wide
+history of moderation actions — the Web UI counterpart to per-user `/modlog`.
+Each row shows the timestamp, target user, acting moderator, action, reason, and
+source; user and moderator snowflakes are resolved to display names when the
+members are still in the guild (a page of 50 rows is resolved with a single
+batched member fetch rather than one request per id) and fall back to the raw id
+otherwise. `warn` rows are KoolBot's own record written by `/warn`, while
+`kick` / `ban` / `unban` / `timeout` / `untimeout` rows are mirrored from the
+guild audit log — so the `source` column reads `command` or `audit` accordingly.
+Two filters narrow the view — an **action** dropdown (warn, kick, ban, unban,
+timeout, untimeout) and a **user** filter — and results are paginated 50 rows
+per page. The page is gated by `moderation.enabled` (the #610 disabled-feature
+pattern): when moderation is off it renders the disabled banner and an empty
+table without touching the database.
 
 **Milestone celebrations** (`#657`, Part 2) have no dedicated page: they are
 configured entirely under **Settings** (`celebrations.enabled`,

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -878,7 +878,7 @@ category / announcement channel / timezone themselves live under **Settings**
 
 The **Moderation** page (`/admin/moderation`) is a read-only, server-wide
 history of moderation actions — the Web UI counterpart to per-user `/modlog`.
-Each row shows the timestamp, target user, acting moderator, action, reason, and
+Each row shows the timestamp, target user, action, acting moderator, reason, and
 source; user and moderator snowflakes are resolved to display names when the
 members are still in the guild (a page of 50 rows is resolved with a single
 batched member fetch rather than one request per id) and fall back to the raw id


### PR DESCRIPTION
## Description

`WEBUI.md`'s admin-panel walkthrough documented every admin page with its own paragraph except two, which had no coverage at all:

- `/admin/moderation` — the read-only, server-wide moderation history (action/user filters, 50-row pagination).
- `/admin/events` — event RSVP/lifecycle management.

This PR adds a short per-page paragraph for each, matching the existing per-page documentation pattern, and adds their rows to the admin-panel page table:

- **Events** paragraph: status card (feature / category / announcement-channel / timezone), the events table (title, start time, lifecycle state, RSVP tallies, channel, id), the **Start now** / **Cancel** lifecycle controls, and the schedule-a-new-event form; notes the `events.enabled` gate and that config lives under Settings.
- **Moderation** paragraph: the row columns (time, user, moderator, action, reason, source), name resolution via a single batched member fetch, the `command`/`audit` source distinction, the action + user filters, 50-row pagination, and the `moderation.enabled` gate.

## Type of Change

- [x] 📚 Documentation update

## Related Issues

Fixes #743

## How Has This Been Tested?

Documentation-only change. Verified line lengths against the repo's markdownlint `MD013` config (160-char limit; tables and code blocks excluded) — all added prose is within limit, and the only long lines are table rows, which are excluded.

## Additional Notes

Content derived from the current route/renderer implementations (`src/web/read-only-routes.ts` for both pages, `src/web/admin-views.ts` for the events view, `src/models/moderation-log.ts` for the action/source definitions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1gnd48uW97z5HqSyvPPJS)_