### PR TITLE
feat(webui): add retention cleanup for WebAuditLog

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -1260,6 +1260,23 @@ batched (every few minutes, never per-invocation) and pruned by a TTL index.
 - `monitoring.metrics_retention_days` (number, default: 30) — days to keep
   persisted daily buckets before the TTL index prunes them.
 
+#### Audit Logs (operator visibility)
+
+Two audit trails record who did what and when. Both are cross-cutting
+operator-visibility features rather than user-facing toggles, so they record
+by default; each has a daily cleanup job that prunes rows past its retention
+window (staggered at 03:00 / 03:15 server time to avoid contention).
+
+- `core.command_audit.enabled` (bool, default: true) — record one row per
+  Discord slash-command invocation (who, what, when, outcome). Raw command
+  arguments are never stored.
+- `core.command_audit.retention_days` (number, default: 90) — days to keep
+  slash-command audit rows before the daily cleanup (03:00) prunes them.
+- `core.web_audit.retention_days` (number, default: 90) — days to keep WebUI
+  audit-log rows (one per state-changing WebUI request) before the daily
+  cleanup (03:15) prunes them. Set to `0` to keep history forever. WebUI
+  audit rows are always written, so there is no separate enable toggle.
+
 ### Bootstrap env vars (read-only in Web UI)
 
 - `DISCORD_TOKEN`, `CLIENT_ID`, `GUILD_ID`, `MONGODB_URI`

--- a/__tests__/services/web-audit-cleanup.test.ts
+++ b/__tests__/services/web-audit-cleanup.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+
+const mockGetNumber = jest.fn<(key: string, def: number) => Promise<number>>();
+
+jest.unstable_mockModule("../../src/services/config-service.js", () => ({
+  ConfigService: {
+    getInstance: jest.fn(() => ({
+      getNumber: mockGetNumber,
+    })),
+  },
+}));
+
+const mockDeleteMany = jest.fn<() => Promise<{ deletedCount: number }>>();
+
+jest.unstable_mockModule("../../src/models/web-audit-log.js", () => ({
+  WebAuditLog: { deleteMany: mockDeleteMany },
+}));
+
+jest.unstable_mockModule("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.unstable_mockModule("cron", () => ({
+  CronJob: class {
+    start(): void {}
+    stop(): void {}
+  },
+}));
+
+const { WebAuditLogCleanupService } = await import(
+  "../../src/services/web-audit-cleanup.js"
+);
+
+describe("WebAuditLogCleanupService", () => {
+  beforeEach(() => {
+    WebAuditLogCleanupService.reset();
+    mockGetNumber.mockReset();
+    mockDeleteMany.mockReset();
+  });
+
+  it("is a no-op when retention is zero (keep forever)", async () => {
+    mockGetNumber.mockResolvedValue(0);
+    const result = await WebAuditLogCleanupService.getInstance().runCleanup();
+    expect(result).toBeNull();
+    expect(mockDeleteMany).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when retention is negative", async () => {
+    mockGetNumber.mockResolvedValue(-1);
+    const result = await WebAuditLogCleanupService.getInstance().runCleanup();
+    expect(result).toBeNull();
+    expect(mockDeleteMany).not.toHaveBeenCalled();
+  });
+
+  it("deletes rows older than the configured retention window", async () => {
+    mockGetNumber.mockResolvedValue(7);
+    mockDeleteMany.mockResolvedValue({ deletedCount: 4 });
+
+    const before = Date.now();
+    const result = await WebAuditLogCleanupService.getInstance().runCleanup();
+    const after = Date.now();
+
+    expect(result).toEqual({ deleted: 4 });
+    expect(mockDeleteMany).toHaveBeenCalledTimes(1);
+    const arg = mockDeleteMany.mock.calls[0]?.[0] as {
+      createdAt: { $lt: Date };
+    };
+    const cutoff = arg.createdAt.$lt.getTime();
+    const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+    // Cutoff is "now - 7d" computed inside the service; allow for the
+    // tiny wall-clock drift between the test's bounds and the service call.
+    expect(cutoff).toBeGreaterThanOrEqual(before - sevenDaysMs);
+    expect(cutoff).toBeLessThanOrEqual(after - sevenDaysMs);
+  });
+
+  it("returns null and swallows DB errors", async () => {
+    mockGetNumber.mockResolvedValue(30);
+    mockDeleteMany.mockRejectedValueOnce(new Error("mongo down"));
+    const result = await WebAuditLogCleanupService.getInstance().runCleanup();
+    expect(result).toBeNull();
+  });
+});

--- a/__tests__/services/web-audit-cleanup.test.ts
+++ b/__tests__/services/web-audit-cleanup.test.ts
@@ -25,22 +25,63 @@ jest.unstable_mockModule("../../src/utils/logger.js", () => ({
   },
 }));
 
+// Observable CronJob mock: records every constructed job so the tests can
+// assert on the schedule expression and start/stop lifecycle.
+interface MockCronJob {
+  expression: string;
+  started: boolean;
+  stopped: boolean;
+}
+const cronInstances: MockCronJob[] = [];
+
 jest.unstable_mockModule("cron", () => ({
-  CronJob: class {
-    start(): void {}
-    stop(): void {}
+  CronJob: class implements MockCronJob {
+    expression: string;
+    started = false;
+    stopped = false;
+    constructor(expression: string) {
+      this.expression = expression;
+      cronInstances.push(this);
+    }
+    start(): void {
+      this.started = true;
+    }
+    stop(): void {
+      this.stopped = true;
+    }
   },
 }));
 
-const { WebAuditLogCleanupService } = await import(
-  "../../src/services/web-audit-cleanup.js"
-);
+const { WebAuditLogCleanupService } =
+  await import("../../src/services/web-audit-cleanup.js");
 
 describe("WebAuditLogCleanupService", () => {
   beforeEach(() => {
     WebAuditLogCleanupService.reset();
     mockGetNumber.mockReset();
     mockDeleteMany.mockReset();
+    cronInstances.length = 0;
+  });
+
+  it("schedules a daily job at 03:15 and start() is idempotent", () => {
+    const service = WebAuditLogCleanupService.getInstance();
+    service.start();
+    expect(cronInstances).toHaveLength(1);
+    expect(cronInstances[0]?.expression).toBe("15 3 * * *");
+    expect(cronInstances[0]?.started).toBe(true);
+    // A second start() while a job exists must not schedule a duplicate.
+    service.start();
+    expect(cronInstances).toHaveLength(1);
+  });
+
+  it("destroy() stops the scheduled job and allows a later restart", () => {
+    const service = WebAuditLogCleanupService.getInstance();
+    service.start();
+    service.destroy();
+    expect(cronInstances[0]?.stopped).toBe(true);
+    service.start();
+    expect(cronInstances).toHaveLength(2);
+    expect(cronInstances[1]?.started).toBe(true);
   });
 
   it("is a no-op when retention is zero (keep forever)", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { MessageActivityCleanupService } from "./services/message-activity-clean
 import { ReactionActivityTracker } from "./services/reaction-activity-tracker.js";
 import { PollParticipationTracker } from "./services/poll-participation-tracker.js";
 import { CommandAuditCleanupService } from "./services/command-audit-cleanup.js";
+import { WebAuditLogCleanupService } from "./services/web-audit-cleanup.js";
 import { ModerationLogCleanupService } from "./services/moderation-log-cleanup.js";
 import { ScheduledAnnouncementService } from "./services/scheduled-announcement-service.js";
 import { ChannelInitializer } from "./services/channel-initializer.js";
@@ -496,6 +497,7 @@ async function gracefulShutdown(signal: string): Promise<void> {
         voiceChannelTruncation.destroy();
         messageActivityCleanup.destroy();
         CommandAuditCleanupService.getInstance().destroy();
+        WebAuditLogCleanupService.getInstance().destroy();
         ModerationLogCleanupService.getInstance().destroy();
         await noticesChannelManager.stop();
         pollService.destroy();
@@ -721,6 +723,10 @@ async function initializeServices(): Promise<void> {
 
     // Start the slash-command audit log cleanup cron (#459)
     CommandAuditCleanupService.getInstance().start();
+
+    // Start the WebUI audit log retention cleanup cron (#756). Gates on
+    // `core.web_audit.retention_days` at run time (0 = keep forever).
+    WebAuditLogCleanupService.getInstance().start();
 
     // Start the moderation-log retention cleanup cron (#742). Gates on
     // `moderation.enabled` and `moderation.retention_days` at run time.

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -133,6 +133,9 @@ export interface ConfigSchema {
   "core.command_audit.enabled": boolean;
   "core.command_audit.retention_days": number;
 
+  // WebUI audit log retention (issue #756)
+  "core.web_audit.retention_days": number; // 0 = keep history forever
+
   // Persisted command metrics (issue #648)
   "monitoring.metrics_persistence.enabled": boolean;
   "monitoring.metrics_retention_days": number;
@@ -337,6 +340,12 @@ export const defaultConfig: ConfigSchema = {
   // matches the proposal in the issue (90 days).
   "core.command_audit.enabled": true,
   "core.command_audit.retention_days": 90,
+
+  // WebUI audit log retention default (#756). WebAuditLog rows are written
+  // unconditionally on every state-changing WebUI request, so there's no
+  // enabled toggle — retention alone governs pruning. 90 days matches
+  // command_audit; set to 0 to keep history forever.
+  "core.web_audit.retention_days": 90,
 
   // Persisted command metrics defaults (#648). On by default so fresh
   // installs get historical command analytics in the Admin → Command
@@ -1410,6 +1419,13 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
     label: "Slash-command audit retention (days)",
     description:
       "Days to keep slash-command audit rows before the cleanup job prunes them.",
+    category: "core",
+    type: "number",
+  },
+  "core.web_audit.retention_days": {
+    label: "WebUI audit retention (days)",
+    description:
+      "Days to keep WebUI audit-log rows before the daily cleanup job prunes them. Set to 0 to keep history forever.",
     category: "core",
     type: "number",
   },

--- a/src/services/web-audit-cleanup.ts
+++ b/src/services/web-audit-cleanup.ts
@@ -1,0 +1,80 @@
+import { CronJob } from "cron";
+import logger from "../utils/logger.js";
+import { WebAuditLog } from "../models/web-audit-log.js";
+import { ConfigService } from "./config-service.js";
+
+/**
+ * Periodically prune WebUI audit rows older than
+ * `core.web_audit.retention_days` (issue #756). Runs once a day at 03:15
+ * server time — offset from the command-audit cleanup at 03:00 and the
+ * moderation-log cleanup at 03:30 to avoid contention.
+ *
+ * `WebAuditLog` rows are written unconditionally on every state-changing
+ * WebUI request (there's no `web_audit.enabled` toggle), so unlike its
+ * sibling `CommandAuditCleanupService` this job gates only on retention:
+ * a zero or negative value is the documented "keep history forever"
+ * setting and makes the job a no-op.
+ */
+export class WebAuditLogCleanupService {
+  private static instance: WebAuditLogCleanupService;
+  private configService: ConfigService;
+  private job: CronJob | null = null;
+
+  private constructor() {
+    this.configService = ConfigService.getInstance();
+  }
+
+  public static getInstance(): WebAuditLogCleanupService {
+    if (!WebAuditLogCleanupService.instance) {
+      WebAuditLogCleanupService.instance = new WebAuditLogCleanupService();
+    }
+    return WebAuditLogCleanupService.instance;
+  }
+
+  public static reset(): void {
+    WebAuditLogCleanupService.instance =
+      undefined as unknown as WebAuditLogCleanupService;
+  }
+
+  public start(): void {
+    if (this.job) return;
+    this.job = new CronJob("15 3 * * *", () => {
+      this.runCleanup().catch((err) => {
+        logger.error("Web audit cleanup failed:", err);
+      });
+    });
+    this.job.start();
+    logger.info("Web audit cleanup scheduled (daily at 03:15)");
+  }
+
+  public destroy(): void {
+    if (this.job) {
+      this.job.stop();
+      this.job = null;
+    }
+  }
+
+  public async runCleanup(): Promise<{ deleted: number } | null> {
+    const retentionDays = await this.configService
+      .getNumber("core.web_audit.retention_days", 90)
+      .catch(() => 90);
+    if (!Number.isFinite(retentionDays) || retentionDays <= 0) return null;
+
+    const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+    try {
+      const result = await WebAuditLog.deleteMany({
+        createdAt: { $lt: cutoff },
+      });
+      const deleted = result.deletedCount ?? 0;
+      if (deleted > 0) {
+        logger.info(
+          `Web audit cleanup removed ${deleted} rows older than ${retentionDays}d`,
+        );
+      }
+      return { deleted };
+    } catch (err) {
+      logger.error("Web audit deleteMany failed:", err);
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
## Description

`WebAuditLog` (`src/models/web-audit-log.ts`, written from `src/web/audit.ts` on every state-changing WebUI request) grew unbounded: no cleanup job anywhere in `src/services/` referenced it, and there was no retention config key — unlike its sibling `DiscordCommandAuditLog`, which has a dedicated `CommandAuditCleanupService`.

This adds a `WebAuditLogCleanupService` following the exact pattern already established in `command-audit-cleanup.ts`:

- New config key `core.web_audit.retention_days` (default `90`, matching `command_audit`; `0` = keep history forever). Declared in the schema interface, `DEFAULT_CONFIG`, and the schema metadata in `config-schema.ts`.
- `WebAuditLogCleanupService` runs a daily cron at **03:15** server time — staggered from command-audit (03:00) and moderation (03:30) to avoid contention. Wired into `src/index.ts` (`start()` on boot, `destroy()` on shutdown).
- Because `WebAuditLog` rows are written unconditionally (there is no `web_audit.enabled` toggle), the job gates on retention alone — a zero/negative value is the documented "keep forever" no-op, consistent with `moderation.retention_days` (#742).
- Documented the new key in `SETTINGS.md`.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Related Issues

Closes #756

## How Has This Been Tested?

- [x] Existing tests pass (`npm run test:ci` — 132 suites, 1625 passed, coverage thresholds hold)
- [x] Added new tests for new functionality (`__tests__/services/web-audit-cleanup.test.ts` — no-op on zero/negative retention, deletes rows older than the window, swallows DB errors)
- [x] `npm run build`, `npm run lint`, `npm run format:check`, and `markdownlint SETTINGS.md` all pass

## Checklist

### Configuration

- [x] New configuration key added to `config-schema.ts` (interface, defaults, metadata)
- [x] Documented new configuration key in `SETTINGS.md`
- [x] Follows the established gating pattern; `0` retention is a safe no-op

## Additional Notes

Same unbounded-growth pattern tracked for the moderation log in #742, applied here to the WebUI audit trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDGDhkorBUPWjAQRKvz9o4)_