### PR TITLE
feat(reactionroles): add button and select-menu self-assign role surfaces

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -759,6 +759,7 @@ the Web UI's **Reaction Roles** page.
 | --- | --- | --- |
 | `reactionroles.enabled` | `false` | Enable reaction role system |
 | `reactionroles.message_channel_id` | `""` | Channel ID where reaction-role messages are posted |
+| `reactionroles.style` | `reaction` | Surface style for new role messages: `reaction` (classic emoji), `button`, or `select` (menu) |
 
 ### How it works
 
@@ -768,12 +769,22 @@ the Web UI's **Reaction Roles** page.
    - A Discord role with the specified name
    - A category visible only to role members
    - A text channel inside the category
-   - A reaction message in `reactionroles.message_channel_id`
-3. Users react with the emoji to get the role; remove the reaction to
-   lose it.
-4. The Web UI lets you **Archive** (disable reactions but keep the role
-   and channels), **Unarchive** (re-enable), or **Delete** (remove
-   everything).
+   - A self-assign message in `reactionroles.message_channel_id`, using
+     the surface configured by `reactionroles.style`
+3. Users pick the role from the message:
+   - `reaction`: react with the emoji to get the role; remove the reaction
+     to lose it.
+   - `button`: click the button to toggle the role; an ephemeral "✅ You
+     now have @Role" reply confirms each click. No reaction intents or
+     partials required.
+   - `select`: pick the role from the menu to add it, or deselect to
+     remove it, with an ephemeral confirmation.
+4. `reactionroles.style` only affects **newly created** messages. Existing
+   messages keep whichever style they were created with, so switching the
+   setting never breaks live role pickers.
+5. The Web UI lets you **Archive** (disable the message but keep the role
+   and channels), **Unarchive** (re-enable, preserving the original
+   style), or **Delete** (remove everything).
 
 ### Use cases
 
@@ -1133,6 +1144,7 @@ leave the graph in a broken state.
 
 - `reactionroles.enabled` (bool, default: false)
 - `reactionroles.message_channel_id` (string, default: "")
+- `reactionroles.style` (string, default: "reaction"; one of: reaction, button, select)
 
 #### Leaderboard Role Rewards
 

--- a/__tests__/services/reaction-role-components.test.ts
+++ b/__tests__/services/reaction-role-components.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+const mockGetBoolean = jest.fn<() => Promise<boolean>>();
+const mockGetString = jest.fn<() => Promise<string>>();
+const mockFindOne = jest.fn();
+const mockFind = jest.fn();
+
+jest.unstable_mockModule("../../src/services/config-service.js", () => ({
+  ConfigService: {
+    getInstance: jest.fn(() => ({
+      getBoolean: mockGetBoolean,
+      getString: mockGetString,
+    })),
+  },
+}));
+
+jest.unstable_mockModule("../../src/models/reaction-role-config.js", () => ({
+  ReactionRoleConfig: {
+    findOne: mockFindOne,
+    find: mockFind,
+  },
+  REACTION_ROLE_STYLES: ["reaction", "button", "select"],
+}));
+
+jest.unstable_mockModule("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const { ReactionRoleService } =
+  await import("../../src/services/reaction-role-service.js");
+
+/**
+ * Build a member whose role membership is backed by a real Set, so
+ * add/remove mutate the same state the handler reads back.
+ */
+function createMember(userId: string, roleIds: string[] = []): any {
+  const roles = new Set(roleIds);
+  return {
+    user: { id: userId, tag: `user#${userId}` },
+    roles: {
+      cache: {
+        has: (id: string) => roles.has(id),
+      },
+      add: jest.fn(async (role: { id: string }) => {
+        roles.add(role.id);
+      }),
+      remove: jest.fn(async (role: { id: string }) => {
+        roles.delete(role.id);
+      }),
+    },
+  };
+}
+
+function createGuild(member: any, roles: Record<string, string>): any {
+  const roleCache = new Map(
+    Object.entries(roles).map(([id, name]) => [id, { id, name }]),
+  );
+  return {
+    members: { fetch: jest.fn(async () => member) },
+    roles: {
+      cache: { get: (id: string) => roleCache.get(id) },
+      fetch: jest.fn(async (id: string) => roleCache.get(id) ?? null),
+    },
+  };
+}
+
+describe("ReactionRoleService component interactions", () => {
+  let service: InstanceType<typeof ReactionRoleService>;
+  let mockClient: any;
+  let guild: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetBoolean.mockResolvedValue(true);
+    mockGetString.mockResolvedValue("reaction");
+
+    mockClient = {
+      isReady: jest.fn().mockReturnValue(true),
+      guilds: { fetch: jest.fn(async () => guild) },
+      on: jest.fn(),
+    };
+    service = ReactionRoleService.getInstance(mockClient);
+  });
+
+  describe("handleButtonInteraction", () => {
+    function buildInteraction(overrides: any = {}): any {
+      return {
+        customId: "reactrole:btn:role1",
+        guildId: "guild1",
+        user: { id: "user1" },
+        message: { id: "msg1" },
+        replied: false,
+        deferred: false,
+        reply: jest.fn(),
+        followUp: jest.fn(),
+        ...overrides,
+      };
+    }
+
+    it("adds the role and confirms when the member lacks it", async () => {
+      const member = createMember("user1", []);
+      guild = createGuild(member, { role1: "Gamer" });
+      mockFindOne.mockResolvedValue({ roleId: "role1", roleName: "Gamer" });
+
+      const interaction = buildInteraction();
+      await service.handleButtonInteraction(interaction);
+
+      expect(member.roles.add).toHaveBeenCalledTimes(1);
+      expect(member.roles.remove).not.toHaveBeenCalled();
+      expect(interaction.reply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining("You now have **Gamer**"),
+          ephemeral: true,
+        }),
+      );
+    });
+
+    it("removes the role and confirms when the member already has it", async () => {
+      const member = createMember("user1", ["role1"]);
+      guild = createGuild(member, { role1: "Gamer" });
+      mockFindOne.mockResolvedValue({ roleId: "role1", roleName: "Gamer" });
+
+      const interaction = buildInteraction();
+      await service.handleButtonInteraction(interaction);
+
+      expect(member.roles.remove).toHaveBeenCalledTimes(1);
+      expect(member.roles.add).not.toHaveBeenCalled();
+      expect(interaction.reply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining("Removed **Gamer**"),
+          ephemeral: true,
+        }),
+      );
+    });
+
+    it("refuses when the feature is disabled", async () => {
+      mockGetBoolean.mockResolvedValue(false);
+      const interaction = buildInteraction();
+
+      await service.handleButtonInteraction(interaction);
+
+      expect(mockFindOne).not.toHaveBeenCalled();
+      expect(interaction.reply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining("disabled"),
+          ephemeral: true,
+        }),
+      );
+    });
+
+    it("reports when the mapping no longer exists", async () => {
+      guild = createGuild(createMember("user1"), {});
+      mockFindOne.mockResolvedValue(null);
+      const interaction = buildInteraction();
+
+      await service.handleButtonInteraction(interaction);
+
+      expect(interaction.reply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining("no longer available"),
+          ephemeral: true,
+        }),
+      );
+    });
+  });
+
+  describe("handleSelectInteraction", () => {
+    function buildInteraction(values: string[]): any {
+      return {
+        customId: "reactrole:sel",
+        guildId: "guild1",
+        user: { id: "user1" },
+        message: { id: "msg1" },
+        values,
+        replied: false,
+        deferred: false,
+        reply: jest.fn(),
+        followUp: jest.fn(),
+      };
+    }
+
+    it("adds a selected managed role", async () => {
+      const member = createMember("user1", []);
+      guild = createGuild(member, { role1: "Gamer" });
+      mockFind.mockResolvedValue([{ roleId: "role1", roleName: "Gamer" }]);
+
+      const interaction = buildInteraction(["role1"]);
+      await service.handleSelectInteraction(interaction);
+
+      expect(member.roles.add).toHaveBeenCalledTimes(1);
+      expect(interaction.reply).toHaveBeenCalledWith(
+        expect.objectContaining({ ephemeral: true }),
+      );
+    });
+
+    it("removes a managed role that was deselected", async () => {
+      const member = createMember("user1", ["role1"]);
+      guild = createGuild(member, { role1: "Gamer" });
+      mockFind.mockResolvedValue([{ roleId: "role1", roleName: "Gamer" }]);
+
+      const interaction = buildInteraction([]);
+      await service.handleSelectInteraction(interaction);
+
+      expect(member.roles.remove).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports no changes when selection matches current roles", async () => {
+      const member = createMember("user1", ["role1"]);
+      guild = createGuild(member, { role1: "Gamer" });
+      mockFind.mockResolvedValue([{ roleId: "role1", roleName: "Gamer" }]);
+
+      const interaction = buildInteraction(["role1"]);
+      await service.handleSelectInteraction(interaction);
+
+      expect(member.roles.add).not.toHaveBeenCalled();
+      expect(member.roles.remove).not.toHaveBeenCalled();
+      expect(interaction.reply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: "No changes made.",
+          ephemeral: true,
+        }),
+      );
+    });
+  });
+
+  describe("buildRoleMessagePayload", () => {
+    it("emits a button component for the button style", () => {
+      const payload = (service as any).buildRoleMessagePayload({
+        emoji: "🎮",
+        roleName: "Gamer",
+        roleId: "role1",
+        style: "button",
+      });
+      const button = payload.components[0].components[0];
+      expect(button.data.custom_id).toBe("reactrole:btn:role1");
+      expect(button.data.label).toBe("Gamer");
+    });
+
+    it("emits a select menu carrying the roleId as the option value", () => {
+      const payload = (service as any).buildRoleMessagePayload({
+        emoji: "🎮",
+        roleName: "Gamer",
+        roleId: "role1",
+        style: "select",
+      });
+      const menu = payload.components[0].components[0];
+      expect(menu.data.custom_id).toBe("reactrole:sel");
+      expect(menu.options[0].data.value).toBe("role1");
+    });
+
+    it("emits no components for the reaction style", () => {
+      const payload = (service as any).buildRoleMessagePayload({
+        emoji: "🎮",
+        roleName: "Gamer",
+        roleId: "role1",
+        style: "reaction",
+      });
+      expect(payload.components).toBeUndefined();
+      expect(payload.embeds).toHaveLength(1);
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -818,6 +818,8 @@ client.on(Events.InteractionCreate, async (interaction) => {
         const { handleEventRsvpButton } =
           await import("./handlers/event-rsvp-handler.js");
         await handleEventRsvpButton(interaction);
+      } else if (interaction.customId.startsWith("reactrole:btn:")) {
+        await reactionRoleService.handleButtonInteraction(interaction);
       } else {
         logger.debug(
           `Ignoring button interaction with unrecognized customId: ${interaction.customId}`,
@@ -845,6 +847,8 @@ client.on(Events.InteractionCreate, async (interaction) => {
         const { handleVCPresetSelect } =
           await import("./handlers/vc-preset-handler.js");
         await handleVCPresetSelect(interaction);
+      } else if (interaction.customId === "reactrole:sel") {
+        await reactionRoleService.handleSelectInteraction(interaction);
       } else {
         logger.debug(
           `Ignoring select menu interaction with unrecognized customId: ${interaction.customId}`,

--- a/src/models/reaction-role-config.ts
+++ b/src/models/reaction-role-config.ts
@@ -1,5 +1,22 @@
 import mongoose, { Schema, Document } from "mongoose";
 
+/**
+ * Surface style used to self-assign the role:
+ * - `reaction`: classic emoji reaction on the message (legacy default).
+ * - `button`:   a clickable button component on the message.
+ * - `select`:   a string select-menu option on the message.
+ *
+ * `button` and `select` are component-backed and resolve the acting member
+ * directly from the interaction (no reaction intents/partials required).
+ */
+export type ReactionRoleStyle = "reaction" | "button" | "select";
+
+export const REACTION_ROLE_STYLES: ReactionRoleStyle[] = [
+  "reaction",
+  "button",
+  "select",
+];
+
 export interface IReactionRoleConfig extends Document {
   guildId: string;
   messageId: string;
@@ -8,6 +25,7 @@ export interface IReactionRoleConfig extends Document {
   categoryId: string;
   emoji: string;
   roleName: string;
+  style: ReactionRoleStyle;
   isArchived: boolean;
   createdAt: Date;
   updatedAt: Date;
@@ -46,6 +64,15 @@ const ReactionRoleConfigSchema = new Schema<IReactionRoleConfig>(
     roleName: {
       type: String,
       required: true,
+    },
+    style: {
+      type: String,
+      enum: REACTION_ROLE_STYLES,
+      // Existing documents predate this field; default to the legacy reaction
+      // surface so they keep behaving exactly as before.
+      default: "reaction",
+      required: true,
+      index: true,
     },
     isArchived: {
       type: Boolean,

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -115,6 +115,7 @@ export interface ConfigSchema {
   // Reaction Roles
   "reactionroles.enabled": boolean;
   "reactionroles.message_channel_id": string; // Channel for reaction role messages
+  "reactionroles.style": string; // Surface style for new role messages: reaction | button | select
 
   // Notices System
   "notices.enabled": boolean;
@@ -323,6 +324,7 @@ export const defaultConfig: ConfigSchema = {
   // Reaction Roles defaults
   "reactionroles.enabled": false,
   "reactionroles.message_channel_id": "",
+  "reactionroles.style": "reaction",
 
   // Notices System defaults
   "notices.enabled": false,
@@ -729,7 +731,7 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
   reactionroles: {
     title: "Reaction Roles",
     description:
-      "Let users self-assign roles by reacting to a configured message.",
+      "Let users self-assign roles from a configured message — via a classic emoji reaction, or modern button / select-menu components.",
   },
   notices: {
     title: "Notices",
@@ -1341,6 +1343,18 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
     description: "Channel ID where reaction-role messages are posted.",
     category: "reactionroles",
     type: "channel",
+  },
+  "reactionroles.style": {
+    label: "Self-assign surface style",
+    description:
+      "How new self-assign role messages let members pick a role. 'reaction' is the classic emoji reaction (legacy default). 'button' and 'select' post interactive components — no reaction intents or partials, and an ephemeral confirmation per click. Existing messages keep whichever style they were created with.",
+    category: "reactionroles",
+    type: "string",
+    options: [
+      { value: "reaction", label: "Emoji reaction (classic)" },
+      { value: "button", label: "Button" },
+      { value: "select", label: "Select menu" },
+    ],
   },
 
   // Notices System

--- a/src/services/reaction-role-service.ts
+++ b/src/services/reaction-role-service.ts
@@ -10,6 +10,14 @@ import {
   PartialUser,
   Role,
   Message,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ButtonInteraction,
+  StringSelectMenuBuilder,
+  StringSelectMenuInteraction,
+  ComponentEmojiResolvable,
+  MessageCreateOptions,
 } from "discord.js";
 import { ConfigService } from "./config-service.js";
 import logger from "../utils/logger.js";
@@ -17,7 +25,20 @@ import { sanitizeForLog } from "../utils/log-sanitize.js";
 import {
   ReactionRoleConfig,
   IReactionRoleConfig,
+  ReactionRoleStyle,
+  REACTION_ROLE_STYLES,
 } from "../models/reaction-role-config.js";
+
+/**
+ * customId prefixes for component-backed self-assign roles. Buttons encode the
+ * target roleId (`reactrole:btn:<roleId>`) so a single click maps to exactly
+ * one config; select menus carry roleIds as their option values and use a
+ * static customId (`reactrole:sel`). Both resolve the concrete config from the
+ * interaction's own message id, so no privileged reaction intents or partials
+ * are involved.
+ */
+export const REACTION_ROLE_BUTTON_PREFIX = "reactrole:btn:";
+export const REACTION_ROLE_SELECT_ID = "reactrole:sel";
 
 export class ReactionRoleService {
   private static instance: ReactionRoleService;
@@ -257,6 +278,345 @@ export class ReactionRoleService {
     }
   }
 
+  /**
+   * Resolve the configured default surface style for newly created role
+   * messages. Falls back to the legacy `reaction` surface for any unknown value
+   * so a mistyped config can never break message creation.
+   */
+  private async resolveDefaultStyle(): Promise<ReactionRoleStyle> {
+    const raw = await this.configService.getString(
+      "reactionroles.style",
+      "reaction",
+    );
+    return REACTION_ROLE_STYLES.includes(raw as ReactionRoleStyle)
+      ? (raw as ReactionRoleStyle)
+      : "reaction";
+  }
+
+  /**
+   * Convert a stored emoji string into a component-emoji resolvable.
+   * Custom emojis are stored as `<a?:name:id>`; components need the id (and the
+   * animated flag). Standard emojis are passed through as the Unicode string.
+   * Returns undefined when there is nothing usable, so the button/option simply
+   * renders without an emoji instead of throwing.
+   */
+  private resolveComponentEmoji(
+    emoji: string,
+  ): ComponentEmojiResolvable | undefined {
+    if (!emoji) {
+      return undefined;
+    }
+    const customMatch = emoji.match(/<(a?):(\w+):(\d+)>/);
+    if (customMatch) {
+      return {
+        animated: customMatch[1] === "a",
+        name: customMatch[2],
+        id: customMatch[3],
+      };
+    }
+    return emoji;
+  }
+
+  /**
+   * Build the message payload (embed + optional components) for a self-assign
+   * role message given its style. Used by both create and unarchive so the two
+   * paths never drift.
+   */
+  private buildRoleMessagePayload(config: {
+    emoji: string;
+    roleName: string;
+    roleId: string;
+    style: ReactionRoleStyle;
+  }): MessageCreateOptions {
+    const { emoji, roleName, roleId, style } = config;
+
+    if (style === "button") {
+      const embed = new EmbedBuilder()
+        .setColor(0x5865f2)
+        .setTitle(`${emoji} ${roleName}`)
+        .setDescription(
+          `Click the button below to toggle the **${roleName}** role and its channels.`,
+        )
+        .setFooter({ text: "Click again to remove the role" })
+        .setTimestamp();
+
+      const button = new ButtonBuilder()
+        .setCustomId(`${REACTION_ROLE_BUTTON_PREFIX}${roleId}`)
+        .setLabel(roleName)
+        .setStyle(ButtonStyle.Primary);
+      const componentEmoji = this.resolveComponentEmoji(emoji);
+      if (componentEmoji) {
+        button.setEmoji(componentEmoji);
+      }
+
+      const row = new ActionRowBuilder<ButtonBuilder>().addComponents(button);
+      return { embeds: [embed], components: [row] };
+    }
+
+    if (style === "select") {
+      const embed = new EmbedBuilder()
+        .setColor(0x5865f2)
+        .setTitle(`${emoji} ${roleName}`)
+        .setDescription(
+          `Use the menu below to give yourself the **${roleName}** role and its channels.`,
+        )
+        .setFooter({ text: "Deselect to remove the role" })
+        .setTimestamp();
+
+      const option = {
+        label: roleName,
+        value: roleId,
+        description: `Toggle the ${roleName} role`.slice(0, 100),
+      } as {
+        label: string;
+        value: string;
+        description: string;
+        emoji?: ComponentEmojiResolvable;
+      };
+      const componentEmoji = this.resolveComponentEmoji(emoji);
+      if (componentEmoji) {
+        option.emoji = componentEmoji;
+      }
+
+      const menu = new StringSelectMenuBuilder()
+        .setCustomId(REACTION_ROLE_SELECT_ID)
+        .setPlaceholder(`Pick to toggle ${roleName}`.slice(0, 150))
+        .setMinValues(0)
+        .setMaxValues(1)
+        .addOptions(option);
+
+      const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+        menu,
+      );
+      return { embeds: [embed], components: [row] };
+    }
+
+    // Default: legacy reaction surface. The caller adds the reaction after send.
+    const embed = new EmbedBuilder()
+      .setColor(0x5865f2)
+      .setTitle(`${emoji} ${roleName}`)
+      .setDescription(
+        `React with ${emoji} to get access to the **${roleName}** role and channels!`,
+      )
+      .setFooter({ text: "Remove your reaction to lose access" })
+      .setTimestamp();
+    return { embeds: [embed] };
+  }
+
+  /**
+   * Add or remove a role on a member and return a human-readable, ephemeral
+   * confirmation line. Shared by the button and select component handlers.
+   */
+  private async applyRoleToggle(
+    guildId: string,
+    userId: string,
+    roleId: string,
+    desired: "add" | "remove",
+  ): Promise<string> {
+    const guild = await this.client.guilds.fetch(guildId);
+    const member = await guild.members.fetch(userId);
+    const role =
+      guild.roles.cache.get(roleId) ?? (await guild.roles.fetch(roleId));
+
+    if (!role) {
+      logger.error(`Role ${roleId} not found while applying self-assign role`);
+      return `⚠️ That role no longer exists.`;
+    }
+
+    const hasRole = member.roles.cache.has(roleId);
+
+    if (desired === "add") {
+      if (hasRole) {
+        return `You already have **${role.name}**.`;
+      }
+      await member.roles.add(role);
+      logger.info(`Added role ${role.name} to user ${member.user.tag}`);
+      return `✅ You now have **${role.name}**.`;
+    }
+
+    if (!hasRole) {
+      return `You don't have **${role.name}**.`;
+    }
+    await member.roles.remove(role);
+    logger.info(`Removed role ${role.name} from user ${member.user.tag}`);
+    return `➖ Removed **${role.name}**.`;
+  }
+
+  /**
+   * Handle a button click on a component-backed self-assign role message.
+   * customId format: `reactrole:btn:<roleId>`. Toggles the role for the acting
+   * member and replies ephemerally. Routed from the central interaction handler
+   * in `index.ts`, not a service-owned `client.on`.
+   */
+  public async handleButtonInteraction(
+    interaction: ButtonInteraction,
+  ): Promise<void> {
+    try {
+      const roleId = interaction.customId.slice(
+        REACTION_ROLE_BUTTON_PREFIX.length,
+      );
+      if (!roleId || !interaction.guildId) {
+        await interaction.reply({
+          content: "⚠️ This role button is invalid.",
+          ephemeral: true,
+        });
+        return;
+      }
+
+      const enabled = await this.configService.getBoolean(
+        "reactionroles.enabled",
+        false,
+      );
+      if (!enabled) {
+        await interaction.reply({
+          content: "⚠️ Self-assign roles are currently disabled.",
+          ephemeral: true,
+        });
+        return;
+      }
+
+      const config = await ReactionRoleConfig.findOne({
+        messageId: interaction.message.id,
+        roleId,
+        isArchived: false,
+      });
+      if (!config) {
+        await interaction.reply({
+          content: "⚠️ This role is no longer available.",
+          ephemeral: true,
+        });
+        return;
+      }
+
+      const hasRole = await this.memberHasRole(
+        interaction.guildId,
+        interaction.user.id,
+        roleId,
+      );
+      const message = await this.applyRoleToggle(
+        interaction.guildId,
+        interaction.user.id,
+        roleId,
+        hasRole ? "remove" : "add",
+      );
+
+      await interaction.reply({ content: message, ephemeral: true });
+    } catch (error) {
+      logger.error("Error handling reaction-role button:", error);
+      await this.safeErrorReply(interaction);
+    }
+  }
+
+  /**
+   * Handle a selection on a component-backed self-assign role message.
+   * customId is the static `reactrole:sel`; the selected option values are
+   * roleIds. The set of roles this message manages is every non-archived
+   * select-style config bound to the message, so a deselect removes a role and
+   * a select adds one. Forward-compatible with multiple roles per message.
+   */
+  public async handleSelectInteraction(
+    interaction: StringSelectMenuInteraction,
+  ): Promise<void> {
+    try {
+      if (!interaction.guildId) {
+        await interaction.reply({
+          content: "⚠️ This menu is invalid.",
+          ephemeral: true,
+        });
+        return;
+      }
+
+      const enabled = await this.configService.getBoolean(
+        "reactionroles.enabled",
+        false,
+      );
+      if (!enabled) {
+        await interaction.reply({
+          content: "⚠️ Self-assign roles are currently disabled.",
+          ephemeral: true,
+        });
+        return;
+      }
+
+      const configs = await ReactionRoleConfig.find({
+        messageId: interaction.message.id,
+        style: "select",
+        isArchived: false,
+      });
+      if (configs.length === 0) {
+        await interaction.reply({
+          content: "⚠️ These roles are no longer available.",
+          ephemeral: true,
+        });
+        return;
+      }
+
+      const managedRoleIds = new Set(configs.map((c) => c.roleId));
+      const selected = new Set(
+        interaction.values.filter((v) => managedRoleIds.has(v)),
+      );
+
+      const lines: string[] = [];
+      for (const roleId of managedRoleIds) {
+        const desired = selected.has(roleId) ? "add" : "remove";
+        const hasRole = await this.memberHasRole(
+          interaction.guildId,
+          interaction.user.id,
+          roleId,
+        );
+        // Only act (and report) when the selection actually changes state.
+        if (
+          (desired === "add" && !hasRole) ||
+          (desired === "remove" && hasRole)
+        ) {
+          lines.push(
+            await this.applyRoleToggle(
+              interaction.guildId,
+              interaction.user.id,
+              roleId,
+              desired,
+            ),
+          );
+        }
+      }
+
+      await interaction.reply({
+        content: lines.length > 0 ? lines.join("\n") : "No changes made.",
+        ephemeral: true,
+      });
+    } catch (error) {
+      logger.error("Error handling reaction-role select menu:", error);
+      await this.safeErrorReply(interaction);
+    }
+  }
+
+  /** Whether a guild member currently holds a role (cache-first, then fetch). */
+  private async memberHasRole(
+    guildId: string,
+    userId: string,
+    roleId: string,
+  ): Promise<boolean> {
+    const guild = await this.client.guilds.fetch(guildId);
+    const member = await guild.members.fetch(userId);
+    return member.roles.cache.has(roleId);
+  }
+
+  /** Reply (or follow up) with a generic error without throwing again. */
+  private async safeErrorReply(
+    interaction: ButtonInteraction | StringSelectMenuInteraction,
+  ): Promise<void> {
+    const content = "⚠️ Something went wrong updating your roles.";
+    try {
+      if (interaction.replied || interaction.deferred) {
+        await interaction.followUp({ content, ephemeral: true });
+      } else {
+        await interaction.reply({ content, ephemeral: true });
+      }
+    } catch {
+      // Nothing more we can do if the interaction can't be answered.
+    }
+  }
+
   public async createReactionRole(
     guildId: string,
     roleName: string,
@@ -386,30 +746,33 @@ export class ReactionRoleService {
         );
       }
 
-      // Create the reaction role message
-      const embed = new EmbedBuilder()
-        .setColor(0x5865f2)
-        .setTitle(`${emoji} ${roleName}`)
-        .setDescription(
-          `React with ${emoji} to get access to the **${roleName}** role and channels!`,
-        )
-        .setFooter({ text: "Remove your reaction to lose access" })
-        .setTimestamp();
+      // Determine the surface style for this message from config.
+      const style = await this.resolveDefaultStyle();
 
-      message = await messageChannel.send({ embeds: [embed] });
+      // Create the self-assign role message with the appropriate surface.
+      message = await messageChannel.send(
+        this.buildRoleMessagePayload({
+          emoji,
+          roleName,
+          roleId: role.id,
+          style,
+        }),
+      );
 
-      // Try to add reaction
-      try {
-        await message.react(emoji);
-      } catch (reactionError) {
-        logger.error("Failed to add reaction to message:", reactionError);
-        throw new Error(
-          "Failed to add reaction. The emoji might be invalid or inaccessible.",
-        );
+      // Only the legacy reaction surface needs an actual reaction added.
+      if (style === "reaction") {
+        try {
+          await message.react(emoji);
+        } catch (reactionError) {
+          logger.error("Failed to add reaction to message:", reactionError);
+          throw new Error(
+            "Failed to add reaction. The emoji might be invalid or inaccessible.",
+          );
+        }
       }
 
       logger.info(
-        `Created reaction role message ${message.id} in channel ${messageChannel.name}`,
+        `Created ${style} self-assign role message ${message.id} in channel ${messageChannel.name}`,
       );
 
       // Save to database
@@ -421,6 +784,7 @@ export class ReactionRoleService {
         categoryId: category.id,
         emoji: normalizedEmoji,
         roleName,
+        style,
         isArchived: false,
       });
 
@@ -604,39 +968,42 @@ export class ReactionRoleService {
         };
       }
 
-      // Create a new reaction role message
-      const embed = new EmbedBuilder()
-        .setColor(0x5865f2)
-        .setTitle(`${config.emoji} ${config.roleName}`)
-        .setDescription(
-          `React with ${config.emoji} to get access to the **${config.roleName}** role and channels!`,
-        )
-        .setFooter({ text: "Remove your reaction to lose access" })
-        .setTimestamp();
+      // Recreate the message using the style the config was created with, so
+      // component-backed configs stay component-backed after unarchiving.
+      const style: ReactionRoleStyle = config.style ?? "reaction";
+      const message = await messageChannel.send(
+        this.buildRoleMessagePayload({
+          emoji: config.emoji,
+          roleName: config.roleName,
+          roleId: config.roleId,
+          style,
+        }),
+      );
 
-      const message = await messageChannel.send({ embeds: [embed] });
-
-      // Try to add reaction, if it fails, delete the message and abort
-      try {
-        await message.react(config.emoji);
-      } catch (reactionError) {
-        logger.error("Failed to add reaction to message:", reactionError);
+      // Only the legacy reaction surface needs an actual reaction added; if it
+      // fails, delete the message and abort.
+      if (style === "reaction") {
         try {
-          await message.delete();
-        } catch (deleteError) {
-          logger.error(
-            "Failed to delete message after reaction error:",
-            deleteError,
-          );
+          await message.react(config.emoji);
+        } catch (reactionError) {
+          logger.error("Failed to add reaction to message:", reactionError);
+          try {
+            await message.delete();
+          } catch (deleteError) {
+            logger.error(
+              "Failed to delete message after reaction error:",
+              deleteError,
+            );
+          }
+          return {
+            success: false,
+            message: `Failed to add reaction to message. The emoji might be invalid.`,
+          };
         }
-        return {
-          success: false,
-          message: `Failed to add reaction to message. The emoji might be invalid.`,
-        };
       }
 
       logger.info(
-        `Created new reaction role message ${message.id} for unarchived role ${sanitizeForLog(roleName)}`,
+        `Recreated ${style} self-assign role message ${message.id} for unarchived role ${sanitizeForLog(roleName)}`,
       );
 
       // Update database with error handling

--- a/src/services/reaction-role-service.ts
+++ b/src/services/reaction-role-service.ts
@@ -9,6 +9,7 @@ import {
   PartialMessageReaction,
   PartialUser,
   Role,
+  GuildMember,
   Message,
   ActionRowBuilder,
   ButtonBuilder,
@@ -342,7 +343,8 @@ export class ReactionRoleService {
 
       const button = new ButtonBuilder()
         .setCustomId(`${REACTION_ROLE_BUTTON_PREFIX}${roleId}`)
-        .setLabel(roleName)
+        // Discord caps button labels at 80 chars; role names may be up to 100.
+        .setLabel(roleName.slice(0, 80))
         .setStyle(ButtonStyle.Primary);
       const componentEmoji = this.resolveComponentEmoji(emoji);
       if (componentEmoji) {
@@ -364,7 +366,8 @@ export class ReactionRoleService {
         .setTimestamp();
 
       const option = {
-        label: roleName,
+        // Discord caps select-option labels at 100 chars.
+        label: roleName.slice(0, 100),
         value: roleId,
         description: `Toggle the ${roleName} role`.slice(0, 100),
       } as {
@@ -404,26 +407,17 @@ export class ReactionRoleService {
   }
 
   /**
-   * Add or remove a role on a member and return a human-readable, ephemeral
-   * confirmation line. Shared by the button and select component handlers.
+   * Add or remove a role on an already-fetched member and return a
+   * human-readable, ephemeral confirmation line. The caller resolves the guild,
+   * member and role once and reuses them, so a multi-role message only pays for
+   * a single guild/member fetch. Shared by the button and select handlers.
    */
-  private async applyRoleToggle(
-    guildId: string,
-    userId: string,
-    roleId: string,
+  private async applyRoleToggleForMember(
+    member: GuildMember,
+    role: Role,
     desired: "add" | "remove",
   ): Promise<string> {
-    const guild = await this.client.guilds.fetch(guildId);
-    const member = await guild.members.fetch(userId);
-    const role =
-      guild.roles.cache.get(roleId) ?? (await guild.roles.fetch(roleId));
-
-    if (!role) {
-      logger.error(`Role ${roleId} not found while applying self-assign role`);
-      return `⚠️ That role no longer exists.`;
-    }
-
-    const hasRole = member.roles.cache.has(roleId);
+    const hasRole = member.roles.cache.has(role.id);
 
     if (desired === "add") {
       if (hasRole) {
@@ -488,16 +482,26 @@ export class ReactionRoleService {
         return;
       }
 
-      const hasRole = await this.memberHasRole(
-        interaction.guildId,
-        interaction.user.id,
-        roleId,
-      );
-      const message = await this.applyRoleToggle(
-        interaction.guildId,
-        interaction.user.id,
-        roleId,
-        hasRole ? "remove" : "add",
+      const guild = await this.client.guilds.fetch(interaction.guildId);
+      const member = await guild.members.fetch(interaction.user.id);
+      const role =
+        guild.roles.cache.get(roleId) ?? (await guild.roles.fetch(roleId));
+      if (!role) {
+        logger.error(
+          `Role ${roleId} not found while toggling self-assign role`,
+        );
+        await interaction.reply({
+          content: "⚠️ That role no longer exists.",
+          ephemeral: true,
+        });
+        return;
+      }
+
+      const desired = member.roles.cache.has(roleId) ? "remove" : "add";
+      const message = await this.applyRoleToggleForMember(
+        member,
+        role,
+        desired,
       );
 
       await interaction.reply({ content: message, ephemeral: true });
@@ -556,26 +560,30 @@ export class ReactionRoleService {
         interaction.values.filter((v) => managedRoleIds.has(v)),
       );
 
+      // Fetch the guild and member once, then reason about every managed role
+      // against the member's cached roles — no per-role REST fetches.
+      const guild = await this.client.guilds.fetch(interaction.guildId);
+      const member = await guild.members.fetch(interaction.user.id);
+
       const lines: string[] = [];
       for (const roleId of managedRoleIds) {
         const desired = selected.has(roleId) ? "add" : "remove";
-        const hasRole = await this.memberHasRole(
-          interaction.guildId,
-          interaction.user.id,
-          roleId,
-        );
+        const hasRole = member.roles.cache.has(roleId);
         // Only act (and report) when the selection actually changes state.
         if (
           (desired === "add" && !hasRole) ||
           (desired === "remove" && hasRole)
         ) {
+          const role =
+            guild.roles.cache.get(roleId) ?? (await guild.roles.fetch(roleId));
+          if (!role) {
+            logger.error(
+              `Role ${roleId} not found while toggling self-assign role`,
+            );
+            continue;
+          }
           lines.push(
-            await this.applyRoleToggle(
-              interaction.guildId,
-              interaction.user.id,
-              roleId,
-              desired,
-            ),
+            await this.applyRoleToggleForMember(member, role, desired),
           );
         }
       }
@@ -588,17 +596,6 @@ export class ReactionRoleService {
       logger.error("Error handling reaction-role select menu:", error);
       await this.safeErrorReply(interaction);
     }
-  }
-
-  /** Whether a guild member currently holds a role (cache-first, then fetch). */
-  private async memberHasRole(
-    guildId: string,
-    userId: string,
-    roleId: string,
-  ): Promise<boolean> {
-    const guild = await this.client.guilds.fetch(guildId);
-    const member = await guild.members.fetch(userId);
-    return member.roles.cache.has(roleId);
   }
 
   /** Reply (or follow up) with a generic error without throwing again. */

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -331,7 +331,11 @@ const WIZARD_FEATURE_SETTINGS: Record<string, string[]> = {
     "achievements.announcements.enabled",
     "achievements.dm_notifications.enabled",
   ],
-  reactionroles: ["reactionroles.enabled", "reactionroles.message_channel_id"],
+  reactionroles: [
+    "reactionroles.enabled",
+    "reactionroles.message_channel_id",
+    "reactionroles.style",
+  ],
   announcements: ["announcements.enabled"],
   notices: ["notices.enabled", "notices.channel_id", "notices.header_enabled"],
   polls: [


### PR DESCRIPTION
## Description

Adds an interaction-component path for self-assign roles — a **button** or a **select menu** on the role message — as the modern alternative to emoji reactions. This is the headline modernization item from #808: it mirrors how current community bots (Carl-bot, Mee6, etc.) do role pickers.

A new `reactionroles.style` config (`reaction` | `button` | `select`) chooses the surface for **newly created** role messages, defaulting to `reaction` so nothing changes for existing setups. Each config also persists its own `style`, so switching the setting never breaks live role pickers, and archive/unarchive round-trips the original surface.

Component surfaces resolve the acting member directly from the interaction — no `GuildMessageReactions` intent, no message/reaction/user partials, no cache misses — and reply ephemerally (e.g. "✅ You now have **@Role**") on every click.

### What changed

- **Model** (`src/models/reaction-role-config.ts`): new `style: reaction | button | select` field (defaults to `reaction` for pre-existing documents), with an exported `ReactionRoleStyle` type / `REACTION_ROLE_STYLES` list.
- **Service** (`src/services/reaction-role-service.ts`):
  - `buildRoleMessagePayload()` renders the embed plus the button / select components (shared by create and unarchive so the two paths can't drift).
  - `handleButtonInteraction()` toggles the role for `reactrole:btn:<roleId>` clicks.
  - `handleSelectInteraction()` (static `reactrole:sel` customId, roleIds as option values) adds selected managed roles and removes deselected ones — forward-compatible with multiple roles per message.
  - The reaction path is untouched; only the reaction surface adds an actual reaction after send.
- **Routing** (`src/index.ts`): button/select interactions are dispatched from the existing central `InteractionCreate` handler — no new service-owned `client.on`.
- **Config** (`src/services/config-schema.ts`, `src/web/write-routes.ts`): declares `reactionroles.style` with its option whitelist and adds it to the Web UI settings/wizard allowlist.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Related Issues

Closes #811
Refs #808

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`) — 133 suites / 1660 tests green
- [x] Added new tests for new functionality (`__tests__/services/reaction-role-components.test.ts`: button add/remove/disabled/missing, select add/remove/no-op, and payload shape per style)
- [x] `npm run build`, `npm run lint`, `npm run format:check`, and `markdownlint` all pass; coverage remains above thresholds

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] My changes generate no new warnings or errors

### Documentation

- [x] `SETTINGS.md` updated with the new `reactionroles.style` key and per-style behavior
- [x] Inline code comments for the customId scheme and toggle logic
- [x] Markdown validated with `markdownlint`

### Configuration

- [x] New behavior is opt-in — `reactionroles.style` defaults to the existing `reaction` surface
- [x] Configuration schema entry added in `config-schema.ts`
- [x] New configuration key documented in `SETTINGS.md`

## Out of scope

- Removing the reaction path (kept working for existing configs).
- Migration tooling from reaction configs → button configs (follow-up).
- Multiple roles bound to one message; the select handler is already written to support it, but message creation is still one-role-per-message today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPQPr6aM1spLzbJ3pyemmE)_