### PR TITLE
feat(voicetracking): extend weekly recap with quote of the week and poll turnout

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -379,13 +379,20 @@ Excluded channels won't count toward leaderboards or statistics.
 
 ### Voice channel statistics announcements
 
-Automated weekly voice channel statistics post.
+Automated weekly recap post. The top voice-time leaderboard is the core
+section; when their own features are enabled, the recap also includes accolades
+earned, the quote of the week, and poll turnout. Each section can be toggled
+independently.
 
 | Setting | Default | Description |
 | --- | --- | --- |
-| `voicetracking.announcements.enabled` | `false` | Enable weekly stats announcements |
+| `voicetracking.announcements.enabled` | `false` | Enable the weekly recap |
 | `voicetracking.announcements.channel` | `"voice-stats"` | Channel name or ID for announcements |
 | `voicetracking.announcements.schedule` | `"0 16 * * 5"` | Cron schedule (default: Fridays 4 PM) |
+| `voicetracking.announcements.include_voice_stats` | `true` | Include the top voice-time leaderboard |
+| `voicetracking.announcements.include_accolades` | `true` | Include accolades earned this week (needs achievements + achievement announcements enabled) |
+| `voicetracking.announcements.include_quote_of_week` | `true` | Include the most-liked quote added this week (needs quotes enabled) |
+| `voicetracking.announcements.include_poll_turnout` | `true` | Include how many members voted in polls this week (needs poll participation tracking enabled) |
 
 To trigger one out of schedule, use the **Post weekly stats now** button
 on the Web UI's Announcements page (replaces the old
@@ -1182,6 +1189,10 @@ leave the graph in a broken state.
 - `voicetracking.announcements.enabled` (bool, default: false)
 - `voicetracking.announcements.channel` (string, default: "voice-stats")
 - `voicetracking.announcements.schedule` (string, default: `"0 16 * * 5"`)
+- `voicetracking.announcements.include_voice_stats` (bool, default: true)
+- `voicetracking.announcements.include_accolades` (bool, default: true)
+- `voicetracking.announcements.include_quote_of_week` (bool, default: true)
+- `voicetracking.announcements.include_poll_turnout` (bool, default: true)
 - `announcements.enabled` (bool, default: false)
 
 #### Achievements

--- a/__tests__/handlers/vc-modal-handler.test.ts
+++ b/__tests__/handlers/vc-modal-handler.test.ts
@@ -138,9 +138,7 @@ describe("VCModalHandler - Custom Name Tracking", () => {
     beforeEach(() => {
       // The feature gate reads real ConfigService (backed by mocked mongoose,
       // whose schema default disables presets) — force it on for these tests.
-      jest
-        .spyOn(ConfigService.prototype, "getBoolean")
-        .mockResolvedValue(true);
+      jest.spyOn(ConfigService.prototype, "getBoolean").mockResolvedValue(true);
       mockService = {
         getPrefs: jest.fn(),
         renamePreset: jest.fn(),

--- a/__tests__/models/moderation-log.test.ts
+++ b/__tests__/models/moderation-log.test.ts
@@ -15,12 +15,7 @@ describe("ModerationLog model", () => {
       userId: "u1",
       moderatorId: "m1" as string | null,
       action: "warn" as
-        | "warn"
-        | "kick"
-        | "ban"
-        | "unban"
-        | "timeout"
-        | "untimeout",
+        "warn" | "kick" | "ban" | "unban" | "timeout" | "untimeout",
       reason: "spamming" as string | null,
       source: "command" as "command" | "audit",
       createdAt: new Date(),

--- a/__tests__/models/user-voice-preferences.test.ts
+++ b/__tests__/models/user-voice-preferences.test.ts
@@ -21,7 +21,12 @@ describe("UserVoicePreferences Model Schema", () => {
         userId: "test-user-123",
         namePattern: "{username}'s Room",
         presets: [
-          { name: "Squad", channelName: "Squad HQ", userLimit: 10, bitrate: 96 },
+          {
+            name: "Squad",
+            channelName: "Squad HQ",
+            userLimit: 10,
+            bitrate: 96,
+          },
         ],
       };
 

--- a/__tests__/services/achievements-service.test.ts
+++ b/__tests__/services/achievements-service.test.ts
@@ -659,7 +659,11 @@ describe("AchievementsService", () => {
       >["mockConfigService"],
       opts: { enabled?: boolean; channelId?: string; guildId?: string } = {},
     ) {
-      const { enabled = true, channelId = "chan-1", guildId = "guild-1" } = opts;
+      const {
+        enabled = true,
+        channelId = "chan-1",
+        guildId = "guild-1",
+      } = opts;
       mockConfigService.getBoolean.mockResolvedValue(enabled);
       (mockConfigService.getString as jest.Mock).mockImplementation(
         (key: unknown) => {

--- a/__tests__/services/achievements-timezone.test.ts
+++ b/__tests__/services/achievements-timezone.test.ts
@@ -1,12 +1,17 @@
-import { describe, it, expect, jest, beforeEach } from '@jest/globals';
-import type { Client } from 'discord.js';
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import type { Client } from "discord.js";
 
 // Rely on the global mongoose mock from setup.ts.
-jest.mock('../../src/utils/logger.js', () => ({
-  default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+jest.mock("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
 }));
 
-jest.mock('../../src/services/quote-service.js', () => ({
+jest.mock("../../src/services/quote-service.js", () => ({
   quoteService: {
     getQuotesAuthoredByUser: jest.fn().mockResolvedValue(0),
     getQuotesAddedByUser: jest.fn().mockResolvedValue(0),
@@ -14,9 +19,9 @@ jest.mock('../../src/services/quote-service.js', () => ({
   },
 }));
 
-import { AchievementsService } from '../../src/services/achievements-service.js';
-import { UserNotificationPrefsService } from '../../src/services/user-notification-prefs-service.js';
-import type { IVoiceChannelTracking } from '../../src/models/voice-channel-tracking.js';
+import { AchievementsService } from "../../src/services/achievements-service.js";
+import { UserNotificationPrefsService } from "../../src/services/user-notification-prefs-service.js";
+import type { IVoiceChannelTracking } from "../../src/models/voice-channel-tracking.js";
 
 // Closure shapes — the accolade logic now takes a trailing `timeZone` arg (#658).
 type CheckFn = (
@@ -37,12 +42,12 @@ function makeService(): {
   const mockClient = { users: { fetch: jest.fn() } } as unknown as Client;
   const service = AchievementsService.getInstance(mockClient);
   const mockConfigService = {
-    getString: jest.fn().mockResolvedValue('guild-1'),
+    getString: jest.fn().mockResolvedValue("guild-1"),
     getBoolean: jest.fn().mockResolvedValue(true),
     getNumber: jest.fn().mockResolvedValue(0),
   };
-  (service as never)['configService'] = mockConfigService;
-  (service as never)['isConnected'] = true;
+  (service as never)["configService"] = mockConfigService;
+  (service as never)["isConnected"] = true;
   return { service, mockConfigService };
 }
 
@@ -50,8 +55,8 @@ function trackingWith(
   sessions: Array<{ startTime: Date; endTime?: Date; duration?: number }>,
 ): IVoiceChannelTracking {
   return {
-    userId: 'user123',
-    username: 'TestUser',
+    userId: "user123",
+    username: "TestUser",
     totalTime: 0,
     sessions,
   } as unknown as IVoiceChannelTracking;
@@ -60,173 +65,172 @@ function trackingWith(
 function accoladeLogic(
   service: AchievementsService,
 ): Record<string, { checkFunction: CheckFn; metadataFunction?: MetaFn }> {
-  return (service as never)['accoladeLogic'];
+  return (service as never)["accoladeLogic"];
 }
 
-describe('AchievementsService timezone-aware accolades (#658)', () => {
+describe("AchievementsService timezone-aware accolades (#658)", () => {
   beforeEach(() => {
     jest.restoreAllMocks();
-    (AchievementsService as unknown as { instance: unknown }).instance = undefined;
-    (UserNotificationPrefsService as unknown as { instance: unknown }).instance = null;
+    (AchievementsService as unknown as { instance: unknown }).instance =
+      undefined;
+    (
+      UserNotificationPrefsService as unknown as { instance: unknown }
+    ).instance = null;
   });
 
-  describe('time-of-day windows (Night Owl / Early Bird)', () => {
+  describe("time-of-day windows (Night Owl / Early Bird)", () => {
     // 12:00–16:00 UTC: daytime in UTC, but 00:00–04:00 in Auckland (+12),
     // which lands entirely in the late-night window (22:00–06:00).
     const session = {
-      startTime: new Date('2026-06-22T12:00:00Z'),
-      endTime: new Date('2026-06-22T16:00:00Z'),
+      startTime: new Date("2026-06-22T12:00:00Z"),
+      endTime: new Date("2026-06-22T16:00:00Z"),
       duration: 4 * 3600,
     };
 
-    it('counts no late-night hours under the UTC default', async () => {
+    it("counts no late-night hours under the UTC default", async () => {
       const { service } = makeService();
       const meta = await accoladeLogic(service).night_owl.metadataFunction!(
-        'user123',
+        "user123",
         trackingWith([session]),
-        'UTC',
+        "UTC",
       );
       expect(meta.value).toBe(0);
     });
 
-    it('counts the session as late-night in the user timezone', async () => {
+    it("counts the session as late-night in the user timezone", async () => {
       const { service } = makeService();
       const meta = await accoladeLogic(service).night_owl.metadataFunction!(
-        'user123',
+        "user123",
         trackingWith([session]),
-        'Pacific/Auckland',
+        "Pacific/Auckland",
       );
       expect(meta.value).toBe(4);
     });
 
-    it('buckets early-morning hours in the user timezone', async () => {
+    it("buckets early-morning hours in the user timezone", async () => {
       const { service } = makeService();
       // 18:00–22:00 UTC → 06:00–10:00 in Auckland (early-morning window).
       const early = {
-        startTime: new Date('2026-06-22T18:00:00Z'),
-        endTime: new Date('2026-06-22T22:00:00Z'),
+        startTime: new Date("2026-06-22T18:00:00Z"),
+        endTime: new Date("2026-06-22T22:00:00Z"),
         duration: 4 * 3600,
       };
       const utc = await accoladeLogic(service).early_bird.metadataFunction!(
-        'user123',
+        "user123",
         trackingWith([early]),
-        'UTC',
+        "UTC",
       );
       const akl = await accoladeLogic(service).early_bird.metadataFunction!(
-        'user123',
+        "user123",
         trackingWith([early]),
-        'Pacific/Auckland',
+        "Pacific/Auckland",
       );
       expect(utc.value).toBe(0);
       expect(akl.value).toBe(4);
     });
   });
 
-  describe('day-of-week (Weekend / Weekday Warrior)', () => {
+  describe("day-of-week (Weekend / Weekday Warrior)", () => {
     // Friday 23:00 UTC is still Friday in UTC, but Saturday in Auckland (+12).
     const session = {
-      startTime: new Date('2026-06-19T23:00:00Z'),
+      startTime: new Date("2026-06-19T23:00:00Z"),
       duration: 3600,
     };
 
-    it('treats the session as a weekday under the UTC default', async () => {
+    it("treats the session as a weekday under the UTC default", async () => {
       const { service } = makeService();
-      const weekend = await accoladeLogic(service).weekend_warrior.metadataFunction!(
-        'user123',
-        trackingWith([session]),
-        'UTC',
-      );
-      const weekday = await accoladeLogic(service).weekday_warrior.metadataFunction!(
-        'user123',
-        trackingWith([session]),
-        'UTC',
-      );
+      const weekend = await accoladeLogic(service).weekend_warrior
+        .metadataFunction!("user123", trackingWith([session]), "UTC");
+      const weekday = await accoladeLogic(service).weekday_warrior
+        .metadataFunction!("user123", trackingWith([session]), "UTC");
       expect(weekend.value).toBe(0);
       expect(weekday.value).toBe(1);
     });
 
-    it('treats the session as a weekend day in the user timezone', async () => {
+    it("treats the session as a weekend day in the user timezone", async () => {
       const { service } = makeService();
-      const weekend = await accoladeLogic(service).weekend_warrior.metadataFunction!(
-        'user123',
+      const weekend = await accoladeLogic(service).weekend_warrior
+        .metadataFunction!(
+        "user123",
         trackingWith([session]),
-        'Pacific/Auckland',
+        "Pacific/Auckland",
       );
-      const weekday = await accoladeLogic(service).weekday_warrior.metadataFunction!(
-        'user123',
+      const weekday = await accoladeLogic(service).weekday_warrior
+        .metadataFunction!(
+        "user123",
         trackingWith([session]),
-        'Pacific/Auckland',
+        "Pacific/Auckland",
       );
       expect(weekend.value).toBe(1);
       expect(weekday.value).toBe(0);
     });
   });
 
-  describe('consistency streaks', () => {
+  describe("consistency streaks", () => {
     // Two sessions on the same UTC calendar day, but split across two
     // consecutive days in Los Angeles (UTC-7): 18:00 on the 21st and
     // 06:00 on the 22nd.
     const sessions = [
-      { startTime: new Date('2026-06-22T01:00:00Z'), duration: 600 },
-      { startTime: new Date('2026-06-22T13:00:00Z'), duration: 600 },
+      { startTime: new Date("2026-06-22T01:00:00Z"), duration: 600 },
+      { startTime: new Date("2026-06-22T13:00:00Z"), duration: 600 },
     ];
 
-    it('buckets both sessions into one day under the UTC default', async () => {
+    it("buckets both sessions into one day under the UTC default", async () => {
       const { service } = makeService();
-      const meta = await accoladeLogic(service).consistent_week.metadataFunction!(
-        'user123',
-        trackingWith(sessions),
-        'UTC',
-      );
+      const meta = await accoladeLogic(service).consistent_week
+        .metadataFunction!("user123", trackingWith(sessions), "UTC");
       expect(meta.value).toBe(1);
     });
 
-    it('splits the sessions across two local days, forming a 2-day streak', async () => {
+    it("splits the sessions across two local days, forming a 2-day streak", async () => {
       const { service } = makeService();
-      const meta = await accoladeLogic(service).consistent_week.metadataFunction!(
-        'user123',
+      const meta = await accoladeLogic(service).consistent_week
+        .metadataFunction!(
+        "user123",
         trackingWith(sessions),
-        'America/Los_Angeles',
+        "America/Los_Angeles",
       );
       expect(meta.value).toBe(2);
     });
   });
 
-  describe('resolveUserTimezone', () => {
-    const resolve = (service: AchievementsService): ((userId: string) => Promise<string>) =>
-      (service as never)['resolveUserTimezone'].bind(service);
+  describe("resolveUserTimezone", () => {
+    const resolve = (
+      service: AchievementsService,
+    ): ((userId: string) => Promise<string>) =>
+      (service as never)["resolveUserTimezone"].bind(service);
 
-    it('returns the stored valid timezone when set', async () => {
+    it("returns the stored valid timezone when set", async () => {
       const { service } = makeService();
       jest
-        .spyOn(UserNotificationPrefsService.prototype, 'getTimezone')
-        .mockResolvedValue('Pacific/Auckland');
-      expect(await resolve(service)('user123')).toBe('Pacific/Auckland');
+        .spyOn(UserNotificationPrefsService.prototype, "getTimezone")
+        .mockResolvedValue("Pacific/Auckland");
+      expect(await resolve(service)("user123")).toBe("Pacific/Auckland");
     });
 
-    it('falls back to UTC when no timezone is set', async () => {
+    it("falls back to UTC when no timezone is set", async () => {
       const { service } = makeService();
       jest
-        .spyOn(UserNotificationPrefsService.prototype, 'getTimezone')
+        .spyOn(UserNotificationPrefsService.prototype, "getTimezone")
         .mockResolvedValue(null);
-      expect(await resolve(service)('user123')).toBe('UTC');
+      expect(await resolve(service)("user123")).toBe("UTC");
     });
 
-    it('falls back to UTC when an invalid timezone is stored', async () => {
+    it("falls back to UTC when an invalid timezone is stored", async () => {
       const { service } = makeService();
       jest
-        .spyOn(UserNotificationPrefsService.prototype, 'getTimezone')
-        .mockResolvedValue('Not/AZone');
-      expect(await resolve(service)('user123')).toBe('UTC');
+        .spyOn(UserNotificationPrefsService.prototype, "getTimezone")
+        .mockResolvedValue("Not/AZone");
+      expect(await resolve(service)("user123")).toBe("UTC");
     });
 
-    it('falls back to UTC when no guild id is configured', async () => {
+    it("falls back to UTC when no guild id is configured", async () => {
       const { service, mockConfigService } = makeService();
-      mockConfigService.getString.mockResolvedValue('');
+      mockConfigService.getString.mockResolvedValue("");
       const spy = jest
-        .spyOn(UserNotificationPrefsService.prototype, 'getTimezone')
-        .mockResolvedValue('Pacific/Auckland');
-      expect(await resolve(service)('user123')).toBe('UTC');
+        .spyOn(UserNotificationPrefsService.prototype, "getTimezone")
+        .mockResolvedValue("Pacific/Auckland");
+      expect(await resolve(service)("user123")).toBe("UTC");
       expect(spy).not.toHaveBeenCalled();
     });
   });

--- a/__tests__/services/birthday-service.test.ts
+++ b/__tests__/services/birthday-service.test.ts
@@ -155,18 +155,48 @@ describe("birthday pure helpers", () => {
 
   describe("isBirthdayToday", () => {
     it("matches the exact month/day", () => {
-      expect(isBirthdayToday({ month: 3, day: 14 }, { year: 2026, month: 3, day: 14 })).toBe(true);
-      expect(isBirthdayToday({ month: 3, day: 14 }, { year: 2026, month: 3, day: 15 })).toBe(false);
+      expect(
+        isBirthdayToday(
+          { month: 3, day: 14 },
+          { year: 2026, month: 3, day: 14 },
+        ),
+      ).toBe(true);
+      expect(
+        isBirthdayToday(
+          { month: 3, day: 14 },
+          { year: 2026, month: 3, day: 15 },
+        ),
+      ).toBe(false);
     });
     it("celebrates a Feb 29 birthday on Mar 1 in non-leap years", () => {
       // 2026 is not a leap year.
-      expect(isBirthdayToday({ month: 2, day: 29 }, { year: 2026, month: 3, day: 1 })).toBe(true);
-      expect(isBirthdayToday({ month: 2, day: 29 }, { year: 2026, month: 2, day: 28 })).toBe(false);
+      expect(
+        isBirthdayToday(
+          { month: 2, day: 29 },
+          { year: 2026, month: 3, day: 1 },
+        ),
+      ).toBe(true);
+      expect(
+        isBirthdayToday(
+          { month: 2, day: 29 },
+          { year: 2026, month: 2, day: 28 },
+        ),
+      ).toBe(false);
     });
     it("celebrates a Feb 29 birthday on Feb 29 in leap years (not Mar 1)", () => {
       // 2028 is a leap year.
-      expect(isBirthdayToday({ month: 2, day: 29 }, { year: 2028, month: 2, day: 29 })).toBe(true);
-      expect(isBirthdayToday({ month: 2, day: 29 }, { year: 2028, month: 3, day: 1 })).toBe(false);
+      expect(
+        isBirthdayToday(
+          { month: 2, day: 29 },
+          { year: 2028, month: 2, day: 29 },
+        ),
+      ).toBe(true);
+      expect(
+        isBirthdayToday(
+          { month: 2, day: 29 },
+          { year: 2028, month: 3, day: 1 },
+        ),
+      ).toBe(false);
     });
   });
 
@@ -175,17 +205,26 @@ describe("birthday pure helpers", () => {
     it("announces when it's the birthday and not yet announced this year", () => {
       expect(shouldAnnounceBirthday({ month: 5, day: 10 }, local)).toBe(true);
       expect(
-        shouldAnnounceBirthday({ month: 5, day: 10, lastAnnouncedYear: 2025 }, local),
+        shouldAnnounceBirthday(
+          { month: 5, day: 10, lastAnnouncedYear: 2025 },
+          local,
+        ),
       ).toBe(true);
     });
     it("suppresses a second announcement in the same local year", () => {
       expect(
-        shouldAnnounceBirthday({ month: 5, day: 10, lastAnnouncedYear: 2026 }, local),
+        shouldAnnounceBirthday(
+          { month: 5, day: 10, lastAnnouncedYear: 2026 },
+          local,
+        ),
       ).toBe(false);
     });
     it("does not announce when it isn't the birthday regardless of guard", () => {
       expect(
-        shouldAnnounceBirthday({ month: 5, day: 11, lastAnnouncedYear: 2025 }, local),
+        shouldAnnounceBirthday(
+          { month: 5, day: 11, lastAnnouncedYear: 2025 },
+          local,
+        ),
       ).toBe(false);
     });
   });
@@ -231,15 +270,19 @@ describe("BirthdayService", () => {
       if (k === "birthdays.mention") return true;
       return false;
     });
-    mockConfigGetString.mockImplementation(async (key: unknown, def: unknown) => {
-      const k = key as string;
-      if (k === "GUILD_ID") return "guild-1";
-      if (k === "birthdays.cron") return "0 * * * *";
-      return (def as string) ?? "";
-    });
-    mockConfigGetNumber.mockImplementation(async (key: unknown, def: unknown) => {
-      return (def as number) ?? 0;
-    });
+    mockConfigGetString.mockImplementation(
+      async (key: unknown, def: unknown) => {
+        const k = key as string;
+        if (k === "GUILD_ID") return "guild-1";
+        if (k === "birthdays.cron") return "0 * * * *";
+        return (def as string) ?? "";
+      },
+    );
+    mockConfigGetNumber.mockImplementation(
+      async (key: unknown, def: unknown) => {
+        return (def as number) ?? 0;
+      },
+    );
     mockGetTimezone.mockResolvedValue(null);
   });
 
@@ -463,8 +506,7 @@ describe("BirthdayService", () => {
       const row = {
         userId: "user-3",
         roleAssignedAt: new Date(now.getTime() - 1 * MS_PER_HOUR) as
-          | Date
-          | undefined,
+          Date | undefined,
         save: jest.fn().mockResolvedValue(undefined),
       };
       mockBirthdayFind.mockResolvedValue([row]);

--- a/__tests__/services/bot-status-pools.test.ts
+++ b/__tests__/services/bot-status-pools.test.ts
@@ -60,8 +60,7 @@ describe("BotStatusService status pools", () => {
   const presenceName = (): string | undefined => {
     const calls = setPresence.mock.calls;
     const last = calls[calls.length - 1]?.[0] as
-      | { activities?: Array<{ name?: string }> }
-      | undefined;
+      { activities?: Array<{ name?: string }> } | undefined;
     return last?.activities?.[0]?.name;
   };
 

--- a/__tests__/services/message-activity-cleanup.test.ts
+++ b/__tests__/services/message-activity-cleanup.test.ts
@@ -104,9 +104,8 @@ describe("MessageActivityCleanupService", () => {
     expect(update.$set).toEqual({ lastCleanupDate: expect.any(Date) });
 
     // The cutoff honours the configured retention window (400 days).
-    const cutoff = (
-      update.$pull.recentMessages as { sentAt: { $lt: Date } }
-    ).sentAt.$lt;
+    const cutoff = (update.$pull.recentMessages as { sentAt: { $lt: Date } })
+      .sentAt.$lt;
     const expectedCutoff = Date.now() - 400 * DAY_MS;
     expect(Math.abs(cutoff.getTime() - expectedCutoff)).toBeLessThan(60_000);
 

--- a/__tests__/services/moderation-service.test.ts
+++ b/__tests__/services/moderation-service.test.ts
@@ -53,9 +53,8 @@ jest.unstable_mockModule("../../src/utils/log-sanitize.js", () => ({
   sanitizeForLog: (v: unknown) => String(v),
 }));
 
-const { ModerationService, mapAuditLogEntry } = await import(
-  "../../src/services/moderation-service.js"
-);
+const { ModerationService, mapAuditLogEntry } =
+  await import("../../src/services/moderation-service.js");
 
 // A distinct fake client per test keeps the getInstance singleton from
 // leaking a stale client across the suite.
@@ -74,7 +73,9 @@ describe("mapAuditLogEntry", () => {
   const base = { reason: "spam", changes: [] as never[] };
 
   it("maps kick / ban / unban actions", () => {
-    expect(mapAuditLogEntry({ ...base, action: AuditLogEvent.MemberKick })).toEqual({
+    expect(
+      mapAuditLogEntry({ ...base, action: AuditLogEvent.MemberKick }),
+    ).toEqual({
       action: "kick",
       reason: "spam",
     });

--- a/__tests__/services/poll-participation-tracker.test.ts
+++ b/__tests__/services/poll-participation-tracker.test.ts
@@ -141,9 +141,8 @@ describe("PollParticipationTracker", () => {
     let findOne: jest.Mock;
 
     beforeEach(() => {
-      findOne = (
-        PollParticipationTracking as unknown as { findOne: jest.Mock }
-      ).findOne;
+      findOne = (PollParticipationTracking as unknown as { findOne: jest.Mock })
+        .findOne;
     });
 
     it("returns lifetime, this-year, and last-voted from the row", async () => {

--- a/__tests__/services/poll-participation-tracker.test.ts
+++ b/__tests__/services/poll-participation-tracker.test.ts
@@ -18,6 +18,9 @@ import { PollParticipationTracking } from "../../src/models/poll-participation-t
   jest.fn();
 (PollParticipationTracking as unknown as { findOne: jest.Mock }).findOne =
   jest.fn();
+(
+  PollParticipationTracking as unknown as { countDocuments: jest.Mock }
+).countDocuments = jest.fn();
 
 // Mirror the model's `findOne(...).lean()` chain used by
 // `getParticipationSummary`.
@@ -205,6 +208,38 @@ describe("PollParticipationTracker", () => {
 
       const summary = await tracker.getParticipationSummary("voter1", "guild1");
       expect(summary).toBeNull();
+    });
+  });
+
+  describe("getRecentVoterCount (#777)", () => {
+    let countDocuments: jest.Mock;
+
+    beforeEach(() => {
+      countDocuments = (
+        PollParticipationTracking as unknown as { countDocuments: jest.Mock }
+      ).countDocuments;
+    });
+
+    it("counts members whose last vote falls within the window", async () => {
+      const { tracker } = createTracker({ username: "Voter", bot: false });
+      countDocuments.mockResolvedValue(4);
+      const since = new Date("2026-08-06T00:00:00Z");
+
+      const count = await tracker.getRecentVoterCount("guild1", since);
+
+      expect(countDocuments).toHaveBeenCalledWith({
+        guildId: "guild1",
+        lastVoteAt: { $gte: since },
+      });
+      expect(count).toBe(4);
+    });
+
+    it("degrades to 0 on a DB error", async () => {
+      const { tracker } = createTracker({ username: "Voter", bot: false });
+      countDocuments.mockRejectedValue(new Error("DB error"));
+
+      const count = await tracker.getRecentVoterCount("guild1", new Date());
+      expect(count).toBe(0);
     });
   });
 });

--- a/__tests__/services/quote-service.test.ts
+++ b/__tests__/services/quote-service.test.ts
@@ -78,4 +78,31 @@ describe("QuoteService", () => {
       expect(quoteService.getAllQuotes.length).toBe(0);
     });
   });
+
+  describe("getTopQuoteSince (#777)", () => {
+    it("queries most-liked quote added since the window, likes > 0", async () => {
+      const sort = jest.fn().mockResolvedValue({ content: "hi", likes: 5 });
+      const findOne = jest.fn().mockReturnValue({ sort });
+      (quoteService as never)["model"] = { findOne };
+
+      const since = new Date("2026-08-06T00:00:00Z");
+      const result = await quoteService.getTopQuoteSince(since);
+
+      expect(findOne).toHaveBeenCalledWith({
+        createdAt: { $gte: since },
+        likes: { $gt: 0 },
+      });
+      expect(sort).toHaveBeenCalledWith({ likes: -1 });
+      expect(result).toEqual({ content: "hi", likes: 5 });
+    });
+
+    it("returns null when no qualifying quote exists", async () => {
+      const sort = jest.fn().mockResolvedValue(null);
+      const findOne = jest.fn().mockReturnValue({ sort });
+      (quoteService as never)["model"] = { findOne };
+
+      const result = await quoteService.getTopQuoteSince(new Date());
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/__tests__/services/rewind-service.test.ts
+++ b/__tests__/services/rewind-service.test.ts
@@ -1891,9 +1891,7 @@ describe("RewindService reaction helpers (#653)", () => {
     });
 
     it("does not mark hasData when the requested year has no votes", async () => {
-      mockFindOnePoll.mockReturnValueOnce(
-        lean({ yearlyVotes: { "2024": 5 } }),
-      );
+      mockFindOnePoll.mockReturnValueOnce(lean({ yearlyVotes: { "2024": 5 } }));
 
       const summary = await makeSvc().getSummary("u1", "g1", 2026);
       expect(summary!.hasData).toBe(false);

--- a/__tests__/services/scheduled-announcement-post-now.test.ts
+++ b/__tests__/services/scheduled-announcement-post-now.test.ts
@@ -33,9 +33,8 @@ describe("ScheduledAnnouncementService.postAnnouncementNow", () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    const { ScheduledAnnouncementService } = await import(
-      "../../src/services/scheduled-announcement-service.js"
-    );
+    const { ScheduledAnnouncementService } =
+      await import("../../src/services/scheduled-announcement-service.js");
     ScheduledAnnouncementService.reset();
 
     mockClient = {
@@ -46,9 +45,8 @@ describe("ScheduledAnnouncementService.postAnnouncementNow", () => {
 
   it("returns false when the announcement does not exist", async () => {
     findById.mockResolvedValue(null);
-    const { ScheduledAnnouncementService } = await import(
-      "../../src/services/scheduled-announcement-service.js"
-    );
+    const { ScheduledAnnouncementService } =
+      await import("../../src/services/scheduled-announcement-service.js");
     const service = ScheduledAnnouncementService.getInstance(
       mockClient as Client,
     );
@@ -68,9 +66,8 @@ describe("ScheduledAnnouncementService.postAnnouncementNow", () => {
       message: "hi",
       placeholders: false,
     });
-    const { ScheduledAnnouncementService } = await import(
-      "../../src/services/scheduled-announcement-service.js"
-    );
+    const { ScheduledAnnouncementService } =
+      await import("../../src/services/scheduled-announcement-service.js");
     const service = ScheduledAnnouncementService.getInstance(
       mockClient as Client,
     );

--- a/__tests__/services/scheduled-announcement-service.test.ts
+++ b/__tests__/services/scheduled-announcement-service.test.ts
@@ -33,9 +33,8 @@ describe("ScheduledAnnouncementService.getAnnouncement", () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    const { ScheduledAnnouncementService } = await import(
-      "../../src/services/scheduled-announcement-service.js"
-    );
+    const { ScheduledAnnouncementService } =
+      await import("../../src/services/scheduled-announcement-service.js");
     ScheduledAnnouncementService.reset();
 
     mockClient = {
@@ -47,9 +46,8 @@ describe("ScheduledAnnouncementService.getAnnouncement", () => {
   it("returns the announcement when findById resolves", async () => {
     const announcement = { _id: "a1", guildId: "g1" };
     findById.mockResolvedValue(announcement);
-    const { ScheduledAnnouncementService } = await import(
-      "../../src/services/scheduled-announcement-service.js"
-    );
+    const { ScheduledAnnouncementService } =
+      await import("../../src/services/scheduled-announcement-service.js");
     const service = ScheduledAnnouncementService.getInstance(
       mockClient as Client,
     );
@@ -63,9 +61,8 @@ describe("ScheduledAnnouncementService.getAnnouncement", () => {
     const castError = new Error("Cast to ObjectId failed");
     castError.name = "CastError";
     findById.mockImplementation(() => Promise.reject(castError));
-    const { ScheduledAnnouncementService } = await import(
-      "../../src/services/scheduled-announcement-service.js"
-    );
+    const { ScheduledAnnouncementService } =
+      await import("../../src/services/scheduled-announcement-service.js");
     const service = ScheduledAnnouncementService.getInstance(
       mockClient as Client,
     );
@@ -77,9 +74,8 @@ describe("ScheduledAnnouncementService.getAnnouncement", () => {
     findById.mockImplementation(() =>
       Promise.reject(new Error("connection timed out")),
     );
-    const { ScheduledAnnouncementService } = await import(
-      "../../src/services/scheduled-announcement-service.js"
-    );
+    const { ScheduledAnnouncementService } =
+      await import("../../src/services/scheduled-announcement-service.js");
     const service = ScheduledAnnouncementService.getInstance(
       mockClient as Client,
     );

--- a/__tests__/services/user-voice-prefs-service.test.ts
+++ b/__tests__/services/user-voice-prefs-service.test.ts
@@ -150,18 +150,18 @@ describe("UserVoicePrefsService preset CRUD", () => {
       presets: [{ name: "a" }, { name: "b" }, { name: "c" }],
     });
     stubGetPrefs(doc);
-    await expect(
-      service.savePreset("u1", "d", {}, 3),
-    ).rejects.toBeInstanceOf(VoicePrefsValidationError);
+    await expect(service.savePreset("u1", "d", {}, 3)).rejects.toBeInstanceOf(
+      VoicePrefsValidationError,
+    );
     expect(doc.save).not.toHaveBeenCalled();
   });
 
   it("savePreset rejects an empty name", async () => {
     const doc = makeDoc();
     stubGetPrefs(doc);
-    await expect(
-      service.savePreset("u1", "   ", {}, 3),
-    ).rejects.toBeInstanceOf(VoicePrefsValidationError);
+    await expect(service.savePreset("u1", "   ", {}, 3)).rejects.toBeInstanceOf(
+      VoicePrefsValidationError,
+    );
   });
 
   it("editPreset validates bounds and updates fields", async () => {

--- a/__tests__/services/voice-activity-analytics.test.ts
+++ b/__tests__/services/voice-activity-analytics.test.ts
@@ -6,9 +6,8 @@ jest.unstable_mockModule("../../src/models/voice-channel-tracking.js", () => ({
   VoiceChannelTracking: { aggregate: jest.fn() },
 }));
 
-const { buildGuildHeatmap, emptyGuildHeatmap } = await import(
-  "../../src/services/voice-activity-analytics.js"
-);
+const { buildGuildHeatmap, emptyGuildHeatmap } =
+  await import("../../src/services/voice-activity-analytics.js");
 
 describe("voice-activity-analytics (#675 Part B)", () => {
   describe("emptyGuildHeatmap", () => {

--- a/__tests__/services/voice-channel-announcer.test.ts
+++ b/__tests__/services/voice-channel-announcer.test.ts
@@ -4,6 +4,8 @@ import { VoiceChannelAnnouncer } from "../../src/services/voice-channel-announce
 // Mock dependencies
 jest.mock("../../src/services/config-service.js");
 jest.mock("../../src/services/voice-channel-tracker.js");
+jest.mock("../../src/services/quote-service.js");
+jest.mock("../../src/services/poll-participation-tracker.js");
 jest.mock("../../src/utils/logger.js");
 
 describe("VoiceChannelAnnouncer", () => {

--- a/__tests__/services/voice-channel-announcer.test.ts
+++ b/__tests__/services/voice-channel-announcer.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 import { VoiceChannelAnnouncer } from "../../src/services/voice-channel-announcer.js";
+import { VoiceChannelTracker } from "../../src/services/voice-channel-tracker.js";
+import { AchievementsService } from "../../src/services/achievements-service.js";
+import { PollParticipationTracker } from "../../src/services/poll-participation-tracker.js";
+import { quoteService } from "../../src/services/quote-service.js";
 
 // Mock dependencies
 jest.mock("../../src/services/config-service.js");
 jest.mock("../../src/services/voice-channel-tracker.js");
+jest.mock("../../src/services/achievements-service.js");
 jest.mock("../../src/services/quote-service.js");
 jest.mock("../../src/services/poll-participation-tracker.js");
 jest.mock("../../src/utils/logger.js");
@@ -49,6 +54,297 @@ describe("VoiceChannelAnnouncer", () => {
 
     it("should have destroy method", () => {
       expect(typeof service.destroy).toBe("function");
+    });
+  });
+
+  // The section methods carry all the recap logic (toggles, feature gates,
+  // rendering, mention restriction, per-section failure isolation);
+  // makeAnnouncement is a thin sequential awaiter over them. Exercising them
+  // directly avoids the guild/channel-resolution plumbing while still covering
+  // the behaviour a reviewer cares about.
+  describe("recap sections (#777)", () => {
+    let channel: { send: jest.Mock };
+
+    // Route each config key to a fixed boolean; unknown keys fall back to the
+    // caller-supplied default so real defaults (e.g. include_* → true) apply.
+    function setConfig(overrides: Record<string, boolean>): void {
+      (service as any).configService = {
+        getBoolean: jest.fn(async (key: string, def = false) =>
+          key in overrides ? overrides[key] : def,
+        ),
+        getString: jest.fn(async (_key: string, def = "") => def),
+      };
+    }
+
+    beforeEach(() => {
+      channel = { send: jest.fn<any>().mockResolvedValue(undefined) };
+    });
+
+    describe("announceVoiceStats", () => {
+      it("skips sending when the section toggle is off", async () => {
+        setConfig({ "voicetracking.announcements.include_voice_stats": false });
+        await (service as any).announceVoiceStats(channel);
+        expect(channel.send).not.toHaveBeenCalled();
+      });
+
+      it("renders the leaderboard when there is activity", async () => {
+        setConfig({ "voicetracking.announcements.include_voice_stats": true });
+        ((VoiceChannelTracker as any).getInstance = jest.fn()).mockReturnValue({
+          getTopUsers: jest.fn<any>().mockResolvedValue([
+            { userId: "111", username: "Alice", totalTime: 3661 },
+            { userId: "222", username: "Bob", totalTime: 600 },
+          ]),
+        });
+
+        await (service as any).announceVoiceStats(channel);
+
+        expect(channel.send).toHaveBeenCalledTimes(1);
+        const msg = channel.send.mock.calls[0][0] as string;
+        expect(msg).toContain("Weekly Voice Channel Activity Report");
+        expect(msg).toContain("🥇 <@111>: 1h 1m");
+        expect(msg).toContain("🥈 <@222>: 0h 10m");
+      });
+
+      it("posts the no-activity note when nobody was active", async () => {
+        setConfig({ "voicetracking.announcements.include_voice_stats": true });
+        ((VoiceChannelTracker as any).getInstance = jest.fn()).mockReturnValue({
+          getTopUsers: jest.fn<any>().mockResolvedValue([]),
+        });
+
+        await (service as any).announceVoiceStats(channel);
+        expect(channel.send).toHaveBeenCalledWith(
+          "No voice channel activity recorded this week.",
+        );
+      });
+
+      it("swallows its own errors (isolation contract)", async () => {
+        setConfig({ "voicetracking.announcements.include_voice_stats": true });
+        ((VoiceChannelTracker as any).getInstance = jest.fn()).mockReturnValue({
+          getTopUsers: jest
+            .fn<any>()
+            .mockRejectedValue(new Error("tracker boom")),
+        });
+
+        await expect(
+          (service as any).announceVoiceStats(channel),
+        ).resolves.toBeUndefined();
+      });
+    });
+
+    describe("announceQuoteOfWeek", () => {
+      it("skips when the section toggle is off", async () => {
+        setConfig({
+          "voicetracking.announcements.include_quote_of_week": false,
+          "quotes.enabled": true,
+        });
+        await (service as any).announceQuoteOfWeek(channel, new Date());
+        expect(channel.send).not.toHaveBeenCalled();
+      });
+
+      it("skips when the quotes feature is disabled", async () => {
+        setConfig({
+          "voicetracking.announcements.include_quote_of_week": true,
+          "quotes.enabled": false,
+        });
+        await (service as any).announceQuoteOfWeek(channel, new Date());
+        expect(channel.send).not.toHaveBeenCalled();
+      });
+
+      it("skips when there is no qualifying quote", async () => {
+        setConfig({
+          "voicetracking.announcements.include_quote_of_week": true,
+          "quotes.enabled": true,
+        });
+        ((quoteService as any).getTopQuoteSince =
+          jest.fn<any>()).mockResolvedValue(null);
+        await (service as any).announceQuoteOfWeek(channel, new Date());
+        expect(channel.send).not.toHaveBeenCalled();
+      });
+
+      it("renders a clean author mention and restricts allowed mentions", async () => {
+        setConfig({
+          "voicetracking.announcements.include_quote_of_week": true,
+          "quotes.enabled": true,
+        });
+        ((quoteService as any).getTopQuoteSince =
+          jest.fn<any>()).mockResolvedValue({
+          content: "the best quote",
+          authorId: "<@!555>",
+          likes: 1,
+        });
+
+        await (service as any).announceQuoteOfWeek(channel, new Date());
+
+        const arg = channel.send.mock.calls[0][0] as any;
+        expect(arg.content).toContain("the best quote");
+        expect(arg.content).toContain("<@555>");
+        expect(arg.content).toContain("👍 1 like");
+        // Only the resolved author is mentionable; no @everyone/@here/roles.
+        expect(arg.allowedMentions).toEqual({ parse: [], users: ["555"] });
+      });
+
+      it("emits NO mention for a malformed author id (no unrelated ping)", async () => {
+        setConfig({
+          "voicetracking.announcements.include_quote_of_week": true,
+          "quotes.enabled": true,
+        });
+        ((quoteService as any).getTopQuoteSince =
+          jest.fn<any>()).mockResolvedValue({
+          content: "legacy import",
+          authorId: "user-999-imported",
+          likes: 4,
+        });
+
+        await (service as any).announceQuoteOfWeek(channel, new Date());
+
+        const arg = channel.send.mock.calls[0][0] as any;
+        expect(arg.content).toContain("someone");
+        expect(arg.content).not.toContain("<@");
+        expect(arg.allowedMentions).toEqual({ parse: [] });
+      });
+
+      it("swallows its own errors (isolation contract)", async () => {
+        setConfig({
+          "voicetracking.announcements.include_quote_of_week": true,
+          "quotes.enabled": true,
+        });
+        ((quoteService as any).getTopQuoteSince =
+          jest.fn<any>()).mockRejectedValue(new Error("quote boom"));
+        await expect(
+          (service as any).announceQuoteOfWeek(channel, new Date()),
+        ).resolves.toBeUndefined();
+      });
+    });
+
+    describe("announcePollTurnout", () => {
+      it("skips when the section toggle is off", async () => {
+        setConfig({
+          "voicetracking.announcements.include_poll_turnout": false,
+          "polls.participation.enabled": true,
+        });
+        await (service as any).announcePollTurnout(channel, "g1", new Date());
+        expect(channel.send).not.toHaveBeenCalled();
+      });
+
+      it("skips when poll participation tracking is disabled", async () => {
+        setConfig({
+          "voicetracking.announcements.include_poll_turnout": true,
+          "polls.participation.enabled": false,
+        });
+        await (service as any).announcePollTurnout(channel, "g1", new Date());
+        expect(channel.send).not.toHaveBeenCalled();
+      });
+
+      it("renders the voter count when at least one member voted", async () => {
+        setConfig({
+          "voicetracking.announcements.include_poll_turnout": true,
+          "polls.participation.enabled": true,
+        });
+        ((PollParticipationTracker as any).getInstance =
+          jest.fn()).mockReturnValue({
+          getRecentVoterCount: jest.fn<any>().mockResolvedValue(3),
+        });
+
+        await (service as any).announcePollTurnout(channel, "g1", new Date());
+
+        const msg = channel.send.mock.calls[0][0] as string;
+        expect(msg).toContain("Poll Participation");
+        expect(msg).toContain("3 members voted in polls this week");
+      });
+
+      it("skips when nobody voted", async () => {
+        setConfig({
+          "voicetracking.announcements.include_poll_turnout": true,
+          "polls.participation.enabled": true,
+        });
+        ((PollParticipationTracker as any).getInstance =
+          jest.fn()).mockReturnValue({
+          getRecentVoterCount: jest.fn<any>().mockResolvedValue(0),
+        });
+
+        await (service as any).announcePollTurnout(channel, "g1", new Date());
+        expect(channel.send).not.toHaveBeenCalled();
+      });
+
+      it("swallows its own errors (isolation contract)", async () => {
+        setConfig({
+          "voicetracking.announcements.include_poll_turnout": true,
+          "polls.participation.enabled": true,
+        });
+        ((PollParticipationTracker as any).getInstance =
+          jest.fn()).mockReturnValue({
+          getRecentVoterCount: jest
+            .fn<any>()
+            .mockRejectedValue(new Error("poll boom")),
+        });
+
+        await expect(
+          (service as any).announcePollTurnout(channel, "g1", new Date()),
+        ).resolves.toBeUndefined();
+      });
+    });
+
+    describe("announceAccolades", () => {
+      it("skips when the section toggle is off", async () => {
+        setConfig({
+          "voicetracking.announcements.include_accolades": false,
+          "achievements.enabled": true,
+          "achievements.announcements.enabled": true,
+        });
+        await (service as any).announceAccolades(channel);
+        expect(channel.send).not.toHaveBeenCalled();
+      });
+
+      it("skips when achievements are disabled", async () => {
+        setConfig({
+          "voicetracking.announcements.include_accolades": true,
+          "achievements.enabled": false,
+          "achievements.announcements.enabled": true,
+        });
+        await (service as any).announceAccolades(channel);
+        expect(channel.send).not.toHaveBeenCalled();
+      });
+
+      it("renders accolades earned this week", async () => {
+        setConfig({
+          "voicetracking.announcements.include_accolades": true,
+          "achievements.enabled": true,
+          "achievements.announcements.enabled": true,
+        });
+        ((AchievementsService as any).getInstance = jest.fn()).mockReturnValue({
+          getNewAccoladesSinceLastWeek: jest
+            .fn<any>()
+            .mockResolvedValue([
+              { userId: "777", accolades: [{ type: "chatterbox" }] },
+            ]),
+          getAccoladeDefinition: jest
+            .fn<any>()
+            .mockReturnValue({ emoji: "🎖️", name: "Chatterbox" }),
+        });
+
+        await (service as any).announceAccolades(channel);
+
+        const msg = channel.send.mock.calls[0][0] as string;
+        expect(msg).toContain("New Accolades This Week");
+        expect(msg).toContain("🎖️ <@777> earned **Chatterbox**!");
+      });
+
+      it("swallows its own errors (isolation contract)", async () => {
+        setConfig({
+          "voicetracking.announcements.include_accolades": true,
+          "achievements.enabled": true,
+          "achievements.announcements.enabled": true,
+        });
+        ((AchievementsService as any).getInstance = jest.fn()).mockReturnValue({
+          getNewAccoladesSinceLastWeek: jest
+            .fn<any>()
+            .mockRejectedValue(new Error("accolade boom")),
+        });
+
+        await expect(
+          (service as any).announceAccolades(channel),
+        ).resolves.toBeUndefined();
+      });
     });
   });
 });

--- a/__tests__/services/voice-channel-truncation.test.ts
+++ b/__tests__/services/voice-channel-truncation.test.ts
@@ -54,9 +54,9 @@ describe("VoiceChannelTruncationService", () => {
       let reloadCallback: (() => Promise<void>) | undefined;
       const mockConfigService = {
         getString: jest.fn<() => Promise<string>>().mockResolvedValue(""),
-        getBoolean: jest.fn<() => Promise<boolean>>().mockResolvedValue(
-          enabled,
-        ),
+        getBoolean: jest
+          .fn<() => Promise<boolean>>()
+          .mockResolvedValue(enabled),
         getNumber: jest.fn<() => Promise<number>>().mockResolvedValue(400),
         get: jest.fn<() => Promise<unknown>>().mockResolvedValue(null),
         registerReloadCallback: jest.fn((cb: () => Promise<void>) => {
@@ -70,7 +70,11 @@ describe("VoiceChannelTruncationService", () => {
         VoiceChannelTruncationService as unknown as { instance: unknown }
       ).instance = undefined;
       const svc = VoiceChannelTruncationService.getInstance(mockClient);
-      return { svc, mockConfigService, getReloadCallback: () => reloadCallback };
+      return {
+        svc,
+        mockConfigService,
+        getReloadCallback: () => reloadCallback,
+      };
     }
 
     function getCleanupJob(
@@ -78,7 +82,10 @@ describe("VoiceChannelTruncationService", () => {
     ): { isActive: boolean; cronTime: { source: unknown } } | null {
       return (
         svc as unknown as {
-          cleanupJob: { isActive: boolean; cronTime: { source: unknown } } | null;
+          cleanupJob: {
+            isActive: boolean;
+            cronTime: { source: unknown };
+          } | null;
         }
       ).cleanupJob;
     }

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -1769,9 +1769,7 @@ describe("renderVoiceChannelsPage", () => {
     expect(html).toContain(
       '<input type="hidden" name="redirect" value="/admin/voice-channels">',
     );
-    expect(html).toContain(
-      '<input type="hidden" name="no_cascade" value="1">',
-    );
+    expect(html).toContain('<input type="hidden" name="no_cascade" value="1">');
     expect(html).toContain(
       '<input type="hidden" name="category" value="voicechannels">',
     );

--- a/__tests__/web/user-routes.test.ts
+++ b/__tests__/web/user-routes.test.ts
@@ -243,9 +243,8 @@ describe("createUserRouter / index page", () => {
   // their default-off). The real ConfigService is used here, so spy its
   // singleton to flip just the one key.
   async function enablePollParticipationGate(): Promise<void> {
-    const { ConfigService } = await import(
-      "../../src/services/config-service.js"
-    );
+    const { ConfigService } =
+      await import("../../src/services/config-service.js");
     jest.spyOn(ConfigService, "getInstance").mockReturnValue({
       getBoolean: async (key: string) => key === "polls.participation.enabled",
     } as never);
@@ -253,9 +252,8 @@ describe("createUserRouter / index page", () => {
 
   it("renders the poll-participation card when the member has a tracking row (#655)", async () => {
     await enablePollParticipationGate();
-    const { PollParticipationTracker } = await import(
-      "../../src/services/poll-participation-tracker.js"
-    );
+    const { PollParticipationTracker } =
+      await import("../../src/services/poll-participation-tracker.js");
     jest.spyOn(PollParticipationTracker, "getInstance").mockReturnValue({
       getParticipationSummary: async () => ({
         totalVotes: 42,
@@ -273,9 +271,8 @@ describe("createUserRouter / index page", () => {
 
   it("omits the poll-participation card when the member has never voted (#655)", async () => {
     await enablePollParticipationGate();
-    const { PollParticipationTracker } = await import(
-      "../../src/services/poll-participation-tracker.js"
-    );
+    const { PollParticipationTracker } =
+      await import("../../src/services/poll-participation-tracker.js");
     jest.spyOn(PollParticipationTracker, "getInstance").mockReturnValue({
       getParticipationSummary: async () => null,
     } as never);
@@ -1075,7 +1072,9 @@ describe("/me/voice (#656)", () => {
         opts.prefs ?? { namePattern: undefined, presets: [] },
       setNamePattern: jest
         .fn<(u: string, raw: string) => Promise<string | null>>()
-        .mockImplementation(async (_u, raw) => (raw.trim() === "" ? null : raw.trim())),
+        .mockImplementation(async (_u, raw) =>
+          raw.trim() === "" ? null : raw.trim(),
+        ),
       setDefault: jest
         .fn()
         .mockResolvedValue({ name: "Squad", isDefault: true } as never),
@@ -1157,8 +1156,7 @@ describe("/me/voice (#656)", () => {
     await new Promise((r) => setTimeout(r, 10));
 
     const auditCall = createSpy.mock.calls.at(-1)?.[0] as
-      | Record<string, unknown>
-      | undefined;
+      Record<string, unknown> | undefined;
     return { ...captured, audit: auditCall };
   }
 
@@ -1275,9 +1273,7 @@ describe("/me/voice (#656)", () => {
   });
 
   it("edits a preset's fields through the service", async () => {
-    const editPreset = jest
-      .fn()
-      .mockResolvedValue({ name: "Squad+" } as never);
+    const editPreset = jest.fn().mockResolvedValue({ name: "Squad+" } as never);
     const out = await dispatch({
       method: "POST",
       url: "/voice/preset/edit",
@@ -1488,8 +1484,7 @@ describe("/me/timezone (#524)", () => {
     // Spies accumulate across the suite, so read the most recent create
     // call — the one this dispatch produced.
     const auditCall = createSpy.mock.calls.at(-1)?.[0] as
-      | Record<string, unknown>
-      | undefined;
+      Record<string, unknown> | undefined;
     return { ...captured, audit: auditCall };
   }
 

--- a/__tests__/web/write-routes.test.ts
+++ b/__tests__/web/write-routes.test.ts
@@ -515,7 +515,9 @@ describe("wizardApplyFailureMessage (#780)", () => {
       rolledBackKeys: ["quotes.channel_id", "quotes.enabled"],
     });
     expect(msg).toContain("quotes.delete_roles failed (mongo write failed)");
-    expect(msg).toContain("2 settings written before the failure were rolled back");
+    expect(msg).toContain(
+      "2 settings written before the failure were rolled back",
+    );
     expect(msg).toContain("no changes were applied");
   });
 
@@ -527,7 +529,9 @@ describe("wizardApplyFailureMessage (#780)", () => {
       appliedKeys: ["quotes.enabled"],
       rolledBackKeys: ["quotes.enabled"],
     });
-    expect(msg).toContain("1 setting written before the failure was rolled back");
+    expect(msg).toContain(
+      "1 setting written before the failure was rolled back",
+    );
   });
 
   it("names keys that could not be rolled back and says they are in effect", () => {

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -21,6 +21,13 @@ export interface ConfigSchema {
   "voicetracking.announcements.enabled": boolean;
   "voicetracking.announcements.schedule": string; // Cron schedule
   "voicetracking.announcements.channel_id": string; // Channel ID for voice-stats announcements
+  // Weekly recap section toggles (#777) — admins can turn each part of the
+  // scheduled recap on/off independently. A section also stays hidden unless
+  // the feature that produces its data is itself enabled.
+  "voicetracking.announcements.include_voice_stats": boolean;
+  "voicetracking.announcements.include_accolades": boolean;
+  "voicetracking.announcements.include_quote_of_week": boolean;
+  "voicetracking.announcements.include_poll_turnout": boolean;
 
   // Voice Channel Cleanup
   "voicetracking.cleanup.enabled": boolean;
@@ -202,6 +209,11 @@ export const defaultConfig: ConfigSchema = {
   "voicetracking.announcements.enabled": false,
   "voicetracking.announcements.schedule": "0 16 * * 5", // Every Friday at 16:00
   "voicetracking.announcements.channel_id": "",
+  // Recap sections default on; each is inert until its own feature is enabled.
+  "voicetracking.announcements.include_voice_stats": true,
+  "voicetracking.announcements.include_accolades": true,
+  "voicetracking.announcements.include_quote_of_week": true,
+  "voicetracking.announcements.include_poll_turnout": true,
 
   // Voice Channel Cleanup
   "voicetracking.cleanup.enabled": false,
@@ -862,8 +874,9 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
     channelKind: "voice",
   },
   "voicetracking.announcements.enabled": {
-    label: "Scheduled voice-stats announcements enabled",
-    description: "Enable scheduled voice-stats announcements.",
+    label: "Scheduled weekly recap enabled",
+    description:
+      "Enable the scheduled weekly recap posted to a channel (top voice-time members plus, when their features are enabled, accolades earned, quote of the week, and poll turnout). Sections are toggled individually below.",
     category: "voicetracking",
     type: "boolean",
     dependsOn: ["voicetracking.enabled"],
@@ -876,10 +889,37 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
   },
   "voicetracking.announcements.channel_id": {
     label: "Announcement channel",
-    description:
-      "Discord channel ID where voice-stats announcements are posted.",
+    description: "Discord channel ID where the weekly recap is posted.",
     category: "voicetracking",
     type: "channel",
+  },
+  "voicetracking.announcements.include_voice_stats": {
+    label: "Recap: top voice-time members",
+    description:
+      "Include the weekly top voice-time leaderboard in the scheduled recap.",
+    category: "voicetracking",
+    type: "boolean",
+  },
+  "voicetracking.announcements.include_accolades": {
+    label: "Recap: accolades earned",
+    description:
+      "Include accolades earned in the last week in the scheduled recap (also requires achievements and achievement announcements to be enabled).",
+    category: "voicetracking",
+    type: "boolean",
+  },
+  "voicetracking.announcements.include_quote_of_week": {
+    label: "Recap: quote of the week",
+    description:
+      "Include the most-liked quote added in the last week in the scheduled recap (also requires the quotes feature to be enabled).",
+    category: "voicetracking",
+    type: "boolean",
+  },
+  "voicetracking.announcements.include_poll_turnout": {
+    label: "Recap: poll participation",
+    description:
+      "Include how many members voted in polls in the last week in the scheduled recap (also requires poll participation tracking to be enabled).",
+    category: "voicetracking",
+    type: "boolean",
   },
 
   // Voice Channel Cleanup (dbtrunk)

--- a/src/services/poll-participation-tracker.ts
+++ b/src/services/poll-participation-tracker.ts
@@ -207,6 +207,33 @@ export class PollParticipationTracker {
     }
   }
 
+  /**
+   * Count distinct members who cast at least one poll vote since `since`, for
+   * the public weekly recap (#777). Uses each member's `lastVoteAt` — the only
+   * time-scoped signal this tracker keeps. The lifetime totals and per-year
+   * buckets cannot answer "this week", and a member whose most recent vote
+   * predates the window is excluded even if they voted earlier in the period.
+   * This is therefore a distinct-recent-voter count, not a per-poll turnout:
+   * "how many polls ran this week" is not recorded anywhere (see the follow-up
+   * tracking issue referenced from #777). Best-effort — returns 0 on any DB
+   * error so the recap never fails on this section.
+   */
+  public async getRecentVoterCount(
+    guildId: string,
+    since: Date,
+  ): Promise<number> {
+    try {
+      await this.ensureConnection();
+      return await PollParticipationTracking.countDocuments({
+        guildId,
+        lastVoteAt: { $gte: since },
+      });
+    } catch (error) {
+      logger.error("Error counting recent poll voters:", error);
+      return 0;
+    }
+  }
+
   public async initialize(): Promise<void> {
     try {
       await this.ensureConnection();

--- a/src/services/poll-participation-tracker.ts
+++ b/src/services/poll-participation-tracker.ts
@@ -209,14 +209,14 @@ export class PollParticipationTracker {
 
   /**
    * Count distinct members who cast at least one poll vote since `since`, for
-   * the public weekly recap (#777). Uses each member's `lastVoteAt` — the only
-   * time-scoped signal this tracker keeps. The lifetime totals and per-year
-   * buckets cannot answer "this week", and a member whose most recent vote
-   * predates the window is excluded even if they voted earlier in the period.
-   * This is therefore a distinct-recent-voter count, not a per-poll turnout:
-   * "how many polls ran this week" is not recorded anywhere (see the follow-up
-   * tracking issue referenced from #777). Best-effort — returns 0 on any DB
-   * error so the recap never fails on this section.
+   * the public weekly recap (#777). `lastVoteAt` is each member's most recent
+   * vote, so `lastVoteAt >= since` is true for exactly the members who voted at
+   * least once inside the window — this is an *exact* distinct-member count for
+   * captured votes, not an approximation. What this tracker cannot provide is
+   * how many polls ran or how many votes each member cast (there is no per-poll
+   * record and no weekly frequency bucket; see the follow-up tracking issue
+   * referenced from #777). Best-effort — returns 0 on any DB error so the recap
+   * never fails on this section.
    */
   public async getRecentVoterCount(
     guildId: string,

--- a/src/services/quote-service.ts
+++ b/src/services/quote-service.ts
@@ -378,6 +378,24 @@ export class QuoteService {
   }
 
   /**
+   * Return the most-liked quote added since `since`, for the public weekly
+   * recap (#777). Only quotes with at least one like qualify, so a quiet week
+   * surfaces nothing rather than an arbitrary zero-vote quote. Scoped by
+   * `createdAt` (when the quote was added) because vote events are not
+   * timestamped — "top-voted this week" can only be approximated as
+   * "most-liked among quotes added this week". Returns null when nothing
+   * qualifies.
+   */
+  async getTopQuoteSince(since: Date): Promise<IQuote | null> {
+    return this.model
+      .findOne({
+        createdAt: { $gte: since },
+        likes: { $gt: 0 },
+      })
+      .sort({ likes: -1 });
+  }
+
+  /**
    * Get the count of quotes added by a specific user
    * Handles legacy quote data with various ID formats (<@123>, <@!123>, @123, 123)
    */

--- a/src/services/voice-channel-announcer.ts
+++ b/src/services/voice-channel-announcer.ts
@@ -4,6 +4,11 @@ import { ConfigService } from "./config-service.js";
 import logger from "../utils/logger.js";
 import { VoiceChannelTracker } from "./voice-channel-tracker.js";
 import { AchievementsService } from "./achievements-service.js";
+import { quoteService } from "./quote-service.js";
+import { PollParticipationTracker } from "./poll-participation-tracker.js";
+
+/** One week, in milliseconds — the window every recap section covers. */
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
 export class VoiceChannelAnnouncer {
   private static instance: VoiceChannelAnnouncer;
@@ -190,44 +195,78 @@ export class VoiceChannelAnnouncer {
         return;
       }
 
-      const tracker = VoiceChannelTracker.getInstance(this.client);
-      const topUsers = await tracker.getTopUsers(10, "week");
+      const weekAgo = new Date(Date.now() - ONE_WEEK_MS);
 
-      if (topUsers.length === 0) {
-        await channel.send("No voice channel activity recorded this week.");
-        return;
-      }
+      // Each section is independently toggleable (#777) and self-contained:
+      // a section stays hidden unless both its recap toggle and the feature
+      // that produces its data are enabled, and a failure in one never breaks
+      // the others.
+      await this.announceVoiceStats(channel);
+      await this.announceAccolades(channel);
+      await this.announceQuoteOfWeek(channel, weekAgo);
+      await this.announcePollTurnout(channel, guildId, weekAgo);
 
-      const formatTime = (seconds: number): string => {
-        const hours = Math.floor(seconds / 3600);
-        const minutes = Math.floor((seconds % 3600) / 60);
-        return `${hours}h ${minutes}m`;
-      };
+      logger.info("Weekly voice channel announcement sent successfully");
+    } catch (error) {
+      logger.error("Error making voice channel announcement:", error);
+    }
+  }
 
-      const message = [
-        "🎙️ **Weekly Voice Channel Activity Report** 🎙️",
-        "",
-        "**Top 10 Most Active Members This Week:**",
-        ...topUsers.map((user, index) => {
-          const rank = index + 1;
-          const medal =
-            rank === 1
-              ? "🥇"
-              : rank === 2
-                ? "🥈"
-                : rank === 3
-                  ? "🥉"
-                  : `${rank}.`;
-          const mention = rank <= 3 ? `<@${user.userId}>` : user.username;
-          return `${medal} ${mention}: ${formatTime(user.totalTime)}`;
-        }),
-        "",
-        "Keep up the great conversations! 🎮",
-      ].join("\n");
+  /** Recap section: the weekly top voice-time leaderboard. */
+  private async announceVoiceStats(channel: TextChannel): Promise<void> {
+    const include = await this.configService.getBoolean(
+      "voicetracking.announcements.include_voice_stats",
+      true,
+    );
+    if (!include) return;
 
-      await channel.send(message);
+    const tracker = VoiceChannelTracker.getInstance(this.client);
+    const topUsers = await tracker.getTopUsers(10, "week");
 
-      // Add accolades announcement if enabled
+    if (topUsers.length === 0) {
+      await channel.send("No voice channel activity recorded this week.");
+      return;
+    }
+
+    const formatTime = (seconds: number): string => {
+      const hours = Math.floor(seconds / 3600);
+      const minutes = Math.floor((seconds % 3600) / 60);
+      return `${hours}h ${minutes}m`;
+    };
+
+    const message = [
+      "🎙️ **Weekly Voice Channel Activity Report** 🎙️",
+      "",
+      "**Top 10 Most Active Members This Week:**",
+      ...topUsers.map((user, index) => {
+        const rank = index + 1;
+        const medal =
+          rank === 1
+            ? "🥇"
+            : rank === 2
+              ? "🥈"
+              : rank === 3
+                ? "🥉"
+                : `${rank}.`;
+        const mention = rank <= 3 ? `<@${user.userId}>` : user.username;
+        return `${medal} ${mention}: ${formatTime(user.totalTime)}`;
+      }),
+      "",
+      "Keep up the great conversations! 🎮",
+    ].join("\n");
+
+    await channel.send(message);
+  }
+
+  /** Recap section: accolades earned in the last week. */
+  private async announceAccolades(channel: TextChannel): Promise<void> {
+    try {
+      const include = await this.configService.getBoolean(
+        "voicetracking.announcements.include_accolades",
+        true,
+      );
+      if (!include) return;
+
       const achievementsEnabled = await this.configService.getBoolean(
         "achievements.enabled",
         false,
@@ -236,50 +275,122 @@ export class VoiceChannelAnnouncer {
         "achievements.announcements.enabled",
         true,
       );
+      if (!achievementsEnabled || !announcementsEnabled) return;
 
-      if (achievementsEnabled && announcementsEnabled) {
-        try {
-          const achievementsService = AchievementsService.getInstance(
-            this.client,
-          );
-          const newAccolades =
-            await achievementsService.getNewAccoladesSinceLastWeek();
+      const achievementsService = AchievementsService.getInstance(this.client);
+      const newAccolades =
+        await achievementsService.getNewAccoladesSinceLastWeek();
+      if (newAccolades.length === 0) return;
 
-          if (newAccolades.length > 0) {
-            const accoladeMessages = newAccolades
-              .flatMap((userAccolades) => {
-                return userAccolades.accolades
-                  .map((accolade) => {
-                    const definition =
-                      achievementsService.getAccoladeDefinition(accolade.type);
-                    if (!definition) return null;
+      const accoladeMessages = newAccolades
+        .flatMap((userAccolades) =>
+          userAccolades.accolades
+            .map((accolade) => {
+              const definition = achievementsService.getAccoladeDefinition(
+                accolade.type,
+              );
+              if (!definition) return null;
+              return `${definition.emoji} <@${userAccolades.userId}> earned **${definition.name}**!`;
+            })
+            .filter(Boolean),
+        )
+        .slice(0, 10); // Limit to 10 announcements
 
-                    return `${definition.emoji} <@${userAccolades.userId}> earned **${definition.name}**!`;
-                  })
-                  .filter(Boolean);
-              })
-              .slice(0, 10); // Limit to 10 announcements
-
-            if (accoladeMessages.length > 0) {
-              const accoladeAnnouncement = [
-                "",
-                "🏆 **New Accolades This Week** 🏆",
-                "",
-                ...accoladeMessages,
-              ].join("\n");
-
-              await channel.send(accoladeAnnouncement);
-            }
-          }
-        } catch (error) {
-          logger.error("Error announcing accolades:", error);
-          // Don't let accolade errors break the main announcement
-        }
+      if (accoladeMessages.length > 0) {
+        await channel.send(
+          [
+            "",
+            "🏆 **New Accolades This Week** 🏆",
+            "",
+            ...accoladeMessages,
+          ].join("\n"),
+        );
       }
-
-      logger.info("Weekly voice channel announcement sent successfully");
     } catch (error) {
-      logger.error("Error making voice channel announcement:", error);
+      logger.error("Error announcing accolades:", error);
+      // Don't let accolade errors break the main announcement
+    }
+  }
+
+  /** Recap section: the most-liked quote added in the last week (#777). */
+  private async announceQuoteOfWeek(
+    channel: TextChannel,
+    since: Date,
+  ): Promise<void> {
+    try {
+      const include = await this.configService.getBoolean(
+        "voicetracking.announcements.include_quote_of_week",
+        true,
+      );
+      if (!include) return;
+
+      const quotesEnabled = await this.configService.getBoolean(
+        "quotes.enabled",
+        false,
+      );
+      if (!quotesEnabled) return;
+
+      const topQuote = await quoteService.getTopQuoteSince(since);
+      if (!topQuote) return;
+
+      // Author IDs may be stored in legacy formats (<@123>, @123, 123); keep
+      // only the digits to build a clean mention. Restrict allowed mentions so
+      // untrusted quote text can never ping @everyone/@here or arbitrary roles.
+      const authorId = topQuote.authorId.replace(/\D/g, "");
+      const author = authorId ? `<@${authorId}>` : "someone";
+      const likeLabel = topQuote.likes === 1 ? "like" : "likes";
+
+      await channel.send({
+        content: [
+          "",
+          "💬 **Quote of the Week** 💬",
+          "",
+          `> ${topQuote.content}`,
+          `— ${author} · 👍 ${topQuote.likes} ${likeLabel}`,
+        ].join("\n"),
+        allowedMentions: authorId
+          ? { parse: [], users: [authorId] }
+          : { parse: [] },
+      });
+    } catch (error) {
+      logger.error("Error announcing quote of the week:", error);
+    }
+  }
+
+  /** Recap section: how many members voted in polls this week (#777). */
+  private async announcePollTurnout(
+    channel: TextChannel,
+    guildId: string,
+    since: Date,
+  ): Promise<void> {
+    try {
+      const include = await this.configService.getBoolean(
+        "voicetracking.announcements.include_poll_turnout",
+        true,
+      );
+      if (!include) return;
+
+      const participationEnabled = await this.configService.getBoolean(
+        "polls.participation.enabled",
+        false,
+      );
+      if (!participationEnabled) return;
+
+      const tracker = PollParticipationTracker.getInstance(this.client);
+      const voters = await tracker.getRecentVoterCount(guildId, since);
+      if (voters <= 0) return;
+
+      const memberLabel = voters === 1 ? "member" : "members";
+      await channel.send(
+        [
+          "",
+          "🗳️ **Poll Participation** 🗳️",
+          "",
+          `${voters} ${memberLabel} voted in polls this week. Thanks for weighing in!`,
+        ].join("\n"),
+      );
+    } catch (error) {
+      logger.error("Error announcing poll participation:", error);
     }
   }
 

--- a/src/services/voice-channel-announcer.ts
+++ b/src/services/voice-channel-announcer.ts
@@ -10,6 +10,21 @@ import { PollParticipationTracker } from "./poll-participation-tracker.js";
 /** One week, in milliseconds — the window every recap section covers. */
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
+/**
+ * Resolve a quote's stored author id to a bare Discord snowflake, but only when
+ * the whole string is exactly one of the supported formats (`<@id>`, `<@!id>`,
+ * `@id`, or a plain numeric id). Anything else returns null so the recap emits
+ * no mention. This is deliberately strict rather than "strip non-digits":
+ * the returned id is allowlisted in `allowedMentions`, so assembling a
+ * snowflake out of malformed or imported author data could otherwise ping an
+ * unrelated member.
+ */
+function resolveAuthorMentionId(authorId: string): string | null {
+  const match = authorId.match(/^(?:<@!?(\d+)>|@?(\d+))$/);
+  if (!match) return null;
+  return match[1] ?? match[2] ?? null;
+}
+
 export class VoiceChannelAnnouncer {
   private static instance: VoiceChannelAnnouncer;
   private client: Client;
@@ -214,48 +229,53 @@ export class VoiceChannelAnnouncer {
 
   /** Recap section: the weekly top voice-time leaderboard. */
   private async announceVoiceStats(channel: TextChannel): Promise<void> {
-    const include = await this.configService.getBoolean(
-      "voicetracking.announcements.include_voice_stats",
-      true,
-    );
-    if (!include) return;
+    try {
+      const include = await this.configService.getBoolean(
+        "voicetracking.announcements.include_voice_stats",
+        true,
+      );
+      if (!include) return;
 
-    const tracker = VoiceChannelTracker.getInstance(this.client);
-    const topUsers = await tracker.getTopUsers(10, "week");
+      const tracker = VoiceChannelTracker.getInstance(this.client);
+      const topUsers = await tracker.getTopUsers(10, "week");
 
-    if (topUsers.length === 0) {
-      await channel.send("No voice channel activity recorded this week.");
-      return;
+      if (topUsers.length === 0) {
+        await channel.send("No voice channel activity recorded this week.");
+        return;
+      }
+
+      const formatTime = (seconds: number): string => {
+        const hours = Math.floor(seconds / 3600);
+        const minutes = Math.floor((seconds % 3600) / 60);
+        return `${hours}h ${minutes}m`;
+      };
+
+      const message = [
+        "🎙️ **Weekly Voice Channel Activity Report** 🎙️",
+        "",
+        "**Top 10 Most Active Members This Week:**",
+        ...topUsers.map((user, index) => {
+          const rank = index + 1;
+          const medal =
+            rank === 1
+              ? "🥇"
+              : rank === 2
+                ? "🥈"
+                : rank === 3
+                  ? "🥉"
+                  : `${rank}.`;
+          const mention = rank <= 3 ? `<@${user.userId}>` : user.username;
+          return `${medal} ${mention}: ${formatTime(user.totalTime)}`;
+        }),
+        "",
+        "Keep up the great conversations! 🎮",
+      ].join("\n");
+
+      await channel.send(message);
+    } catch (error) {
+      logger.error("Error announcing voice stats:", error);
+      // Isolated like every other section: never break the rest of the recap.
     }
-
-    const formatTime = (seconds: number): string => {
-      const hours = Math.floor(seconds / 3600);
-      const minutes = Math.floor((seconds % 3600) / 60);
-      return `${hours}h ${minutes}m`;
-    };
-
-    const message = [
-      "🎙️ **Weekly Voice Channel Activity Report** 🎙️",
-      "",
-      "**Top 10 Most Active Members This Week:**",
-      ...topUsers.map((user, index) => {
-        const rank = index + 1;
-        const medal =
-          rank === 1
-            ? "🥇"
-            : rank === 2
-              ? "🥈"
-              : rank === 3
-                ? "🥉"
-                : `${rank}.`;
-        const mention = rank <= 3 ? `<@${user.userId}>` : user.username;
-        return `${medal} ${mention}: ${formatTime(user.totalTime)}`;
-      }),
-      "",
-      "Keep up the great conversations! 🎮",
-    ].join("\n");
-
-    await channel.send(message);
   }
 
   /** Recap section: accolades earned in the last week. */
@@ -333,10 +353,12 @@ export class VoiceChannelAnnouncer {
       const topQuote = await quoteService.getTopQuoteSince(since);
       if (!topQuote) return;
 
-      // Author IDs may be stored in legacy formats (<@123>, @123, 123); keep
-      // only the digits to build a clean mention. Restrict allowed mentions so
-      // untrusted quote text can never ping @everyone/@here or arbitrary roles.
-      const authorId = topQuote.authorId.replace(/\D/g, "");
+      // Author IDs may be stored in legacy formats (<@123>, <@!123>, @123,
+      // 123). Only resolve a mention when the whole value is exactly one of
+      // those, so malformed data can't assemble an unrelated snowflake — and
+      // restrict allowed mentions so untrusted quote text can never ping
+      // @everyone/@here or arbitrary roles.
+      const authorId = resolveAuthorMentionId(topQuote.authorId);
       const author = authorId ? `<@${authorId}>` : "someone";
       const likeLabel = topQuote.likes === 1 ? "like" : "likes";
 


### PR DESCRIPTION
## Description

Implements the public weekly recap requested in #777 by **extending the existing scheduled voice-stats announcement** (`VoiceChannelAnnouncer`) rather than adding a parallel `WeeklyRecapService`. The announcer is already a public, channel-posted, cron-scheduled weekly rollup that shows the top voice-time leaderboard and accolades earned — so this reuses that surface and adds the two missing sections, avoiding a second Friday post that would duplicate the top-10 list.

New recap sections:

- **Quote of the week** — the most-liked quote added in the last 7 days (`QuoteService.getTopQuoteSince`). Sent with `allowedMentions` restricted so untrusted quote text can never ping `@everyone`/`@here` or arbitrary roles; only the quoted author is mentionable.
- **Poll participation** — how many members voted in polls in the last 7 days (`PollParticipationTracker.getRecentVoterCount`, derived from `lastVoteAt`).

Per-section admin toggles (the issue listed these as out-of-scope; requested during implementation):
`include_voice_stats`, `include_accolades`, `include_quote_of_week`, `include_poll_turnout` — all default `true`, and each section also stays hidden unless the feature that produces its data (quotes, poll participation, achievements) is itself enabled. Sections are self-contained, so a failure in one never breaks the others.

No new tracking or data model — every figure comes from a service that already computes it.

### Data limitations & follow-ups

Two parts of the issue's ideal shape aren't fully derivable from existing data, so this PR ships honest approximations and files follow-ups:

- **"N members across M polls this week"** — `PollParticipationTracking` keeps only lifetime/yearly totals plus a single `lastVoteAt`; there's no weekly bucket and no per-poll turnout record. Shipped as a distinct-recent-voter count (no "M polls"). → **#816**
- **"top-voted this week"** — quote votes aren't timestamped, so this is approximated as "most-liked among quotes added this week." → **#817**

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Related Issues

Closes #777
Refs #816, #817

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality

Added unit tests for `QuoteService.getTopQuoteSince` (query shape + null path) and `PollParticipationTracker.getRecentVoterCount` (window query + DB-error degradation); updated the announcer suite to mock the new dependencies. Full suite: `npm run test:ci` → 1625 passing, coverage thresholds held. `npm run build`, `npm run lint`, `npm run format:check`, and `markdownlint` all pass.

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary:
  - [x] `SETTINGS.md` (new config keys documented)
- [x] I have validated markdown with `markdownlint`

### Configuration

- [x] New sections default on but are inert until their parent feature is enabled; the recap itself remains off by default (`voicetracking.announcements.enabled`)
- [x] I have added configuration schema entries in `config-schema.ts`
- [x] I have documented new configuration keys in `SETTINGS.md`

## Additional Notes

The recap continues to fire only when `voicetracking.announcements.enabled` (and `voicetracking.enabled`) are on, on the existing `voicetracking.announcements.schedule` (default Fridays 16:00). Output stays plain text to match the current announcement style — no embed migration in this PR.

## Pre-Submission Verification

- [x] I have rebased my branch on the latest main branch
- [x] I have resolved any merge conflicts
- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYaKVm1tVW8eoA2ge8Faya)_