### PR TITLE
docs(reaction-roles): document Web-UI-only admin surface, drop stale /reactrole references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,23 @@ Prometheus metrics at `src/web/metrics.ts`). It is gated by env/config — see `
 **Static content (`src/content/`)** holds achievement/accolade/status/notice definitions; `examples/`
 holds example poll libraries.
 
+### Admin surface: Web UI only (design decision — read before proposing a new command)
+
+**From v1.0 onward the Web UI is the _only_ admin surface.** Slash commands are reserved for day-to-day
+moderation and member self-service (e.g. `/warn`, `/modlog`, `/quote`, `/seen`, `/voicestats`,
+`/achievements`, plus `/config`, which just DMs a one-time Web UI sign-in link). Everything that
+_configures or manages_ a feature lives in `src/web/` — the admin management commands that used to exist
+(`/permissions`, `/setup`, `/announce`, `/poll`, `/reactrole`, `/notice`, `/dbtrunk`, `/vc`, `/botstats`)
+were **deliberately retired** in the Web UI migration, not lost. See `WEBUI.md` and the "Replaces (legacy
+slash command)" table in `COMMANDS.md`.
+
+Do **not** re-add an admin management command as a slash command "for parity" — that reverses the
+decision. If a config-schema description, doc, or UI string still advertises a retired command, the fix is
+to correct the stale text, not to ship the command. (This is why issue #812, "add `/reactrole`", was closed
+as not-planned: reaction-role management is configuration and belongs to the Reaction Roles Web UI page.)
+New slash commands are appropriate only when the interaction is genuinely day-to-day
+moderation/self-service that a member or moderator runs in Discord — not admin setup.
+
 ### The command pattern (read before adding a command)
 
 Each file in `src/commands/` exports `data: SlashCommandBuilder` and `execute(interaction)`. Registration

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -1332,7 +1332,8 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
   },
   "reactionroles.enabled": {
     label: "Reaction roles enabled",
-    description: "Enable the reaction-role system and the /reactrole command.",
+    description:
+      "Enable the reaction-role system. Manage mappings from the admin Web UI (Reaction Roles page).",
     category: "reactionroles",
     type: "boolean",
   },

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -2132,7 +2132,7 @@ export function renderReactionRolesPage(props: ReactionRolesProps): string {
 
   const body = `
 <h1>Reaction Roles</h1>
-<p class="subtitle">Per-message reaction-role mappings. Replaces <code>/reactrole create|archive|unarchive|delete|list|status</code>; the slash commands still work in parallel during migration.</p>
+<p class="subtitle">Per-message reaction-role mappings. This page is the admin surface for reaction roles; the legacy <code>/reactrole</code> slash command was retired in the Web UI migration.</p>
 ${renderFlash(props.flash)}
 ${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Reaction Roles", featureKey: "reactionroles.enabled", returnTo: "/admin/reaction-roles", csrfToken: props.csrfToken })}
 <div class="card">


### PR DESCRIPTION
## Description

Issue #812 asked to add a `/reactrole` slash command "for parity," on the grounds that the config
schema advertised a command that no code implements. But the missing command is not an oversight —
`/reactrole` was **deliberately retired** in the v1.0 Web-UI-only admin migration (see `WEBUI.md`, the
"Replaces (legacy slash command)" table in `COMMANDS.md`, `README.md`, `.env.example`). Reaction-role
management is *configuration* and lives on the Reaction Roles admin Web UI page.

The real defect was two stale strings that still advertised the retired command, contradicting that
decision:

- **`src/services/config-schema.ts`** — the `reactionroles.enabled` description said "…and the
  /reactrole command." Now points admins at the Reaction Roles Web UI page.
- **`src/web/admin-views.ts`** — the Reaction Roles page subtitle claimed "the slash commands still work
  in parallel during migration." Corrected to state the legacy command was retired.

To prevent the same confusion next time, the design decision is now documented in **`CLAUDE.md`** as an
"Admin surface: Web UI only" callout at the top of the command-pattern section — the exact spot a
contributor reads before proposing a new command: admin management/configuration commands are not to be
re-added as slash commands; slash commands are reserved for day-to-day moderation and member
self-service. It references #812 as the worked example.

Note: several other admin pages (`announcements`, `polls`, `notices`, `dbtrunk`, `vc`) carry the same
"still work in parallel during migration" line for commands that are also gone — a broader doc cleanup
left out of scope here to keep this focused on #812.

## Type of Change

- [x] 📚 Documentation update

## Related Issues

Closes #812

## How Has This Been Tested?

No behavioral change — the edits are description/UI strings and Markdown docs. Verified the CI gates:

- `npm run build` — passes (typecheck clean)
- `npx eslint` on the touched TS files — clean
- `npx prettier --check` on the touched TS files — clean
- `npx markdownlint CLAUDE.md` — clean

No test asserted the old strings (grep-verified), so no tests needed updating.

## Additional Notes

Reviewed the full diff; three files changed (`CLAUDE.md`, `src/services/config-schema.ts`,
`src/web/admin-views.ts`). Branch is based on the latest `origin/main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZk1Zb3pvbWBL5YXwSv744)_