### PR TITLE
feat(reaction-roles): multiple mappings per message and bind to existing roles

### DIFF
--- a/WEBUI.md
+++ b/WEBUI.md
@@ -776,8 +776,9 @@ an **Open Settings** link.
 
 The **Reaction Roles** page offers two ways to add a mapping (#813). *Create a
 reaction role* mints a brand-new Discord role and posts a picker message; the
-*Create a private category + channel* checkbox is now opt-in — untick it for a
-plain self-assign role with no attached channel. *Bind an existing role* maps an
+*Create a private category + channel* checkbox is on by default (preserving the
+original behaviour) — untick it to opt out and get a plain self-assign role with
+no attached channel. *Bind an existing role* maps an
 emoji to a role you already manage (no role/category/channel is created) and,
 when given an existing message ID, adds the mapping to that message — so one
 picker message can carry many emoji→role mappings. Both paths validate the role

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -774,6 +774,19 @@ page renders a banner explaining the state with an inline **Enable** button
 (flips the flag via `/admin/settings/set` and returns you to the page) plus
 an **Open Settings** link.
 
+The **Reaction Roles** page offers two ways to add a mapping (#813). *Create a
+reaction role* mints a brand-new Discord role and posts a picker message; the
+*Create a private category + channel* checkbox is now opt-in — untick it for a
+plain self-assign role with no attached channel. *Bind an existing role* maps an
+emoji to a role you already manage (no role/category/channel is created) and,
+when given an existing message ID, adds the mapping to that message — so one
+picker message can carry many emoji→role mappings. Both paths validate the role
+hierarchy up front (the bot needs **Manage Roles** and a role ranked above the
+target) and surface an actionable error instead of silently failing at reaction
+time. Rows are tagged **managed** (bot-created; delete tears down the role +
+category + channel) or **bound** (points at a pre-existing role; *Remove* only
+unbinds the mapping and never deletes the role).
+
 On the **Settings** page, a toggle whose feature declares a hard dependency
 (`dependsOn` in `settingsMetadata`) is rendered **disabled and greyed** with an
 inline *"Requires X enabled"* hint until every dependency is on — the hint names

--- a/__tests__/services/reaction-role-migrator.test.ts
+++ b/__tests__/services/reaction-role-migrator.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+// Rely on the global mongoose mock (see __tests__/setup.ts) and assign the
+// statics this migration touches directly onto the imported model — the repo's
+// convention for model-level unit tests under the ESM jest setup.
+jest.mock("../../src/models/reaction-role-config.js");
+
+import { runReactionRoleMigrations } from "../../src/services/reaction-role-migrator.js";
+import { ReactionRoleConfig } from "../../src/models/reaction-role-config.js";
+
+const Model = ReactionRoleConfig as unknown as {
+  countDocuments: jest.Mock;
+  updateMany: jest.Mock;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Model.countDocuments = jest.fn();
+  Model.updateMany = jest.fn();
+});
+
+describe("runReactionRoleMigrations", () => {
+  it("backfills autoCreated=true on legacy rows missing the field", async () => {
+    Model.countDocuments.mockResolvedValue(3);
+    Model.updateMany.mockResolvedValue({ modifiedCount: 3 });
+
+    await runReactionRoleMigrations();
+
+    expect(Model.updateMany).toHaveBeenCalledWith(
+      { autoCreated: { $exists: false } },
+      { $set: { autoCreated: true } },
+    );
+  });
+
+  it("is a no-op when every row already carries the field", async () => {
+    Model.countDocuments.mockResolvedValue(0);
+
+    await runReactionRoleMigrations();
+
+    expect(Model.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("never throws when the backfill query fails", async () => {
+    Model.countDocuments.mockRejectedValue(new Error("db down"));
+
+    await expect(runReactionRoleMigrations()).resolves.toBeUndefined();
+  });
+});

--- a/__tests__/services/reaction-role-migrator.test.ts
+++ b/__tests__/services/reaction-role-migrator.test.ts
@@ -11,12 +11,14 @@ import { ReactionRoleConfig } from "../../src/models/reaction-role-config.js";
 const Model = ReactionRoleConfig as unknown as {
   countDocuments: jest.Mock;
   updateMany: jest.Mock;
+  collection?: unknown;
 };
 
 beforeEach(() => {
   jest.clearAllMocks();
-  Model.countDocuments = jest.fn();
+  Model.countDocuments = jest.fn().mockResolvedValue(0);
   Model.updateMany = jest.fn();
+  Model.collection = undefined;
 });
 
 describe("runReactionRoleMigrations", () => {
@@ -44,5 +46,43 @@ describe("runReactionRoleMigrations", () => {
     Model.countDocuments.mockRejectedValue(new Error("db down"));
 
     await expect(runReactionRoleMigrations()).resolves.toBeUndefined();
+  });
+
+  it("drops the stale guildId_1_roleName_1 unique index when present", async () => {
+    const dropIndex = jest
+      .fn<() => Promise<unknown>>()
+      .mockResolvedValue(undefined);
+    Model.collection = {
+      indexes: jest
+        .fn<() => Promise<unknown>>()
+        .mockResolvedValue([
+          { name: "_id_" },
+          { name: "guildId_1_roleName_1", unique: true },
+          { name: "guildId_1_messageId_1_emoji_1", unique: true },
+        ]),
+      dropIndex,
+    };
+
+    await runReactionRoleMigrations();
+
+    expect(dropIndex).toHaveBeenCalledWith("guildId_1_roleName_1");
+  });
+
+  it("leaves indexes alone when the stale unique index is absent", async () => {
+    const dropIndex = jest
+      .fn<() => Promise<unknown>>()
+      .mockResolvedValue(undefined);
+    Model.collection = {
+      indexes: jest.fn<() => Promise<unknown>>().mockResolvedValue([
+        { name: "_id_" },
+        // Same key but non-unique — this is the new declaration, keep it.
+        { name: "guildId_1_roleName_1", unique: false },
+      ]),
+      dropIndex,
+    };
+
+    await runReactionRoleMigrations();
+
+    expect(dropIndex).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/services/reaction-role-service-bind-persist.test.ts
+++ b/__tests__/services/reaction-role-service-bind-persist.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import type { Client } from "discord.js";
+
+// The rest of the reaction-role suites rely on the global mongoose mock, under
+// which `ReactionRoleConfig` is a non-constructible plain object — so those
+// tests can only assert branch behaviour up to the DB write. Here we use the
+// ESM-correct `jest.unstable_mockModule` + dynamic import so the model is a
+// real constructor with a spy-able `save`, letting us assert that a successful
+// bind actually persists the expected mapping payload (issue #813 review).
+
+const mockSave = jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined);
+const constructed: Array<Record<string, unknown>> = [];
+
+jest.unstable_mockModule("../../src/utils/logger.js", () => ({
+  default: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.unstable_mockModule("../../src/models/reaction-role-config.js", () => {
+  class ReactionRoleConfig {
+    constructor(data: Record<string, unknown>) {
+      Object.assign(this, data);
+      constructed.push(data);
+    }
+    save = mockSave;
+    static findOne = jest.fn();
+  }
+  return {
+    ReactionRoleConfig,
+    REACTION_ROLE_STYLES: ["reaction", "button", "select"],
+  };
+});
+
+const { ReactionRoleService } =
+  await import("../../src/services/reaction-role-service.js");
+const { ReactionRoleConfig } =
+  await import("../../src/models/reaction-role-config.js");
+
+const Model = ReactionRoleConfig as unknown as { findOne: jest.Mock };
+
+function makeService(guild: unknown) {
+  const client = {
+    guilds: {
+      fetch: jest.fn<() => Promise<unknown>>().mockResolvedValue(guild),
+    },
+    user: { id: "bot1" },
+  } as unknown as Client;
+  const service = ReactionRoleService.getInstance(client);
+  (service as never)["configService"] = {
+    getString: jest.fn<() => Promise<string>>().mockResolvedValue("chan1"),
+    getBoolean: jest.fn<() => Promise<boolean>>().mockResolvedValue(true),
+    getNumber: jest.fn(),
+  };
+  return service;
+}
+
+function buildGuild() {
+  const newMessage = {
+    id: "newmsg",
+    react: jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+    delete: jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+  };
+  const botMember = {
+    permissions: { has: jest.fn().mockReturnValue(true) },
+    roles: { highest: { comparePositionTo: jest.fn().mockReturnValue(1) } },
+  };
+  const messageChannel = {
+    isTextBased: () => true,
+    send: jest.fn<() => Promise<unknown>>().mockResolvedValue(newMessage),
+    messages: { fetch: jest.fn() },
+  };
+  const guild = {
+    id: "guild1",
+    members: {
+      me: botMember,
+      fetchMe: jest.fn<() => Promise<unknown>>().mockResolvedValue(botMember),
+    },
+    roles: {
+      everyone: { id: "guild1" },
+      fetch: jest
+        .fn<() => Promise<unknown>>()
+        .mockResolvedValue({ id: "role1", name: "Gamer", managed: false }),
+    },
+    channels: {
+      fetch: jest
+        .fn<() => Promise<unknown>>()
+        .mockResolvedValue(messageChannel),
+    },
+  };
+  return { guild, newMessage };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  constructed.length = 0;
+  Model.findOne = jest.fn();
+  (ReactionRoleService as unknown as { instance?: unknown }).instance =
+    undefined;
+});
+
+describe("bindReactionRole persistence", () => {
+  it("succeeds and persists a bound (autoCreated=false) mapping", async () => {
+    const { guild, newMessage } = buildGuild();
+    Model.findOne.mockResolvedValue(null);
+    const service = makeService(guild);
+
+    const result = await service.bindReactionRole("guild1", "<@&role1>", "🎨");
+
+    expect(result.success).toBe(true);
+    expect(result.messageId).toBe("newmsg");
+    expect(newMessage.react).toHaveBeenCalledWith("🎨");
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    expect(constructed).toHaveLength(1);
+    expect(constructed[0]).toMatchObject({
+      guildId: "guild1",
+      messageId: "newmsg",
+      roleId: "role1",
+      emoji: "🎨",
+      roleName: "Gamer",
+      autoCreated: false,
+    });
+    // Bound mappings own no category/channel.
+    expect(constructed[0].categoryId).toBeUndefined();
+    expect(constructed[0].channelId).toBeUndefined();
+  });
+});

--- a/__tests__/services/reaction-role-service-binding.test.ts
+++ b/__tests__/services/reaction-role-service-binding.test.ts
@@ -69,7 +69,9 @@ function buildGuild(opts: BuildOpts) {
       fetch: jest.fn<() => Promise<unknown>>().mockResolvedValue(role),
     },
     channels: {
-      fetch: jest.fn<() => Promise<unknown>>().mockResolvedValue(messageChannel),
+      fetch: jest
+        .fn<() => Promise<unknown>>()
+        .mockResolvedValue(messageChannel),
     },
   };
   return { guild, messageChannel, newMessage, botMember };
@@ -225,7 +227,9 @@ describe("ReactionRoleService.createReactionRole channel opt-out", () => {
     const guild = {
       id: "guild1",
       members: {
-        me: { permissions: { has: jest.fn().mockReturnValue(botHasManageRoles) } },
+        me: {
+          permissions: { has: jest.fn().mockReturnValue(botHasManageRoles) },
+        },
         fetchMe: jest.fn(),
       },
       roles: { create: rolesCreate, everyone: { id: "guild1" } },

--- a/__tests__/services/reaction-role-service-binding.test.ts
+++ b/__tests__/services/reaction-role-service-binding.test.ts
@@ -1,0 +1,445 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import type { Client } from "discord.js";
+
+// This suite follows the repo's model-testing convention: the global mongoose
+// mock in __tests__/setup.ts already replaces `mongoose.model(...)` with a
+// plain object, so we assign the statics we need directly onto the imported
+// model rather than trying to construct it. Assertions therefore target the
+// service's branch behaviour and Discord side effects up to (and including)
+// the point where the DB row would be written — which is exactly where the
+// #813 validation logic lives.
+jest.mock("../../src/models/reaction-role-config.js");
+
+import { ReactionRoleService } from "../../src/services/reaction-role-service.js";
+import { ReactionRoleConfig } from "../../src/models/reaction-role-config.js";
+
+const Model = ReactionRoleConfig as unknown as {
+  findOne: jest.Mock;
+  countDocuments: jest.Mock;
+  deleteOne: jest.Mock;
+};
+
+interface BuildOpts {
+  role?: Record<string, unknown> | null;
+  botHasManageRoles?: boolean;
+  botHigher?: boolean;
+  roleManaged?: boolean;
+  existingMessage?: Record<string, unknown> | null;
+}
+
+function buildGuild(opts: BuildOpts) {
+  const newMessage = {
+    id: "newmsg",
+    react: jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+    delete: jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+  };
+  const botMember = {
+    permissions: {
+      has: jest.fn().mockReturnValue(opts.botHasManageRoles ?? true),
+    },
+    roles: {
+      highest: {
+        comparePositionTo: jest
+          .fn()
+          .mockReturnValue((opts.botHigher ?? true) ? 1 : -1),
+      },
+    },
+  };
+  const messageChannel = {
+    isTextBased: () => true,
+    send: jest.fn<() => Promise<unknown>>().mockResolvedValue(newMessage),
+    messages: {
+      fetch: jest
+        .fn<() => Promise<unknown>>()
+        .mockResolvedValue(opts.existingMessage ?? null),
+    },
+  };
+  const role =
+    "role" in opts
+      ? opts.role
+      : { id: "role1", name: "Gamer", managed: opts.roleManaged ?? false };
+  const guild = {
+    id: "guild1",
+    members: {
+      me: botMember,
+      fetchMe: jest.fn<() => Promise<unknown>>().mockResolvedValue(botMember),
+    },
+    roles: {
+      everyone: { id: "guild1" },
+      fetch: jest.fn<() => Promise<unknown>>().mockResolvedValue(role),
+    },
+    channels: {
+      fetch: jest.fn<() => Promise<unknown>>().mockResolvedValue(messageChannel),
+    },
+  };
+  return { guild, messageChannel, newMessage, botMember };
+}
+
+function makeService(guild: unknown, messageChannelId = "chan1") {
+  const client = {
+    guilds: {
+      fetch: jest.fn<() => Promise<unknown>>().mockResolvedValue(guild),
+    },
+    user: { id: "bot1" },
+  } as unknown as Client;
+  const service = ReactionRoleService.getInstance(client);
+  (service as never)["configService"] = {
+    getString: jest
+      .fn<() => Promise<string>>()
+      .mockResolvedValue(messageChannelId),
+    getBoolean: jest.fn<() => Promise<boolean>>().mockResolvedValue(true),
+    getNumber: jest.fn(),
+  };
+  return service;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Model.findOne = jest.fn();
+  Model.countDocuments = jest.fn();
+  Model.deleteOne = jest.fn();
+  (
+    ReactionRoleService as unknown as { instance?: ReactionRoleService }
+  ).instance = undefined;
+});
+
+describe("ReactionRoleService.bindReactionRole validation", () => {
+  it("fails when the target role does not exist", async () => {
+    const { guild } = buildGuild({ role: null });
+    const service = makeService(guild);
+
+    const result = await service.bindReactionRole("guild1", "missing", "🎨");
+
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/not found/i);
+  });
+
+  it("fails with an actionable message when the bot lacks Manage Roles", async () => {
+    const { guild } = buildGuild({ botHasManageRoles: false });
+    const service = makeService(guild);
+
+    const result = await service.bindReactionRole("guild1", "role1", "🎨");
+
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/Manage Roles/);
+  });
+
+  it("fails when the bot's highest role is not above the target role", async () => {
+    const { guild } = buildGuild({ botHigher: false });
+    const service = makeService(guild);
+
+    const result = await service.bindReactionRole("guild1", "role1", "🎨");
+
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/highest role/i);
+  });
+
+  it("fails when the target role is integration-managed", async () => {
+    const { guild } = buildGuild({ roleManaged: true });
+    const service = makeService(guild);
+
+    const result = await service.bindReactionRole("guild1", "role1", "🎨");
+
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/managed/i);
+  });
+
+  it("rejects a duplicate emoji already mapped on the same message", async () => {
+    const existingMessage = {
+      id: "picker1",
+      react: jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+    };
+    const { guild } = buildGuild({ existingMessage });
+    Model.findOne.mockResolvedValue({ _id: "dup" }); // duplicate exists
+    const service = makeService(guild);
+
+    const result = await service.bindReactionRole("guild1", "role1", "🎨", {
+      messageId: "picker1",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/already mapped/i);
+    expect(existingMessage.react).not.toHaveBeenCalled();
+  });
+
+  it("errors when the referenced picker message cannot be fetched", async () => {
+    const { guild } = buildGuild({ existingMessage: null });
+    Model.findOne.mockResolvedValue(null);
+    const service = makeService(guild);
+
+    const result = await service.bindReactionRole("guild1", "role1", "🎨", {
+      messageId: "ghost",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/not found/i);
+  });
+
+  it("reacts to a freshly posted message for a valid new binding", async () => {
+    const { guild, messageChannel, newMessage } = buildGuild({});
+    Model.findOne.mockResolvedValue(null);
+    const service = makeService(guild);
+
+    // The DB write itself can't complete under the global mongoose mock, but
+    // the service reaches it only after posting + reacting, which is the
+    // behaviour we assert here.
+    await service.bindReactionRole("guild1", "role1", "🎨");
+
+    expect(messageChannel.send).toHaveBeenCalledTimes(1);
+    expect(newMessage.react).toHaveBeenCalledWith("🎨");
+  });
+
+  it("adds to an existing picker message instead of posting a new one", async () => {
+    const existingMessage = {
+      id: "picker1",
+      react: jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+    };
+    const { guild, messageChannel } = buildGuild({ existingMessage });
+    Model.findOne.mockResolvedValue(null);
+    const service = makeService(guild);
+
+    await service.bindReactionRole("guild1", "role1", "🎨", {
+      messageId: "picker1",
+    });
+
+    expect(messageChannel.send).not.toHaveBeenCalled();
+    expect(existingMessage.react).toHaveBeenCalledWith("🎨");
+  });
+});
+
+describe("ReactionRoleService.createReactionRole channel opt-out", () => {
+  function buildCreateGuild(botHasManageRoles = true) {
+    const rolesCreate = jest
+      .fn<() => Promise<unknown>>()
+      .mockResolvedValue({ id: "role1", name: "Gamer" });
+    const channelsCreate = jest.fn<() => Promise<unknown>>();
+    const newMessage = {
+      id: "newmsg",
+      react: jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+      delete: jest.fn(),
+    };
+    const messageChannel = {
+      isTextBased: () => true,
+      send: jest.fn<() => Promise<unknown>>().mockResolvedValue(newMessage),
+    };
+    const guild = {
+      id: "guild1",
+      members: {
+        me: { permissions: { has: jest.fn().mockReturnValue(botHasManageRoles) } },
+        fetchMe: jest.fn(),
+      },
+      roles: { create: rolesCreate, everyone: { id: "guild1" } },
+      channels: {
+        create: channelsCreate,
+        fetch: jest
+          .fn<() => Promise<unknown>>()
+          .mockResolvedValue(messageChannel),
+      },
+    };
+    return { guild, rolesCreate, channelsCreate, messageChannel };
+  }
+
+  it("creates the role but no category/channel when createChannel is false", async () => {
+    const { guild, rolesCreate, channelsCreate } = buildCreateGuild();
+    Model.findOne.mockResolvedValue(null);
+    const service = makeService(guild);
+
+    await service.createReactionRole("guild1", "Gamer", "🎮", {
+      createChannel: false,
+    });
+
+    expect(rolesCreate).toHaveBeenCalledTimes(1);
+    expect(channelsCreate).not.toHaveBeenCalled();
+  });
+
+  it("creates a category + channel when createChannel is true (default)", async () => {
+    const channelsCreate = jest.fn<() => Promise<unknown>>().mockResolvedValue({
+      id: "cat1",
+      name: "Gamer",
+      permissionOverwrites: { edit: jest.fn().mockResolvedValue(undefined) },
+    });
+    const rolesCreate = jest
+      .fn<() => Promise<unknown>>()
+      .mockResolvedValue({ id: "role1", name: "Gamer" });
+    const messageChannel = {
+      isTextBased: () => true,
+      send: jest.fn<() => Promise<unknown>>().mockResolvedValue({
+        id: "newmsg",
+        react: jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+      }),
+    };
+    const guild = {
+      id: "guild1",
+      members: {
+        me: {
+          permissions: { has: jest.fn().mockReturnValue(true) },
+        },
+        fetchMe: jest.fn(),
+      },
+      roles: { create: rolesCreate, everyone: { id: "guild1" } },
+      channels: {
+        create: channelsCreate,
+        fetch: jest
+          .fn<() => Promise<unknown>>()
+          .mockResolvedValue(messageChannel),
+      },
+    };
+    Model.findOne.mockResolvedValue(null);
+    const service = makeService(guild);
+
+    await service.createReactionRole("guild1", "Gamer", "🎮");
+
+    // One create for the category, one for the text channel.
+    expect(channelsCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("refuses to create when the bot lacks Manage Roles", async () => {
+    const { guild, rolesCreate } = buildCreateGuild(false);
+    Model.findOne.mockResolvedValue(null);
+    const service = makeService(guild);
+
+    const result = await service.createReactionRole("guild1", "Gamer", "🎮");
+
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/Manage Roles/);
+    expect(rolesCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("ReactionRoleService.removeReactionRoleMapping", () => {
+  function reactionlessChannel() {
+    return {
+      messages: {
+        fetch: jest.fn<() => Promise<unknown>>().mockResolvedValue({
+          reactions: { cache: { find: jest.fn().mockReturnValue(undefined) } },
+        }),
+      },
+    };
+  }
+
+  it("returns an error when no mapping matches", async () => {
+    Model.findOne.mockResolvedValue(null);
+    const guild = { channels: { fetch: jest.fn() } };
+    const service = makeService(guild);
+
+    const result = await service.removeReactionRoleMapping(
+      "guild1",
+      "m1",
+      "🎨",
+    );
+
+    expect(result.success).toBe(false);
+    expect(Model.deleteOne).not.toHaveBeenCalled();
+  });
+
+  it("never deletes the role for a bound (non-auto-created) mapping", async () => {
+    Model.findOne.mockResolvedValue({
+      _id: "cfg1",
+      roleId: "role1",
+      roleName: "Gamer",
+      messageId: "m1",
+      emoji: "🎨",
+      autoCreated: false,
+    });
+    Model.deleteOne.mockResolvedValue({ deletedCount: 1 });
+    const roleDelete = jest.fn();
+    const guild = {
+      channels: {
+        fetch: jest
+          .fn<() => Promise<unknown>>()
+          .mockResolvedValue(reactionlessChannel()),
+      },
+      roles: {
+        fetch: jest
+          .fn<() => Promise<unknown>>()
+          .mockResolvedValue({ delete: roleDelete }),
+      },
+    };
+    const service = makeService(guild);
+
+    const result = await service.removeReactionRoleMapping(
+      "guild1",
+      "m1",
+      "🎨",
+    );
+
+    expect(result.success).toBe(true);
+    expect(roleDelete).not.toHaveBeenCalled();
+    expect(Model.deleteOne).toHaveBeenCalledWith({ _id: "cfg1" });
+  });
+
+  it("deletes an auto-created role when no other mapping references it", async () => {
+    Model.findOne.mockResolvedValue({
+      _id: "cfg1",
+      roleId: "role1",
+      roleName: "Gamer",
+      messageId: "m1",
+      emoji: "🎮",
+      autoCreated: true,
+    });
+    Model.countDocuments.mockResolvedValue(0);
+    Model.deleteOne.mockResolvedValue({ deletedCount: 1 });
+    const roleDelete = jest
+      .fn<() => Promise<unknown>>()
+      .mockResolvedValue(undefined);
+    const guild = {
+      channels: {
+        fetch: jest
+          .fn<() => Promise<unknown>>()
+          .mockResolvedValue(reactionlessChannel()),
+      },
+      roles: {
+        fetch: jest
+          .fn<() => Promise<unknown>>()
+          .mockResolvedValue({ delete: roleDelete }),
+      },
+    };
+    const service = makeService(guild);
+
+    const result = await service.removeReactionRoleMapping(
+      "guild1",
+      "m1",
+      "🎮",
+    );
+
+    expect(result.success).toBe(true);
+    expect(roleDelete).toHaveBeenCalledTimes(1);
+    expect(Model.deleteOne).toHaveBeenCalledWith({ _id: "cfg1" });
+  });
+
+  it("keeps an auto-created role that other mappings still reference", async () => {
+    Model.findOne.mockResolvedValue({
+      _id: "cfg1",
+      roleId: "role1",
+      roleName: "Gamer",
+      messageId: "m1",
+      emoji: "🎮",
+      autoCreated: true,
+    });
+    Model.countDocuments.mockResolvedValue(2); // still referenced elsewhere
+    Model.deleteOne.mockResolvedValue({ deletedCount: 1 });
+    const roleDelete = jest.fn();
+    const guild = {
+      channels: {
+        fetch: jest
+          .fn<() => Promise<unknown>>()
+          .mockResolvedValue(reactionlessChannel()),
+      },
+      roles: {
+        fetch: jest
+          .fn<() => Promise<unknown>>()
+          .mockResolvedValue({ delete: roleDelete }),
+      },
+    };
+    const service = makeService(guild);
+
+    const result = await service.removeReactionRoleMapping(
+      "guild1",
+      "m1",
+      "🎮",
+    );
+
+    expect(result.success).toBe(true);
+    expect(roleDelete).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/web/admin-views.test.ts
+++ b/__tests__/web/admin-views.test.ts
@@ -1466,12 +1466,14 @@ describe("renderReactionRolesPage", () => {
       configChannel: { name: "roles", id: "c1" },
       active: [
         {
+          mappingId: "aaaaaaaaaaaaaaaaaaaaaaaa",
           emoji: "🎮",
           roleName: "Gamer",
           roleId: "r1",
           categoryName: "Roles",
           channelName: "roles",
           messageId: "m1",
+          autoCreated: true,
           isArchived: false,
           archivedAt: null,
         },
@@ -1485,6 +1487,37 @@ describe("renderReactionRolesPage", () => {
     expect(html).toContain("/admin/reaction-roles/create");
     expect(html).toContain("/admin/reaction-roles/archive");
     expect(html).toContain("/admin/reaction-roles/delete");
+    // Managed rows key their actions on the stable mapping id, not roleName.
+    expect(html).toContain(
+      '<input type="hidden" name="mappingId" value="aaaaaaaaaaaaaaaaaaaaaaaa">',
+    );
+  });
+
+  it("renders a bound mapping with a remove-mapping control and bound tag", () => {
+    const html = renderReactionRolesPage({
+      ...COMMON,
+      enabled: true,
+      configChannel: { name: "roles", id: "c1" },
+      active: [
+        {
+          mappingId: "bbbbbbbbbbbbbbbbbbbbbbbb",
+          emoji: "🎨",
+          roleName: "Artist",
+          roleId: "r9",
+          categoryName: "—",
+          channelName: "—",
+          messageId: "m9",
+          autoCreated: false,
+          isArchived: false,
+          archivedAt: null,
+        },
+      ],
+      archived: [],
+    });
+    expect(html).toContain("/admin/reaction-roles/remove-mapping");
+    expect(html).toContain(">bound<");
+    // Bound rows do not offer archive.
+    expect(html).not.toContain("/admin/reaction-roles/archive");
   });
 
   it("renders unarchive control for archived rows", () => {
@@ -1495,12 +1528,14 @@ describe("renderReactionRolesPage", () => {
       active: [],
       archived: [
         {
+          mappingId: "cccccccccccccccccccccccc",
           emoji: "📦",
           roleName: "Old",
           roleId: "r2",
           categoryName: "Roles",
           channelName: "old",
           messageId: "m2",
+          autoCreated: true,
           isArchived: true,
           archivedAt: "2026-05-08T00:00:00.000Z",
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { env, getMissingRequiredEnv } from "./config/env.js";
 import logger, { isDebugMode } from "./utils/logger.js";
 import { ConfigService } from "./services/config-service.js";
 import { runNameToIdMigrations } from "./services/name-id-migrator.js";
+import { runReactionRoleMigrations } from "./services/reaction-role-migrator.js";
 import { CommandManager } from "./services/command-manager.js";
 import {
   VoiceChannelManager,
@@ -679,6 +680,11 @@ async function initializeServices(): Promise<void> {
     // or channel names) into IDs before services that consume them start
     // up. One-shot, idempotent, no-op on already-migrated deployments.
     await runNameToIdMigrations(client, guildId, configService);
+
+    // Backfill the autoCreated flag on legacy reaction-role mappings so their
+    // delete semantics survive the #813 schema change. Idempotent no-op once
+    // every row carries the field.
+    await runReactionRoleMigrations();
 
     // Initialize voice channel services
     await voiceChannelManager.initialize(guildId);

--- a/src/models/reaction-role-config.ts
+++ b/src/models/reaction-role-config.ts
@@ -20,12 +20,30 @@ export const REACTION_ROLE_STYLES: ReactionRoleStyle[] = [
 export interface IReactionRoleConfig extends Document {
   guildId: string;
   messageId: string;
-  channelId: string;
+  /**
+   * The private text channel created for an auto-created reaction role.
+   * Optional: mappings that bind to an existing role (or opt out of the
+   * private category/channel) have no owned channel.
+   */
+  channelId?: string;
   roleId: string;
-  categoryId: string;
+  /**
+   * The private category created for an auto-created reaction role.
+   * Optional for the same reasons as {@link channelId}.
+   */
+  categoryId?: string;
   emoji: string;
   roleName: string;
   style: ReactionRoleStyle;
+  /**
+   * True when the bot created the role (and, when present, its category and
+   * channel) as part of this mapping and therefore owns their lifecycle.
+   * When false the mapping merely points at a pre-existing role, so deleting
+   * the mapping must never delete the role. Legacy rows created before this
+   * field existed are all auto-created; the startup migration backfills them
+   * with `true` (see reaction-role-migrator.ts).
+   */
+  autoCreated: boolean;
   isArchived: boolean;
   createdAt: Date;
   updatedAt: Date;
@@ -46,7 +64,7 @@ const ReactionRoleConfigSchema = new Schema<IReactionRoleConfig>(
     },
     channelId: {
       type: String,
-      required: true,
+      required: false,
     },
     roleId: {
       type: String,
@@ -55,7 +73,7 @@ const ReactionRoleConfigSchema = new Schema<IReactionRoleConfig>(
     },
     categoryId: {
       type: String,
-      required: true,
+      required: false,
     },
     emoji: {
       type: String,
@@ -74,6 +92,11 @@ const ReactionRoleConfigSchema = new Schema<IReactionRoleConfig>(
       required: true,
       index: true,
     },
+    autoCreated: {
+      type: Boolean,
+      default: true,
+      index: true,
+    },
     isArchived: {
       type: Boolean,
       default: false,
@@ -89,10 +112,18 @@ const ReactionRoleConfigSchema = new Schema<IReactionRoleConfig>(
   },
 );
 
-// Compound index for efficient queries
-ReactionRoleConfigSchema.index({ guildId: 1, messageId: 1, emoji: 1 });
+// A single message can now carry many emoji→role mappings, but a given emoji
+// on a given message must still resolve to exactly one mapping — otherwise the
+// reaction handlers wouldn't know which role to grant. This unique compound
+// index enforces that and replaces the former `{ guildId, roleName }` unique
+// index, which wrongly assumed a role could only ever appear on one picker.
+ReactionRoleConfigSchema.index(
+  { guildId: 1, messageId: 1, emoji: 1 },
+  { unique: true },
+);
 ReactionRoleConfigSchema.index({ guildId: 1, roleId: 1 });
-ReactionRoleConfigSchema.index({ guildId: 1, roleName: 1 }, { unique: true });
+// Non-unique: the same role name may appear across multiple pickers/messages.
+ReactionRoleConfigSchema.index({ guildId: 1, roleName: 1 });
 
 export const ReactionRoleConfig = mongoose.model<IReactionRoleConfig>(
   "ReactionRoleConfig",

--- a/src/services/reaction-role-migrator.ts
+++ b/src/services/reaction-role-migrator.ts
@@ -16,12 +16,22 @@ import { ReactionRoleConfig } from "../models/reaction-role-config.js";
  * `autoCreated: true` on any row missing the field, restoring the original
  * delete semantics for pre-#813 data.
  *
- * It is idempotent: once every row carries the field, the `$exists: false`
- * filter matches nothing and the migration is a no-op on subsequent starts.
- * Runs after the Mongo connection is established and before services that
- * consume reaction-role configs initialise.
+ * It is idempotent: once every row carries the field and the legacy index is
+ * gone, both steps become no-ops on subsequent starts. Runs after the Mongo
+ * connection is established and before services that consume reaction-role
+ * configs initialise.
  */
+const LEGACY_ROLE_NAME_INDEX = "guildId_1_roleName_1";
+
 export async function runReactionRoleMigrations(): Promise<void> {
+  await backfillAutoCreated();
+  await dropLegacyRoleNameIndex();
+}
+
+/**
+ * Backfill `autoCreated: true` on rows written before the field existed.
+ */
+async function backfillAutoCreated(): Promise<void> {
   try {
     const legacyCount = await ReactionRoleConfig.countDocuments({
       autoCreated: { $exists: false },
@@ -47,5 +57,45 @@ export async function runReactionRoleMigrations(): Promise<void> {
     // in the schema for any row written afterwards, and delete paths tolerate
     // missing category/channel ids.
     logger.error("Reaction-role migration failed:", error);
+  }
+}
+
+/**
+ * Drop the deployed `{ guildId, roleName }` unique index. Changing the schema
+ * declaration alone does not remove an index already built in MongoDB, so the
+ * old unique constraint would keep rejecting the same role name across multiple
+ * pickers — exactly what #813 needs to allow. Mongoose recreates the new
+ * (non-unique roleName + unique messageId/emoji) indexes on model init, so we
+ * only have to remove the stale one. Idempotent: a missing index is ignored.
+ */
+async function dropLegacyRoleNameIndex(): Promise<void> {
+  try {
+    const collection = ReactionRoleConfig.collection;
+    // Guarded for environments where the driver collection isn't available
+    // (e.g. the mocked model used in unit tests).
+    if (!collection || typeof collection.indexes !== "function") {
+      return;
+    }
+
+    const indexes = await collection.indexes();
+    const stale = indexes.find(
+      (idx: { name?: string; unique?: boolean }) =>
+        idx.name === LEGACY_ROLE_NAME_INDEX && idx.unique,
+    );
+    if (!stale) {
+      return;
+    }
+
+    await collection.dropIndex(LEGACY_ROLE_NAME_INDEX);
+    logger.info(
+      `Reaction-role migration: dropped stale unique index ${LEGACY_ROLE_NAME_INDEX}`,
+    );
+  } catch (error) {
+    // Non-fatal: worst case the new declaration and the old index coexist until
+    // an operator drops it manually; log so it's visible.
+    logger.warn(
+      "Reaction-role migration: could not drop legacy roleName index:",
+      error,
+    );
   }
 }

--- a/src/services/reaction-role-migrator.ts
+++ b/src/services/reaction-role-migrator.ts
@@ -1,0 +1,51 @@
+import logger from "../utils/logger.js";
+import { ReactionRoleConfig } from "../models/reaction-role-config.js";
+
+/**
+ * One-shot data migration for the reaction-roles modernization (issue #813).
+ *
+ * Before #813 every `ReactionRoleConfig` row was auto-created: the bot always
+ * minted a fresh Role + Category + Channel per mapping, so `categoryId` and
+ * `channelId` were required and there was no notion of "bind to an existing
+ * role". The new schema adds an `autoCreated` flag that governs whether
+ * deleting a mapping tears down the underlying Discord role/category/channel.
+ *
+ * Legacy rows predate that flag, so on read they'd default to `undefined`
+ * (falsy) — which would wrongly treat every historical mapping as a plain
+ * binding and skip resource teardown on delete. This migration backfills
+ * `autoCreated: true` on any row missing the field, restoring the original
+ * delete semantics for pre-#813 data.
+ *
+ * It is idempotent: once every row carries the field, the `$exists: false`
+ * filter matches nothing and the migration is a no-op on subsequent starts.
+ * Runs after the Mongo connection is established and before services that
+ * consume reaction-role configs initialise.
+ */
+export async function runReactionRoleMigrations(): Promise<void> {
+  try {
+    const legacyCount = await ReactionRoleConfig.countDocuments({
+      autoCreated: { $exists: false },
+    });
+
+    if (legacyCount === 0) {
+      logger.debug(
+        "Reaction-role migration: no legacy rows to backfill (autoCreated present on all rows)",
+      );
+      return;
+    }
+
+    const result = await ReactionRoleConfig.updateMany(
+      { autoCreated: { $exists: false } },
+      { $set: { autoCreated: true } },
+    );
+
+    logger.info(
+      `Reaction-role migration: backfilled autoCreated=true on ${result.modifiedCount} legacy mapping(s)`,
+    );
+  } catch (error) {
+    // A failed backfill must never crash startup; the field defaults to true
+    // in the schema for any row written afterwards, and delete paths tolerate
+    // missing category/channel ids.
+    logger.error("Reaction-role migration failed:", error);
+  }
+}

--- a/src/services/reaction-role-service.ts
+++ b/src/services/reaction-role-service.ts
@@ -9,6 +9,8 @@ import {
   Role,
   GuildMember,
   Message,
+  Guild,
+  PermissionFlagsBits,
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
@@ -580,10 +582,84 @@ export class ReactionRoleService {
     }
   }
 
+  /**
+   * Normalize an emoji into the format stored in the database. Custom emojis
+   * are kept as their full `<:name:id>` / `<a:name:id>` markup; standard
+   * emojis are stored as their Unicode character unchanged.
+   */
+  private normalizeEmoji(emoji: string): string {
+    const customEmojiMatch = emoji.match(/<a?:(\w+):(\d+)>/);
+    return customEmojiMatch ? customEmojiMatch[0] : emoji;
+  }
+
+  /**
+   * Validate up front that the bot can actually assign `role` before we wire a
+   * reaction to it. `member.roles.add()` fails at runtime when the bot lacks
+   * Manage Roles, when the target role sits at or above the bot's highest
+   * role, or when the role is integration-managed — historically this only
+   * surfaced as a `logger.error` deep inside `handleReactionAdd`. Surfacing it
+   * at create/bind time turns a silent no-op into an actionable message.
+   */
+  private async validateRoleAssignable(
+    guild: Guild,
+    role: Role,
+  ): Promise<{ ok: true } | { ok: false; message: string }> {
+    const botMember =
+      guild.members.me ?? (await guild.members.fetchMe().catch(() => null));
+
+    if (!botMember) {
+      return {
+        ok: false,
+        message: "I couldn't resolve my own membership in this server.",
+      };
+    }
+
+    if (!botMember.permissions.has(PermissionFlagsBits.ManageRoles)) {
+      return {
+        ok: false,
+        message:
+          "I need the **Manage Roles** permission to assign roles from reactions.",
+      };
+    }
+
+    if (role.id === guild.roles.everyone.id) {
+      return {
+        ok: false,
+        message: "The @everyone role can't be used as a reaction role.",
+      };
+    }
+
+    if (role.managed) {
+      return {
+        ok: false,
+        message: `**${role.name}** is managed by an integration or bot and can't be assigned manually.`,
+      };
+    }
+
+    if (botMember.roles.highest.comparePositionTo(role) <= 0) {
+      return {
+        ok: false,
+        message: `My highest role must be above **${role.name}** in the role list. Move my role higher under Server Settings → Roles, then try again.`,
+      };
+    }
+
+    return { ok: true };
+  }
+
+  /**
+   * Create a brand-new role (and, unless opted out, a private category +
+   * channel) and post a single-emoji reaction-role message for it. This is the
+   * original, heavily-opinionated flow, preserved for backward compatibility.
+   *
+   * @param options.createChannel When `true` (default) the bot also creates a
+   *   private category + text channel locked to the new role. Set `false` to
+   *   create a self-assign role with no attached channel (issue #813).
+   */
   public async createReactionRole(
     guildId: string,
     roleName: string,
     emoji: string,
+    options: { createChannel?: boolean } = {},
   ): Promise<{
     success: boolean;
     message: string;
@@ -592,6 +668,7 @@ export class ReactionRoleService {
     channelId?: string;
     messageId?: string;
   }> {
+    const createChannel = options.createChannel ?? true;
     let role: Role | null = null;
     let category: CategoryChannel | null = null;
     let channel: TextChannel | null = null;
@@ -613,16 +690,20 @@ export class ReactionRoleService {
 
       const guild = await this.client.guilds.fetch(guildId);
 
-      // Parse emoji to determine if it's custom or standard
-      // Custom emoji format: <:name:id> or <a:name:id>
-      // Store the emoji as-is for both standard (Unicode) and custom (full format)
-      let normalizedEmoji: string = emoji;
-      const customEmojiMatch = emoji.match(/<a?:(\w+):(\d+)>/);
-      if (customEmojiMatch) {
-        // For custom emojis, store the full markup to preserve name and animated flag
-        normalizedEmoji = customEmojiMatch[0];
+      // Verify up front that the bot can manage roles at all — otherwise we'd
+      // create a role, category, and channel only for `member.roles.add()` to
+      // fail silently at reaction time (#813).
+      const botMemberEarly =
+        guild.members.me ?? (await guild.members.fetchMe().catch(() => null));
+      if (!botMemberEarly?.permissions.has(PermissionFlagsBits.ManageRoles)) {
+        return {
+          success: false,
+          message:
+            "I need the **Manage Roles** permission to create reaction roles.",
+        };
       }
-      // For standard emojis, normalizedEmoji is already set to the Unicode character
+
+      const normalizedEmoji = this.normalizeEmoji(emoji);
 
       // Create the role
       role = await guild.roles.create({
@@ -632,60 +713,62 @@ export class ReactionRoleService {
 
       logger.info(`Created role: ${role.name} (${role.id})`);
 
-      // Create category
-      category = (await guild.channels.create({
-        name: roleName,
-        type: ChannelType.GuildCategory,
-        reason: `Category for reaction role: ${roleName}`,
-      })) as CategoryChannel;
+      if (createChannel) {
+        // Create category
+        category = (await guild.channels.create({
+          name: roleName,
+          type: ChannelType.GuildCategory,
+          reason: `Category for reaction role: ${roleName}`,
+        })) as CategoryChannel;
 
-      logger.info(`Created category: ${category.name} (${category.id})`);
+        logger.info(`Created category: ${category.name} (${category.id})`);
 
-      // Set category permissions - only role members can view
-      await category.permissionOverwrites.edit(guild.roles.everyone, {
-        ViewChannel: false,
-      });
-
-      await category.permissionOverwrites.edit(role, {
-        ViewChannel: true,
-      });
-
-      // Ensure the bot can always manage this category and its channels
-      const botMember = guild.members.me;
-      if (botMember) {
-        await category.permissionOverwrites.edit(botMember, {
-          ViewChannel: true,
-          ManageChannels: true,
-          ManageRoles: true,
+        // Set category permissions - only role members can view
+        await category.permissionOverwrites.edit(guild.roles.everyone, {
+          ViewChannel: false,
         });
-      } else {
-        logger.warn(
-          `Unable to set category permissions for bot user in guild ${guild.id} - guild.members.me is null`,
-        );
+
+        await category.permissionOverwrites.edit(role, {
+          ViewChannel: true,
+        });
+
+        // Ensure the bot can always manage this category and its channels
+        const botMember = guild.members.me;
+        if (botMember) {
+          await category.permissionOverwrites.edit(botMember, {
+            ViewChannel: true,
+            ManageChannels: true,
+            ManageRoles: true,
+          });
+        } else {
+          logger.warn(
+            `Unable to set category permissions for bot user in guild ${guild.id} - guild.members.me is null`,
+          );
+        }
+
+        // Create text channel in the category with sanitized name
+        // Discord channel names: lowercase, no spaces, 1-100 chars, alphanumeric + hyphens/underscores
+        const sanitizedName = roleName
+          .toLowerCase()
+          .replace(/\s+/g, "-") // Replace spaces with hyphens
+          .replace(/[^a-z0-9-_]/g, "") // Remove special characters
+          .substring(0, 100); // Limit to 100 characters
+
+        if (!sanitizedName) {
+          throw new Error(
+            "Role name must contain at least one alphanumeric character for channel creation",
+          );
+        }
+
+        channel = (await guild.channels.create({
+          name: sanitizedName,
+          type: ChannelType.GuildText,
+          parent: category.id,
+          reason: `Channel for reaction role: ${roleName}`,
+        })) as TextChannel;
+
+        logger.info(`Created channel: ${channel.name} (${channel.id})`);
       }
-
-      // Create text channel in the category with sanitized name
-      // Discord channel names: lowercase, no spaces, 1-100 chars, alphanumeric + hyphens/underscores
-      const sanitizedName = roleName
-        .toLowerCase()
-        .replace(/\s+/g, "-") // Replace spaces with hyphens
-        .replace(/[^a-z0-9-_]/g, "") // Remove special characters
-        .substring(0, 100); // Limit to 100 characters
-
-      if (!sanitizedName) {
-        throw new Error(
-          "Role name must contain at least one alphanumeric character for channel creation",
-        );
-      }
-
-      channel = (await guild.channels.create({
-        name: sanitizedName,
-        type: ChannelType.GuildText,
-        parent: category.id,
-        reason: `Channel for reaction role: ${roleName}`,
-      })) as TextChannel;
-
-      logger.info(`Created channel: ${channel.name} (${channel.id})`);
 
       // Get the configured message channel
       const messageChannelId = await this.configService.getString(
@@ -742,12 +825,13 @@ export class ReactionRoleService {
       const reactionRoleConfig = new ReactionRoleConfig({
         guildId,
         messageId: message.id,
-        channelId: channel.id,
+        channelId: channel?.id,
         roleId: role.id,
-        categoryId: category.id,
+        categoryId: category?.id,
         emoji: normalizedEmoji,
         roleName,
         style,
+        autoCreated: true,
         isArchived: false,
       });
 
@@ -764,8 +848,8 @@ export class ReactionRoleService {
         success: true,
         message: `Successfully created reaction role **${roleName}**!`,
         roleId: role.id,
-        categoryId: category.id,
-        channelId: channel.id,
+        categoryId: category?.id,
+        channelId: channel?.id,
         messageId: message.id,
       };
     } catch (error) {
@@ -812,6 +896,309 @@ export class ReactionRoleService {
         success: false,
         message: `Failed to create reaction role: ${error instanceof Error ? error.message : "Unknown error"}`,
       };
+    }
+  }
+
+  /**
+   * Bind an emoji reaction to an **existing** role, without creating a role,
+   * category, or channel (issue #813). When `options.messageId` is supplied
+   * the mapping is added to that existing message — letting one picker message
+   * carry many emoji→role mappings — otherwise a fresh single-mapping message
+   * is posted to the configured reaction-role channel.
+   *
+   * The role hierarchy is validated up front so binding to an unassignable
+   * role fails fast with an actionable message rather than silently no-opping
+   * at reaction time.
+   */
+  public async bindReactionRole(
+    guildId: string,
+    roleId: string,
+    emoji: string,
+    options: { messageId?: string; messageChannelId?: string } = {},
+  ): Promise<{
+    success: boolean;
+    message: string;
+    roleId?: string;
+    messageId?: string;
+  }> {
+    let postedMessage: Message | null = null;
+
+    try {
+      const guild = await this.client.guilds.fetch(guildId);
+
+      const role = await guild.roles.fetch(roleId).catch(() => null);
+      if (!role) {
+        return {
+          success: false,
+          message: `Role \`${roleId}\` was not found in this server.`,
+        };
+      }
+
+      // Up-front hierarchy / permission validation (#813).
+      const assignable = await this.validateRoleAssignable(guild, role);
+      if (!assignable.ok) {
+        return { success: false, message: assignable.message };
+      }
+
+      const normalizedEmoji = this.normalizeEmoji(emoji);
+
+      // Resolve the channel that owns (or will own) the reaction message.
+      const messageChannelId =
+        options.messageChannelId ||
+        (await this.configService.getString(
+          "reactionroles.message_channel_id",
+          "",
+        ));
+
+      if (!messageChannelId) {
+        return {
+          success: false,
+          message:
+            "Reaction role message channel not configured. Set reactionroles.message_channel_id",
+        };
+      }
+
+      const messageChannel = (await guild.channels
+        .fetch(messageChannelId)
+        .catch(() => null)) as TextChannel | null;
+
+      if (!messageChannel || !messageChannel.isTextBased()) {
+        return {
+          success: false,
+          message: `Message channel ${messageChannelId} not found or is not a text channel.`,
+        };
+      }
+
+      let targetMessage: Message;
+
+      if (options.messageId) {
+        // Add a mapping to an existing picker message.
+        const existingMessage = await messageChannel.messages
+          .fetch(options.messageId)
+          .catch(() => null);
+        if (!existingMessage) {
+          return {
+            success: false,
+            message: `Message \`${options.messageId}\` was not found in <#${messageChannelId}>.`,
+          };
+        }
+
+        // Reject a duplicate emoji on the same message: the reaction handlers
+        // resolve one role per (message, emoji), so a collision is ambiguous.
+        const duplicate = await ReactionRoleConfig.findOne({
+          guildId,
+          messageId: options.messageId,
+          emoji: normalizedEmoji,
+        });
+        if (duplicate) {
+          return {
+            success: false,
+            message: `That emoji is already mapped to a role on message \`${options.messageId}\`.`,
+          };
+        }
+
+        targetMessage = existingMessage;
+      } else {
+        // Post a fresh single-mapping message for this existing role.
+        const embed = new EmbedBuilder()
+          .setColor(0x5865f2)
+          .setTitle(`${emoji} ${role.name}`)
+          .setDescription(
+            `React with ${emoji} to get the **${role.name}** role!`,
+          )
+          .setFooter({ text: "Remove your reaction to lose the role" })
+          .setTimestamp();
+        postedMessage = await messageChannel.send({ embeds: [embed] });
+        targetMessage = postedMessage;
+      }
+
+      try {
+        await targetMessage.react(emoji);
+      } catch (reactionError) {
+        logger.error("Failed to add reaction to message:", reactionError);
+        // Only clean up a message we ourselves just posted.
+        if (postedMessage) {
+          await postedMessage.delete().catch((err) => {
+            logger.warn("Could not delete message after reaction error:", err);
+          });
+        }
+        return {
+          success: false,
+          message:
+            "Failed to add reaction. The emoji might be invalid or inaccessible.",
+        };
+      }
+
+      const reactionRoleConfig = new ReactionRoleConfig({
+        guildId,
+        messageId: targetMessage.id,
+        roleId: role.id,
+        emoji: normalizedEmoji,
+        roleName: role.name,
+        autoCreated: false,
+        isArchived: false,
+      });
+
+      try {
+        await reactionRoleConfig.save();
+      } catch (dbError) {
+        logger.error("Failed to save reaction role binding:", dbError);
+        if (postedMessage) {
+          await postedMessage.delete().catch((err) => {
+            logger.warn("Could not delete message after DB error:", err);
+          });
+        }
+        return {
+          success: false,
+          message: "Failed to save configuration to database.",
+        };
+      }
+
+      logger.info(
+        `Bound reaction ${normalizedEmoji} → existing role ${sanitizeForLog(role.name)} on message ${targetMessage.id}`,
+      );
+
+      return {
+        success: true,
+        message: `Bound ${emoji} to existing role **${role.name}**.`,
+        roleId: role.id,
+        messageId: targetMessage.id,
+      };
+    } catch (error) {
+      logger.error("Error binding reaction role:", error);
+      if (postedMessage) {
+        await postedMessage.delete().catch((err) => {
+          logger.warn("Could not delete message during rollback:", err);
+        });
+      }
+      return {
+        success: false,
+        message: `Failed to bind reaction role: ${error instanceof Error ? error.message : "Unknown error"}`,
+      };
+    }
+  }
+
+  /**
+   * Remove a single emoji→role mapping identified by its message + emoji.
+   * Unlike {@link deleteReactionRole} (which tears down an entire auto-created
+   * role + category + channel), this only unbinds one mapping: it removes the
+   * bot's reaction and deletes the DB row, and deletes the underlying Discord
+   * role/category/channel only when this mapping auto-created them and no other
+   * mapping still references them.
+   */
+  public async removeReactionRoleMapping(
+    guildId: string,
+    messageId: string,
+    emoji: string,
+  ): Promise<{ success: boolean; message: string }> {
+    try {
+      const normalizedEmoji = this.normalizeEmoji(emoji);
+      const config = await ReactionRoleConfig.findOne({
+        guildId,
+        messageId,
+        emoji: normalizedEmoji,
+      });
+
+      if (!config) {
+        return {
+          success: false,
+          message: `No mapping found for that emoji on message \`${messageId}\`.`,
+        };
+      }
+
+      const guild = await this.client.guilds.fetch(guildId).catch(() => null);
+
+      // Best-effort: remove the bot's own reaction so the picker stays tidy.
+      if (guild) {
+        try {
+          const messageChannelId = await this.configService.getString(
+            "reactionroles.message_channel_id",
+            "",
+          );
+          if (messageChannelId) {
+            const channel = (await guild.channels
+              .fetch(messageChannelId)
+              .catch(() => null)) as TextChannel | null;
+            const message = await channel?.messages
+              .fetch(messageId)
+              .catch(() => null);
+            const reaction = message?.reactions.cache.find(
+              (r) => this.buildEmojiIdentifier(r) === normalizedEmoji,
+            );
+            await reaction?.users.remove(this.client.user?.id);
+          }
+        } catch (err) {
+          logger.warn("Could not remove bot reaction while unbinding:", err);
+        }
+      }
+
+      // Tear down auto-created Discord resources only when nothing else uses
+      // them. Bound (non-auto-created) mappings never delete their role.
+      if (guild && config.autoCreated) {
+        if (config.categoryId) {
+          await this.deleteCategoryTree(guild, config.categoryId);
+        }
+        const stillUsed = await ReactionRoleConfig.countDocuments({
+          guildId,
+          roleId: config.roleId,
+          _id: { $ne: config._id },
+        });
+        if (stillUsed === 0 && config.roleId) {
+          try {
+            const role = await guild.roles.fetch(config.roleId);
+            if (role) {
+              await role.delete();
+              logger.info(`Deleted role ${config.roleId}`);
+            }
+          } catch (err) {
+            logger.warn("Could not delete role while unbinding:", err);
+          }
+        }
+      }
+
+      await ReactionRoleConfig.deleteOne({ _id: config._id });
+
+      logger.info(
+        `Removed reaction-role mapping ${normalizedEmoji} on message ${messageId} (${sanitizeForLog(config.roleName)})`,
+      );
+
+      return {
+        success: true,
+        message: `Removed the ${emoji} → **${config.roleName}** mapping.`,
+      };
+    } catch (error) {
+      logger.error("Error removing reaction role mapping:", error);
+      return {
+        success: false,
+        message: `Failed to remove mapping: ${error instanceof Error ? error.message : "Unknown error"}`,
+      };
+    }
+  }
+
+  /**
+   * Delete a category and every channel nested under it. Shared by the
+   * full-delete and unbind paths.
+   */
+  private async deleteCategoryTree(
+    guild: Guild,
+    categoryId: string,
+  ): Promise<void> {
+    try {
+      const category = await guild.channels.fetch(categoryId).catch(() => null);
+      if (category) {
+        const categoryChannel = category as CategoryChannel;
+        for (const [, channel] of categoryChannel.children.cache) {
+          try {
+            await channel.delete();
+          } catch (err) {
+            logger.warn(`Could not delete channel ${channel.id}:`, err);
+          }
+        }
+        await category.delete();
+        logger.info(`Deleted category ${categoryId}`);
+      }
+    } catch (error) {
+      logger.warn("Could not delete category:", error);
     }
   }
 
@@ -1026,58 +1413,53 @@ export class ReactionRoleService {
 
       const guild = await this.client.guilds.fetch(guildId);
 
-      // Delete message
-      try {
-        const messageChannelId = await this.configService.getString(
-          "reactionroles.message_channel_id",
-          "",
-        );
-        if (messageChannelId) {
-          const messageChannel = (await guild.channels.fetch(
-            messageChannelId,
-          )) as TextChannel;
-          if (messageChannel) {
-            const message = await messageChannel.messages.fetch(
-              config.messageId,
-            );
-            if (message) {
-              await message.delete();
+      // Delete the reaction message only for auto-created mappings, which each
+      // own a dedicated single-emoji message. Bound mappings may live on a
+      // shared picker message alongside other mappings, so deleting it would
+      // wipe those too — leave it in place (#813).
+      if (config.autoCreated) {
+        try {
+          const messageChannelId = await this.configService.getString(
+            "reactionroles.message_channel_id",
+            "",
+          );
+          if (messageChannelId) {
+            const messageChannel = (await guild.channels.fetch(
+              messageChannelId,
+            )) as TextChannel;
+            if (messageChannel) {
+              const message = await messageChannel.messages.fetch(
+                config.messageId,
+              );
+              if (message) {
+                await message.delete();
+              }
             }
           }
+        } catch (error) {
+          logger.warn("Could not delete reaction message:", error);
         }
-      } catch (error) {
-        logger.warn("Could not delete reaction message:", error);
       }
 
-      // Delete category (which will handle all child channels)
-      try {
-        const category = await guild.channels.fetch(config.categoryId);
-        if (category) {
-          // Delete all channels in category first
-          const categoryChannel = category as CategoryChannel;
-          for (const [, channel] of categoryChannel.children.cache) {
-            try {
-              await channel.delete();
-            } catch (err) {
-              logger.warn(`Could not delete channel ${channel.id}:`, err);
-            }
+      // Only tear down the underlying Discord resources for mappings the bot
+      // auto-created. Mappings that bind to a pre-existing role must never
+      // delete that role, its category, or its channel (#813).
+      if (config.autoCreated) {
+        // Delete category (which will handle all child channels)
+        if (config.categoryId) {
+          await this.deleteCategoryTree(guild, config.categoryId);
+        }
+
+        // Delete role
+        try {
+          const role = await guild.roles.fetch(config.roleId);
+          if (role) {
+            await role.delete();
+            logger.info(`Deleted role ${config.roleId}`);
           }
-          await category.delete();
-          logger.info(`Deleted category ${config.categoryId}`);
+        } catch (error) {
+          logger.warn("Could not delete role:", error);
         }
-      } catch (error) {
-        logger.warn("Could not delete category:", error);
-      }
-
-      // Delete role
-      try {
-        const role = await guild.roles.fetch(config.roleId);
-        if (role) {
-          await role.delete();
-          logger.info(`Deleted role ${config.roleId}`);
-        }
-      } catch (error) {
-        logger.warn("Could not delete role:", error);
       }
 
       // Delete from database
@@ -1087,7 +1469,9 @@ export class ReactionRoleService {
 
       return {
         success: true,
-        message: `Successfully deleted reaction role **${roleName}** and all associated resources.`,
+        message: config.autoCreated
+          ? `Successfully deleted reaction role **${roleName}** and all associated resources.`
+          : `Removed the reaction-role mapping for **${roleName}**. The existing role was left untouched.`,
       };
     } catch (error) {
       logger.error("Error deleting reaction role:", error);

--- a/src/services/reaction-role-service.ts
+++ b/src/services/reaction-role-service.ts
@@ -20,6 +20,7 @@ import {
   ComponentEmojiResolvable,
   MessageCreateOptions,
 } from "discord.js";
+import { isValidObjectId } from "mongoose";
 import { ConfigService } from "./config-service.js";
 import logger from "../utils/logger.js";
 import { sanitizeForLog } from "../utils/log-sanitize.js";
@@ -593,6 +594,18 @@ export class ReactionRoleService {
   }
 
   /**
+   * Resolve a role reference to its snowflake. Accepts a raw id, a role mention
+   * (`<@&123>`), or an id with surrounding whitespace, so the bind path honours
+   * the "accept a role id/mention" contract (#813). Returns the trimmed input
+   * unchanged when no snowflake is found, letting `roles.fetch` reject it with a
+   * clear "not found" message.
+   */
+  private normalizeRoleId(roleRef: string): string {
+    const match = roleRef.match(/(\d{17,20})/);
+    return match ? match[1] : roleRef.trim();
+  }
+
+  /**
    * Validate up front that the bot can actually assign `role` before we wire a
    * reaction to it. `member.roles.add()` fails at runtime when the bot lacks
    * Manage Roles, when the target role sits at or above the bot's highest
@@ -926,7 +939,9 @@ export class ReactionRoleService {
     try {
       const guild = await this.client.guilds.fetch(guildId);
 
-      const role = await guild.roles.fetch(roleId).catch(() => null);
+      // Accept a role id or a `<@&id>` mention.
+      const resolvedRoleId = this.normalizeRoleId(roleId);
+      const role = await guild.roles.fetch(resolvedRoleId).catch(() => null);
       if (!role) {
         return {
           success: false,
@@ -1043,10 +1058,17 @@ export class ReactionRoleService {
         await reactionRoleConfig.save();
       } catch (dbError) {
         logger.error("Failed to save reaction role binding:", dbError);
+        // Roll back the reaction we just added so users can't react to a
+        // mapping that was never persisted (e.g. a duplicate lost the unique
+        // index race). A freshly posted message is deleted outright, taking its
+        // reaction with it; on an existing picker message we only remove the
+        // bot's reaction and leave the message intact.
         if (postedMessage) {
           await postedMessage.delete().catch((err) => {
             logger.warn("Could not delete message after DB error:", err);
           });
+        } else {
+          await this.removeBotReaction(targetMessage, normalizedEmoji);
         }
         return {
           success: false,
@@ -1122,28 +1144,30 @@ export class ReactionRoleService {
             const message = await channel?.messages
               .fetch(messageId)
               .catch(() => null);
-            const reaction = message?.reactions.cache.find(
-              (r) => this.buildEmojiIdentifier(r) === normalizedEmoji,
-            );
-            await reaction?.users.remove(this.client.user?.id);
+            if (message) {
+              await this.removeBotReaction(message, normalizedEmoji);
+            }
           }
         } catch (err) {
           logger.warn("Could not remove bot reaction while unbinding:", err);
         }
       }
 
-      // Tear down auto-created Discord resources only when nothing else uses
-      // them. Bound (non-auto-created) mappings never delete their role.
-      if (guild && config.autoCreated) {
-        if (config.categoryId) {
-          await this.deleteCategoryTree(guild, config.categoryId);
-        }
+      // Tear down auto-created Discord resources only when no other mapping
+      // still references the same role. Checking the reference count *before*
+      // touching the category or role means a role shared across several
+      // pickers keeps its private channels until the last mapping is removed.
+      // Bound (non-auto-created) mappings never delete their role.
+      if (guild && config.autoCreated && config.roleId) {
         const stillUsed = await ReactionRoleConfig.countDocuments({
           guildId,
           roleId: config.roleId,
           _id: { $ne: config._id },
         });
-        if (stillUsed === 0 && config.roleId) {
+        if (stillUsed === 0) {
+          if (config.categoryId) {
+            await this.deleteCategoryTree(guild, config.categoryId);
+          }
           try {
             const role = await guild.roles.fetch(config.roleId);
             if (role) {
@@ -1176,6 +1200,25 @@ export class ReactionRoleService {
   }
 
   /**
+   * Best-effort removal of the bot's own reaction for a stored emoji from a
+   * message. Used both to tidy a picker after unbinding and to roll back a
+   * reaction whose mapping failed to persist.
+   */
+  private async removeBotReaction(
+    message: Message,
+    normalizedEmoji: string,
+  ): Promise<void> {
+    try {
+      const reaction = message.reactions.cache.find(
+        (r) => this.buildEmojiIdentifier(r) === normalizedEmoji,
+      );
+      await reaction?.users.remove(this.client.user?.id);
+    } catch (err) {
+      logger.warn("Could not remove bot reaction:", err);
+    }
+  }
+
+  /**
    * Delete a category and every channel nested under it. Shared by the
    * full-delete and unbind paths.
    */
@@ -1204,21 +1247,29 @@ export class ReactionRoleService {
 
   public async archiveReactionRole(
     guildId: string,
-    roleName: string,
+    mappingId: string,
   ): Promise<{ success: boolean; message: string }> {
     try {
+      // Identify the mapping by its stable `_id`: role names are no longer
+      // unique (#813), so keying on the name could archive the wrong picker.
+      if (!isValidObjectId(mappingId)) {
+        return { success: false, message: "Reaction role mapping not found." };
+      }
+
       const config = await ReactionRoleConfig.findOne({
+        _id: mappingId,
         guildId,
-        roleName,
         isArchived: false,
       });
 
       if (!config) {
         return {
           success: false,
-          message: `Reaction role **${roleName}** not found or already archived`,
+          message: "Reaction role mapping not found or already archived.",
         };
       }
+
+      const roleName = config.roleName;
 
       // Mark as archived
       config.isArchived = true;
@@ -1266,21 +1317,30 @@ export class ReactionRoleService {
 
   public async unarchiveReactionRole(
     guildId: string,
-    roleName: string,
+    mappingId: string,
   ): Promise<{ success: boolean; message: string }> {
     try {
+      if (!isValidObjectId(mappingId)) {
+        return {
+          success: false,
+          message: "Archived reaction role mapping not found.",
+        };
+      }
+
       const config = await ReactionRoleConfig.findOne({
+        _id: mappingId,
         guildId,
-        roleName,
         isArchived: true,
       });
 
       if (!config) {
         return {
           success: false,
-          message: `Archived reaction role **${roleName}** not found`,
+          message: "Archived reaction role mapping not found.",
         };
       }
+
+      const roleName = config.roleName;
 
       const guild = await this.client.guilds.fetch(guildId);
 
@@ -1396,20 +1456,26 @@ export class ReactionRoleService {
 
   public async deleteReactionRole(
     guildId: string,
-    roleName: string,
+    mappingId: string,
   ): Promise<{ success: boolean; message: string }> {
     try {
+      if (!isValidObjectId(mappingId)) {
+        return { success: false, message: "Reaction role mapping not found." };
+      }
+
       const config = await ReactionRoleConfig.findOne({
+        _id: mappingId,
         guildId,
-        roleName,
       });
 
       if (!config) {
         return {
           success: false,
-          message: `Reaction role **${roleName}** not found`,
+          message: "Reaction role mapping not found.",
         };
       }
+
+      const roleName = config.roleName;
 
       const guild = await this.client.guilds.fetch(guildId);
 
@@ -1442,23 +1508,38 @@ export class ReactionRoleService {
       }
 
       // Only tear down the underlying Discord resources for mappings the bot
-      // auto-created. Mappings that bind to a pre-existing role must never
-      // delete that role, its category, or its channel (#813).
+      // auto-created, and only when no other mapping still references the same
+      // role. Now that a role can appear on more than one picker (#813),
+      // deleting it here while another mapping points at it would leave that
+      // mapping dangling and silently break its reactions — so gate the
+      // category + role teardown on the reference count. Bound mappings never
+      // delete their role.
       if (config.autoCreated) {
-        // Delete category (which will handle all child channels)
-        if (config.categoryId) {
-          await this.deleteCategoryTree(guild, config.categoryId);
-        }
-
-        // Delete role
-        try {
-          const role = await guild.roles.fetch(config.roleId);
-          if (role) {
-            await role.delete();
-            logger.info(`Deleted role ${config.roleId}`);
+        const stillUsed = await ReactionRoleConfig.countDocuments({
+          guildId,
+          roleId: config.roleId,
+          _id: { $ne: config._id },
+        });
+        if (stillUsed === 0) {
+          // Delete category (which will handle all child channels)
+          if (config.categoryId) {
+            await this.deleteCategoryTree(guild, config.categoryId);
           }
-        } catch (error) {
-          logger.warn("Could not delete role:", error);
+
+          // Delete role
+          try {
+            const role = await guild.roles.fetch(config.roleId);
+            if (role) {
+              await role.delete();
+              logger.info(`Deleted role ${config.roleId}`);
+            }
+          } catch (error) {
+            logger.warn("Could not delete role:", error);
+          }
+        } else {
+          logger.info(
+            `Kept role ${config.roleId}: still referenced by ${stillUsed} other mapping(s)`,
+          );
         }
       }
 

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -2079,6 +2079,8 @@ ${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Polls", featureK
 // ---------- Reaction Roles ----------
 
 export interface ReactionRoleRow {
+  /** Stable mapping identity (`_id`); role names are no longer unique (#813). */
+  mappingId: string;
   emoji: string;
   roleName: string;
   roleId: string;
@@ -2110,6 +2112,7 @@ function reactionRoleRow(rr: ReactionRoleRow, csrfInput: string): string {
   const managed = rr.autoCreated ?? true;
   const escapedEmoji = escapeHtml(rr.emoji);
   const escapedMessageId = escapeHtml(rr.messageId);
+  const escapedMappingId = escapeHtml(rr.mappingId);
 
   let actions: string;
   if (!managed) {
@@ -2118,11 +2121,13 @@ function reactionRoleRow(rr: ReactionRoleRow, csrfInput: string): string {
     // archived — that would delete a message other mappings still use.
     actions = `<form method="POST" action="/admin/reaction-roles/remove-mapping" onsubmit="return confirm('Remove the ${escapeJsInAttr(rr.emoji)} → ${jsName} mapping? The existing role is left untouched.');">${csrfInput}<input type="hidden" name="messageId" value="${escapedMessageId}"><input type="hidden" name="emoji" value="${escapedEmoji}"><button type="submit" class="btn btn-danger">Remove</button></form>`;
   } else if (rr.isArchived) {
-    actions = `<form method="POST" action="/admin/reaction-roles/unarchive">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn">Unarchive</button></form>
-  <form method="POST" action="/admin/reaction-roles/delete" onsubmit="return confirm('Permanently delete reaction role ${jsName}? This removes the Discord role, category, and channel.');">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn btn-danger">Delete</button></form>`;
+    // Managed rows are keyed by their stable mapping id, not roleName, so
+    // identically named pickers can't collide (#813).
+    actions = `<form method="POST" action="/admin/reaction-roles/unarchive">${csrfInput}<input type="hidden" name="mappingId" value="${escapedMappingId}"><button type="submit" class="btn">Unarchive</button></form>
+  <form method="POST" action="/admin/reaction-roles/delete" onsubmit="return confirm('Permanently delete reaction role ${jsName}? This removes the Discord role, category, and channel.');">${csrfInput}<input type="hidden" name="mappingId" value="${escapedMappingId}"><button type="submit" class="btn btn-danger">Delete</button></form>`;
   } else {
-    actions = `<form method="POST" action="/admin/reaction-roles/archive" onsubmit="return confirm('Archive reaction role ${jsName}? The reaction message will be removed but the role/channels are preserved.');">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn">Archive</button></form>
-  <form method="POST" action="/admin/reaction-roles/delete" onsubmit="return confirm('Permanently delete reaction role ${jsName}? This removes the Discord role, category, and channel.');">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn btn-danger">Delete</button></form>`;
+    actions = `<form method="POST" action="/admin/reaction-roles/archive" onsubmit="return confirm('Archive reaction role ${jsName}? The reaction message will be removed but the role/channels are preserved.');">${csrfInput}<input type="hidden" name="mappingId" value="${escapedMappingId}"><button type="submit" class="btn">Archive</button></form>
+  <form method="POST" action="/admin/reaction-roles/delete" onsubmit="return confirm('Permanently delete reaction role ${jsName}? This removes the Discord role, category, and channel.');">${csrfInput}<input type="hidden" name="mappingId" value="${escapedMappingId}"><button type="submit" class="btn btn-danger">Delete</button></form>`;
   }
 
   const typeTag = managed

--- a/src/web/admin-views.ts
+++ b/src/web/admin-views.ts
@@ -2085,6 +2085,12 @@ export interface ReactionRoleRow {
   categoryName: string;
   channelName: string;
   messageId: string;
+  /**
+   * Whether the bot auto-created the role + category + channel for this
+   * mapping. Bound mappings (issue #813) point at a pre-existing role and set
+   * this false. Optional/undefined is treated as `true` for legacy rows.
+   */
+  autoCreated?: boolean;
   isArchived: boolean;
   archivedAt: string | null;
 }
@@ -2100,18 +2106,38 @@ export interface ReactionRolesProps extends CommonProps {
 function reactionRoleRow(rr: ReactionRoleRow, csrfInput: string): string {
   const escapedName = escapeHtml(rr.roleName);
   const jsName = escapeJsInAttr(rr.roleName);
-  const actions = rr.isArchived
-    ? `<form method="POST" action="/admin/reaction-roles/unarchive">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn">Unarchive</button></form>
-  <form method="POST" action="/admin/reaction-roles/delete" onsubmit="return confirm('Permanently delete reaction role ${jsName}? This removes the Discord role, category, and channel.');">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn btn-danger">Delete</button></form>`
-    : `<form method="POST" action="/admin/reaction-roles/archive" onsubmit="return confirm('Archive reaction role ${jsName}? The reaction message will be removed but the role/channels are preserved.');">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn">Archive</button></form>
+  // Legacy rows lack the flag; treat undefined as managed (auto-created).
+  const managed = rr.autoCreated ?? true;
+  const escapedEmoji = escapeHtml(rr.emoji);
+  const escapedMessageId = escapeHtml(rr.messageId);
+
+  let actions: string;
+  if (!managed) {
+    // Bound mappings point at a pre-existing role and may share a picker
+    // message, so they are removed per-mapping (message + emoji) and never
+    // archived — that would delete a message other mappings still use.
+    actions = `<form method="POST" action="/admin/reaction-roles/remove-mapping" onsubmit="return confirm('Remove the ${escapeJsInAttr(rr.emoji)} → ${jsName} mapping? The existing role is left untouched.');">${csrfInput}<input type="hidden" name="messageId" value="${escapedMessageId}"><input type="hidden" name="emoji" value="${escapedEmoji}"><button type="submit" class="btn btn-danger">Remove</button></form>`;
+  } else if (rr.isArchived) {
+    actions = `<form method="POST" action="/admin/reaction-roles/unarchive">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn">Unarchive</button></form>
   <form method="POST" action="/admin/reaction-roles/delete" onsubmit="return confirm('Permanently delete reaction role ${jsName}? This removes the Discord role, category, and channel.');">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn btn-danger">Delete</button></form>`;
+  } else {
+    actions = `<form method="POST" action="/admin/reaction-roles/archive" onsubmit="return confirm('Archive reaction role ${jsName}? The reaction message will be removed but the role/channels are preserved.');">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn">Archive</button></form>
+  <form method="POST" action="/admin/reaction-roles/delete" onsubmit="return confirm('Permanently delete reaction role ${jsName}? This removes the Discord role, category, and channel.');">${csrfInput}<input type="hidden" name="roleName" value="${escapedName}"><button type="submit" class="btn btn-danger">Delete</button></form>`;
+  }
+
+  const typeTag = managed
+    ? `<span class="tag tag-on">managed</span>`
+    : `<span class="tag">bound</span>`;
+  const channelCell =
+    rr.channelName === "—" ? "—" : `#${escapeHtml(rr.channelName)}`;
 
   return `<tr>
-<td class="mono">${escapeHtml(rr.emoji)}</td>
+<td class="mono">${escapedEmoji}</td>
 <td>${escapedName} <span class="muted mono">${escapeHtml(rr.roleId)}</span></td>
+<td>${typeTag}</td>
 <td>${escapeHtml(rr.categoryName)}</td>
-<td>#${escapeHtml(rr.channelName)}</td>
-<td class="mono">${escapeHtml(rr.messageId)}</td>
+<td>${channelCell}</td>
+<td class="mono">${escapedMessageId}</td>
 <td><span class="tag ${rr.isArchived ? "tag-off" : "tag-on"}">${rr.isArchived ? "archived" : "active"}</span></td>
 <td class="muted">${escapeHtml(rr.archivedAt ?? "")}</td>
 <td class="actions">${actions}</td>
@@ -2149,12 +2175,12 @@ ${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Reaction Roles",
   ${
     props.active.length === 0
       ? `<div class="empty">No active reaction-role mappings.</div>`
-      : `<table><thead><tr><th>Emoji</th><th>Role</th><th>Category</th><th>Channel</th><th>Message ID</th><th>Status</th><th>Archived</th><th>Actions</th></tr></thead><tbody>${activeRows}</tbody></table>`
+      : `<table><thead><tr><th>Emoji</th><th>Role</th><th>Type</th><th>Category</th><th>Channel</th><th>Message ID</th><th>Status</th><th>Archived</th><th>Actions</th></tr></thead><tbody>${activeRows}</tbody></table>`
   }
 </div>
 <div class="card">
   <h2>Create a reaction role</h2>
-  <p class="muted">Creates a Discord role + category + text channel, posts a reaction-role message to the configured channel, and adds the reaction. The new channel preview is <code>${escapeHtml(props.configChannel?.name ?? "(unset)")}</code>.</p>
+  <p class="muted">Creates a new Discord role, posts a reaction-role message to the configured channel, and adds the reaction. Tick <em>Create a private channel</em> to also mint a private category + text channel locked to the new role. Untick it for a plain self-assign role.</p>
   <form method="POST" action="/admin/reaction-roles/create" class="stack">
     ${csrfInput}
     <label>Role name
@@ -2163,7 +2189,25 @@ ${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Reaction Roles",
     <label>Emoji (Unicode or <code>&lt;:name:id&gt;</code>)
       <input type="text" name="emoji" required maxlength="100" placeholder="🎮">
     </label>
+    <label class="inline"><input type="checkbox" name="createChannel" value="1" checked> Create a private category + channel for this role</label>
     <button type="submit" class="btn btn-primary">Create reaction role</button>
+  </form>
+</div>
+<div class="card">
+  <h2>Bind an existing role</h2>
+  <p class="muted">Maps an emoji to a role you already manage — no new role, category, or channel is created. Leave <em>Message ID</em> blank to post a fresh message to the configured channel, or paste an existing reaction-role message ID to add this mapping to it (one message can carry many emoji→role mappings).</p>
+  <form method="POST" action="/admin/reaction-roles/bind" class="stack">
+    ${csrfInput}
+    <label>Role ID
+      <input type="text" name="roleId" required maxlength="30" placeholder="123456789012345678">
+    </label>
+    <label>Emoji (Unicode or <code>&lt;:name:id&gt;</code>)
+      <input type="text" name="emoji" required maxlength="100" placeholder="🎨">
+    </label>
+    <label>Message ID <span class="muted">(optional — add to an existing picker message)</span>
+      <input type="text" name="messageId" maxlength="30" placeholder="(new message)">
+    </label>
+    <button type="submit" class="btn btn-primary">Bind existing role</button>
   </form>
 </div>
 <div class="card">
@@ -2171,7 +2215,7 @@ ${renderFeatureDisabledNotice({ enabled: props.enabled, label: "Reaction Roles",
   ${
     props.archived.length === 0
       ? `<div class="empty">No archived mappings.</div>`
-      : `<table><thead><tr><th>Emoji</th><th>Role</th><th>Category</th><th>Channel</th><th>Message ID</th><th>Status</th><th>Archived</th><th>Actions</th></tr></thead><tbody>${archivedRows}</tbody></table>`
+      : `<table><thead><tr><th>Emoji</th><th>Role</th><th>Type</th><th>Category</th><th>Channel</th><th>Message ID</th><th>Status</th><th>Archived</th><th>Actions</th></tr></thead><tbody>${archivedRows}</tbody></table>`
   }
 </div>
 `;

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -743,22 +743,28 @@ export function createReadOnlyRouter(
       const channelNames = channelData.names;
 
       const active = all.filter((rr) => !rr.isArchived);
+      // Bound mappings (#813) have no owned category/channel, so those ids may
+      // be absent — fall back to an em dash so the table renders cleanly.
+      const resolveChannel = (id?: string | null): string =>
+        id ? (channelNames.get(id) ?? id) : "—";
       const shape = (rr: {
         emoji: string;
         roleName: string;
         roleId: string;
-        categoryId: string;
-        channelId: string;
+        categoryId?: string | null;
+        channelId?: string | null;
         messageId: string;
+        autoCreated?: boolean;
         isArchived: boolean;
         archivedAt?: Date | null;
       }): ReactionRoleRow => ({
         emoji: rr.emoji,
         roleName: rr.roleName,
         roleId: rr.roleId,
-        categoryName: channelNames.get(rr.categoryId) ?? rr.categoryId,
-        channelName: channelNames.get(rr.channelId) ?? rr.channelId,
+        categoryName: resolveChannel(rr.categoryId),
+        channelName: resolveChannel(rr.channelId),
         messageId: rr.messageId,
+        autoCreated: rr.autoCreated ?? true,
         isArchived: rr.isArchived,
         archivedAt: rr.archivedAt
           ? new Date(rr.archivedAt).toISOString()

--- a/src/web/read-only-routes.ts
+++ b/src/web/read-only-routes.ts
@@ -748,6 +748,7 @@ export function createReadOnlyRouter(
       const resolveChannel = (id?: string | null): string =>
         id ? (channelNames.get(id) ?? id) : "—";
       const shape = (rr: {
+        _id?: unknown;
         emoji: string;
         roleName: string;
         roleId: string;
@@ -758,6 +759,7 @@ export function createReadOnlyRouter(
         isArchived: boolean;
         archivedAt?: Date | null;
       }): ReactionRoleRow => ({
+        mappingId: String(rr._id ?? ""),
         emoji: rr.emoji,
         roleName: rr.roleName,
         roleId: rr.roleId,

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -3226,11 +3226,11 @@ export function createWriteRouter(
     "/reaction-roles/archive",
     asyncHandler(async (req, res) => {
       const session = requireSessionContext(req);
-      const roleName = getString(req, "roleName");
-      if (!roleName) {
+      const mappingId = getString(req, "mappingId");
+      if (!mappingId) {
         flashRedirect(res, "/admin/reaction-roles", {
           type: "err",
-          text: "Role name is required.",
+          text: "Mapping id is required.",
         });
         return;
       }
@@ -3238,12 +3238,12 @@ export function createWriteRouter(
       try {
         const result = await service.archiveReactionRole(
           session.guildId,
-          roleName,
+          mappingId,
         );
         await recordAudit(session, {
           action: "reactionrole.archive",
-          targetId: roleName,
-          details: { roleName },
+          targetId: mappingId,
+          details: { mappingId },
           result: result.success ? "success" : "failure",
           errorMessage: result.success ? null : result.message,
         });
@@ -3256,13 +3256,13 @@ export function createWriteRouter(
         logger.error("Archive reaction role failed", err);
         await recordAudit(session, {
           action: "reactionrole.archive",
-          targetId: roleName,
+          targetId: mappingId,
           result: "failure",
           errorMessage: text,
         });
         flashRedirect(res, "/admin/reaction-roles", {
           type: "err",
-          text: `Failed to archive ${roleName}: ${text}`,
+          text: `Failed to archive reaction role: ${text}`,
         });
       }
     }),
@@ -3272,11 +3272,11 @@ export function createWriteRouter(
     "/reaction-roles/unarchive",
     asyncHandler(async (req, res) => {
       const session = requireSessionContext(req);
-      const roleName = getString(req, "roleName");
-      if (!roleName) {
+      const mappingId = getString(req, "mappingId");
+      if (!mappingId) {
         flashRedirect(res, "/admin/reaction-roles", {
           type: "err",
-          text: "Role name is required.",
+          text: "Mapping id is required.",
         });
         return;
       }
@@ -3284,12 +3284,12 @@ export function createWriteRouter(
       try {
         const result = await service.unarchiveReactionRole(
           session.guildId,
-          roleName,
+          mappingId,
         );
         await recordAudit(session, {
           action: "reactionrole.unarchive",
-          targetId: roleName,
-          details: { roleName },
+          targetId: mappingId,
+          details: { mappingId },
           result: result.success ? "success" : "failure",
           errorMessage: result.success ? null : result.message,
         });
@@ -3302,13 +3302,13 @@ export function createWriteRouter(
         logger.error("Unarchive reaction role failed", err);
         await recordAudit(session, {
           action: "reactionrole.unarchive",
-          targetId: roleName,
+          targetId: mappingId,
           result: "failure",
           errorMessage: text,
         });
         flashRedirect(res, "/admin/reaction-roles", {
           type: "err",
-          text: `Failed to unarchive ${roleName}: ${text}`,
+          text: `Failed to unarchive reaction role: ${text}`,
         });
       }
     }),
@@ -3318,11 +3318,11 @@ export function createWriteRouter(
     "/reaction-roles/delete",
     asyncHandler(async (req, res) => {
       const session = requireSessionContext(req);
-      const roleName = getString(req, "roleName");
-      if (!roleName) {
+      const mappingId = getString(req, "mappingId");
+      if (!mappingId) {
         flashRedirect(res, "/admin/reaction-roles", {
           type: "err",
-          text: "Role name is required.",
+          text: "Mapping id is required.",
         });
         return;
       }
@@ -3330,12 +3330,12 @@ export function createWriteRouter(
       try {
         const result = await service.deleteReactionRole(
           session.guildId,
-          roleName,
+          mappingId,
         );
         await recordAudit(session, {
           action: "reactionrole.delete",
-          targetId: roleName,
-          details: { roleName },
+          targetId: mappingId,
+          details: { mappingId },
           result: result.success ? "success" : "failure",
           errorMessage: result.success ? null : result.message,
         });
@@ -3348,13 +3348,13 @@ export function createWriteRouter(
         logger.error("Delete reaction role failed", err);
         await recordAudit(session, {
           action: "reactionrole.delete",
-          targetId: roleName,
+          targetId: mappingId,
           result: "failure",
           errorMessage: text,
         });
         flashRedirect(res, "/admin/reaction-roles", {
           type: "err",
-          text: `Failed to delete ${roleName}: ${text}`,
+          text: `Failed to delete reaction role: ${text}`,
         });
       }
     }),

--- a/src/web/write-routes.ts
+++ b/src/web/write-routes.ts
@@ -3062,12 +3062,15 @@ export function createWriteRouter(
         return;
       }
 
+      const createChannel = getCheckbox(req, "createChannel");
+
       const service = ReactionRoleService.getInstance(client);
       try {
         const result = await service.createReactionRole(
           session.guildId,
           name,
           emoji,
+          { createChannel },
         );
         await recordAudit(session, {
           action: "reactionrole.create",
@@ -3075,6 +3078,7 @@ export function createWriteRouter(
           details: {
             roleName: name,
             emoji,
+            createChannel,
             categoryId: result.categoryId,
             channelId: result.channelId,
             messageId: result.messageId,
@@ -3098,6 +3102,121 @@ export function createWriteRouter(
         flashRedirect(res, "/admin/reaction-roles", {
           type: "err",
           text: `Failed to create reaction role: ${text}`,
+        });
+      }
+    }),
+  );
+
+  router.post(
+    "/reaction-roles/bind",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const roleId = getString(req, "roleId");
+      const emoji = getString(req, "emoji");
+      const messageId = getString(req, "messageId");
+
+      if (!roleId || !emoji) {
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: "err",
+          text: "Role ID and emoji are both required.",
+        });
+        return;
+      }
+      if (emoji.length > 100) {
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: "err",
+          text: "Emoji input must be 100 characters or fewer.",
+        });
+        return;
+      }
+
+      const service = ReactionRoleService.getInstance(client);
+      try {
+        const result = await service.bindReactionRole(
+          session.guildId,
+          roleId,
+          emoji,
+          messageId ? { messageId } : {},
+        );
+        await recordAudit(session, {
+          action: "reactionrole.bind",
+          targetId: result.roleId ?? roleId,
+          details: {
+            roleId,
+            emoji,
+            messageId: result.messageId ?? messageId,
+          },
+          result: result.success ? "success" : "failure",
+          errorMessage: result.success ? null : result.message,
+        });
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: result.success ? "ok" : "err",
+          text: result.message,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Bind reaction role failed", err);
+        await recordAudit(session, {
+          action: "reactionrole.bind",
+          targetId: roleId,
+          details: { roleId, emoji, messageId },
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: "err",
+          text: `Failed to bind reaction role: ${text}`,
+        });
+      }
+    }),
+  );
+
+  router.post(
+    "/reaction-roles/remove-mapping",
+    asyncHandler(async (req, res) => {
+      const session = requireSessionContext(req);
+      const messageId = getString(req, "messageId");
+      const emoji = getString(req, "emoji");
+
+      if (!messageId || !emoji) {
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: "err",
+          text: "Message ID and emoji are both required.",
+        });
+        return;
+      }
+
+      const service = ReactionRoleService.getInstance(client);
+      try {
+        const result = await service.removeReactionRoleMapping(
+          session.guildId,
+          messageId,
+          emoji,
+        );
+        await recordAudit(session, {
+          action: "reactionrole.remove_mapping",
+          targetId: messageId,
+          details: { messageId, emoji },
+          result: result.success ? "success" : "failure",
+          errorMessage: result.success ? null : result.message,
+        });
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: result.success ? "ok" : "err",
+          text: result.message,
+        });
+      } catch (err) {
+        const text = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Remove reaction role mapping failed", err);
+        await recordAudit(session, {
+          action: "reactionrole.remove_mapping",
+          targetId: messageId,
+          details: { messageId, emoji },
+          result: "failure",
+          errorMessage: text,
+        });
+        flashRedirect(res, "/admin/reaction-roles", {
+          type: "err",
+          text: `Failed to remove mapping: ${text}`,
         });
       }
     }),


### PR DESCRIPTION
## Description

Decouples reaction roles from the always-on "create a new Role + Category + Channel" flow so a single message can carry many emoji→role mappings and a mapping can target a role that **already exists** — the common "React 🎮 for Gamer, 🎨 for Artist" pinned-picker use case. Backward compatibility for existing auto-created role+category+channel configs is preserved.

**Model (`reaction-role-config.ts`)**
- `categoryId` / `channelId` are now optional (bound mappings own no channel).
- New `autoCreated` flag governs whether deleting a mapping tears down the underlying Discord role/category/channel; defaults `true` so legacy rows keep their semantics.
- Replaced the `{ guildId, roleName }` unique index (which wrongly assumed a role could appear on only one picker) with a unique `{ guildId, messageId, emoji }` index; kept a non-unique `roleName` index for lookups.

**Service (`reaction-role-service.ts`)**
- Up-front role-hierarchy/permission validation (Manage Roles, bot's highest role above the target, not `@everyone`/integration-managed) — returns an actionable error instead of silently no-opping at reaction time (previously only a `logger.error` inside `handleReactionAdd`).
- `createReactionRole` gains an opt-in `createChannel` flag (default `true`) to skip the private category/channel; the 3-arg signature stays backward compatible.
- `bindReactionRole` — map an emoji to an existing role, either on a fresh message or appended to an existing picker message (duplicate emoji rejected), never creating a role/category/channel.
- `removeReactionRoleMapping` — unbind one mapping by message + emoji, tearing down auto-created resources only when unreferenced.
- `deleteReactionRole` now respects `autoCreated`: bound mappings only drop the DB row and shared picker messages are left intact.

**Migration (`reaction-role-migrator.ts`)** — one-shot idempotent backfill of `autoCreated=true` on legacy rows, wired into startup in `index.ts`.

**Web UI** — reaction-roles page tolerates optional category/channel, tags rows **managed**/**bound**, adds a "Bind an existing role" form and a create-time "private channel" checkbox, plus `/bind` and `/remove-mapping` routes.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Related Issues

Refs #813
Refs #808

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [x] Added new tests for new functionality

New unit tests cover binding validation (role not found, missing Manage Roles, hierarchy/managed-role rejection, duplicate-emoji rejection, new vs existing message), the `createChannel` opt-out, per-mapping removal (bound vs auto-created teardown), and the idempotent migration. Full `npm run check:all` passes (134 suites, 1672 tests, coverage gate green).

## Checklist

### Code Quality

- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code

### Testing

- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

### Documentation

- [x] I have commented hard-to-understand areas
- [x] Updated `WEBUI.md` for the new reaction-role capabilities (no new config keys or slash commands — the `/reactrole` command surface is a separate #808 sub-issue)
- [x] Validated markdown with `markdownlint`

### Configuration

- No new configuration keys — the "create a private channel" behaviour is now a per-operation flag rather than a global setting.

## Additional Notes

Scope follows the issue's dependency notes: the schema/service/migration changes land here; the `/reactrole` command surface and the button/select-menu UI are coordinated in their own #808 sub-issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133C7xd3VYMUS91HUyTLc4e

---
_Generated by [Claude Code](https://claude.ai/code/session_0133C7xd3VYMUS91HUyTLc4e)_