### PR TITLE
feat(reaction-roles): add assignment modes and startup/deletion reconciliation

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -888,6 +888,23 @@ The bot needs these Discord permissions:
 **For reaction roles:**
 
 - Manage Roles (the bot's highest role must sit above any role it grants)
+- Manage Messages (only for the `unique` assignment mode, so the bot can
+  clear a member's reaction on the sibling options it deselects)
+
+Each mapping has an **assignment mode** chosen at creation
+(`/admin/reaction-roles`):
+
+- **toggle** (default): react to add the role, remove the reaction to
+  lose it.
+- **sticky**: react to add the role; removing the reaction keeps it (good
+  for opt-in cosmetic roles).
+- **unique**: reacting clears the other roles mapped on the same message,
+  so a member ends up with at most one from the set.
+
+On startup the bot reconciles each active mapping — archiving any whose
+message or role was deleted while it was offline, and re-adding its own
+base reaction if it went missing. It also archives a mapping automatically
+when its message, role, category, or channel is deleted.
 
 **For leaderboard role rewards:**
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -901,6 +901,14 @@ Each mapping has an **assignment mode** chosen at creation
 - **unique**: reacting clears the other roles mapped on the same message,
   so a member ends up with at most one from the set.
 
+Because a normal reaction role is created on its own message, `unique`
+only has siblings to clear inside a **role group** — one message that
+offers several roles at once (created via **Create a role group** on
+`/admin/reaction-roles`, e.g. a pick-one-colour set). A group shares a
+single category/channel and is deleted as a unit; the per-role
+archive/delete actions are disabled for its members. Toggle and sticky
+mode also work for groups (each option acts independently / add-only).
+
 On startup the bot reconciles each active mapping — archiving any whose
 message or role was deleted while it was offline, and re-adding its own
 base reaction if it went missing. It also archives a mapping automatically

--- a/__tests__/services/reaction-role-components.test.ts
+++ b/__tests__/services/reaction-role-components.test.ts
@@ -20,6 +20,7 @@ jest.unstable_mockModule("../../src/models/reaction-role-config.js", () => ({
     find: mockFind,
   },
   REACTION_ROLE_STYLES: ["reaction", "button", "select"],
+  REACTION_ROLE_MODES: ["toggle", "sticky", "unique"],
 }));
 
 jest.unstable_mockModule("../../src/utils/logger.js", () => ({
@@ -29,6 +30,9 @@ jest.unstable_mockModule("../../src/utils/logger.js", () => ({
     error: jest.fn(),
     debug: jest.fn(),
   },
+  // reaction-role-service now transitively imports CommandManager, which pulls
+  // in the named `isDebugMode` export — the native ESM mock must provide it.
+  isDebugMode: jest.fn(() => false),
 }));
 
 const { ReactionRoleService } =

--- a/__tests__/services/reaction-role-service-bind-persist.test.ts
+++ b/__tests__/services/reaction-role-service-bind-persist.test.ts
@@ -18,6 +18,9 @@ jest.unstable_mockModule("../../src/utils/logger.js", () => ({
     warn: jest.fn(),
     debug: jest.fn(),
   },
+  // reaction-role-service now transitively imports CommandManager, which pulls
+  // in the named `isDebugMode` export — the native ESM mock must provide it.
+  isDebugMode: jest.fn(() => false),
 }));
 
 jest.unstable_mockModule("../../src/models/reaction-role-config.js", () => {
@@ -32,6 +35,7 @@ jest.unstable_mockModule("../../src/models/reaction-role-config.js", () => {
   return {
     ReactionRoleConfig,
     REACTION_ROLE_STYLES: ["reaction", "button", "select"],
+    REACTION_ROLE_MODES: ["toggle", "sticky", "unique"],
   };
 });
 

--- a/__tests__/services/reaction-role-service-group.test.ts
+++ b/__tests__/services/reaction-role-service-group.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import type { Client } from "discord.js";
+
+jest.mock("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+  isDebugMode: jest.fn(() => false),
+}));
+
+jest.mock("../../src/models/reaction-role-config.js");
+
+import { ReactionRoleService } from "../../src/services/reaction-role-service.js";
+import { ReactionRoleConfig } from "../../src/models/reaction-role-config.js";
+
+const model = ReactionRoleConfig as unknown as {
+  findOne: jest.Mock;
+  find: jest.Mock;
+  insertMany: jest.Mock;
+  deleteMany: jest.Mock;
+};
+model.findOne = jest.fn();
+model.find = jest.fn();
+model.insertMany = jest.fn();
+model.deleteMany = jest.fn();
+
+function createService(client: Partial<Client>) {
+  const service = ReactionRoleService.getInstance(client as Client);
+  const mockConfigService = {
+    getBoolean: jest.fn<() => Promise<boolean>>().mockResolvedValue(true),
+    getString: jest.fn<() => Promise<string>>().mockResolvedValue("msgchan"),
+    getNumber: jest.fn(),
+  };
+  (service as never)["configService"] = mockConfigService;
+  return { service, mockConfigService };
+}
+
+/**
+ * Build a guild whose role/channel/message creation all succeed, capturing the
+ * created message's reactions and the sent payload.
+ */
+function makeCreateClient() {
+  let roleSeq = 0;
+  const message = {
+    id: "grp1",
+    react: jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+    delete: jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+  };
+  const category = {
+    id: "cat1",
+    permissionOverwrites: {
+      edit: jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+    },
+    delete: jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+  };
+  const channel = {
+    id: "chan1",
+    delete: jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+  };
+  const messageChannel = {
+    isTextBased: () => true,
+    send: jest.fn<() => Promise<unknown>>().mockResolvedValue(message),
+  };
+  const guild = {
+    id: "g1",
+    roles: {
+      everyone: { id: "everyone" },
+      create: jest.fn<() => Promise<unknown>>().mockImplementation(async () => {
+        roleSeq += 1;
+        return {
+          id: `role${roleSeq}`,
+          name: `role${roleSeq}`,
+          delete: jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+        };
+      }),
+    },
+    channels: {
+      // First create() is the category, second is the text channel.
+      create: jest
+        .fn<() => Promise<unknown>>()
+        .mockResolvedValueOnce(category)
+        .mockResolvedValueOnce(channel),
+      fetch: jest
+        .fn<() => Promise<unknown>>()
+        .mockResolvedValue(messageChannel),
+    },
+    members: { me: { id: "bot" } },
+  };
+  const client = {
+    guilds: {
+      fetch: jest.fn<() => Promise<unknown>>().mockResolvedValue(guild),
+    },
+  };
+  return { client, guild, message, category, channel, messageChannel };
+}
+
+describe("ReactionRoleService.createReactionRoleGroup", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (
+      ReactionRoleService as unknown as { instance?: ReactionRoleService }
+    ).instance = undefined;
+    model.findOne.mockResolvedValue(null);
+    model.insertMany.mockResolvedValue([]);
+  });
+
+  it("creates one shared message and persists a mapping per option", async () => {
+    const { client, message } = makeCreateClient();
+    const { service } = createService(client);
+
+    const result = await service.createReactionRoleGroup(
+      "g1",
+      "Colour",
+      [
+        { roleName: "Red", emoji: "🔴" },
+        { roleName: "Blue", emoji: "🔵" },
+      ],
+      "unique",
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.groupId).toBe("grp1");
+    expect(result.roleIds).toEqual(["role1", "role2"]);
+
+    // Both emojis reacted onto the single shared message.
+    expect(message.react).toHaveBeenNthCalledWith(1, "🔴");
+    expect(message.react).toHaveBeenNthCalledWith(2, "🔵");
+
+    // One insertMany with two docs sharing message/group/mode.
+    expect(model.insertMany).toHaveBeenCalledTimes(1);
+    const docs = model.insertMany.mock.calls[0][0] as Array<
+      Record<string, unknown>
+    >;
+    expect(docs).toHaveLength(2);
+    expect(docs.every((d) => d.messageId === "grp1")).toBe(true);
+    expect(docs.every((d) => d.groupId === "grp1")).toBe(true);
+    expect(docs.every((d) => d.mode === "unique")).toBe(true);
+    expect(docs.map((d) => d.emoji)).toEqual(["🔴", "🔵"]);
+  });
+
+  it("rejects a group with fewer than two options without touching Discord", async () => {
+    const { client, guild } = makeCreateClient();
+    const { service } = createService(client);
+
+    const result = await service.createReactionRoleGroup("g1", "Solo", [
+      { roleName: "OnlyOne", emoji: "1️⃣" },
+    ]);
+
+    expect(result.success).toBe(false);
+    expect(guild.roles.create).not.toHaveBeenCalled();
+    expect(model.insertMany).not.toHaveBeenCalled();
+  });
+
+  it("rejects duplicate emojis within the group", async () => {
+    const { client, guild } = makeCreateClient();
+    const { service } = createService(client);
+
+    const result = await service.createReactionRoleGroup("g1", "Dup", [
+      { roleName: "Red", emoji: "🔴" },
+      { roleName: "Crimson", emoji: "🔴" },
+    ]);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/emoji/i);
+    expect(guild.roles.create).not.toHaveBeenCalled();
+  });
+
+  it("rolls back created roles/channels/message when persistence fails", async () => {
+    const { client, message, category, channel } = makeCreateClient();
+    const { service } = createService(client);
+    model.insertMany.mockRejectedValue(new Error("db down"));
+
+    const result = await service.createReactionRoleGroup("g1", "Colour", [
+      { roleName: "Red", emoji: "🔴" },
+      { roleName: "Blue", emoji: "🔵" },
+    ]);
+
+    expect(result.success).toBe(false);
+    // Shared resources are torn down on failure.
+    expect(message.delete).toHaveBeenCalledTimes(1);
+    expect(channel.delete).toHaveBeenCalledTimes(1);
+    expect(category.delete).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects when a role name already exists", async () => {
+    const { client, guild } = makeCreateClient();
+    const { service } = createService(client);
+    model.findOne.mockResolvedValue({ roleName: "Red" });
+
+    const result = await service.createReactionRoleGroup("g1", "Colour", [
+      { roleName: "Red", emoji: "🔴" },
+      { roleName: "Blue", emoji: "🔵" },
+    ]);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/already exists/i);
+    expect(guild.roles.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("ReactionRoleService.deleteReactionRoleGroup", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (
+      ReactionRoleService as unknown as { instance?: ReactionRoleService }
+    ).instance = undefined;
+  });
+
+  it("tears down every role plus the shared category, channel, and message", async () => {
+    const message = {
+      delete: jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+    };
+    const messageChannel = {
+      messages: {
+        fetch: jest.fn<() => Promise<unknown>>().mockResolvedValue(message),
+      },
+    };
+    const category = {
+      children: { cache: new Map() },
+      delete: jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+    };
+    const roleDelete = jest
+      .fn<() => Promise<unknown>>()
+      .mockResolvedValue(undefined);
+    const guild = {
+      channels: {
+        fetch: jest
+          .fn<() => Promise<unknown>>()
+          // message channel first, then the group category
+          .mockResolvedValueOnce(messageChannel)
+          .mockResolvedValueOnce(category),
+      },
+      roles: {
+        fetch: jest
+          .fn<() => Promise<unknown>>()
+          .mockResolvedValue({ delete: roleDelete }),
+      },
+    };
+    const client = {
+      guilds: {
+        fetch: jest.fn<() => Promise<unknown>>().mockResolvedValue(guild),
+      },
+    };
+    const { service } = createService(client);
+    model.find.mockResolvedValue([
+      { roleId: "role1", messageId: "grp1", categoryId: "cat1" },
+      { roleId: "role2", messageId: "grp1", categoryId: "cat1" },
+    ]);
+    model.deleteMany.mockResolvedValue({ deletedCount: 2 });
+
+    const result = await service.deleteReactionRoleGroup("g1", "grp1");
+
+    expect(result.success).toBe(true);
+    expect(message.delete).toHaveBeenCalledTimes(1);
+    expect(category.delete).toHaveBeenCalledTimes(1);
+    expect(roleDelete).toHaveBeenCalledTimes(2);
+    expect(model.deleteMany).toHaveBeenCalledWith({
+      guildId: "g1",
+      groupId: "grp1",
+    });
+  });
+
+  it("returns not-found when the group has no configs", async () => {
+    const client = {
+      guilds: { fetch: jest.fn<() => Promise<unknown>>() },
+    };
+    const { service } = createService(client);
+    model.find.mockResolvedValue([]);
+
+    const result = await service.deleteReactionRoleGroup("g1", "nope");
+
+    expect(result.success).toBe(false);
+    expect(model.deleteMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("ReactionRoleService single-role guards on group members", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (
+      ReactionRoleService as unknown as { instance?: ReactionRoleService }
+    ).instance = undefined;
+  });
+
+  // Mappings are addressed by their stable ObjectId (#813/#824), so the guards
+  // are reached only for a valid id whose config carries a groupId.
+  const MAPPING_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
+
+  it("deleteReactionRole refuses a grouped mapping", async () => {
+    const guildFetch = jest.fn();
+    const { service } = createService({ guilds: { fetch: guildFetch } } as never);
+    model.findOne.mockResolvedValue({
+      roleName: "Red",
+      groupId: "grp1",
+    });
+
+    const result = await service.deleteReactionRole("g1", MAPPING_ID);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/role group/i);
+    // Guard returns before any Discord work.
+    expect(guildFetch).not.toHaveBeenCalled();
+  });
+
+  it("archiveReactionRole refuses a grouped mapping", async () => {
+    const { service } = createService({ guilds: { fetch: jest.fn() } } as never);
+    model.findOne.mockResolvedValue({
+      roleName: "Red",
+      groupId: "grp1",
+      isArchived: false,
+    });
+
+    const result = await service.archiveReactionRole("g1", MAPPING_ID);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/role group/i);
+  });
+});

--- a/__tests__/services/reaction-role-service-modes.test.ts
+++ b/__tests__/services/reaction-role-service-modes.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import type { Client, MessageReaction, User } from "discord.js";
+
+jest.mock("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock("../../src/models/reaction-role-config.js");
+
+import { ReactionRoleService } from "../../src/services/reaction-role-service.js";
+import { ReactionRoleConfig } from "../../src/models/reaction-role-config.js";
+
+const findOne = ((
+  ReactionRoleConfig as unknown as { findOne: jest.Mock }
+).findOne = jest.fn());
+const find = ((ReactionRoleConfig as unknown as { find: jest.Mock }).find =
+  jest.fn());
+
+function createService() {
+  const service = ReactionRoleService.getInstance({} as Client);
+  const mockConfigService = {
+    getBoolean: jest.fn<() => Promise<boolean>>().mockResolvedValue(true),
+    getString: jest.fn(),
+    getNumber: jest.fn(),
+  };
+  (service as never)["configService"] = mockConfigService;
+  return { service, mockConfigService };
+}
+
+/**
+ * Build a reaction whose message lives in a guild. `heldRoles` is the set of
+ * role ids the member currently has; `rolesAdd`/`rolesRemove` capture mutations.
+ */
+function makeReaction(opts: {
+  heldRoles: Set<string>;
+  rolesAdd: jest.Mock;
+  rolesRemove: jest.Mock;
+  emojiName?: string;
+}): MessageReaction {
+  const member = {
+    id: "user1",
+    roles: {
+      cache: { has: (id: string) => opts.heldRoles.has(id) },
+      add: opts.rolesAdd,
+      remove: opts.rolesRemove,
+    },
+  };
+  const guild = {
+    members: {
+      fetch: jest.fn<() => Promise<unknown>>().mockResolvedValue(member),
+    },
+    roles: {
+      cache: {
+        get: (id: string) => ({ id, name: id === "role1" ? "Cool" : id }),
+      },
+    },
+  };
+  return {
+    partial: false,
+    emoji: { id: null, name: opts.emojiName ?? "🎮", animated: false },
+    message: { id: "msg1", guild },
+  } as unknown as MessageReaction;
+}
+
+function makeUser(): User {
+  return {
+    partial: false,
+    id: "user1",
+    tag: "User#0001",
+    bot: false,
+  } as unknown as User;
+}
+
+describe("ReactionRoleService assignment modes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (
+      ReactionRoleService as unknown as { instance?: ReactionRoleService }
+    ).instance = undefined;
+  });
+
+  describe("sticky mode", () => {
+    it("handleReactionRemove does NOT revoke the role", async () => {
+      const { service } = createService();
+      findOne.mockResolvedValue({
+        roleId: "role1",
+        roleName: "Cool",
+        mode: "sticky",
+      });
+      const rolesAdd = jest.fn();
+      const rolesRemove = jest.fn();
+
+      await service.handleReactionRemove(
+        makeReaction({
+          heldRoles: new Set(["role1"]),
+          rolesAdd,
+          rolesRemove,
+        }),
+        makeUser(),
+      );
+
+      expect(rolesRemove).not.toHaveBeenCalled();
+    });
+
+    it("handleReactionAdd still grants the role", async () => {
+      const { service } = createService();
+      findOne.mockResolvedValue({
+        roleId: "role1",
+        roleName: "Cool",
+        mode: "sticky",
+      });
+      const rolesAdd = jest
+        .fn<() => Promise<unknown>>()
+        .mockResolvedValue(undefined);
+      const rolesRemove = jest.fn();
+
+      await service.handleReactionAdd(
+        makeReaction({ heldRoles: new Set(), rolesAdd, rolesRemove }),
+        makeUser(),
+      );
+
+      expect(rolesAdd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("toggle mode", () => {
+    it("handleReactionRemove revokes the role", async () => {
+      const { service } = createService();
+      findOne.mockResolvedValue({
+        roleId: "role1",
+        roleName: "Cool",
+        mode: "toggle",
+      });
+      const rolesAdd = jest.fn();
+      const rolesRemove = jest
+        .fn<() => Promise<unknown>>()
+        .mockResolvedValue(undefined);
+
+      await service.handleReactionRemove(
+        makeReaction({
+          heldRoles: new Set(["role1"]),
+          rolesAdd,
+          rolesRemove,
+        }),
+        makeUser(),
+      );
+
+      expect(rolesRemove).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("unique mode", () => {
+    it("handleReactionAdd removes sibling roles on the same message", async () => {
+      const { service } = createService();
+      findOne.mockResolvedValue({
+        roleId: "role1",
+        roleName: "Cool",
+        messageId: "msg1",
+        emoji: "🎮",
+        mode: "unique",
+      });
+      // One sibling config on the same message granting role2, which the
+      // member currently holds.
+      find.mockResolvedValue([
+        { roleId: "role2", roleName: "Warm", emoji: "🔥" },
+      ]);
+      const rolesAdd = jest
+        .fn<() => Promise<unknown>>()
+        .mockResolvedValue(undefined);
+      const rolesRemove = jest
+        .fn<() => Promise<unknown>>()
+        .mockResolvedValue(undefined);
+
+      await service.handleReactionAdd(
+        makeReaction({
+          heldRoles: new Set(["role2"]),
+          rolesAdd,
+          rolesRemove,
+        }),
+        makeUser(),
+      );
+
+      expect(rolesAdd).toHaveBeenCalledTimes(1);
+      expect(rolesRemove).toHaveBeenCalledTimes(1);
+      expect(rolesRemove).toHaveBeenCalledWith("role2");
+      // Sibling lookup is scoped to the same message and excludes the picked role.
+      expect(find).toHaveBeenCalledWith({
+        messageId: "msg1",
+        isArchived: false,
+        roleId: { $ne: "role1" },
+      });
+    });
+
+    it("handleReactionAdd leaves sibling roles the member does not hold", async () => {
+      const { service } = createService();
+      findOne.mockResolvedValue({
+        roleId: "role1",
+        roleName: "Cool",
+        messageId: "msg1",
+        emoji: "🎮",
+        mode: "unique",
+      });
+      find.mockResolvedValue([
+        { roleId: "role2", roleName: "Warm", emoji: "🔥" },
+      ]);
+      const rolesAdd = jest
+        .fn<() => Promise<unknown>>()
+        .mockResolvedValue(undefined);
+      const rolesRemove = jest.fn();
+
+      await service.handleReactionAdd(
+        makeReaction({ heldRoles: new Set(), rolesAdd, rolesRemove }),
+        makeUser(),
+      );
+
+      expect(rolesRemove).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/services/reaction-role-service-modes.test.ts
+++ b/__tests__/services/reaction-role-service-modes.test.ts
@@ -41,6 +41,9 @@ function makeReaction(opts: {
   rolesAdd: jest.Mock;
   rolesRemove: jest.Mock;
   emojiName?: string;
+  // Sibling reactions cached on the message, keyed by emoji name; each value's
+  // `users.remove` captures the per-member reaction-clear call (unique mode).
+  siblingReactions?: Array<{ name: string; usersRemove: jest.Mock }>;
 }): MessageReaction {
   const member = {
     id: "user1",
@@ -60,10 +63,19 @@ function makeReaction(opts: {
       },
     },
   };
+  const cachedReactions = (opts.siblingReactions ?? []).map((s) => ({
+    emoji: { id: null, name: s.name, animated: false },
+    users: { remove: s.usersRemove },
+  }));
+  const reactions = {
+    cache: {
+      find: (pred: (r: unknown) => boolean) => cachedReactions.find(pred),
+    },
+  };
   return {
     partial: false,
     emoji: { id: null, name: opts.emojiName ?? "🎮", animated: false },
-    message: { id: "msg1", guild },
+    message: { id: "msg1", guild, reactions },
   } as unknown as MessageReaction;
 }
 
@@ -219,6 +231,83 @@ describe("ReactionRoleService assignment modes", () => {
       );
 
       expect(rolesRemove).not.toHaveBeenCalled();
+    });
+
+    it("handleReactionAdd clears the member's reaction on sibling emojis", async () => {
+      const { service } = createService();
+      findOne.mockResolvedValue({
+        roleId: "role1",
+        roleName: "Cool",
+        messageId: "msg1",
+        emoji: "🎮",
+        mode: "unique",
+      });
+      find.mockResolvedValue([
+        { roleId: "role2", roleName: "Warm", emoji: "🔥" },
+      ]);
+      const rolesAdd = jest
+        .fn<() => Promise<unknown>>()
+        .mockResolvedValue(undefined);
+      const rolesRemove = jest
+        .fn<() => Promise<unknown>>()
+        .mockResolvedValue(undefined);
+      const usersRemove = jest
+        .fn<() => Promise<unknown>>()
+        .mockResolvedValue(undefined);
+
+      await service.handleReactionAdd(
+        makeReaction({
+          heldRoles: new Set(["role2"]),
+          rolesAdd,
+          rolesRemove,
+          siblingReactions: [{ name: "🔥", usersRemove }],
+        }),
+        makeUser(),
+      );
+
+      // The sibling emoji reaction is cleared for this member (user1).
+      expect(usersRemove).toHaveBeenCalledWith("user1");
+    });
+
+    it("handleReactionAdd fails soft when clearing a sibling reaction throws", async () => {
+      const { service } = createService();
+      findOne.mockResolvedValue({
+        roleId: "role1",
+        roleName: "Cool",
+        messageId: "msg1",
+        emoji: "🎮",
+        mode: "unique",
+      });
+      find.mockResolvedValue([
+        { roleId: "role2", roleName: "Warm", emoji: "🔥" },
+      ]);
+      const rolesAdd = jest
+        .fn<() => Promise<unknown>>()
+        .mockResolvedValue(undefined);
+      const rolesRemove = jest
+        .fn<() => Promise<unknown>>()
+        .mockResolvedValue(undefined);
+      // Simulate a missing Manage Messages permission — clearing the sibling
+      // reaction rejects, but the role mutation must still have happened and
+      // handleReactionAdd must not throw.
+      const usersRemove = jest
+        .fn<() => Promise<unknown>>()
+        .mockRejectedValue(new Error("Missing Permissions"));
+
+      await expect(
+        service.handleReactionAdd(
+          makeReaction({
+            heldRoles: new Set(["role2"]),
+            rolesAdd,
+            rolesRemove,
+            siblingReactions: [{ name: "🔥", usersRemove }],
+          }),
+          makeUser(),
+        ),
+      ).resolves.toBeUndefined();
+
+      expect(rolesRemove).toHaveBeenCalledWith("role2");
+      expect(usersRemove).toHaveBeenCalledWith("user1");
     });
   });
 });

--- a/__tests__/services/reaction-role-service-reconcile.test.ts
+++ b/__tests__/services/reaction-role-service-reconcile.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import type { Client, Role, Message } from "discord.js";
+
+jest.mock("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock("../../src/models/reaction-role-config.js");
+
+import { ReactionRoleService } from "../../src/services/reaction-role-service.js";
+import { ReactionRoleConfig } from "../../src/models/reaction-role-config.js";
+
+const find = ((ReactionRoleConfig as unknown as { find: jest.Mock }).find =
+  jest.fn());
+
+// One shared client for every test. reconcileConfigs constructs the real
+// CommandManager (and, transitively, PermissionsService) via getInstance, both
+// of which are singletons that reject a *different* client — so all tests must
+// hand them the same client reference. The real makeDiscordApiCall simply races
+// the wrapped REST call against a timeout, so it resolves instantly here.
+const guildFetch = jest.fn<() => Promise<unknown>>();
+const sharedClient = { guilds: { fetch: guildFetch } } as unknown as Client;
+
+interface FakeConfig {
+  _id: string;
+  guildId: string;
+  roleId: string;
+  messageId: string;
+  emoji: string;
+  roleName: string;
+  isArchived: boolean;
+  archivedAt?: Date;
+  save: jest.Mock;
+}
+
+function makeConfig(overrides: Partial<FakeConfig> = {}): FakeConfig {
+  return {
+    _id: "cfg1",
+    guildId: "g1",
+    roleId: "role1",
+    messageId: "msg1",
+    emoji: "🎮",
+    roleName: "Cool",
+    isArchived: false,
+    save: jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function createService() {
+  const service = ReactionRoleService.getInstance(sharedClient);
+  const mockConfigService = {
+    getBoolean: jest.fn<() => Promise<boolean>>().mockResolvedValue(true),
+    getString: jest.fn<() => Promise<string>>().mockResolvedValue("chan1"),
+    getNumber: jest.fn(),
+  };
+  (service as never)["configService"] = mockConfigService;
+  return { service, mockConfigService };
+}
+
+/**
+ * Wire the shared client's guild.fetch to return a guild whose role/message
+ * lookups resolve to the supplied values.
+ */
+function primeGuild(opts: { role: unknown; message: unknown }): void {
+  const messageChannel = {
+    isTextBased: () => true,
+    messages: {
+      fetch: jest.fn<() => Promise<unknown>>().mockResolvedValue(opts.message),
+    },
+  };
+  const guild = {
+    id: "g1",
+    roles: {
+      fetch: jest.fn<() => Promise<unknown>>().mockResolvedValue(opts.role),
+    },
+    channels: {
+      fetch: jest
+        .fn<() => Promise<unknown>>()
+        .mockResolvedValue(messageChannel),
+    },
+  };
+  guildFetch.mockResolvedValue(guild);
+}
+
+function makeMessage(opts: { hasOwnReaction: boolean }): {
+  react: jest.Mock;
+  reactions: { cache: { some: (p: (r: unknown) => boolean) => boolean } };
+} {
+  const reactions = opts.hasOwnReaction
+    ? [{ emoji: { id: null, name: "🎮" }, me: true }]
+    : [];
+  return {
+    react: jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+    reactions: {
+      cache: {
+        some: (pred: (r: unknown) => boolean) => reactions.some(pred),
+      },
+    },
+  };
+}
+
+describe("ReactionRoleService.reconcileConfigs", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (
+      ReactionRoleService as unknown as { instance?: ReactionRoleService }
+    ).instance = undefined;
+  });
+
+  it("archives a config whose role no longer exists", async () => {
+    const config = makeConfig();
+    find.mockResolvedValue([config]);
+    primeGuild({ role: null, message: makeMessage({ hasOwnReaction: true }) });
+    const { service } = createService();
+
+    await service.reconcileConfigs();
+
+    expect(config.isArchived).toBe(true);
+    expect(config.save).toHaveBeenCalledTimes(1);
+  });
+
+  it("archives a config whose reaction message no longer exists", async () => {
+    const config = makeConfig();
+    find.mockResolvedValue([config]);
+    primeGuild({ role: { id: "role1", name: "Cool" }, message: null });
+    const { service } = createService();
+
+    await service.reconcileConfigs();
+
+    expect(config.isArchived).toBe(true);
+    expect(config.save).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-adds the bot's base reaction when it went missing", async () => {
+    const config = makeConfig();
+    find.mockResolvedValue([config]);
+    const message = makeMessage({ hasOwnReaction: false });
+    primeGuild({ role: { id: "role1", name: "Cool" }, message });
+    const { service } = createService();
+
+    await service.reconcileConfigs();
+
+    expect(message.react).toHaveBeenCalledWith("🎮");
+    expect(config.isArchived).toBe(false);
+    expect(config.save).not.toHaveBeenCalled();
+  });
+
+  it("leaves a fully-healthy config untouched", async () => {
+    const config = makeConfig();
+    find.mockResolvedValue([config]);
+    const message = makeMessage({ hasOwnReaction: true });
+    primeGuild({ role: { id: "role1", name: "Cool" }, message });
+    const { service } = createService();
+
+    await service.reconcileConfigs();
+
+    expect(message.react).not.toHaveBeenCalled();
+    expect(config.save).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when there are no active configs", async () => {
+    find.mockResolvedValue([]);
+    const { service } = createService();
+
+    await service.reconcileConfigs();
+
+    // No config processing means no guild is ever fetched.
+    expect(guildFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("ReactionRoleService stale-config cleanup handlers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (
+      ReactionRoleService as unknown as { instance?: ReactionRoleService }
+    ).instance = undefined;
+  });
+
+  it("handleMessageDelete archives configs backed by the deleted message", async () => {
+    const config = makeConfig();
+    find.mockResolvedValue([config]);
+    const { service } = createService();
+
+    await service.handleMessageDelete({ id: "msg1" } as unknown as Message);
+
+    expect(find).toHaveBeenCalledWith({
+      messageId: "msg1",
+      isArchived: false,
+    });
+    expect(config.isArchived).toBe(true);
+    expect(config.save).toHaveBeenCalledTimes(1);
+  });
+
+  it("handleRoleDelete archives configs that granted the deleted role", async () => {
+    const config = makeConfig();
+    find.mockResolvedValue([config]);
+    const { service } = createService();
+
+    await service.handleRoleDelete({
+      id: "role1",
+      guild: { id: "g1" },
+    } as unknown as Role);
+
+    expect(find).toHaveBeenCalledWith({
+      guildId: "g1",
+      roleId: "role1",
+      isArchived: false,
+    });
+    expect(config.isArchived).toBe(true);
+    expect(config.save).toHaveBeenCalledTimes(1);
+  });
+
+  it("handleChannelDelete archives configs whose backing channel was deleted", async () => {
+    const config = makeConfig();
+    find.mockResolvedValue([config]);
+    const { service, mockConfigService } = createService();
+    // Message channel is a different channel, so this exercises the
+    // category/channel branch rather than the "message channel deleted" branch.
+    mockConfigService.getString.mockResolvedValue("some-other-channel");
+
+    await service.handleChannelDelete({
+      id: "chan1",
+      guild: { id: "g1" },
+    } as never);
+
+    expect(config.isArchived).toBe(true);
+    expect(config.save).toHaveBeenCalledTimes(1);
+  });
+
+  it("handleChannelDelete ignores DM channels (no guild)", async () => {
+    const { service } = createService();
+
+    await service.handleChannelDelete({ id: "dm1" } as never);
+
+    expect(find).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/services/reaction-role-service-reconcile.test.ts
+++ b/__tests__/services/reaction-role-service-reconcile.test.ts
@@ -67,18 +67,33 @@ function createService() {
  * Wire the shared client's guild.fetch to return a guild whose role/message
  * lookups resolve to the supplied values.
  */
-function primeGuild(opts: { role: unknown; message: unknown }): void {
+function primeGuild(opts: {
+  role?: unknown;
+  message?: unknown;
+  roleError?: unknown;
+  messageError?: unknown;
+}): void {
+  const roleFetch = jest.fn<() => Promise<unknown>>();
+  if (opts.roleError !== undefined) {
+    roleFetch.mockRejectedValue(opts.roleError);
+  } else {
+    roleFetch.mockResolvedValue(opts.role);
+  }
+
+  const messageFetch = jest.fn<() => Promise<unknown>>();
+  if (opts.messageError !== undefined) {
+    messageFetch.mockRejectedValue(opts.messageError);
+  } else {
+    messageFetch.mockResolvedValue(opts.message);
+  }
+
   const messageChannel = {
     isTextBased: () => true,
-    messages: {
-      fetch: jest.fn<() => Promise<unknown>>().mockResolvedValue(opts.message),
-    },
+    messages: { fetch: messageFetch },
   };
   const guild = {
     id: "g1",
-    roles: {
-      fetch: jest.fn<() => Promise<unknown>>().mockResolvedValue(opts.role),
-    },
+    roles: { fetch: roleFetch },
     channels: {
       fetch: jest
         .fn<() => Promise<unknown>>()
@@ -161,6 +176,35 @@ describe("ReactionRoleService.reconcileConfigs", () => {
     await service.reconcileConfigs();
 
     expect(message.react).not.toHaveBeenCalled();
+    expect(config.save).not.toHaveBeenCalled();
+  });
+
+  it("does NOT archive on a transient role-fetch error", async () => {
+    const config = makeConfig();
+    find.mockResolvedValue([config]);
+    // A plain Error is not a confirmed Unknown Role (10011), so it must be
+    // treated as transient and skipped — never archived.
+    primeGuild({ roleError: new Error("network blip") });
+    const { service } = createService();
+
+    await service.reconcileConfigs();
+
+    expect(config.isArchived).toBe(false);
+    expect(config.save).not.toHaveBeenCalled();
+  });
+
+  it("does NOT archive on a transient message-fetch error", async () => {
+    const config = makeConfig();
+    find.mockResolvedValue([config]);
+    primeGuild({
+      role: { id: "role1", name: "Cool" },
+      messageError: new Error("504 gateway timeout"),
+    });
+    const { service } = createService();
+
+    await service.reconcileConfigs();
+
+    expect(config.isArchived).toBe(false);
     expect(config.save).not.toHaveBeenCalled();
   });
 

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -1475,6 +1475,7 @@ describe("renderReactionRolesPage", () => {
           messageId: "m1",
           autoCreated: true,
           mode: "sticky",
+          groupId: null,
           isArchived: false,
           archivedAt: null,
         },
@@ -1493,6 +1494,9 @@ describe("renderReactionRolesPage", () => {
     expect(html).toContain(
       '<input type="hidden" name="mappingId" value="aaaaaaaaaaaaaaaaaaaaaaaa">',
     );
+    // The one-of-set group creation form is offered.
+    expect(html).toContain("/admin/reaction-roles/group/create");
+    expect(html).toContain("Create a role group");
   });
 
   it("renders a bound mapping with a remove-mapping control and bound tag", () => {
@@ -1523,6 +1527,35 @@ describe("renderReactionRolesPage", () => {
     expect(html).not.toContain("/admin/reaction-roles/archive");
   });
 
+  it("renders a group-delete control for grouped rows instead of per-role controls", () => {
+    const html = renderReactionRolesPage({
+      ...COMMON,
+      enabled: true,
+      configChannel: { name: "roles", id: "c1" },
+      active: [
+        {
+          mappingId: "dddddddddddddddddddddddd",
+          emoji: "🔴",
+          roleName: "Red",
+          roleId: "r1",
+          categoryName: "Colour",
+          channelName: "colour",
+          messageId: "grp1",
+          autoCreated: true,
+          mode: "unique",
+          groupId: "grp1",
+          isArchived: false,
+          archivedAt: null,
+        },
+      ],
+      archived: [],
+    });
+    expect(html).toContain("/admin/reaction-roles/group/delete");
+    expect(html).toContain('name="groupId" value="grp1"');
+    // Grouped rows must not expose the per-role archive control.
+    expect(html).not.toContain("/admin/reaction-roles/archive");
+  });
+
   it("renders unarchive control for archived rows", () => {
     const html = renderReactionRolesPage({
       ...COMMON,
@@ -1540,6 +1573,7 @@ describe("renderReactionRolesPage", () => {
           messageId: "m2",
           autoCreated: true,
           mode: "toggle",
+          groupId: null,
           isArchived: true,
           archivedAt: "2026-05-08T00:00:00.000Z",
         },

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -1474,6 +1474,7 @@ describe("renderReactionRolesPage", () => {
           channelName: "roles",
           messageId: "m1",
           autoCreated: true,
+          mode: "sticky",
           isArchived: false,
           archivedAt: null,
         },
@@ -1484,6 +1485,7 @@ describe("renderReactionRolesPage", () => {
     expect(html).toContain("Gamer");
     expect(html).toContain("#roles");
     expect(html).toContain('class="tag tag-on">active');
+    expect(html).toContain("sticky");
     expect(html).toContain("/admin/reaction-roles/create");
     expect(html).toContain("/admin/reaction-roles/archive");
     expect(html).toContain("/admin/reaction-roles/delete");
@@ -1508,6 +1510,7 @@ describe("renderReactionRolesPage", () => {
           channelName: "—",
           messageId: "m9",
           autoCreated: false,
+          mode: "toggle",
           isArchived: false,
           archivedAt: null,
         },
@@ -1536,6 +1539,7 @@ describe("renderReactionRolesPage", () => {
           channelName: "old",
           messageId: "m2",
           autoCreated: true,
+          mode: "toggle",
           isArchived: true,
           archivedAt: "2026-05-08T00:00:00.000Z",
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1028,6 +1028,36 @@ client.on(Events.MessageReactionRemove, async (reaction, user) => {
   }
 });
 
+// Self-heal reaction-role configs when their backing Discord objects are
+// deleted out from under the bot (#814). Each handler archives the affected
+// config(s) so the DB stops drifting from reality; gating lives in the service.
+client.on(Events.MessageDelete, async (message) => {
+  recordDiscordEvent("messageDelete");
+  try {
+    await reactionRoleService.handleMessageDelete(message);
+  } catch (error) {
+    logger.error("Error handling messageDelete:", error);
+  }
+});
+
+client.on(Events.GuildRoleDelete, async (role) => {
+  recordDiscordEvent("roleDelete");
+  try {
+    await reactionRoleService.handleRoleDelete(role);
+  } catch (error) {
+    logger.error("Error handling roleDelete:", error);
+  }
+});
+
+client.on(Events.ChannelDelete, async (channel) => {
+  recordDiscordEvent("channelDelete");
+  try {
+    await reactionRoleService.handleChannelDelete(channel);
+  } catch (error) {
+    logger.error("Error handling channelDelete:", error);
+  }
+});
+
 // Handle native-poll votes for per-user participation tracking (#570).
 // Gating (enabled, DM/bot) lives in the tracker.
 client.on(Events.MessagePollVoteAdd, async (pollAnswer, userId) => {

--- a/src/models/reaction-role-config.ts
+++ b/src/models/reaction-role-config.ts
@@ -60,6 +60,10 @@ export interface IReactionRoleConfig extends Document {
    */
   autoCreated: boolean;
   mode: ReactionRoleMode;
+  // Correlates the mappings that share one message as a one-of-set group
+  // (#814). Populated only for grouped mappings; single mappings leave it
+  // undefined. Equal to the group's anchor message id at creation time.
+  groupId?: string;
   isArchived: boolean;
   createdAt: Date;
   updatedAt: Date;
@@ -118,6 +122,11 @@ const ReactionRoleConfigSchema = new Schema<IReactionRoleConfig>(
       enum: REACTION_ROLE_MODES,
       default: "toggle",
       required: true,
+    },
+    groupId: {
+      type: String,
+      required: false,
+      index: true,
     },
     isArchived: {
       type: Boolean,

--- a/src/models/reaction-role-config.ts
+++ b/src/models/reaction-role-config.ts
@@ -17,6 +17,21 @@ export const REACTION_ROLE_STYLES: ReactionRoleStyle[] = [
   "select",
 ];
 
+/**
+ * Assignment behaviour for a reaction role (#814):
+ * - `toggle` (default, back-compat): react = add, unreact = remove.
+ * - `sticky`: react grants the role; removing the reaction does NOT revoke it.
+ * - `unique`: reacting removes the sibling roles configured on the same
+ *   message (one-of-set / pick exactly one).
+ */
+export type ReactionRoleMode = "toggle" | "sticky" | "unique";
+
+export const REACTION_ROLE_MODES: readonly ReactionRoleMode[] = [
+  "toggle",
+  "sticky",
+  "unique",
+];
+
 export interface IReactionRoleConfig extends Document {
   guildId: string;
   messageId: string;
@@ -44,6 +59,7 @@ export interface IReactionRoleConfig extends Document {
    * with `true` (see reaction-role-migrator.ts).
    */
   autoCreated: boolean;
+  mode: ReactionRoleMode;
   isArchived: boolean;
   createdAt: Date;
   updatedAt: Date;
@@ -96,6 +112,12 @@ const ReactionRoleConfigSchema = new Schema<IReactionRoleConfig>(
       type: Boolean,
       default: true,
       index: true,
+    },
+    mode: {
+      type: String,
+      enum: REACTION_ROLE_MODES,
+      default: "toggle",
+      required: true,
     },
     isArchived: {
       type: Boolean,

--- a/src/services/command-manager.ts
+++ b/src/services/command-manager.ts
@@ -143,21 +143,29 @@ export class CommandManager {
     return this.loadCommandsDynamically();
   }
 
-  // Helper function to make Discord API calls with timeout and retry logic
-  private async makeDiscordApiCall<T>(
+  // Helper function to make Discord API calls with timeout and retry logic.
+  // Public so other services (e.g. ReactionRoleService's startup
+  // reconciliation) can reuse the shared timeout + backoff behaviour for bulk
+  // REST work, per CLAUDE.md's resilience guidance.
+  public async makeDiscordApiCall<T>(
     apiCall: () => Promise<T>,
     operationName: string,
     timeoutMs: number = 30000,
     maxRetries: number = 3,
   ): Promise<T> {
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      // Track the timeout handle so it can be cleared once the race settles —
+      // otherwise a fast-resolving apiCall leaves the timer pending, keeping
+      // the event loop alive (and tripping Jest's open-handle warning).
+      let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
       try {
         // Create a timeout promise
         const timeoutPromise = new Promise<never>((_, reject) => {
-          setTimeout(
+          timeoutHandle = setTimeout(
             () => reject(new Error(`Discord API timeout after ${timeoutMs}ms`)),
             timeoutMs,
           );
+          timeoutHandle.unref?.();
         });
 
         // Race the API call against the timeout
@@ -212,6 +220,10 @@ export class CommandManager {
           throw new Error(
             `Failed to ${operationName} after ${maxRetries} attempts`,
           );
+        }
+      } finally {
+        if (timeoutHandle) {
+          clearTimeout(timeoutHandle);
         }
       }
     }

--- a/src/services/reaction-role-service.ts
+++ b/src/services/reaction-role-service.ts
@@ -1601,6 +1601,359 @@ export class ReactionRoleService {
     }
   }
 
+  /**
+   * Create a one-of-set role group (#814): one shared reaction message carries
+   * several role options, and each option's mapping shares the message id (and
+   * a `groupId`) so `unique` mode has real siblings to clear. All options live
+   * under a single shared category/channel gated to any of the group's roles.
+   *
+   * Reaction-surface only — `unique` is a reaction concept, and mixing button/
+   * select components with one-of-set semantics is out of scope here.
+   *
+   * Fully transactional: on any failure every created role/channel/category/
+   * message is rolled back so a partial group never lingers.
+   */
+  public async createReactionRoleGroup(
+    guildId: string,
+    groupName: string,
+    entries: Array<{ roleName: string; emoji: string }>,
+    mode: ReactionRoleMode = "unique",
+  ): Promise<{
+    success: boolean;
+    message: string;
+    groupId?: string;
+    messageId?: string;
+    roleIds?: string[];
+  }> {
+    // Validate the group shape before touching Discord.
+    if (entries.length < 2) {
+      return {
+        success: false,
+        message: "A role group needs at least two role options.",
+      };
+    }
+    if (entries.length > 20) {
+      return {
+        success: false,
+        message: "A role group can have at most 20 role options.",
+      };
+    }
+    const names = entries.map((e) => e.roleName.trim());
+    if (names.some((n) => n.length === 0)) {
+      return { success: false, message: "Every role option needs a name." };
+    }
+    if (names.some((n) => n.length > 100)) {
+      return {
+        success: false,
+        message: "Role names must be 100 characters or fewer.",
+      };
+    }
+    const lowerNames = names.map((n) => n.toLowerCase());
+    if (new Set(lowerNames).size !== lowerNames.length) {
+      return {
+        success: false,
+        message: "Role names within a group must be unique.",
+      };
+    }
+    const emojis = entries.map((e) => this.normalizeEmoji(e.emoji.trim()));
+    if (emojis.some((e) => e.length === 0)) {
+      return { success: false, message: "Every role option needs an emoji." };
+    }
+    if (new Set(emojis).size !== emojis.length) {
+      return {
+        success: false,
+        message: "Emojis within a group must be unique.",
+      };
+    }
+
+    const createdRoles: Role[] = [];
+    let category: CategoryChannel | null = null;
+    let channel: TextChannel | null = null;
+    let message: Message | null = null;
+
+    try {
+      // A group is always one-of-set; anything else is meaningless for a shared
+      // message, so coerce to `unique` unless a caller explicitly picks another
+      // valid mode (e.g. sticky opt-in sets).
+      const normalizedMode: ReactionRoleMode = REACTION_ROLE_MODES.includes(
+        mode,
+      )
+        ? mode
+        : "unique";
+
+      // Reject if any target role name already exists (roleName is unique).
+      const clash = await ReactionRoleConfig.findOne({
+        guildId,
+        roleName: { $in: names },
+      });
+      if (clash) {
+        return {
+          success: false,
+          message: `A reaction role named **${clash.roleName}** already exists in this server.`,
+        };
+      }
+
+      const guild = await this.client.guilds.fetch(guildId);
+
+      const messageChannelId = await this.configService.getString(
+        "reactionroles.message_channel_id",
+        "",
+      );
+      if (!messageChannelId) {
+        throw new Error(
+          "Reaction role message channel not configured. Set reactionroles.message_channel_id",
+        );
+      }
+      const messageChannel = (await guild.channels.fetch(
+        messageChannelId,
+      )) as TextChannel;
+      if (!messageChannel || !messageChannel.isTextBased()) {
+        throw new Error(
+          `Message channel ${messageChannelId} not found or is not a text channel`,
+        );
+      }
+
+      // Create every role first so we can gate the shared category to all of
+      // them at once.
+      for (const name of names) {
+        const role = await guild.roles.create({
+          name,
+          reason: `Reaction role group created: ${groupName}`,
+        });
+        createdRoles.push(role);
+        logger.info(`Created role: ${role.name} (${role.id})`);
+      }
+
+      // One shared category, visible only to members of any role in the group.
+      category = (await guild.channels.create({
+        name: groupName,
+        type: ChannelType.GuildCategory,
+        reason: `Category for reaction role group: ${groupName}`,
+      })) as CategoryChannel;
+      await category.permissionOverwrites.edit(guild.roles.everyone, {
+        ViewChannel: false,
+      });
+      for (const role of createdRoles) {
+        await category.permissionOverwrites.edit(role, { ViewChannel: true });
+      }
+      const botMember = guild.members.me;
+      if (botMember) {
+        await category.permissionOverwrites.edit(botMember, {
+          ViewChannel: true,
+          ManageChannels: true,
+          ManageRoles: true,
+        });
+      } else {
+        logger.warn(
+          `Unable to set category permissions for bot user in guild ${guild.id} - guild.members.me is null`,
+        );
+      }
+
+      const sanitizedName =
+        groupName
+          .toLowerCase()
+          .replace(/\s+/g, "-")
+          .replace(/[^a-z0-9-_]/g, "")
+          .substring(0, 100) || "role-group";
+      channel = (await guild.channels.create({
+        name: sanitizedName,
+        type: ChannelType.GuildText,
+        parent: category.id,
+        reason: `Channel for reaction role group: ${groupName}`,
+      })) as TextChannel;
+
+      // One message listing every option; unreact behaviour follows the mode.
+      const optionLines = entries.map(
+        (e, i) => `${emojis[i]} — **${names[i]}**`,
+      );
+      const footer =
+        normalizedMode === "unique"
+          ? "Pick one — reacting swaps you to that role"
+          : normalizedMode === "sticky"
+            ? "React to opt in — removing your reaction keeps the role"
+            : "React to add a role, remove your reaction to lose it";
+      const embed = new EmbedBuilder()
+        .setColor(0x5865f2)
+        .setTitle(groupName)
+        .setDescription(
+          `React to choose your **${groupName}** role:\n\n${optionLines.join("\n")}`,
+        )
+        .setFooter({ text: footer })
+        .setTimestamp();
+      message = await messageChannel.send({ embeds: [embed] });
+
+      // React with each option's emoji in order so the picker is ready to use.
+      for (const emoji of emojis) {
+        await message.react(emoji);
+      }
+
+      // groupId anchors the set; equal to the message id at creation.
+      const groupId = message.id;
+
+      // Persist one mapping per option, all sharing message/category/channel.
+      const docs = entries.map((_, i) => ({
+        guildId,
+        messageId: message!.id,
+        channelId: channel!.id,
+        roleId: createdRoles[i].id,
+        categoryId: category!.id,
+        emoji: emojis[i],
+        roleName: names[i],
+        style: "reaction" as ReactionRoleStyle,
+        // The bot creates every role/category/channel in a group, so it owns
+        // their lifecycle (#824's autoCreated model); group delete tears down.
+        autoCreated: true,
+        mode: normalizedMode,
+        groupId,
+        isArchived: false,
+      }));
+      await ReactionRoleConfig.insertMany(docs);
+
+      logger.info(
+        `Created reaction role group ${sanitizeForLog(groupName)} (${docs.length} roles, mode ${normalizedMode})`,
+      );
+
+      return {
+        success: true,
+        message: `Successfully created role group **${groupName}** with ${docs.length} roles.`,
+        groupId,
+        messageId: message.id,
+        roleIds: createdRoles.map((r) => r.id),
+      };
+    } catch (error) {
+      logger.error("Error creating reaction role group, rolling back:", error);
+
+      if (message) {
+        await message
+          .delete()
+          .catch((err) =>
+            logger.warn("Could not delete group message during rollback:", err),
+          );
+      }
+      if (channel) {
+        await channel
+          .delete()
+          .catch((err) =>
+            logger.warn("Could not delete group channel during rollback:", err),
+          );
+      }
+      if (category) {
+        await category
+          .delete()
+          .catch((err) =>
+            logger.warn(
+              "Could not delete group category during rollback:",
+              err,
+            ),
+          );
+      }
+      for (const role of createdRoles) {
+        await role
+          .delete()
+          .catch((err) =>
+            logger.warn("Could not delete group role during rollback:", err),
+          );
+      }
+
+      return {
+        success: false,
+        message: `Failed to create role group: ${error instanceof Error ? error.message : "Unknown error"}`,
+      };
+    }
+  }
+
+  /**
+   * Fully delete a role group (#814): every role in the group, the shared
+   * category + channel, the shared message, and all the group's config rows.
+   * Best-effort per resource so one failure never leaves the DB inconsistent.
+   */
+  public async deleteReactionRoleGroup(
+    guildId: string,
+    groupId: string,
+  ): Promise<{ success: boolean; message: string }> {
+    try {
+      const configs = await ReactionRoleConfig.find({ guildId, groupId });
+      if (configs.length === 0) {
+        return { success: false, message: `Role group not found.` };
+      }
+
+      const guild = await this.client.guilds.fetch(guildId);
+      const first = configs[0];
+
+      // Delete the shared message.
+      try {
+        const messageChannelId = await this.configService.getString(
+          "reactionroles.message_channel_id",
+          "",
+        );
+        if (messageChannelId) {
+          const messageChannel = (await guild.channels.fetch(
+            messageChannelId,
+          )) as TextChannel;
+          if (messageChannel) {
+            const message = await messageChannel.messages.fetch(
+              first.messageId,
+            );
+            if (message) {
+              await message.delete();
+            }
+          }
+        }
+      } catch (error) {
+        logger.warn("Could not delete group message:", error);
+      }
+
+      // Delete the shared category (and its child channels).
+      try {
+        const category = first.categoryId
+          ? await guild.channels.fetch(first.categoryId)
+          : null;
+        if (category) {
+          const categoryChannel = category as CategoryChannel;
+          for (const [, child] of categoryChannel.children.cache) {
+            await child
+              .delete()
+              .catch((err) =>
+                logger.warn(`Could not delete channel ${child.id}:`, err),
+              );
+          }
+          await category.delete();
+        }
+      } catch (error) {
+        logger.warn("Could not delete group category:", error);
+      }
+
+      // Delete every role in the group.
+      for (const config of configs) {
+        try {
+          const role = await guild.roles.fetch(config.roleId);
+          if (role) {
+            await role.delete();
+          }
+        } catch (error) {
+          logger.warn(`Could not delete role ${config.roleId}:`, error);
+        }
+      }
+
+      await ReactionRoleConfig.deleteMany({ guildId, groupId });
+
+      logger.info(
+        `Fully deleted reaction role group ${groupId} (${configs.length} roles)`,
+      );
+
+      return {
+        success: true,
+        message: `Successfully deleted role group and its ${configs.length} roles.`,
+      };
+    } catch (error) {
+      logger.error("Error deleting reaction role group:", error);
+      return {
+        success: false,
+        message: `Failed to delete role group: ${error instanceof Error ? error.message : "Unknown error"}`,
+      };
+    }
+  }
+
   public async archiveReactionRole(
     guildId: string,
     mappingId: string,
@@ -1626,6 +1979,15 @@ export class ReactionRoleService {
       }
 
       const roleName = config.roleName;
+
+      // Group members share one message/category/channel; archiving a single
+      // member would orphan the rest, so require the group-level operation.
+      if (config.groupId) {
+        return {
+          success: false,
+          message: `**${roleName}** belongs to a role group; archive or delete the whole group instead.`,
+        };
+      }
 
       // Mark as archived
       config.isArchived = true;
@@ -1697,6 +2059,15 @@ export class ReactionRoleService {
       }
 
       const roleName = config.roleName;
+
+      // Unarchiving one group member would recreate a single-role message
+      // detached from its siblings; group lifecycle is managed as a unit.
+      if (config.groupId) {
+        return {
+          success: false,
+          message: `**${roleName}** belongs to a role group and cannot be unarchived individually.`,
+        };
+      }
 
       const guild = await this.client.guilds.fetch(guildId);
 
@@ -1833,6 +2204,16 @@ export class ReactionRoleService {
       }
 
       const roleName = config.roleName;
+
+      // Group members share resources; deleting one alone would tear down the
+      // shared category/channel/message and orphan the siblings. Route the
+      // caller to the group-level delete instead.
+      if (config.groupId) {
+        return {
+          success: false,
+          message: `**${roleName}** belongs to a role group; delete the whole group instead.`,
+        };
+      }
 
       const guild = await this.client.guilds.fetch(guildId);
 

--- a/src/services/reaction-role-service.ts
+++ b/src/services/reaction-role-service.ts
@@ -22,6 +22,7 @@ import {
   PartialMessage,
   DMChannel,
   NonThreadGuildBasedChannel,
+  DiscordAPIError,
 } from "discord.js";
 import { isValidObjectId } from "mongoose";
 import { ConfigService } from "./config-service.js";
@@ -163,8 +164,24 @@ export class ReactionRoleService {
       try {
         const guild = await this.client.guilds.fetch(config.guildId);
 
-        // Verify the target role still exists.
-        const role = await guild.roles.fetch(config.roleId).catch(() => null);
+        // Verify the target role still exists. Only a *confirmed* Unknown Role
+        // (10011) — or an explicit null from the manager — means the role was
+        // deleted; a transient network/permission error must not archive a
+        // healthy mapping, so we log and skip it for this pass instead.
+        let role: Role | null;
+        try {
+          role = await guild.roles.fetch(config.roleId);
+        } catch (error) {
+          if (this.isUnknownEntityError(error, 10011)) {
+            role = null;
+          } else {
+            logger.warn(
+              `Reaction role reconciliation: transient error fetching role ${config.roleId}, skipping`,
+              error,
+            );
+            continue;
+          }
+        }
         if (!role) {
           await this.archiveConfig(
             config,
@@ -178,16 +195,46 @@ export class ReactionRoleService {
         if (!messageChannelId) {
           continue;
         }
-        const messageChannel = (await guild.channels
-          .fetch(messageChannelId)
-          .catch(() => null)) as TextChannel | null;
+        let messageChannel: TextChannel | null;
+        try {
+          messageChannel = (await guild.channels.fetch(
+            messageChannelId,
+          )) as TextChannel | null;
+        } catch (error) {
+          // A deleted message channel takes every mapping's message with it,
+          // but that is handled live by handleChannelDelete; here we only skip
+          // (archiving all mappings off one shared-channel fetch would be too
+          // blunt, and the message-channel id is global rather than per-row).
+          logger.warn(
+            `Reaction role reconciliation: could not fetch message channel ${messageChannelId}, skipping`,
+            error,
+          );
+          continue;
+        }
         if (!messageChannel || !messageChannel.isTextBased()) {
           continue;
         }
 
-        const message = await messageChannel.messages
-          .fetch(config.messageId)
-          .catch(() => null);
+        // Only a confirmed Unknown Message (10008) means the reaction message
+        // was deleted; transient fetch failures skip rather than archive.
+        let message: Message | null;
+        try {
+          message = await messageChannel.messages.fetch(config.messageId);
+        } catch (error) {
+          if (this.isUnknownEntityError(error, 10008)) {
+            await this.archiveConfig(
+              config,
+              `reaction message ${config.messageId} no longer exists`,
+            );
+            archived++;
+            continue;
+          }
+          logger.warn(
+            `Reaction role reconciliation: transient error fetching message ${config.messageId}, skipping`,
+            error,
+          );
+          continue;
+        }
         if (!message) {
           await this.archiveConfig(
             config,
@@ -222,6 +269,16 @@ export class ReactionRoleService {
     logger.info(
       `Reaction role reconciliation complete: ${configs.length} checked, ${archived} archived, ${repaired} reaction(s) repaired`,
     );
+  }
+
+  /**
+   * True only for a Discord REST error whose numeric code confirms the entity
+   * is genuinely gone (e.g. 10008 Unknown Message, 10011 Unknown Role, 10003
+   * Unknown Channel) — as opposed to a transient network/timeout/permission
+   * failure, which must not be treated as a deletion.
+   */
+  private isUnknownEntityError(error: unknown, code: number): boolean {
+    return error instanceof DiscordAPIError && error.code === code;
   }
 
   /**
@@ -578,8 +635,9 @@ export class ReactionRoleService {
     roleName: string;
     roleId: string;
     style: ReactionRoleStyle;
+    mode?: ReactionRoleMode;
   }): MessageCreateOptions {
-    const { emoji, roleName, roleId, style } = config;
+    const { emoji, roleName, roleId, style, mode = "toggle" } = config;
 
     if (style === "button") {
       const embed = new EmbedBuilder()
@@ -645,13 +703,22 @@ export class ReactionRoleService {
     }
 
     // Default: legacy reaction surface. The caller adds the reaction after send.
+    // Description/footer track the assignment mode so a sticky mapping never
+    // tells members that unreacting removes the role (it doesn't).
+    let description = `React with ${emoji} to get access to the **${roleName}** role and channels!`;
+    let footer = "Remove your reaction to lose access";
+    if (mode === "sticky") {
+      footer = "Removing your reaction keeps the role";
+    } else if (mode === "unique") {
+      description = `React with ${emoji} to get the **${roleName}** role and its channels. This clears the other roles offered on this message.`;
+      footer = "Reacting here swaps you to this role";
+    }
+
     const embed = new EmbedBuilder()
       .setColor(0x5865f2)
       .setTitle(`${emoji} ${roleName}`)
-      .setDescription(
-        `React with ${emoji} to get access to the **${roleName}** role and channels!`,
-      )
-      .setFooter({ text: "Remove your reaction to lose access" })
+      .setDescription(description)
+      .setFooter({ text: footer })
       .setTimestamp();
     return { embeds: [embed] };
   }
@@ -1102,6 +1169,7 @@ export class ReactionRoleService {
           roleName,
           roleId: role.id,
           style,
+          mode: normalizedMode,
         }),
       );
 
@@ -1675,6 +1743,7 @@ export class ReactionRoleService {
           roleName: config.roleName,
           roleId: config.roleId,
           style,
+          mode: config.mode ?? "toggle",
         }),
       );
 

--- a/src/services/reaction-role-service.ts
+++ b/src/services/reaction-role-service.ts
@@ -19,9 +19,13 @@ import {
   StringSelectMenuInteraction,
   ComponentEmojiResolvable,
   MessageCreateOptions,
+  PartialMessage,
+  DMChannel,
+  NonThreadGuildBasedChannel,
 } from "discord.js";
 import { isValidObjectId } from "mongoose";
 import { ConfigService } from "./config-service.js";
+import { CommandManager } from "./command-manager.js";
 import logger from "../utils/logger.js";
 import { sanitizeForLog } from "../utils/log-sanitize.js";
 import {
@@ -29,6 +33,8 @@ import {
   IReactionRoleConfig,
   ReactionRoleStyle,
   REACTION_ROLE_STYLES,
+  ReactionRoleMode,
+  REACTION_ROLE_MODES,
 } from "../models/reaction-role-config.js";
 
 /**
@@ -101,12 +107,228 @@ export class ReactionRoleService {
 
       // Gateway reaction events are routed from src/index.ts into
       // handleReactionAdd/handleReactionRemove; the service no longer
-      // subscribes to the client directly.
+      // subscribes to the client directly. messageDelete / roleDelete /
+      // channelDelete are likewise routed in to the handle*Delete methods.
+
+      // Self-heal after downtime: verify each active config still points at a
+      // live message + role, archive the ones that don't, and re-add the bot's
+      // own base reaction if it went missing while offline.
+      await this.reconcileConfigs();
+
       logger.info("Reaction role service initialized successfully");
     } catch (error) {
       logger.error("Error initializing reaction role service:", error);
       // Reset initialization flag on error to allow retry
       this.isInitialized = false;
+    }
+  }
+
+  /**
+   * Startup reconciliation (#814). For every active reaction-role config,
+   * confirm the reaction message and the target role still exist; archive the
+   * config when either is gone, and otherwise re-add the bot's own base
+   * reaction if a member (or Discord) cleared it while the bot was offline.
+   *
+   * Best-effort and defensive: a failure on one config is logged and never
+   * aborts the pass or crashes startup. Bulk REST work goes through
+   * `CommandManager.makeDiscordApiCall` for shared timeout + backoff.
+   */
+  public async reconcileConfigs(): Promise<void> {
+    let configs: IReactionRoleConfig[];
+    try {
+      configs = await ReactionRoleConfig.find({ isArchived: false });
+    } catch (error) {
+      logger.error(
+        "Reaction role reconciliation: failed to load configs",
+        error,
+      );
+      return;
+    }
+
+    if (configs.length === 0) {
+      logger.debug("Reaction role reconciliation: no active configs");
+      return;
+    }
+
+    const messageChannelId = await this.configService.getString(
+      "reactionroles.message_channel_id",
+      "",
+    );
+    const commandManager = CommandManager.getInstance(this.client);
+
+    let archived = 0;
+    let repaired = 0;
+
+    for (const config of configs) {
+      try {
+        const guild = await this.client.guilds.fetch(config.guildId);
+
+        // Verify the target role still exists.
+        const role = await guild.roles.fetch(config.roleId).catch(() => null);
+        if (!role) {
+          await this.archiveConfig(
+            config,
+            `role ${config.roleId} no longer exists`,
+          );
+          archived++;
+          continue;
+        }
+
+        // Verify the reaction message still exists in the configured channel.
+        if (!messageChannelId) {
+          continue;
+        }
+        const messageChannel = (await guild.channels
+          .fetch(messageChannelId)
+          .catch(() => null)) as TextChannel | null;
+        if (!messageChannel || !messageChannel.isTextBased()) {
+          continue;
+        }
+
+        const message = await messageChannel.messages
+          .fetch(config.messageId)
+          .catch(() => null);
+        if (!message) {
+          await this.archiveConfig(
+            config,
+            `reaction message ${config.messageId} no longer exists`,
+          );
+          archived++;
+          continue;
+        }
+
+        // Re-add the bot's own base reaction if it went missing.
+        const hasOwnReaction = message.reactions.cache.some(
+          (r) => this.buildEmojiIdentifier(r) === config.emoji && r.me,
+        );
+        if (!hasOwnReaction) {
+          await commandManager.makeDiscordApiCall(
+            () => message.react(config.emoji),
+            `re-add reaction ${config.emoji} on message ${config.messageId}`,
+          );
+          repaired++;
+          logger.info(
+            `Reaction role reconciliation: re-added base reaction for ${sanitizeForLog(config.roleName)}`,
+          );
+        }
+      } catch (error) {
+        logger.warn(
+          `Reaction role reconciliation: error processing config ${config._id}`,
+          error,
+        );
+      }
+    }
+
+    logger.info(
+      `Reaction role reconciliation complete: ${configs.length} checked, ${archived} archived, ${repaired} reaction(s) repaired`,
+    );
+  }
+
+  /**
+   * Archive a config as part of self-healing (stale message/role/channel).
+   * Idempotent and swallows write errors so cleanup never crashes a caller.
+   */
+  private async archiveConfig(
+    config: IReactionRoleConfig,
+    reason: string,
+  ): Promise<void> {
+    if (config.isArchived) {
+      return;
+    }
+    try {
+      config.isArchived = true;
+      config.archivedAt = new Date();
+      await config.save();
+      logger.info(
+        `Archived reaction role ${sanitizeForLog(config.roleName)}: ${reason}`,
+      );
+    } catch (error) {
+      logger.error(
+        `Failed to archive reaction role ${sanitizeForLog(config.roleName)}:`,
+        error,
+      );
+    }
+  }
+
+  /**
+   * Handle a `messageDelete` event routed from `src/index.ts`. If the deleted
+   * message backed one or more active reaction-role configs, archive them so
+   * the config table stops drifting from reality (#814).
+   */
+  public async handleMessageDelete(
+    message: Message | PartialMessage,
+  ): Promise<void> {
+    try {
+      const configs = await ReactionRoleConfig.find({
+        messageId: message.id,
+        isArchived: false,
+      });
+      for (const config of configs) {
+        await this.archiveConfig(
+          config,
+          `reaction message ${message.id} was deleted`,
+        );
+      }
+    } catch (error) {
+      logger.error("Error handling reaction-role message delete:", error);
+    }
+  }
+
+  /**
+   * Handle a `roleDelete` event routed from `src/index.ts`. Archive any active
+   * config that granted the now-deleted role (#814).
+   */
+  public async handleRoleDelete(role: Role): Promise<void> {
+    try {
+      const configs = await ReactionRoleConfig.find({
+        guildId: role.guild.id,
+        roleId: role.id,
+        isArchived: false,
+      });
+      for (const config of configs) {
+        await this.archiveConfig(config, `role ${role.id} was deleted`);
+      }
+    } catch (error) {
+      logger.error("Error handling reaction-role role delete:", error);
+    }
+  }
+
+  /**
+   * Handle a `channelDelete` event routed from `src/index.ts`. Archive any
+   * active config whose backing category/channel — or whose reaction message
+   * channel — was deleted (#814).
+   */
+  public async handleChannelDelete(
+    channel: DMChannel | NonThreadGuildBasedChannel,
+  ): Promise<void> {
+    try {
+      // DM channels can never back a reaction role.
+      if (!("guild" in channel) || !channel.guild) {
+        return;
+      }
+
+      const messageChannelId = await this.configService.getString(
+        "reactionroles.message_channel_id",
+        "",
+      );
+
+      const configs = await ReactionRoleConfig.find({
+        guildId: channel.guild.id,
+        isArchived: false,
+        $or: [
+          { channelId: channel.id },
+          { categoryId: channel.id },
+          ...(messageChannelId === channel.id
+            ? [{ channelId: { $exists: true } }]
+            : []),
+        ],
+      });
+
+      for (const config of configs) {
+        await this.archiveConfig(config, `channel ${channel.id} was deleted`);
+      }
+    } catch (error) {
+      logger.error("Error handling reaction-role channel delete:", error);
     }
   }
 
@@ -176,15 +398,65 @@ export class ReactionRoleService {
         return;
       }
 
-      if (member.roles.cache.has(config.roleId)) {
+      if (!member.roles.cache.has(config.roleId)) {
+        await member.roles.add(role);
+        logger.info(`Added role ${role.name} to user ${user.tag}`);
+      } else {
         logger.debug(`User ${user.tag} already has role ${role.name}`);
-        return;
       }
 
-      await member.roles.add(role);
-      logger.info(`Added role ${role.name} to user ${user.tag}`);
+      // `unique` (one-of-set): reacting to one option clears the sibling
+      // roles configured on the same message, so a member ends up with at
+      // most one role from the group (e.g. exactly one colour role).
+      if (config.mode === "unique") {
+        await this.applyUniqueMode(reaction, member, config);
+      }
     } catch (error) {
       logger.error("Error adding role from reaction:", error);
+    }
+  }
+
+  /**
+   * Enforce `unique` mode: remove every sibling role configured on the same
+   * message (any active config with the same `messageId` but a different
+   * `roleId`) and, best-effort, clear the member's reaction on those sibling
+   * emojis so the visible reactions match the single active choice.
+   */
+  private async applyUniqueMode(
+    reaction: MessageReaction,
+    member: GuildMember,
+    config: IReactionRoleConfig,
+  ): Promise<void> {
+    const siblings = await ReactionRoleConfig.find({
+      messageId: config.messageId,
+      isArchived: false,
+      roleId: { $ne: config.roleId },
+    });
+
+    for (const sibling of siblings) {
+      try {
+        if (member.roles.cache.has(sibling.roleId)) {
+          await member.roles.remove(sibling.roleId);
+          logger.info(
+            `Removed sibling role ${sibling.roleName} from user ${member.id} (unique mode)`,
+          );
+        }
+
+        // Best-effort: drop the member's reaction on the sibling emoji so the
+        // message reflects the single active choice. Requires ManageMessages;
+        // failures are non-fatal.
+        const siblingReaction = reaction.message.reactions?.cache?.find(
+          (r) => this.buildEmojiIdentifier(r) === sibling.emoji,
+        );
+        if (siblingReaction) {
+          await siblingReaction.users.remove(member.id);
+        }
+      } catch (error) {
+        logger.warn(
+          `Could not clear sibling reaction role ${sibling.roleName} in unique mode:`,
+          error,
+        );
+      }
     }
   }
 
@@ -215,6 +487,15 @@ export class ReactionRoleService {
       });
 
       if (!config) {
+        return;
+      }
+
+      // `sticky` (add-only): reacting grants the role, but removing the
+      // reaction never revokes it. Good for opt-in cosmetic roles.
+      if (config.mode === "sticky") {
+        logger.debug(
+          `Ignoring reaction removal for sticky reaction role ${config.roleName}`,
+        );
         return;
       }
 
@@ -672,7 +953,7 @@ export class ReactionRoleService {
     guildId: string,
     roleName: string,
     emoji: string,
-    options: { createChannel?: boolean } = {},
+    options: { createChannel?: boolean; mode?: ReactionRoleMode } = {},
   ): Promise<{
     success: boolean;
     message: string;
@@ -686,6 +967,12 @@ export class ReactionRoleService {
     let category: CategoryChannel | null = null;
     let channel: TextChannel | null = null;
     let message: Message | null = null;
+
+    // Guard against unexpected mode values reaching the DB enum validator.
+    const mode: ReactionRoleMode = options.mode ?? "toggle";
+    const normalizedMode: ReactionRoleMode = REACTION_ROLE_MODES.includes(mode)
+      ? mode
+      : "toggle";
 
     try {
       // Check if a reaction role with this name already exists
@@ -845,6 +1132,7 @@ export class ReactionRoleService {
         roleName,
         style,
         autoCreated: true,
+        mode: normalizedMode,
         isArchived: false,
       });
 

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -2094,6 +2094,7 @@ export interface ReactionRoleRow {
    */
   autoCreated?: boolean;
   mode: string;
+  groupId: string | null;
   isArchived: boolean;
   archivedAt: string | null;
 }
@@ -2116,7 +2117,12 @@ function reactionRoleRow(rr: ReactionRoleRow, csrfInput: string): string {
   const escapedMappingId = escapeHtml(rr.mappingId);
 
   let actions: string;
-  if (!managed) {
+  if (rr.groupId) {
+    // Grouped mappings share a message/category/channel, so they can only be
+    // torn down as a unit — offer a single group-delete instead of the
+    // per-mapping archive/delete controls.
+    actions = `<form method="POST" action="/admin/reaction-roles/group/delete" onsubmit="return confirm('Permanently delete the whole role group ${jsName} belongs to? This removes every role in the group and its shared category/channel.');">${csrfInput}<input type="hidden" name="groupId" value="${escapeHtml(rr.groupId)}"><button type="submit" class="btn btn-danger">Delete group</button></form>`;
+  } else if (!managed) {
     // Bound mappings point at a pre-existing role and may share a picker
     // message, so they are removed per-mapping (message + emoji) and never
     // archived — that would delete a message other mappings still use.
@@ -2137,6 +2143,10 @@ function reactionRoleRow(rr: ReactionRoleRow, csrfInput: string): string {
   const channelCell =
     rr.channelName === "—" ? "—" : `#${escapeHtml(rr.channelName)}`;
 
+  const modeCell = rr.groupId
+    ? `${escapeHtml(rr.mode)} <span class="tag">group</span>`
+    : escapeHtml(rr.mode);
+
   return `<tr>
 <td class="mono">${escapedEmoji}</td>
 <td>${escapedName} <span class="muted mono">${escapeHtml(rr.roleId)}</span></td>
@@ -2144,7 +2154,7 @@ function reactionRoleRow(rr: ReactionRoleRow, csrfInput: string): string {
 <td>${escapeHtml(rr.categoryName)}</td>
 <td>${channelCell}</td>
 <td class="mono">${escapedMessageId}</td>
-<td>${escapeHtml(rr.mode)}</td>
+<td>${modeCell}</td>
 <td><span class="tag ${rr.isArchived ? "tag-off" : "tag-on"}">${rr.isArchived ? "archived" : "active"}</span></td>
 <td class="muted">${escapeHtml(rr.archivedAt ?? "")}</td>
 <td class="actions">${actions}</td>
@@ -2201,9 +2211,9 @@ ${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Reaction Roles",
       <select name="mode">
         <option value="toggle" selected>Toggle — react to add, unreact to remove (default)</option>
         <option value="sticky">Sticky — react to add; removing the reaction keeps the role</option>
-        <option value="unique">Unique — reacting clears the other roles on the same message</option>
       </select>
     </label>
+    <p class="muted">For one-of-set (pick exactly one) behaviour, use <strong>Create a role group</strong> below — a single message can't enforce "unique" against itself.</p>
     <button type="submit" class="btn btn-primary">Create reaction role</button>
   </form>
 </div>
@@ -2222,6 +2232,32 @@ ${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Reaction Roles",
       <input type="text" name="messageId" maxlength="30" placeholder="(new message)">
     </label>
     <button type="submit" class="btn btn-primary">Bind existing role</button>
+  </form>
+</div>
+<div class="card">
+  <h2>Create a role group</h2>
+  <p class="muted">Posts one message offering several roles at once. With <strong>Unique</strong> mode, reacting to one option clears the others (e.g. pick exactly one colour). All options share a single category/channel; delete the group as a unit. Fill at least two rows; blank rows are ignored.</p>
+  <form method="POST" action="/admin/reaction-roles/group/create" class="stack">
+    ${csrfInput}
+    <label>Group name
+      <input type="text" name="groupName" required maxlength="100" placeholder="Colour">
+    </label>
+    <label>Group mode
+      <select name="mode">
+        <option value="unique" selected>Unique — pick exactly one (reacting swaps your choice)</option>
+        <option value="sticky">Sticky — add-only, reactions never revoke</option>
+        <option value="toggle">Toggle — independent add/remove per option</option>
+      </select>
+    </label>
+    ${Array.from(
+      { length: 6 },
+      (_unused, i) =>
+        `<div class="inline-form">
+      <input type="text" name="roleName" maxlength="100" placeholder="Role name${i < 2 ? " (required)" : ""}">
+      <input type="text" name="emoji" maxlength="100" placeholder="Emoji${i < 2 ? " (required)" : ""}">
+    </div>`,
+    ).join("")}
+    <button type="submit" class="btn btn-primary">Create role group</button>
   </form>
 </div>
 <div class="card">

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -2093,6 +2093,7 @@ export interface ReactionRoleRow {
    * this false. Optional/undefined is treated as `true` for legacy rows.
    */
   autoCreated?: boolean;
+  mode: string;
   isArchived: boolean;
   archivedAt: string | null;
 }
@@ -2143,6 +2144,7 @@ function reactionRoleRow(rr: ReactionRoleRow, csrfInput: string): string {
 <td>${escapeHtml(rr.categoryName)}</td>
 <td>${channelCell}</td>
 <td class="mono">${escapedMessageId}</td>
+<td>${escapeHtml(rr.mode)}</td>
 <td><span class="tag ${rr.isArchived ? "tag-off" : "tag-on"}">${rr.isArchived ? "archived" : "active"}</span></td>
 <td class="muted">${escapeHtml(rr.archivedAt ?? "")}</td>
 <td class="actions">${actions}</td>
@@ -2180,7 +2182,7 @@ ${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Reaction Roles",
   ${
     props.active.length === 0
       ? `<div class="empty">No active reaction-role mappings.</div>`
-      : `<table><thead><tr><th>Emoji</th><th>Role</th><th>Type</th><th>Category</th><th>Channel</th><th>Message ID</th><th>Status</th><th>Archived</th><th>Actions</th></tr></thead><tbody>${activeRows}</tbody></table>`
+      : `<table><thead><tr><th>Emoji</th><th>Role</th><th>Type</th><th>Category</th><th>Channel</th><th>Message ID</th><th>Mode</th><th>Status</th><th>Archived</th><th>Actions</th></tr></thead><tbody>${activeRows}</tbody></table>`
   }
 </div>
 <div class="card">
@@ -2195,6 +2197,13 @@ ${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Reaction Roles",
       <input type="text" name="emoji" required maxlength="100" placeholder="🎮">
     </label>
     <label class="inline"><input type="checkbox" name="createChannel" value="1" checked> Create a private category + channel for this role</label>
+    <label>Assignment mode
+      <select name="mode">
+        <option value="toggle" selected>Toggle — react to add, unreact to remove (default)</option>
+        <option value="sticky">Sticky — react to add; removing the reaction keeps the role</option>
+        <option value="unique">Unique — reacting clears the other roles on the same message</option>
+      </select>
+    </label>
     <button type="submit" class="btn btn-primary">Create reaction role</button>
   </form>
 </div>
@@ -2220,7 +2229,7 @@ ${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Reaction Roles",
   ${
     props.archived.length === 0
       ? `<div class="empty">No archived mappings.</div>`
-      : `<table><thead><tr><th>Emoji</th><th>Role</th><th>Type</th><th>Category</th><th>Channel</th><th>Message ID</th><th>Status</th><th>Archived</th><th>Actions</th></tr></thead><tbody>${archivedRows}</tbody></table>`
+      : `<table><thead><tr><th>Emoji</th><th>Role</th><th>Type</th><th>Category</th><th>Channel</th><th>Message ID</th><th>Mode</th><th>Status</th><th>Archived</th><th>Actions</th></tr></thead><tbody>${archivedRows}</tbody></table>`
   }
 </div>
 `;

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -756,6 +756,7 @@ export function createReadOnlyRouter(
         channelId?: string | null;
         messageId: string;
         autoCreated?: boolean;
+        mode?: string;
         isArchived: boolean;
         archivedAt?: Date | null;
       }): ReactionRoleRow => ({
@@ -767,6 +768,7 @@ export function createReadOnlyRouter(
         channelName: resolveChannel(rr.channelId),
         messageId: rr.messageId,
         autoCreated: rr.autoCreated ?? true,
+        mode: rr.mode ?? "toggle",
         isArchived: rr.isArchived,
         archivedAt: rr.archivedAt
           ? new Date(rr.archivedAt).toISOString()

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -757,6 +757,7 @@ export function createReadOnlyRouter(
         messageId: string;
         autoCreated?: boolean;
         mode?: string;
+        groupId?: string | null;
         isArchived: boolean;
         archivedAt?: Date | null;
       }): ReactionRoleRow => ({
@@ -769,6 +770,7 @@ export function createReadOnlyRouter(
         messageId: rr.messageId,
         autoCreated: rr.autoCreated ?? true,
         mode: rr.mode ?? "toggle",
+        groupId: rr.groupId ?? null,
         isArchived: rr.isArchived,
         archivedAt: rr.archivedAt
           ? new Date(rr.archivedAt).toISOString()

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -3367,6 +3367,141 @@ export function createWriteRouter(
     }),
   );
 
+  // Create a one-of-set role group (#814): one shared message with several
+  // role options. The form posts parallel roleName[]/emoji[] arrays.
+  router.post(
+    "/reaction-roles/group/create",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const groupName = getString(req, "groupName");
+
+      const body = (req.body as Record<string, unknown> | undefined) ?? {};
+      const toArray = (raw: unknown): string[] =>
+        Array.isArray(raw)
+          ? raw.map(String)
+          : typeof raw === "string"
+            ? [raw]
+            : [];
+      const roleNames = toArray(body["roleName"]);
+      const emojis = toArray(body["emoji"]);
+
+      // Pair positionally and drop rows where either half is blank.
+      const entries: Array<{ roleName: string; emoji: string }> = [];
+      for (let i = 0; i < Math.max(roleNames.length, emojis.length); i++) {
+        const roleName = (roleNames[i] ?? "").trim();
+        const emoji = (emojis[i] ?? "").trim();
+        if (roleName && emoji) {
+          entries.push({ roleName, emoji });
+        }
+      }
+
+      const modeRaw = getString(req, "mode");
+      const mode: ReactionRoleMode =
+        modeRaw === "sticky" || modeRaw === "toggle" ? modeRaw : "unique";
+
+      if (!groupName) {
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: "err",
+          text: "Group name is required.",
+        });
+        return;
+      }
+      if (entries.length < 2) {
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: "err",
+          text: "A role group needs at least two role/emoji options.",
+        });
+        return;
+      }
+
+      const service = ReactionRoleService.getInstance(client);
+      try {
+        const result = await service.createReactionRoleGroup(
+          session.guildId,
+          groupName,
+          entries,
+          mode,
+        );
+        await recordAudit(session, {
+          action: "reactionrole.group.create",
+          targetId: result.groupId ?? null,
+          details: {
+            groupName,
+            mode,
+            count: entries.length,
+            roleIds: result.roleIds,
+            messageId: result.messageId,
+          },
+          result: result.success ? "success" : "failure",
+          errorMessage: result.success ? null : result.message,
+        });
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: result.success ? "ok" : "err",
+          text: result.message,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Create reaction role group failed", err);
+        await recordAudit(session, {
+          action: "reactionrole.group.create",
+          details: { groupName, mode, count: entries.length },
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: "err",
+          text: `Failed to create role group: ${text}`,
+        });
+      }
+    }),
+  );
+
+  router.post(
+    "/reaction-roles/group/delete",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const groupId = getString(req, "groupId");
+      if (!groupId) {
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: "err",
+          text: "Group id is required.",
+        });
+        return;
+      }
+      const service = ReactionRoleService.getInstance(client);
+      try {
+        const result = await service.deleteReactionRoleGroup(
+          session.guildId,
+          groupId,
+        );
+        await recordAudit(session, {
+          action: "reactionrole.group.delete",
+          targetId: groupId,
+          details: { groupId },
+          result: result.success ? "success" : "failure",
+          errorMessage: result.success ? null : result.message,
+        });
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: result.success ? "ok" : "err",
+          text: result.message,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Delete reaction role group failed", err);
+        await recordAudit(session, {
+          action: "reactionrole.group.delete",
+          targetId: groupId,
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: "err",
+          text: `Failed to delete role group: ${text}`,
+        });
+      }
+    }),
+  );
+
   // ============================================================
   // Notices (issue #384)
   // ============================================================

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -23,6 +23,7 @@ import { isValidTimezone, resolveTimezone } from "../utils/timezone.js";
 import { PollService } from "../services/poll-service.js";
 import { VoiceChannelAnnouncer } from "../services/voice-channel-announcer.js";
 import { ReactionRoleService } from "../services/reaction-role-service.js";
+import type { ReactionRoleMode } from "../models/reaction-role-config.js";
 import { NoticesChannelManager } from "../services/notices-channel-manager.js";
 import { VoiceChannelTruncationService } from "../services/voice-channel-truncation.js";
 import { VoiceChannelManager } from "../services/voice-channel-manager.js";
@@ -3063,6 +3064,11 @@ export function createWriteRouter(
       }
 
       const createChannel = getCheckbox(req, "createChannel");
+      // Assignment mode (#814): toggle (default) / sticky. Anything else falls
+      // back to toggle so a bad form value can't reach the DB enum. (unique is
+      // offered on the role-group form, not the single-role form.)
+      const modeRaw = getString(req, "mode");
+      const mode: ReactionRoleMode = modeRaw === "sticky" ? modeRaw : "toggle";
 
       const service = ReactionRoleService.getInstance(client);
       try {
@@ -3070,7 +3076,7 @@ export function createWriteRouter(
           session.guildId,
           name,
           emoji,
-          { createChannel },
+          { createChannel, mode },
         );
         await recordAudit(session, {
           action: "reactionrole.create",
@@ -3079,6 +3085,7 @@ export function createWriteRouter(
             roleName: name,
             emoji,
             createChannel,
+            mode,
             categoryId: result.categoryId,
             channelId: result.channelId,
             messageId: result.messageId,


### PR DESCRIPTION
## Description

Closes the two robustness/UX gaps in the reaction-roles feature described in #814, and adds a one-of-set role-group flow so `unique` mode is actually usable.

**1. Assignment modes.** Adds a per-mapping `mode` field to `ReactionRoleConfig` (default `toggle` for full back-compat) and branches in the add/remove handlers:

- **toggle** (default): react = add, unreact = remove (existing behaviour).
- **sticky** / add-only: reacting grants the role; removing the reaction does *not* revoke it (good for opt-in cosmetic roles).
- **unique** / one-of-set: reacting clears the sibling roles mapped on the same message and, best-effort, clears the member's reactions on those sibling emojis — so a member ends up with at most one role from the set.

**2. Role groups (makes `unique` real).** A single reaction role is created on its own one-emoji message, so `unique` (which groups siblings by shared `messageId`) had nothing to enforce against. This PR adds a real grouping flow:

- `createReactionRoleGroup` posts one shared message offering several roles, persisting one mapping per option that shares the `messageId` and a new `groupId`, under a single shared category/channel gated to any of the group's roles. Fully transactional (rolled back on failure).
- `deleteReactionRoleGroup` tears the whole group down as a unit; the single-mapping archive/delete/unarchive paths refuse grouped members so shared resources can't be orphaned.
- Admin UI gains a "Create a role group" form; grouped rows show a single "Delete group" control and a `group` tag. `unique` is dropped from the single-role form (it can't apply to a one-role message).

**3. Self-healing reconciliation.** The config table no longer drifts from reality:

- **Startup pass** in `initialize()` (`reconcileConfigs()`): for each active mapping, verify the reaction message + role still exist and re-add the bot's own base reaction if it went missing while offline. It archives a mapping only on a *confirmed* Discord `Unknown Role` (10011) / `Unknown Message` (10008); transient network/permission errors are logged and skipped so a healthy mapping is never archived by mistake. Bulk REST work is routed through `CommandManager.makeDiscordApiCall` for the shared timeout + backoff per `CLAUDE.md`.
- **Deletion listeners** wired in `src/index.ts`: on `messageDelete` / `roleDelete` / `channelDelete`, archive the affected mapping(s) and log it.

The reaction picker message's description/footer are mode-aware, so a sticky mapping never tells members that unreacting removes the role.

Supporting change: `makeDiscordApiCall` is made public (per `CLAUDE.md`'s "reuse it for any new bulk REST work" guidance) and its timeout timer is now cleared/`unref`'d so a fast-resolving call no longer leaks a pending handle.

Rebased onto `main` after #824 (multiple mappings per message / bind-to-existing-role); `mode` and `groupId` compose with that model (`autoCreated`, optional category/channel, the `{guildId, messageId, emoji}` unique index).

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Related Issues

Closes #814
Refs #808

## How Has This Been Tested?

- [x] `npm run check:all` (build + lint + format:check + tests) is green — 1714 passing, 1 skipped
- [x] Added new tests for the new functionality

New/updated test suites:

- `reaction-role-service-modes.test.ts` — toggle/sticky/unique branches, including the unique sibling-reaction clearing and its fail-soft path when Manage Messages is missing.
- `reaction-role-service-reconcile.test.ts` — reconciliation archives on confirmed-missing role/message, re-adds the missing base reaction, does **not** archive on transient fetch errors, and the `messageDelete` / `roleDelete` / `channelDelete` cleanup paths.
- `reaction-role-service-group.test.ts` — group creation persists N shared-message mappings, validation/rollback, group delete tears down shared resources, and the single-op guards refuse grouped members.

**Test Configuration**:

- Node.js version: 22 & 24 (CI matrix)
- Discord.js version: v14
- Operating System: Linux

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary:
  - [x] `COMMANDS.md` — documents the three modes, role groups, the startup/deletion reconciliation, and the extra Manage Messages permission `unique` needs
  - [x] No new config keys, so `SETTINGS.md` is unchanged (the `mode`/`groupId` fields live on the model)

### Dependencies & Docker

- [x] No dependency or build changes; `Dockerfile` / `Dockerfile.dev` unchanged

### Configuration (if applicable)

- [x] The reaction-roles feature remains gated behind `reactionroles.enabled`; `mode` defaults to `toggle` and `groupId` is unset for existing mappings, so they are unaffected

## Additional Notes

Clearing a member's sibling reaction (unique mode) needs the **Manage Messages** permission (documented in `COMMANDS.md`); the role removal still works without it and the reaction cleanup fails soft.

Out of scope (per the issue): full audit-log-driven reconciliation of *who* toggled what.

🤖 Generated with [Claude Code](https://claude.com/claude-code)