### PR TITLE
fix(deps): refresh js-yaml, undici and brace-expansion pins to clear npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "discord.js": "^14.27.0",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
-        "js-yaml": "^4.2.0",
+        "js-yaml": "^4.3.1",
         "mongoose": "^9.9.1",
         "prom-client": "^15.1.3",
         "winston": "^3.19.0"
@@ -37,7 +37,7 @@
         "ts-jest": "^29.4.12",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.3",
-        "undici": "^7.28.0"
+        "undici": "^7.29.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -2968,16 +2968,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -5536,9 +5536,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -8227,9 +8227,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "discord.js": "^14.27.0",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.1",
     "mongoose": "^9.9.1",
     "prom-client": "^15.1.3",
     "winston": "^3.19.0"
@@ -58,14 +58,14 @@
     "ts-jest": "^29.4.12",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3",
-    "undici": "^7.28.0"
+    "undici": "^7.29.0"
   },
   "overrides": {
-    "undici": "^7.28.0",
+    "undici": "^7.29.0",
     "diff": "^8.0.3",
     "picomatch": "^4.0.4",
-    "brace-expansion@>=5.0.0 <5.0.6": "5.0.6",
-    "js-yaml": "^4.2.0",
+    "brace-expansion@>=3.0.0 <5.0.9": "5.0.9",
+    "js-yaml": "^4.3.1",
     "markdown-it": "^14.2.0"
   }
 }


### PR DESCRIPTION
## Description

`npm audit` reported 4 high-severity advisories against packages this repo already manages through the
`overrides` block — the pins had simply gone stale since those CVEs were disclosed. This refreshes them.

| Package | Before | After | Why |
| --- | --- | --- | --- |
| `js-yaml` | `^4.2.0` (dependency + override) | `^4.3.1` | Quadratic-CPU parsing via merge-key chains and `!!omap` resolution |
| `undici` | `^7.28.0` (devDependency + override) | `^7.29.0` | Response desync, cache info-disclosure, CRLF injection, cookie-attribute injection |
| `brace-expansion` | `"brace-expansion@>=5.0.0 <5.0.6": "5.0.6"` | `"brace-expansion@>=3.0.0 <5.0.9": "5.0.9"` | Three DoS advisories; the old range key had itself fallen inside the vulnerable range, so it was pinning 5.0.6 in place |

All three are same-major patch releases. `undici` matters beyond CI tooling — `discord.js` / `@discordjs/rest`
pull it in at runtime and resolve to the overridden version.

### Note on the `brace-expansion` override form

The issue suggested a plain `"brace-expansion": "^5.0.9"` pin. That does clear the audit, but it regresses the
build: `brace-expansion@5.x` exports an **object** (`{ expand }`) rather than a callable from its CommonJS
entry point, so forcing it onto `minimatch@3.1.5` (`test-exclude` → `babel-plugin-istanbul` →
`@jest/transform`) makes every brace pattern throw `TypeError: expand is not a function`. Verified directly:

```text
# with a blanket "brace-expansion": "^5.0.9" override
$ node -e "require('minimatch').braceExpand('src/{a,b}.js')"
TypeError: expand is not a function
```

Neither `1.x` nor `2.x` appears in any of the three advisory ranges (they start at `>=3.0.0`), so the
range-keyed override — the pattern already used in this file — scopes the bump to exactly the affected
versions and avoids the regression. Resulting tree:

```text
minimatch@3.1.5   -> brace-expansion@1.1.18   (untouched, not vulnerable)
minimatch@9.0.9   -> brace-expansion@2.1.4    (untouched, not vulnerable)
minimatch@10.2.5  -> brace-expansion@5.0.9    (patched)
```

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] 🧪 Test updates
- [x] 🔧 Build/tooling changes
- [ ] ⚡ Performance improvement

## Related Issues

Fixes #825

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`)
- [ ] Added new tests for new functionality
- [x] Manually tested in development environment
- [ ] Tested in Docker environment

```text
$ npm audit
found 0 vulnerabilities

$ npm run check:all
Test Suites: 139 passed, 139 total
Tests:       1 skipped, 1714 passed, 1715 total

$ npm run test:ci        # coverage thresholds enforced — this is the path that
Test Suites: 139 passed  # exercises minimatch@3 via test-exclude
Tests:       1714 passed
```

Smoke-tested the two bumped libraries and the affected `minimatch` path directly after a clean
`rm -rf node_modules && npm install`:

```text
minimatch@3.1.5 braceExpand: [ 'src/a.js', 'src/b.js' ]
js-yaml@4.3.1 load: {"a":1,"b":["x","y"]}
```

**Test Configuration**:

- Node.js version: 22.22.2 (npm 10.9.7)
- Discord.js version: 14.27.0
- Operating System: Linux

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] New and existing unit tests pass locally with my changes
- [x] I have tested my changes manually

No new tests: the change is dependency version pins with no source diff, and the existing 139 suites already
exercise the affected code paths (`js-yaml` via the poll library / content loaders, `minimatch` via coverage
instrumentation).

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary — no doc changes needed; no commands, settings, or
      user-facing features changed

### Dependencies & Docker

- [x] I have updated `Dockerfile` if dependencies changed — no change needed. Both Dockerfiles only refresh
      the *base image's bundled npm* (its own `undici`/`tar` copies); neither pins any of the packages
      touched here, and the build process is unchanged.
- [x] I have run security checks if adding new dependencies — `npm audit` clean; no new dependencies added

### Configuration (if applicable)

Not applicable — no configuration keys added or changed.

## Additional Notes

`package-lock.json` was regenerated and is committed alongside `package.json`; the lockfile diff is 12 lines
(the three version bumps and their integrity hashes).

## Pre-Submission Verification

- [x] I have rebased my branch on the latest main branch (branched from `afe5caa`, current `origin/main`)
- [x] I have resolved any merge conflicts
- [x] I have reviewed the diff of all my changes
- [x] All automated CI checks are expected to pass
- [x] I am ready for code review

---
_Generated by [Claude Code](https://claude.ai/code/session_016VVQf7zi1ZtEBhDxqa5coN)_