### PR TITLE
fix: add Partials.User so reaction-role events fire for uncached users

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,14 @@ const client = new Client({
     // tracking (#570). The events still only fire for guild polls.
     GatewayIntentBits.GuildMessagePolls,
   ],
-  partials: [Partials.Message, Partials.Reaction],
+  // Partials.User is required for messageReactionAdd/Remove to fire for
+  // uncached users (#809). Without it, discord.js drops the event before any
+  // listener runs — so a member reacting to an old reaction-role message the
+  // bot hasn't cached (common right after a restart) silently gets no role.
+  // Partials.Message/Reaction only cover uncached messages/reactions, not
+  // uncached users. Both consumers (ReactionRoleService, ReactionActivityTracker)
+  // already resolve partial users via user.fetch().
+  partials: [Partials.Message, Partials.Reaction, Partials.User],
 });
 
 // Add commands collection to client


### PR DESCRIPTION
## Description

Reaction-role assignment silently failed for any user whose `User` object wasn't cached, because the Discord client was constructed without `Partials.User`. discord.js only emits `messageReactionAdd` / `messageReactionRemove` for uncached users when `Partials.User` is enabled — otherwise it drops the event before any listener fires, so the partial-resolution / dispatch code in `src/index.ts` never runs.

This adds `Partials.User` to the `partials` array in `src/index.ts` (alongside the existing `Partials.Message` / `Partials.Reaction`, which only cover uncached messages/reactions, not uncached users). The result is most visible right after a restart, when caches are cold: a member reacting to an old reaction-role message the bot hasn't cached now gets their role.

The gateway reaction handlers in `src/index.ts` (added by #819) already resolve partial users via `user.fetch()` before dispatching to `ReactionActivityTracker.handleReactionAdd` and `ReactionRoleService.handleReactionAdd`/`handleReactionRemove`, so enabling the partial makes those events actually arrive with no other change required and no behavioural change to how roles are assigned. `Partials.GuildMember` is not needed here: these events deliver a `User`, not a `GuildMember`, and no member-scoped event is consumed.

Rebased onto `main` after #819 (which moved reaction event registration out of `ReactionRoleService` and into `src/index.ts`); the change is now a focused one-line addition to the client `partials`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #809
Refs #808

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)

`npm run build` (typecheck), ESLint, and Prettier all pass; the full reaction-service test suite (31 tests, including the `handleReactionAdd`/`handleReactionRemove` handler coverage added by #819) passes against the rebased base.

No dedicated partial-`User` unit test is added here because, after #819, the partial resolution (`user.fetch()`) lives in the `src/index.ts` gateway handler rather than in `ReactionRoleService`, and the service handlers are already exercised by the existing suite. This PR's change is purely the client-level `partials` configuration that lets the events reach that handler.

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas

No configuration keys, commands, or dependencies changed, so `COMMANDS.md` / `SETTINGS.md` / `Dockerfile` updates are not applicable.

## Additional Notes

Out of scope: any behavioural change to how roles are assigned — this purely enables the events to arrive. The larger reaction→button migration is tracked by #808's other sub-issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)