### PR TITLE
feat(polls): track weekly vote buckets and per-poll turnout for the recap

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -264,7 +264,9 @@ on the Web UI's **Polls** page; the settings below are global defaults.
 | `polls.enabled` | `false` | Enable/disable the poll system |
 | `polls.default_duration_hours` | `24` | Default poll duration (1-768, max 32 days) |
 | `polls.cooldown_days` | `7` | Minimum days before reusing the same poll question |
-| `polls.participation.enabled` | `false` | Capture per-user "votes cast" (lifetime + per-year) when users vote on any guild poll. Surfaced (#655) on the `/me/` overview "Poll participation" card, the Rewind `Poll votes cast` stat, and the poll-participation accolades (Poll Regular / Poll Devotee) |
+| `polls.participation.enabled` | `false` | Capture per-user "votes cast" (lifetime + per-year + per-ISO-week) and per-poll turnout when users vote on any guild poll. Surfaced (#655) on the `/me/` overview "Poll participation" card, the Rewind `Poll votes cast` stat, the poll-participation accolades (Poll Regular / Poll Devotee), and the weekly recap's "N members voted across M polls this week" line (#816) |
+| `polls.participation.weekly_retention_weeks` | `12` | Weeks of per-member weekly vote counters to keep. Lifetime and per-year totals are never pruned; `0` keeps every week forever |
+| `polls.turnout.retention_days` | `90` | Days to keep the per-poll turnout rows (which polls ran, and who voted on them) behind the recap's "across M polls" line; `0` keeps them forever |
 
 **Features:**
 
@@ -392,7 +394,7 @@ independently.
 | `voicetracking.announcements.include_voice_stats` | `true` | Include the top voice-time leaderboard |
 | `voicetracking.announcements.include_accolades` | `true` | Include accolades earned this week (needs achievements + achievement announcements enabled) |
 | `voicetracking.announcements.include_quote_of_week` | `true` | Include the most-liked quote added this week (needs quotes enabled) |
-| `voicetracking.announcements.include_poll_turnout` | `true` | Include how many members voted in polls this week (needs poll participation tracking enabled) |
+| `voicetracking.announcements.include_poll_turnout` | `true` | Include how many members voted across how many polls this week, plus the best-attended poll when several ran (needs poll participation tracking enabled) |
 
 To trigger one out of schedule, use the **Post weekly stats now** button
 on the Web UI's Announcements page (replaces the old
@@ -1176,6 +1178,9 @@ leave the graph in a broken state.
 - `polls.enabled` (bool, default: false)
 - `polls.default_duration_hours` (number, default: 24)
 - `polls.cooldown_days` (number, default: 7)
+- `polls.participation.enabled` (bool, default: false)
+- `polls.participation.weekly_retention_weeks` (number, default: 12)
+- `polls.turnout.retention_days` (number, default: 90)
 
 #### Voice Channels
 

--- a/WEBUI.md
+++ b/WEBUI.md
@@ -937,9 +937,12 @@ remembered" clearly distinguishable from "broken".
 
 When `polls.participation.enabled` is on and you have voted on at least
 one poll, the **Overview** page also shows a read-only **Poll
-participation** card — lifetime votes, this-year votes, and when you last
-voted (#655). The same per-year count surfaces on **Rewind** as the
-**Poll votes cast** stat, hidden in any year you cast no votes.
+participation** card — lifetime votes, this-year votes, this-week votes,
+and when you last voted (#655, #816). The same per-year count surfaces on
+**Rewind** as the **Poll votes cast** stat, hidden in any year you cast no
+votes. The weekly figure comes from per-ISO-week buckets kept for
+`polls.participation.weekly_retention_weeks`, so it reads 0 for a member
+whose only votes predate the weekly capture.
 
 Notification preferences are scoped per `(userId, guildId)`. The page
 lists every notification type with the current state and a checkbox;

--- a/__tests__/services/poll-participation-tracker.test.ts
+++ b/__tests__/services/poll-participation-tracker.test.ts
@@ -11,16 +11,36 @@ jest.mock("../../src/utils/logger.js", () => ({
   isDebugMode: jest.fn(() => false),
 }));
 
-import { PollParticipationTracker } from "../../src/services/poll-participation-tracker.js";
-import { PollParticipationTracking } from "../../src/models/poll-participation-tracking.js";
+// The global mongoose mock in __tests__/setup.ts hands every `mongoose.model`
+// call the *same* stub object, so the two collections this tracker writes
+// would be indistinguishable. Mock the model modules themselves to keep the
+// participation counters and the per-poll turnout rows apart.
+const PollParticipationTracking = {
+  updateOne: jest.fn(),
+  findOne: jest.fn(),
+  countDocuments: jest.fn(),
+  find: jest.fn(),
+  bulkWrite: jest.fn(),
+};
+const PollTurnout = {
+  updateOne: jest.fn(),
+  countDocuments: jest.fn(),
+  find: jest.fn(),
+  deleteMany: jest.fn(),
+};
 
-(PollParticipationTracking as unknown as { updateOne: jest.Mock }).updateOne =
-  jest.fn();
-(PollParticipationTracking as unknown as { findOne: jest.Mock }).findOne =
-  jest.fn();
-(
-  PollParticipationTracking as unknown as { countDocuments: jest.Mock }
-).countDocuments = jest.fn();
+jest.unstable_mockModule(
+  "../../src/models/poll-participation-tracking.js",
+  () => ({ PollParticipationTracking }),
+);
+jest.unstable_mockModule("../../src/models/poll-turnout.js", () => ({
+  PollTurnout,
+}));
+
+const { PollParticipationTracker } = await import(
+  "../../src/services/poll-participation-tracker.js"
+);
+const { getIsoWeekKey } = await import("../../src/utils/time.js");
 
 // Mirror the model's `findOne(...).lean()` chain used by
 // `getParticipationSummary`.
@@ -54,12 +74,19 @@ function createTracker(voter: { username: string; bot: boolean } | null) {
   return { tracker, mockConfigService, usersFetch };
 }
 
-function makePollAnswer(guildId: string | null = "guild1"): PollAnswer {
+function makePollAnswer(
+  guildId: string | null = "guild1",
+  message: Record<string, unknown> = {},
+): PollAnswer {
   return {
     poll: {
       message: {
         guild: guildId ? { id: guildId } : null,
         guildId: guildId ?? null,
+        id: "msg1",
+        channelId: "chan1",
+        createdAt: new Date("2026-08-10T09:00:00Z"),
+        ...message,
       },
     },
   } as unknown as PollAnswer;
@@ -67,6 +94,7 @@ function makePollAnswer(guildId: string | null = "guild1"): PollAnswer {
 
 describe("PollParticipationTracker", () => {
   let updateOne: jest.Mock;
+  let turnoutUpdateOne: jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -74,6 +102,9 @@ describe("PollParticipationTracker", () => {
       PollParticipationTracking as unknown as { updateOne: jest.Mock }
     ).updateOne;
     updateOne.mockResolvedValue({ matchedCount: 1 });
+    turnoutUpdateOne = (PollTurnout as unknown as { updateOne: jest.Mock })
+      .updateOne;
+    turnoutUpdateOne.mockResolvedValue({ matchedCount: 1 });
     (PollParticipationTracker as unknown as { instance: unknown }).instance =
       undefined;
   });
@@ -124,6 +155,99 @@ describe("PollParticipationTracker", () => {
       expect(update.$inc[`yearlyVotes.${year}`]).toBe(1);
       expect(update.$set.username).toBe("Voter");
     });
+
+    it("records a per-ISO-week bucket alongside the yearly one (#816)", async () => {
+      const { tracker } = createTracker({ username: "Voter", bot: false });
+      await tracker.handlePollVoteAdd(makePollAnswer(), "voter1");
+
+      const [, update] = updateOne.mock.calls[0];
+      const week = getIsoWeekKey(update.$set.lastVoteAt as Date);
+      expect(update.$inc[`weeklyVotes.${week}`]).toBe(1);
+    });
+
+    it("upserts the poll's turnout row, deduping the voter (#816)", async () => {
+      const { tracker } = createTracker({ username: "Voter", bot: false });
+      await tracker.handlePollVoteAdd(
+        makePollAnswer("guild1", { poll: { question: { text: "Best map?" } } }),
+        "voter1",
+      );
+
+      expect(turnoutUpdateOne).toHaveBeenCalledTimes(1);
+      const [filter, update, options] = turnoutUpdateOne.mock.calls[0];
+      expect(filter).toEqual({ guildId: "guild1", messageId: "msg1" });
+      expect(update.$setOnInsert).toMatchObject({
+        guildId: "guild1",
+        messageId: "msg1",
+        channelId: "chan1",
+        question: "Best map?",
+        postedAt: new Date("2026-08-10T09:00:00Z"),
+      });
+      expect(update.$inc).toEqual({ votesCast: 1 });
+      expect(update.$addToSet).toEqual({ voterIds: "voter1" });
+      expect(options).toEqual({ upsert: true });
+    });
+
+    it("leaves the question null when the poll is not cached", async () => {
+      const { tracker } = createTracker({ username: "Voter", bot: false });
+      await tracker.handlePollVoteAdd(makePollAnswer(), "voter1");
+
+      const [, update] = turnoutUpdateOne.mock.calls[0];
+      expect(update.$setOnInsert.question).toBeNull();
+    });
+
+    it("skips the turnout row when the message id is unknown", async () => {
+      const { tracker } = createTracker({ username: "Voter", bot: false });
+      await tracker.handlePollVoteAdd(
+        makePollAnswer("guild1", { id: undefined }),
+        "voter1",
+      );
+
+      expect(updateOne).toHaveBeenCalledTimes(1);
+      expect(turnoutUpdateOne).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("recordPollPosted (#816)", () => {
+    const posted = {
+      guildId: "guild1",
+      messageId: "msg9",
+      channelId: "chan1",
+      question: "Pineapple on pizza?",
+      postedAt: new Date("2026-08-12T10:00:00Z"),
+    };
+
+    it("does not write when participation capture is off", async () => {
+      const { tracker, mockConfigService } = createTracker(null);
+      mockConfigService.getBoolean.mockResolvedValue(false);
+
+      await tracker.recordPollPosted(posted);
+      expect(turnoutUpdateOne).not.toHaveBeenCalled();
+    });
+
+    it("upserts the row with the question and exact post time", async () => {
+      const { tracker } = createTracker(null);
+
+      await tracker.recordPollPosted(posted);
+
+      const [filter, update, options] = turnoutUpdateOne.mock.calls[0];
+      expect(filter).toEqual({ guildId: "guild1", messageId: "msg9" });
+      // Posting is authoritative for these, so they overwrite whatever a
+      // racing vote capture guessed.
+      expect(update.$set).toEqual({
+        channelId: "chan1",
+        question: "Pineapple on pizza?",
+        postedAt: posted.postedAt,
+      });
+      expect(update.$setOnInsert).toMatchObject({ votesCast: 0, voterIds: [] });
+      expect(options).toEqual({ upsert: true });
+    });
+
+    it("swallows DB errors so poll posting never fails on bookkeeping", async () => {
+      const { tracker } = createTracker(null);
+      turnoutUpdateOne.mockRejectedValue(new Error("DB error"));
+
+      await expect(tracker.recordPollPosted(posted)).resolves.toBeUndefined();
+    });
   });
 
   describe("error handling", () => {
@@ -153,6 +277,7 @@ describe("PollParticipationTracker", () => {
         lean({
           totalVotes: 42,
           yearlyVotes: { [year]: 9, "2024": 5 },
+          weeklyVotes: { "2024-W01": 5 },
           lastVoteAt,
         }),
       );
@@ -161,6 +286,7 @@ describe("PollParticipationTracker", () => {
       expect(summary).toEqual({
         totalVotes: 42,
         thisYearVotes: 9,
+        thisWeekVotes: 0,
         lastVoteAt,
       });
     });
@@ -239,6 +365,252 @@ describe("PollParticipationTracker", () => {
 
       const count = await tracker.getRecentVoterCount("guild1", new Date());
       expect(count).toBe(0);
+    });
+  });
+  describe("weekly participation (#816)", () => {
+    let findOne: jest.Mock;
+
+    beforeEach(() => {
+      findOne = (PollParticipationTracking as unknown as { findOne: jest.Mock })
+        .findOne;
+    });
+
+    it("reads this-week votes from the current ISO-week bucket", async () => {
+      const { tracker } = createTracker({ username: "Voter", bot: false });
+      const week = getIsoWeekKey(new Date());
+      findOne.mockReturnValue(
+        lean({
+          totalVotes: 12,
+          yearlyVotes: {},
+          weeklyVotes: { [week]: 4, "2024-W01": 99 },
+          lastVoteAt: null,
+        }),
+      );
+
+      const summary = await tracker.getParticipationSummary("voter1", "guild1");
+      expect(summary?.thisWeekVotes).toBe(4);
+    });
+
+    it("reads 0 for rows written before weekly buckets existed", async () => {
+      const { tracker } = createTracker({ username: "Voter", bot: false });
+      findOne.mockReturnValue(
+        lean({ totalVotes: 12, yearlyVotes: {}, lastVoteAt: null }),
+      );
+
+      const summary = await tracker.getParticipationSummary("voter1", "guild1");
+      expect(summary?.thisWeekVotes).toBe(0);
+    });
+  });
+
+  describe("getRecentPollCount (#816)", () => {
+    let turnoutCount: jest.Mock;
+
+    beforeEach(() => {
+      turnoutCount = (PollTurnout as unknown as { countDocuments: jest.Mock })
+        .countDocuments;
+    });
+
+    it("counts polls that drew a vote inside the window", async () => {
+      const { tracker } = createTracker(null);
+      turnoutCount.mockResolvedValue(3);
+      const since = new Date("2026-08-06T00:00:00Z");
+
+      const count = await tracker.getRecentPollCount("guild1", since);
+
+      expect(turnoutCount).toHaveBeenCalledWith({
+        guildId: "guild1",
+        lastVoteAt: { $gte: since },
+      });
+      expect(count).toBe(3);
+    });
+
+    it("degrades to 0 on a DB error", async () => {
+      const { tracker } = createTracker(null);
+      turnoutCount.mockRejectedValue(new Error("DB error"));
+
+      expect(await tracker.getRecentPollCount("guild1", new Date())).toBe(0);
+    });
+  });
+
+  describe("getRecentPollTurnout (#816)", () => {
+    let find: jest.Mock;
+
+    beforeEach(() => {
+      find = (PollTurnout as unknown as { find: jest.Mock }).find;
+    });
+
+    // Mirrors the model's find(...).sort(...).limit(...).lean() chain.
+    function chain<T>(value: T | Error) {
+      return {
+        sort: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            lean: jest.fn(async () => {
+              if (value instanceof Error) throw value;
+              return value;
+            }),
+          }),
+        }),
+      };
+    }
+
+    it("derives the distinct voter count from the stored voter ids", async () => {
+      const { tracker } = createTracker(null);
+      const postedAt = new Date("2026-08-11T12:00:00Z");
+      find.mockReturnValue(
+        chain([
+          {
+            messageId: "msg1",
+            question: "Best map?",
+            postedAt,
+            voterIds: ["a", "b", "c"],
+            votesCast: 5,
+          },
+          { messageId: "msg2", postedAt, voterIds: [], votesCast: 0 },
+        ]),
+      );
+
+      const rows = await tracker.getRecentPollTurnout("guild1", postedAt);
+
+      expect(rows).toEqual([
+        {
+          messageId: "msg1",
+          question: "Best map?",
+          postedAt,
+          voterCount: 3,
+          votesCast: 5,
+        },
+        {
+          messageId: "msg2",
+          question: null,
+          postedAt,
+          voterCount: 0,
+          votesCast: 0,
+        },
+      ]);
+    });
+
+    it("degrades to an empty list on a DB error", async () => {
+      const { tracker } = createTracker(null);
+      find.mockReturnValue(chain(new Error("DB error")));
+
+      expect(await tracker.getRecentPollTurnout("guild1", new Date())).toEqual(
+        [],
+      );
+    });
+  });
+
+  describe("pruneExpiredData (#816)", () => {
+    let find: jest.Mock;
+    let bulkWrite: jest.Mock;
+    let deleteMany: jest.Mock;
+
+    beforeEach(() => {
+      find = (PollParticipationTracking as unknown as { find: jest.Mock }).find;
+      bulkWrite = (
+        PollParticipationTracking as unknown as { bulkWrite: jest.Mock }
+      ).bulkWrite;
+      deleteMany = (PollTurnout as unknown as { deleteMany: jest.Mock })
+        .deleteMany;
+      find.mockReturnValue({ lean: jest.fn(async () => []) });
+      bulkWrite.mockResolvedValue({});
+      deleteMany.mockResolvedValue({ deletedCount: 0 });
+    });
+
+    // Retention windows come from config; route each key to a fixed number.
+    function setRetention(
+      tracker: { configService?: unknown },
+      weeks: number,
+      days: number,
+    ): void {
+      (
+        tracker as unknown as {
+          configService: { getNumber: jest.Mock };
+        }
+      ).configService.getNumber = jest.fn(async (key: string) =>
+        key === "polls.participation.weekly_retention_weeks" ? weeks : days,
+      ) as unknown as jest.Mock;
+    }
+
+    it("unsets only the week buckets older than the cutoff", async () => {
+      const { tracker } = createTracker(null);
+      setRetention(tracker, 12, 90);
+      const fresh = getIsoWeekKey(new Date());
+      find.mockReturnValue({
+        lean: jest.fn(async () => [
+          { _id: "doc1", weeklyVotes: { "2020-W01": 3, [fresh]: 2 } },
+          { _id: "doc2", weeklyVotes: new Map([[fresh, 1]]) },
+        ]),
+      });
+
+      const result = await tracker.pruneExpiredData();
+
+      expect(result.weekBucketsPruned).toBe(1);
+      const [ops] = bulkWrite.mock.calls[0];
+      expect(ops).toHaveLength(1);
+      expect(ops[0].updateOne.filter).toEqual({ _id: "doc1" });
+      expect(ops[0].updateOne.update.$unset).toEqual({
+        "weeklyVotes.2020-W01": "",
+      });
+    });
+
+    it("does not touch Mongo when nothing is stale", async () => {
+      const { tracker } = createTracker(null);
+      setRetention(tracker, 12, 90);
+      find.mockReturnValue({
+        lean: jest.fn(async () => [
+          { _id: "doc1", weeklyVotes: { [getIsoWeekKey(new Date())]: 2 } },
+        ]),
+      });
+
+      const result = await tracker.pruneExpiredData();
+
+      expect(bulkWrite).not.toHaveBeenCalled();
+      expect(result.weekBucketsPruned).toBe(0);
+    });
+
+    it("deletes turnout rows posted before the retention cutoff", async () => {
+      const { tracker } = createTracker(null);
+      setRetention(tracker, 12, 90);
+      deleteMany.mockResolvedValue({ deletedCount: 7 });
+
+      const result = await tracker.pruneExpiredData();
+
+      const [filter] = deleteMany.mock.calls[0];
+      const cutoff = filter.postedAt.$lt as Date;
+      const days = (Date.now() - cutoff.getTime()) / (24 * 60 * 60 * 1000);
+      expect(days).toBeCloseTo(90, 1);
+      expect(result.turnoutRowsDeleted).toBe(7);
+    });
+
+    it("treats 0 as keep-forever for both windows", async () => {
+      const { tracker } = createTracker(null);
+      setRetention(tracker, 0, 0);
+      find.mockReturnValue({
+        lean: jest.fn(async () => [
+          { _id: "doc1", weeklyVotes: { "2020-W01": 3 } },
+        ]),
+      });
+
+      const result = await tracker.pruneExpiredData();
+
+      expect(bulkWrite).not.toHaveBeenCalled();
+      expect(deleteMany).not.toHaveBeenCalled();
+      expect(result).toEqual({ weekBucketsPruned: 0, turnoutRowsDeleted: 0 });
+    });
+
+    it("swallows DB errors so the daily interval survives a bad sweep", async () => {
+      const { tracker } = createTracker(null);
+      setRetention(tracker, 12, 90);
+      find.mockReturnValue({
+        lean: jest.fn(async () => {
+          throw new Error("DB error");
+        }),
+      });
+
+      await expect(tracker.pruneExpiredData()).resolves.toEqual({
+        weekBucketsPruned: 0,
+        turnoutRowsDeleted: 0,
+      });
     });
   });
 });

--- a/__tests__/services/poll-participation-tracker.test.ts
+++ b/__tests__/services/poll-participation-tracker.test.ts
@@ -19,13 +19,13 @@ const PollParticipationTracking = {
   updateOne: jest.fn(),
   findOne: jest.fn(),
   countDocuments: jest.fn(),
-  find: jest.fn(),
+  aggregate: jest.fn(),
   bulkWrite: jest.fn(),
 };
 const PollTurnout = {
   updateOne: jest.fn(),
   countDocuments: jest.fn(),
-  find: jest.fn(),
+  aggregate: jest.fn(),
   deleteMany: jest.fn(),
 };
 
@@ -37,9 +37,8 @@ jest.unstable_mockModule("../../src/models/poll-turnout.js", () => ({
   PollTurnout,
 }));
 
-const { PollParticipationTracker } = await import(
-  "../../src/services/poll-participation-tracker.js"
-);
+const { PollParticipationTracker } =
+  await import("../../src/services/poll-participation-tracker.js");
 const { getIsoWeekKey } = await import("../../src/utils/time.js");
 
 // Mirror the model's `findOne(...).lean()` chain used by
@@ -173,26 +172,37 @@ describe("PollParticipationTracker", () => {
       );
 
       expect(turnoutUpdateOne).toHaveBeenCalledTimes(1);
-      const [filter, update, options] = turnoutUpdateOne.mock.calls[0];
+      const [filter, pipeline, options] = turnoutUpdateOne.mock.calls[0];
       expect(filter).toEqual({ guildId: "guild1", messageId: "msg1" });
-      expect(update.$setOnInsert).toMatchObject({
+      expect(options).toEqual({ upsert: true });
+
+      // An update pipeline, not plain operators: `firstVoteAt` and
+      // `question` must fill in on first sight even when `recordPollPosted`
+      // already created the row, which `$setOnInsert` could never do.
+      const set = pipeline[0].$set;
+      expect(set).toMatchObject({
         guildId: "guild1",
         messageId: "msg1",
-        channelId: "chan1",
-        question: "Best map?",
-        postedAt: new Date("2026-08-10T09:00:00Z"),
+        channelId: { $ifNull: ["$channelId", "chan1"] },
+        question: { $ifNull: ["$question", "Best map?"] },
+        postedAt: { $ifNull: ["$postedAt", new Date("2026-08-10T09:00:00Z")] },
+        votesCast: { $add: [{ $ifNull: ["$votesCast", 0] }, 1] },
+        voterIds: { $setUnion: [{ $ifNull: ["$voterIds", []] }, ["voter1"]] },
       });
-      expect(update.$inc).toEqual({ votesCast: 1 });
-      expect(update.$addToSet).toEqual({ voterIds: "voter1" });
-      expect(options).toEqual({ upsert: true });
+      // firstVoteAt keeps whatever is already stored, so a row pre-created by
+      // recordPollPosted (firstVoteAt: null) gets stamped by its first vote.
+      expect(set.firstVoteAt.$ifNull[0]).toBe("$firstVoteAt");
+      expect(set.firstVoteAt.$ifNull[1]).toEqual(set.lastVoteAt);
     });
 
-    it("leaves the question null when the poll is not cached", async () => {
+    it("offers a null question when the poll is not cached, keeping any stored one", async () => {
       const { tracker } = createTracker({ username: "Voter", bot: false });
       await tracker.handlePollVoteAdd(makePollAnswer(), "voter1");
 
-      const [, update] = turnoutUpdateOne.mock.calls[0];
-      expect(update.$setOnInsert.question).toBeNull();
+      const [, pipeline] = turnoutUpdateOne.mock.calls[0];
+      expect(pipeline[0].$set.question).toEqual({
+        $ifNull: ["$question", null],
+      });
     });
 
     it("skips the turnout row when the message id is unknown", async () => {
@@ -432,86 +442,104 @@ describe("PollParticipationTracker", () => {
     });
   });
 
-  describe("getRecentPollTurnout (#816)", () => {
-    let find: jest.Mock;
+  describe("getTopPollTurnout (#816)", () => {
+    let aggregate: jest.Mock;
 
     beforeEach(() => {
-      find = (PollTurnout as unknown as { find: jest.Mock }).find;
+      aggregate = (PollTurnout as unknown as { aggregate: jest.Mock })
+        .aggregate;
     });
 
-    // Mirrors the model's find(...).sort(...).limit(...).lean() chain.
-    function chain<T>(value: T | Error) {
-      return {
-        sort: jest.fn().mockReturnValue({
-          limit: jest.fn().mockReturnValue({
-            lean: jest.fn(async () => {
-              if (value instanceof Error) throw value;
-              return value;
-            }),
-          }),
-        }),
-      };
-    }
-
-    it("derives the distinct voter count from the stored voter ids", async () => {
+    it("ranks every matching poll in Mongo, not a page of them", async () => {
       const { tracker } = createTracker(null);
-      const postedAt = new Date("2026-08-11T12:00:00Z");
-      find.mockReturnValue(
-        chain([
-          {
-            messageId: "msg1",
-            question: "Best map?",
-            postedAt,
-            voterIds: ["a", "b", "c"],
-            votesCast: 5,
-          },
-          { messageId: "msg2", postedAt, voterIds: [], votesCast: 0 },
-        ]),
-      );
-
-      const rows = await tracker.getRecentPollTurnout("guild1", postedAt);
-
-      expect(rows).toEqual([
+      const since = new Date("2026-08-06T00:00:00Z");
+      aggregate.mockResolvedValue([
         {
           messageId: "msg1",
           question: "Best map?",
-          postedAt,
-          voterCount: 3,
-          votesCast: 5,
-        },
-        {
-          messageId: "msg2",
-          question: null,
-          postedAt,
-          voterCount: 0,
-          votesCast: 0,
+          postedAt: new Date("2026-08-11T12:00:00Z"),
+          voterCount: 6,
+          votesCast: 9,
         },
       ]);
+
+      const top = await tracker.getTopPollTurnout("guild1", since);
+
+      const [pipeline] = aggregate.mock.calls[0];
+      expect(pipeline[0]).toEqual({
+        $match: { guildId: "guild1", lastVoteAt: { $gte: since } },
+      });
+      // Distinct voters are derived from the id set, and the winner is chosen
+      // by the database over the whole window — no client-side limit to
+      // silently crown a runner-up in a busy week.
+      expect(pipeline[1].$addFields.voterCount).toEqual({
+        $size: { $ifNull: ["$voterIds", []] },
+      });
+      expect(pipeline[2]).toEqual({ $sort: { voterCount: -1, postedAt: -1 } });
+      expect(pipeline[3]).toEqual({ $limit: 1 });
+      expect(top?.voterCount).toBe(6);
+      expect(top?.question).toBe("Best map?");
     });
 
-    it("degrades to an empty list on a DB error", async () => {
+    it("returns null when no poll drew a vote in the window", async () => {
       const { tracker } = createTracker(null);
-      find.mockReturnValue(chain(new Error("DB error")));
+      aggregate.mockResolvedValue([]);
 
-      expect(await tracker.getRecentPollTurnout("guild1", new Date())).toEqual(
-        [],
-      );
+      expect(await tracker.getTopPollTurnout("guild1", new Date())).toBeNull();
+    });
+
+    it("normalises a winner with no stored question", async () => {
+      const { tracker } = createTracker(null);
+      const postedAt = new Date("2026-08-11T12:00:00Z");
+      aggregate.mockResolvedValue([
+        { messageId: "msg2", postedAt, voterCount: 9 },
+      ]);
+
+      expect(await tracker.getTopPollTurnout("guild1", postedAt)).toEqual({
+        messageId: "msg2",
+        question: null,
+        postedAt,
+        voterCount: 9,
+        votesCast: 0,
+      });
+    });
+
+    it("degrades to null on a DB error", async () => {
+      const { tracker } = createTracker(null);
+      aggregate.mockRejectedValue(new Error("DB error"));
+
+      expect(await tracker.getTopPollTurnout("guild1", new Date())).toBeNull();
     });
   });
 
   describe("pruneExpiredData (#816)", () => {
-    let find: jest.Mock;
+    let aggregate: jest.Mock;
     let bulkWrite: jest.Mock;
     let deleteMany: jest.Mock;
 
+    // Mirrors `aggregate(...).cursor()`, which the prune iterates so neither
+    // side of the sweep materialises the whole collection.
+    function cursorOf(docs: unknown[] | Error) {
+      return {
+        cursor: jest.fn(() => ({
+          async *[Symbol.asyncIterator]() {
+            if (docs instanceof Error) throw docs;
+            for (const doc of docs) yield doc;
+          },
+        })),
+      };
+    }
+
     beforeEach(() => {
-      find = (PollParticipationTracking as unknown as { find: jest.Mock }).find;
+      aggregate = (
+        PollParticipationTracking as unknown as { aggregate: jest.Mock }
+      ).aggregate;
       bulkWrite = (
         PollParticipationTracking as unknown as { bulkWrite: jest.Mock }
       ).bulkWrite;
       deleteMany = (PollTurnout as unknown as { deleteMany: jest.Mock })
         .deleteMany;
-      find.mockReturnValue({ lean: jest.fn(async () => []) });
+      aggregate.mockReturnValue(cursorOf([]));
       bulkWrite.mockResolvedValue({});
       deleteMany.mockResolvedValue({ deletedCount: 0 });
     });
@@ -531,36 +559,42 @@ describe("PollParticipationTracker", () => {
       ) as unknown as jest.Mock;
     }
 
-    it("unsets only the week buckets older than the cutoff", async () => {
+    it("asks Mongo for stale keys only, then unsets exactly those", async () => {
       const { tracker } = createTracker(null);
       setRetention(tracker, 12, 90);
-      const fresh = getIsoWeekKey(new Date());
-      find.mockReturnValue({
-        lean: jest.fn(async () => [
-          { _id: "doc1", weeklyVotes: { "2020-W01": 3, [fresh]: 2 } },
-          { _id: "doc2", weeklyVotes: new Map([[fresh, 1]]) },
-        ]),
-      });
+      aggregate.mockReturnValue(
+        cursorOf([{ _id: "doc1", staleKeys: ["2020-W01", "2020-W02"] }]),
+      );
 
       const result = await tracker.pruneExpiredData();
 
-      expect(result.weekBucketsPruned).toBe(1);
+      // The filtering happens in the pipeline, so documents with nothing to
+      // prune are never transferred at all.
+      const [pipeline] = aggregate.mock.calls[0];
+      const cutoffKey = getIsoWeekKey(
+        new Date(Date.now() - 12 * 7 * 24 * 60 * 60 * 1000),
+      );
+      expect(JSON.stringify(pipeline[0].$project.staleKeys)).toContain(
+        cutoffKey,
+      );
+      expect(pipeline[1]).toEqual({
+        $match: { "staleKeys.0": { $exists: true } },
+      });
+
+      expect(result.weekBucketsPruned).toBe(2);
       const [ops] = bulkWrite.mock.calls[0];
       expect(ops).toHaveLength(1);
       expect(ops[0].updateOne.filter).toEqual({ _id: "doc1" });
       expect(ops[0].updateOne.update.$unset).toEqual({
         "weeklyVotes.2020-W01": "",
+        "weeklyVotes.2020-W02": "",
       });
     });
 
     it("does not touch Mongo when nothing is stale", async () => {
       const { tracker } = createTracker(null);
       setRetention(tracker, 12, 90);
-      find.mockReturnValue({
-        lean: jest.fn(async () => [
-          { _id: "doc1", weeklyVotes: { [getIsoWeekKey(new Date())]: 2 } },
-        ]),
-      });
+      aggregate.mockReturnValue(cursorOf([]));
 
       const result = await tracker.pruneExpiredData();
 
@@ -585,14 +619,13 @@ describe("PollParticipationTracker", () => {
     it("treats 0 as keep-forever for both windows", async () => {
       const { tracker } = createTracker(null);
       setRetention(tracker, 0, 0);
-      find.mockReturnValue({
-        lean: jest.fn(async () => [
-          { _id: "doc1", weeklyVotes: { "2020-W01": 3 } },
-        ]),
-      });
+      aggregate.mockReturnValue(
+        cursorOf([{ _id: "doc1", staleKeys: ["2020-W01"] }]),
+      );
 
       const result = await tracker.pruneExpiredData();
 
+      expect(aggregate).not.toHaveBeenCalled();
       expect(bulkWrite).not.toHaveBeenCalled();
       expect(deleteMany).not.toHaveBeenCalled();
       expect(result).toEqual({ weekBucketsPruned: 0, turnoutRowsDeleted: 0 });
@@ -601,11 +634,7 @@ describe("PollParticipationTracker", () => {
     it("swallows DB errors so the daily interval survives a bad sweep", async () => {
       const { tracker } = createTracker(null);
       setRetention(tracker, 12, 90);
-      find.mockReturnValue({
-        lean: jest.fn(async () => {
-          throw new Error("DB error");
-        }),
-      });
+      aggregate.mockReturnValue(cursorOf(new Error("DB error")));
 
       await expect(tracker.pruneExpiredData()).resolves.toEqual({
         weekBucketsPruned: 0,

--- a/__tests__/services/poll-service.test.ts
+++ b/__tests__/services/poll-service.test.ts
@@ -561,7 +561,9 @@ describe("PollService", () => {
         lastUsed: null as Date | null,
         save: jest.fn<any>().mockResolvedValue(undefined),
       };
-      mockPollItemFind.mockReturnValue({ sort: jest.fn(async () => [pollItem]) });
+      mockPollItemFind.mockReturnValue({
+        sort: jest.fn(async () => [pollItem]),
+      });
       const schedule = {
         _id: { toString: () => "sched-1" },
         guildId: "guild-1",
@@ -579,7 +581,10 @@ describe("PollService", () => {
 
     it("logs the posted poll so the recap can count it", async () => {
       const postedAt = new Date("2026-08-12T10:00:00Z");
-      const { channel } = await runTestSchedule({ id: "msg-42", createdAt: postedAt });
+      const { channel } = await runTestSchedule({
+        id: "msg-42",
+        createdAt: postedAt,
+      });
 
       expect(channel.send).toHaveBeenCalledTimes(1);
       expect(mockRecordPollPosted).toHaveBeenCalledWith({

--- a/__tests__/services/poll-service.test.ts
+++ b/__tests__/services/poll-service.test.ts
@@ -4,6 +4,8 @@ const mockFetch = jest.fn<typeof fetch>();
 const mockPollItemFindOne = jest.fn();
 const mockPollItemCreate = jest.fn();
 const mockPollItemFindById = jest.fn();
+const mockPollItemFind = jest.fn();
+const mockRecordPollPosted = jest.fn();
 const mockPollScheduleFindById = jest.fn();
 const mockPollScheduleFindByIdAndDelete = jest.fn();
 const mockRegisterReloadCallback = jest.fn();
@@ -25,8 +27,20 @@ jest.unstable_mockModule("../../src/models/poll-item.js", () => ({
     findOne: mockPollItemFindOne,
     create: mockPollItemCreate,
     findById: mockPollItemFindById,
+    find: mockPollItemFind,
   },
 }));
+
+// Posting a poll logs a turnout row (#816); the tracker itself is covered by
+// its own suite, so here we only assert the hand-off.
+jest.unstable_mockModule(
+  "../../src/services/poll-participation-tracker.js",
+  () => ({
+    PollParticipationTracker: {
+      getInstance: jest.fn(() => ({ recordPollPosted: mockRecordPollPosted })),
+    },
+  }),
+);
 
 jest.unstable_mockModule("../../src/models/poll-schedule.js", () => ({
   PollSchedule: {
@@ -42,6 +56,7 @@ jest.unstable_mockModule("../../src/utils/logger.js", () => ({
     error: jest.fn(),
     debug: jest.fn(),
   },
+  isDebugMode: jest.fn(() => false),
 }));
 
 const { PollService } = await import("../../src/services/poll-service.js");
@@ -55,6 +70,8 @@ describe("PollService", () => {
     mockPollItemFindOne.mockResolvedValue(null);
     mockPollItemCreate.mockResolvedValue({});
     mockPollItemFindById.mockResolvedValue(null);
+    mockPollItemFind.mockReturnValue({ sort: jest.fn(async () => []) });
+    mockRecordPollPosted.mockResolvedValue(undefined);
     mockPollScheduleFindById.mockResolvedValue(null);
     mockPollScheduleFindByIdAndDelete.mockResolvedValue(null);
     // Imports never touch the network (#646); a stub lets the paste-path tests
@@ -511,6 +528,72 @@ describe("PollService", () => {
 
       expect(result).toBe(false);
       expect(mockPollScheduleFindByIdAndDelete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("posting a poll (#816)", () => {
+    // `postPoll` narrows on `instanceof TextChannel`, so the stub is built on
+    // the real prototype rather than a bare object literal.
+    async function makeTextChannel(sent: unknown) {
+      const { TextChannel } = await import("discord.js");
+      const channel = Object.create(TextChannel.prototype) as {
+        send: jest.Mock;
+      };
+      channel.send = jest.fn<any>().mockResolvedValue(sent);
+      return channel;
+    }
+
+    async function runTestSchedule(sent: unknown) {
+      const channel = await makeTextChannel(sent);
+      const client = {
+        isReady: () => true,
+        guilds: {
+          fetch: jest.fn<any>().mockResolvedValue({
+            channels: { fetch: jest.fn<any>().mockResolvedValue(channel) },
+          }),
+        },
+      };
+      const pollItem = {
+        question: "Best map?",
+        answers: ["A", "B"],
+        multiSelect: false,
+        usageCount: 0,
+        lastUsed: null as Date | null,
+        save: jest.fn<any>().mockResolvedValue(undefined),
+      };
+      mockPollItemFind.mockReturnValue({ sort: jest.fn(async () => [pollItem]) });
+      const schedule = {
+        _id: { toString: () => "sched-1" },
+        guildId: "guild-1",
+        channelId: "chan-1",
+        pollDuration: 24,
+        roleIdToPing: null,
+        save: jest.fn<any>().mockResolvedValue(undefined),
+      };
+      mockPollScheduleFindById.mockResolvedValue(schedule);
+
+      const service = PollService.getInstance(client as never);
+      await service.testSchedule("sched-1");
+      return { channel, pollItem };
+    }
+
+    it("logs the posted poll so the recap can count it", async () => {
+      const postedAt = new Date("2026-08-12T10:00:00Z");
+      const { channel } = await runTestSchedule({ id: "msg-42", createdAt: postedAt });
+
+      expect(channel.send).toHaveBeenCalledTimes(1);
+      expect(mockRecordPollPosted).toHaveBeenCalledWith({
+        guildId: "guild-1",
+        messageId: "msg-42",
+        channelId: "chan-1",
+        question: "Best map?",
+        postedAt,
+      });
+    });
+
+    it("skips the turnout row when the send returns no message id", async () => {
+      await runTestSchedule({});
+      expect(mockRecordPollPosted).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/services/reaction-role-service-group.test.ts
+++ b/__tests__/services/reaction-role-service-group.test.ts
@@ -73,7 +73,9 @@ function makeCreateClient() {
         return {
           id: `role${roleSeq}`,
           name: `role${roleSeq}`,
-          delete: jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+          delete: jest
+            .fn<() => Promise<unknown>>()
+            .mockResolvedValue(undefined),
         };
       }),
     },
@@ -291,7 +293,9 @@ describe("ReactionRoleService single-role guards on group members", () => {
 
   it("deleteReactionRole refuses a grouped mapping", async () => {
     const guildFetch = jest.fn();
-    const { service } = createService({ guilds: { fetch: guildFetch } } as never);
+    const { service } = createService({
+      guilds: { fetch: guildFetch },
+    } as never);
     model.findOne.mockResolvedValue({
       roleName: "Red",
       groupId: "grp1",
@@ -306,7 +310,9 @@ describe("ReactionRoleService single-role guards on group members", () => {
   });
 
   it("archiveReactionRole refuses a grouped mapping", async () => {
-    const { service } = createService({ guilds: { fetch: jest.fn() } } as never);
+    const { service } = createService({
+      guilds: { fetch: jest.fn() },
+    } as never);
     model.findOne.mockResolvedValue({
       roleName: "Red",
       groupId: "grp1",

--- a/__tests__/services/voice-channel-announcer.test.ts
+++ b/__tests__/services/voice-channel-announcer.test.ts
@@ -235,21 +235,144 @@ describe("VoiceChannelAnnouncer", () => {
         expect(channel.send).not.toHaveBeenCalled();
       });
 
-      it("renders the voter count when at least one member voted", async () => {
+      // Stub the tracker with the three reads the section makes. Defaults
+      // mirror an install with no turnout rows yet, so each test only states
+      // the counts it cares about.
+      function setTracker(overrides: {
+        voters?: number;
+        polls?: number;
+        turnout?: Array<{
+          question: string | null;
+          voterCount: number;
+          votesCast?: number;
+        }>;
+        voterCountError?: boolean;
+      }): void {
+        ((PollParticipationTracker as any).getInstance =
+          jest.fn()).mockReturnValue({
+          getRecentVoterCount: overrides.voterCountError
+            ? jest.fn<any>().mockRejectedValue(new Error("poll boom"))
+            : jest.fn<any>().mockResolvedValue(overrides.voters ?? 0),
+          getRecentPollCount: jest.fn<any>().mockResolvedValue(
+            overrides.polls ?? 0,
+          ),
+          getRecentPollTurnout: jest
+            .fn<any>()
+            .mockResolvedValue(overrides.turnout ?? []),
+        });
+      }
+
+      it("renders members across polls when turnout rows exist (#816)", async () => {
         setConfig({
           "voicetracking.announcements.include_poll_turnout": true,
           "polls.participation.enabled": true,
         });
-        ((PollParticipationTracker as any).getInstance =
-          jest.fn()).mockReturnValue({
-          getRecentVoterCount: jest.fn<any>().mockResolvedValue(3),
+        setTracker({ voters: 3, polls: 2, turnout: [] });
+
+        await (service as any).announcePollTurnout(channel, "g1", new Date());
+
+        const msg = channel.send.mock.calls[0][0].content as string;
+        expect(msg).toContain("Poll Participation");
+        expect(msg).toContain("3 members voted across 2 polls this week");
+      });
+
+      it("singularises a lone member and a lone poll", async () => {
+        setConfig({
+          "voicetracking.announcements.include_poll_turnout": true,
+          "polls.participation.enabled": true,
+        });
+        setTracker({ voters: 1, polls: 1 });
+
+        await (service as any).announcePollTurnout(channel, "g1", new Date());
+
+        const msg = channel.send.mock.calls[0][0].content as string;
+        expect(msg).toContain("1 member voted across 1 poll this week");
+      });
+
+      it("falls back to the member-only wording with no turnout rows", async () => {
+        setConfig({
+          "voicetracking.announcements.include_poll_turnout": true,
+          "polls.participation.enabled": true,
+        });
+        setTracker({ voters: 3, polls: 0 });
+
+        await (service as any).announcePollTurnout(channel, "g1", new Date());
+
+        const msg = channel.send.mock.calls[0][0].content as string;
+        expect(msg).toContain("3 members voted in polls this week");
+        expect(msg).not.toContain("across");
+      });
+
+      it("highlights the best-attended poll when several ran", async () => {
+        setConfig({
+          "voicetracking.announcements.include_poll_turnout": true,
+          "polls.participation.enabled": true,
+        });
+        setTracker({
+          voters: 7,
+          polls: 3,
+          turnout: [
+            { question: "Pineapple on pizza?", voterCount: 2 },
+            { question: "Best map?", voterCount: 6 },
+            { question: null, voterCount: 9 },
+          ],
         });
 
         await (service as any).announcePollTurnout(channel, "g1", new Date());
 
-        const msg = channel.send.mock.calls[0][0] as string;
-        expect(msg).toContain("Poll Participation");
-        expect(msg).toContain("3 members voted in polls this week");
+        const msg = channel.send.mock.calls[0][0].content as string;
+        // The 9-voter row has no question text, so the highlight falls to the
+        // best-attended poll we can actually name.
+        expect(msg).toContain("Best turnout: “Best map?” — 6 members.");
+      });
+
+      it("omits the highlight when only one poll ran", async () => {
+        setConfig({
+          "voicetracking.announcements.include_poll_turnout": true,
+          "polls.participation.enabled": true,
+        });
+        const tracker = {
+          getRecentVoterCount: jest.fn<any>().mockResolvedValue(4),
+          getRecentPollCount: jest.fn<any>().mockResolvedValue(1),
+          getRecentPollTurnout: jest.fn<any>().mockResolvedValue([]),
+        };
+        ((PollParticipationTracker as any).getInstance =
+          jest.fn()).mockReturnValue(tracker);
+
+        await (service as any).announcePollTurnout(channel, "g1", new Date());
+
+        expect(tracker.getRecentPollTurnout).not.toHaveBeenCalled();
+        expect(channel.send.mock.calls[0][0].content).not.toContain(
+          "Best turnout",
+        );
+      });
+
+      it("flattens and caps an untrusted poll question, and blocks mentions", async () => {
+        setConfig({
+          "voicetracking.announcements.include_poll_turnout": true,
+          "polls.participation.enabled": true,
+        });
+        setTracker({
+          voters: 5,
+          polls: 2,
+          turnout: [
+            {
+              question: `@everyone vote\nnow ${"x".repeat(200)}`,
+              voterCount: 5,
+            },
+          ],
+        });
+
+        await (service as any).announcePollTurnout(channel, "g1", new Date());
+
+        const payload = channel.send.mock.calls[0][0];
+        expect(payload.allowedMentions).toEqual({ parse: [] });
+        const highlight = (payload.content as string)
+          .split("\n")
+          .find((line: string) => line.startsWith("🏆"));
+        expect(highlight).toContain("@everyone vote now");
+        expect(highlight).not.toContain("\n");
+        expect(highlight).toContain("…");
       });
 
       it("skips when nobody voted", async () => {
@@ -257,10 +380,7 @@ describe("VoiceChannelAnnouncer", () => {
           "voicetracking.announcements.include_poll_turnout": true,
           "polls.participation.enabled": true,
         });
-        ((PollParticipationTracker as any).getInstance =
-          jest.fn()).mockReturnValue({
-          getRecentVoterCount: jest.fn<any>().mockResolvedValue(0),
-        });
+        setTracker({ voters: 0, polls: 2 });
 
         await (service as any).announcePollTurnout(channel, "g1", new Date());
         expect(channel.send).not.toHaveBeenCalled();
@@ -271,12 +391,7 @@ describe("VoiceChannelAnnouncer", () => {
           "voicetracking.announcements.include_poll_turnout": true,
           "polls.participation.enabled": true,
         });
-        ((PollParticipationTracker as any).getInstance =
-          jest.fn()).mockReturnValue({
-          getRecentVoterCount: jest
-            .fn<any>()
-            .mockRejectedValue(new Error("poll boom")),
-        });
+        setTracker({ voterCountError: true });
 
         await expect(
           (service as any).announcePollTurnout(channel, "g1", new Date()),

--- a/__tests__/services/voice-channel-announcer.test.ts
+++ b/__tests__/services/voice-channel-announcer.test.ts
@@ -241,11 +241,7 @@ describe("VoiceChannelAnnouncer", () => {
       function setTracker(overrides: {
         voters?: number;
         polls?: number;
-        turnout?: Array<{
-          question: string | null;
-          voterCount: number;
-          votesCast?: number;
-        }>;
+        top?: { question: string | null; voterCount: number } | null;
         voterCountError?: boolean;
       }): void {
         ((PollParticipationTracker as any).getInstance =
@@ -253,12 +249,12 @@ describe("VoiceChannelAnnouncer", () => {
           getRecentVoterCount: overrides.voterCountError
             ? jest.fn<any>().mockRejectedValue(new Error("poll boom"))
             : jest.fn<any>().mockResolvedValue(overrides.voters ?? 0),
-          getRecentPollCount: jest.fn<any>().mockResolvedValue(
-            overrides.polls ?? 0,
-          ),
-          getRecentPollTurnout: jest
+          getRecentPollCount: jest
             .fn<any>()
-            .mockResolvedValue(overrides.turnout ?? []),
+            .mockResolvedValue(overrides.polls ?? 0),
+          getTopPollTurnout: jest
+            .fn<any>()
+            .mockResolvedValue(overrides.top ?? null),
         });
       }
 
@@ -267,7 +263,7 @@ describe("VoiceChannelAnnouncer", () => {
           "voicetracking.announcements.include_poll_turnout": true,
           "polls.participation.enabled": true,
         });
-        setTracker({ voters: 3, polls: 2, turnout: [] });
+        setTracker({ voters: 3, polls: 2 });
 
         await (service as any).announcePollTurnout(channel, "g1", new Date());
 
@@ -311,19 +307,34 @@ describe("VoiceChannelAnnouncer", () => {
         setTracker({
           voters: 7,
           polls: 3,
-          turnout: [
-            { question: "Pineapple on pizza?", voterCount: 2 },
-            { question: "Best map?", voterCount: 6 },
-            { question: null, voterCount: 9 },
-          ],
+          top: { question: "Best map?", voterCount: 6 },
         });
 
         await (service as any).announcePollTurnout(channel, "g1", new Date());
 
         const msg = channel.send.mock.calls[0][0].content as string;
-        // The 9-voter row has no question text, so the highlight falls to the
-        // best-attended poll we can actually name.
         expect(msg).toContain("Best turnout: “Best map?” — 6 members.");
+      });
+
+      it("drops the highlight rather than crowning a runner-up", async () => {
+        setConfig({
+          "voicetracking.announcements.include_poll_turnout": true,
+          "polls.participation.enabled": true,
+        });
+        // The window's most-voted poll has no question text (it was only ever
+        // seen through a partial message). Naming the second-best poll "Best
+        // turnout" would be false, so nothing is highlighted.
+        setTracker({
+          voters: 7,
+          polls: 3,
+          top: { question: null, voterCount: 9 },
+        });
+
+        await (service as any).announcePollTurnout(channel, "g1", new Date());
+
+        const msg = channel.send.mock.calls[0][0].content as string;
+        expect(msg).toContain("7 members voted across 3 polls this week");
+        expect(msg).not.toContain("Best turnout");
       });
 
       it("omits the highlight when only one poll ran", async () => {
@@ -334,14 +345,14 @@ describe("VoiceChannelAnnouncer", () => {
         const tracker = {
           getRecentVoterCount: jest.fn<any>().mockResolvedValue(4),
           getRecentPollCount: jest.fn<any>().mockResolvedValue(1),
-          getRecentPollTurnout: jest.fn<any>().mockResolvedValue([]),
+          getTopPollTurnout: jest.fn<any>().mockResolvedValue(null),
         };
         ((PollParticipationTracker as any).getInstance =
           jest.fn()).mockReturnValue(tracker);
 
         await (service as any).announcePollTurnout(channel, "g1", new Date());
 
-        expect(tracker.getRecentPollTurnout).not.toHaveBeenCalled();
+        expect(tracker.getTopPollTurnout).not.toHaveBeenCalled();
         expect(channel.send.mock.calls[0][0].content).not.toContain(
           "Best turnout",
         );
@@ -355,12 +366,10 @@ describe("VoiceChannelAnnouncer", () => {
         setTracker({
           voters: 5,
           polls: 2,
-          turnout: [
-            {
-              question: `@everyone vote\nnow ${"x".repeat(200)}`,
-              voterCount: 5,
-            },
-          ],
+          top: {
+            question: `@everyone vote\nnow ${"x".repeat(200)}`,
+            voterCount: 5,
+          },
         });
 
         await (service as any).announcePollTurnout(channel, "g1", new Date());

--- a/__tests__/utils/time.test.ts
+++ b/__tests__/utils/time.test.ts
@@ -154,11 +154,7 @@ describe("Time Utilities", () => {
         getIsoWeekKey(new Date("2025-12-29T00:00:00Z")),
         getIsoWeekKey(new Date("2026-11-30T00:00:00Z")),
       ];
-      expect([...keys].sort()).toEqual([
-        "2026-W01",
-        "2026-W02",
-        "2026-W49",
-      ]);
+      expect([...keys].sort()).toEqual(["2026-W01", "2026-W02", "2026-W49"]);
     });
   });
 });

--- a/__tests__/utils/time.test.ts
+++ b/__tests__/utils/time.test.ts
@@ -3,6 +3,7 @@ import {
   formatDuration,
   formatTimeAgo,
   formatDateInTimezone,
+  getIsoWeekKey,
 } from "../../src/utils/time.js";
 
 describe("Time Utilities", () => {
@@ -121,6 +122,43 @@ describe("Time Utilities", () => {
       const date = new Date("2024-01-15T12:00:00Z");
       const result = formatDateInTimezone(date, "Europe/London");
       expect(result).toMatch(/2024-01-15 \d{2}:\d{2}:\d{2}/);
+    });
+  });
+
+  describe("getIsoWeekKey", () => {
+    it("returns the ISO week of a mid-year date", () => {
+      expect(getIsoWeekKey(new Date("2026-08-13T09:58:14Z"))).toBe("2026-W33");
+    });
+
+    it("zero-pads single-digit week numbers", () => {
+      expect(getIsoWeekKey(new Date("2026-01-08T00:00:00Z"))).toBe("2026-W02");
+    });
+
+    it("uses the ISO week-year, not the calendar year, at a boundary", () => {
+      // Dec 30 2024 is a Monday and belongs to ISO week 1 of 2025.
+      expect(getIsoWeekKey(new Date("2024-12-30T00:00:00Z"))).toBe("2025-W01");
+      // Jan 1 2027 is a Friday, still ISO week 53 of 2026.
+      expect(getIsoWeekKey(new Date("2027-01-01T00:00:00Z"))).toBe("2026-W53");
+    });
+
+    it("buckets by UTC, so a late-evening local time cannot shift the week", () => {
+      const sundayEnd = new Date("2026-08-16T23:59:59Z");
+      const mondayStart = new Date("2026-08-17T00:00:00Z");
+      expect(getIsoWeekKey(sundayEnd)).toBe("2026-W33");
+      expect(getIsoWeekKey(mondayStart)).toBe("2026-W34");
+    });
+
+    it("sorts lexicographically in chronological order (retention relies on it)", () => {
+      const keys = [
+        getIsoWeekKey(new Date("2026-01-05T00:00:00Z")),
+        getIsoWeekKey(new Date("2025-12-29T00:00:00Z")),
+        getIsoWeekKey(new Date("2026-11-30T00:00:00Z")),
+      ];
+      expect([...keys].sort()).toEqual([
+        "2026-W01",
+        "2026-W02",
+        "2026-W49",
+      ]);
     });
   });
 });

--- a/__tests__/web/user-routes.test.ts
+++ b/__tests__/web/user-routes.test.ts
@@ -258,6 +258,7 @@ describe("createUserRouter / index page", () => {
       getParticipationSummary: async () => ({
         totalVotes: 42,
         thisYearVotes: 9,
+        thisWeekVotes: 3,
         lastVoteAt: new Date("2026-03-04T00:00:00Z"),
       }),
     } as never);
@@ -267,6 +268,31 @@ describe("createUserRouter / index page", () => {
     expect(html).toContain("Votes cast (all time)");
     expect(html).toContain("42");
     expect(html).toContain("2026-03-04");
+    // The weekly bucket (#816) is wired through the route, not just the
+    // tracker, so assert the rendered stat and its value.
+    expect(html).toContain("Votes cast this week");
+    expect(html).toContain(
+      '<div class="label">Votes cast this week</div><div class="value">3</div>',
+    );
+  });
+
+  it("renders a zero weekly count rather than hiding the stat (#816)", async () => {
+    await enablePollParticipationGate();
+    const { PollParticipationTracker } =
+      await import("../../src/services/poll-participation-tracker.js");
+    jest.spyOn(PollParticipationTracker, "getInstance").mockReturnValue({
+      getParticipationSummary: async () => ({
+        totalVotes: 42,
+        thisYearVotes: 9,
+        thisWeekVotes: 0,
+        lastVoteAt: null,
+      }),
+    } as never);
+
+    const html = await dispatchIndex("user");
+    expect(html).toContain(
+      '<div class="label">Votes cast this week</div><div class="value">0</div>',
+    );
   });
 
   it("omits the poll-participation card when the member has never voted (#655)", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -509,6 +509,7 @@ async function gracefulShutdown(signal: string): Promise<void> {
         ModerationLogCleanupService.getInstance().destroy();
         await noticesChannelManager.stop();
         pollService.destroy();
+        pollParticipationTracker.destroy();
         leaderboardRoleService.destroy();
         digestService.destroy();
         rewindNudgeService.destroy();

--- a/src/models/poll-participation-tracking.ts
+++ b/src/models/poll-participation-tracking.ts
@@ -9,7 +9,15 @@ import mongoose, { Schema, Document } from "mongoose";
  * how many poll votes they have cast. As with reaction tracking we keep only
  * a lifetime total plus per-year buckets keyed by "YYYY", so a future Rewind
  * can read a single year's "votes cast" count without retaining per-vote
- * detail or needing a cleanup pass.
+ * detail.
+ *
+ * `weeklyVotes` (#816) adds the same idea at week granularity — per-ISO-week
+ * buckets keyed by "YYYY-Www" — so a member's *frequency* inside a recap
+ * window ("you voted 4 times this week") is answerable, which neither the
+ * lifetime total nor the single `lastVoteAt` timestamp can express. Unlike
+ * the yearly buckets these are pruned: `PollParticipationTracker` drops keys
+ * older than `polls.participation.weekly_retention_weeks` on a daily pass, so
+ * the map stays bounded however long a member keeps voting.
  *
  * Gated behind `polls.participation.enabled`; nothing is written while that
  * key is false. The captured counts are surfaced (#655) on the `/me/`
@@ -23,6 +31,9 @@ export interface IPollParticipationTracking extends Document {
   totalVotes: number;
   // Per-year vote counters keyed by "YYYY" (host-timezone year at capture).
   yearlyVotes: Map<string, number>;
+  // Per-ISO-week vote counters keyed by "YYYY-Www" (UTC week at capture),
+  // pruned to a retention window. See `getIsoWeekKey` in utils/time.
+  weeklyVotes: Map<string, number>;
   lastVoteAt: Date | null;
 }
 
@@ -32,6 +43,7 @@ const PollParticipationTrackingSchema = new Schema({
   username: { type: String, required: true },
   totalVotes: { type: Number, default: 0 },
   yearlyVotes: { type: Map, of: Number, default: {} },
+  weeklyVotes: { type: Map, of: Number, default: {} },
   lastVoteAt: { type: Date, default: null },
 });
 

--- a/src/models/poll-turnout.ts
+++ b/src/models/poll-turnout.ts
@@ -22,10 +22,16 @@ import mongoose, { Schema, Document } from "mongoose";
  *   recap's member count is computed — it also counts votes on any guild
  *   poll — so the two halves of the sentence cover the same polls.
  *
+ * Because either writer can create the row, the vote path fills fields in on
+ * first sight rather than on insert: `firstVoteAt` is stamped by the first
+ * vote even when the row already existed (a scheduled poll that had not been
+ * voted on yet), and a `question` learned from a later cached vote fills a
+ * row first seen through a partial message. Whatever is already stored wins.
+ *
  * Distinct turnout needs to know *who* voted, so `voterIds` holds the set of
- * members seen voting on that poll (`$addToSet`); `votesCast` counts vote
- * events, which is higher on a multiselect poll where one member picks
- * several answers. Vote *removals* are not tracked (Discord's
+ * members seen voting on that poll; `votesCast` counts vote events, which is
+ * higher on a multiselect poll where one member picks several answers. Vote
+ * *removals* are not tracked (Discord's
  * `messagePollVoteRemove` would need its own bookkeeping to know whether a
  * member has any answers left), so a voter who later retracts still counts —
  * the same "votes cast" semantics the per-member counters already use.

--- a/src/models/poll-turnout.ts
+++ b/src/models/poll-turnout.ts
@@ -1,0 +1,75 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+/**
+ * One row per poll message, recording how that poll did (#816).
+ *
+ * `PollItem` is the poll *template library* (`usageCount` / `lastUsed`) — it
+ * says how often a question has been reused, not what happened when it ran.
+ * `PollParticipationTracking` counts votes per member, which answers "how
+ * many members voted this week" but not "across how many polls". This
+ * collection closes that gap: it is the log of polls that actually ran, with
+ * their turnout, so the weekly recap (#777) can state "N members voted across
+ * M polls this week."
+ *
+ * Rows are written from two places, both gated on
+ * `polls.participation.enabled`:
+ *
+ * - `PollService` upserts a row when it posts a scheduled poll, which is the
+ *   only moment `question` and an exact `postedAt` are known.
+ * - `PollParticipationTracker` upserts on every captured vote, so polls the
+ *   bot did not post (a member's own poll, or one from before the schedule
+ *   existed) still get a row and count toward turnout. This matches how the
+ *   recap's member count is computed — it also counts votes on any guild
+ *   poll — so the two halves of the sentence cover the same polls.
+ *
+ * Distinct turnout needs to know *who* voted, so `voterIds` holds the set of
+ * members seen voting on that poll (`$addToSet`); `votesCast` counts vote
+ * events, which is higher on a multiselect poll where one member picks
+ * several answers. Vote *removals* are not tracked (Discord's
+ * `messagePollVoteRemove` would need its own bookkeeping to know whether a
+ * member has any answers left), so a voter who later retracts still counts —
+ * the same "votes cast" semantics the per-member counters already use.
+ *
+ * Retention: `PollParticipationTracker`'s daily pass deletes rows whose
+ * `postedAt` is older than `polls.turnout.retention_days`, which also bounds
+ * how long the per-poll voter ids are kept.
+ */
+export interface IPollTurnout extends Document {
+  guildId: string;
+  /** Discord message id of the poll — the natural per-poll key. */
+  messageId: string;
+  channelId: string | null;
+  /** Poll question, when known (bot-posted polls, or a non-partial vote). */
+  question: string | null;
+  /** When the poll message was created (best effort for observed polls). */
+  postedAt: Date;
+  firstVoteAt: Date | null;
+  lastVoteAt: Date | null;
+  /** Vote events captured (a multiselect vote counts once per answer). */
+  votesCast: number;
+  /** Distinct members seen voting on this poll. */
+  voterIds: string[];
+}
+
+const PollTurnoutSchema = new Schema({
+  guildId: { type: String, required: true },
+  messageId: { type: String, required: true },
+  channelId: { type: String, default: null },
+  question: { type: String, default: null },
+  postedAt: { type: Date, required: true },
+  firstVoteAt: { type: Date, default: null },
+  lastVoteAt: { type: Date, default: null },
+  votesCast: { type: Number, default: 0 },
+  voterIds: { type: [String], default: [] },
+});
+
+// One row per poll message; the upsert paths key off this pair.
+PollTurnoutSchema.index({ guildId: 1, messageId: 1 }, { unique: true });
+// "Polls with turnout in this window" (the recap) and the retention sweep.
+PollTurnoutSchema.index({ guildId: 1, lastVoteAt: -1 });
+PollTurnoutSchema.index({ postedAt: 1 });
+
+export const PollTurnout = mongoose.model<IPollTurnout>(
+  "PollTurnout",
+  PollTurnoutSchema,
+);

--- a/src/scripts/seed-sample-data.ts
+++ b/src/scripts/seed-sample-data.ts
@@ -27,6 +27,7 @@ import mongoose from "mongoose";
 import { faker } from "@faker-js/faker";
 import { env } from "../config/env.js";
 import logger from "../utils/logger.js";
+import { getIsoWeekKey } from "../utils/time.js";
 import { VoiceChannelTracking } from "../models/voice-channel-tracking.js";
 import { MessageActivityTracking } from "../models/message-activity-tracking.js";
 import { UserAchievements } from "../models/user-achievements.js";
@@ -369,19 +370,6 @@ export function generateMessageActivity(
   };
 }
 
-function isoWeek(date: Date): string {
-  const d = new Date(
-    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
-  );
-  const dayNum = d.getUTCDay() || 7;
-  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
-  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-  const week = Math.ceil(
-    ((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7,
-  );
-  return `${d.getUTCFullYear()}-W${String(week).padStart(2, "0")}`;
-}
-
 /** Generate one user's achievements/accolades document. */
 export function generateUserAchievements(
   identity: SeedIdentity,
@@ -417,7 +405,7 @@ export function generateUserAchievements(
     return {
       type,
       earnedAt,
-      period: isoWeek(earnedAt),
+      period: getIsoWeekKey(earnedAt),
       rank: faker.number.int({ min: 1, max: 10 }),
       metadata: { value: faker.number.int({ min: 1, max: 50 }), unit: "hrs" },
     };

--- a/src/services/achievements-service.ts
+++ b/src/services/achievements-service.ts
@@ -43,6 +43,7 @@ import {
   type AchievementType,
 } from "../content/achievements.js";
 import { sanitizeForLog } from "../utils/log-sanitize.js";
+import { getIsoWeekKey } from "../utils/time.js";
 
 export type { AccoladeType, AchievementType };
 
@@ -1656,16 +1657,7 @@ export class AchievementsService {
    * host timezone.
    */
   private getWeekPeriod(date: Date): string {
-    const d = new Date(
-      Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
-    );
-    const dayNum = d.getUTCDay() || 7;
-    d.setUTCDate(d.getUTCDate() + 4 - dayNum);
-    const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-    const weekNumber = Math.ceil(
-      ((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7,
-    );
-    return `${d.getUTCFullYear()}-W${String(weekNumber).padStart(2, "0")}`;
+    return getIsoWeekKey(date);
   }
 
   /**

--- a/src/services/config-schema.ts
+++ b/src/services/config-schema.ts
@@ -129,6 +129,8 @@ export interface ConfigSchema {
   "polls.default_duration_hours": number; // Default poll duration in hours (1-768)
   "polls.cooldown_days": number; // Minimum days between reusing same poll
   "polls.participation.enabled": boolean; // Capture per-user votes cast for a future Rewind (#570)
+  "polls.participation.weekly_retention_weeks": number; // Keep per-ISO-week vote buckets this long (0 = forever) (#816)
+  "polls.turnout.retention_days": number; // Keep per-poll turnout rows this long (0 = forever) (#816)
 
   // Leaderboard Role Rewards
   "leaderboard_roles.enabled": boolean;
@@ -341,6 +343,13 @@ export const defaultConfig: ConfigSchema = {
   // messagePollVoteAdd listener records per-user "votes cast" for a future
   // Rewind. Independent of whether the bot created the poll.
   "polls.participation.enabled": false,
+  // Retention for the two time-scoped participation stores (#816). 12 weeks
+  // of per-member week buckets comfortably covers the weekly recap plus a
+  // quarter of history; 90 days of per-poll turnout rows matches the other
+  // detail-level retention defaults and bounds how long the per-poll voter
+  // ids are kept. Either set to 0 keeps that store forever.
+  "polls.participation.weekly_retention_weeks": 12,
+  "polls.turnout.retention_days": 90,
 
   // Leaderboard Role Rewards defaults
   "leaderboard_roles.enabled": false,
@@ -1414,9 +1423,23 @@ export const settingsMetadata: Record<keyof ConfigSchema, SettingMetadata> = {
   "polls.participation.enabled": {
     label: "Poll participation tracking enabled",
     description:
-      "Record per-user 'votes cast' (lifetime + per-year) whenever a user votes on any guild poll. Data-capture foundation for a future Rewind stat; off by default.",
+      "Record per-user 'votes cast' (lifetime + per-year + per-week) and per-poll turnout whenever a user votes on any guild poll. Powers the Rewind stat, the poll accolades and the weekly recap's poll line; off by default.",
     category: "polls",
     type: "boolean",
+  },
+  "polls.participation.weekly_retention_weeks": {
+    label: "Weekly vote bucket retention (weeks)",
+    description:
+      "Weeks of per-member weekly vote counters to keep before the daily cleanup drops them. Lifetime and per-year totals are never pruned. Set to 0 to keep every week forever.",
+    category: "polls",
+    type: "number",
+  },
+  "polls.turnout.retention_days": {
+    label: "Poll turnout retention (days)",
+    description:
+      "Days to keep the per-poll turnout rows (which polls ran and who voted on them) that back the weekly recap's 'across M polls' line. Set to 0 to keep them forever.",
+    category: "polls",
+    type: "number",
   },
 
   // Leaderboard Role Rewards

--- a/src/services/poll-participation-tracker.ts
+++ b/src/services/poll-participation-tracker.ts
@@ -201,10 +201,19 @@ export class PollParticipationTracker {
    * which fire one event per chosen answer) fold into one row: `votesCast`
    * counts events while `voterIds` accumulates distinct members.
    *
+   * Written as an update *pipeline* rather than plain operators because two
+   * fields must be filled in on first sight rather than on insert:
+   * `recordPollPosted` may already have created the row for a scheduled poll
+   * (with no votes yet), so `$setOnInsert` would never fire and `firstVoteAt`
+   * would stay null forever. `question` behaves the same way in reverse — a
+   * member-created poll observed first through a partial message has no
+   * question text, and only a later cached vote can supply one. `$ifNull`
+   * gives both "keep what's there, otherwise take what we just learned"
+   * semantics in a single atomic write.
+   *
    * `postedAt` falls back to the message's creation time, which discord.js
    * derives from the snowflake and is therefore available even when the
-   * message is partial; the question text is only present on a fully cached
-   * poll, and stays null otherwise until/unless `recordPollPosted` fills it.
+   * message is partial.
    */
   private async recordTurnout(
     guildId: string,
@@ -228,19 +237,24 @@ export class PollParticipationTracker {
 
     await PollTurnout.updateOne(
       { guildId, messageId },
-      {
-        $setOnInsert: {
-          guildId,
-          messageId,
-          channelId: message.channelId ?? null,
-          question: question ?? null,
-          postedAt: message.createdAt ?? now,
-          firstVoteAt: now,
+      [
+        {
+          $set: {
+            guildId,
+            messageId,
+            channelId: { $ifNull: ["$channelId", message.channelId ?? null] },
+            question: { $ifNull: ["$question", question ?? null] },
+            postedAt: { $ifNull: ["$postedAt", message.createdAt ?? now] },
+            firstVoteAt: { $ifNull: ["$firstVoteAt", now] },
+            lastVoteAt: now,
+            votesCast: { $add: [{ $ifNull: ["$votesCast", 0] }, 1] },
+            // The pipeline equivalent of `$addToSet` for a whole array.
+            voterIds: {
+              $setUnion: [{ $ifNull: ["$voterIds", []] }, [userId]],
+            },
+          },
         },
-        $set: { lastVoteAt: now },
-        $inc: { votesCast: 1 },
-        $addToSet: { voterIds: userId },
-      },
+      ],
       { upsert: true },
     );
   }
@@ -407,53 +421,70 @@ export class PollParticipationTracker {
   }
 
   /**
-   * Per-poll turnout for a window, newest first — the aggregate view behind
-   * the recap line (how many members each poll drew). Distinct voters are
-   * computed from `voterIds` rather than stored, so the count can never drift
-   * from the set it summarises. Best-effort: returns [] on a DB error.
+   * The best-attended poll of a window, or null when none drew a vote — the
+   * "Best turnout" highlight on the recap. Distinct voters are computed from
+   * `voterIds` (`$size`) rather than stored, so the count can never drift
+   * from the set it summarises.
+   *
+   * Ranking happens in Mongo over *every* matching row, not over a page of
+   * them: reading "the most recent N polls" and picking the maximum client
+   * side would silently crown a runner-up in any week busier than N. Ties go
+   * to the most recently posted poll. Best-effort: returns null on a DB
+   * error, and the caller drops the highlight.
    */
-  public async getRecentPollTurnout(
+  public async getTopPollTurnout(
     guildId: string,
     since: Date,
-    limit = 25,
-  ): Promise<
-    Array<{
-      messageId: string;
-      question: string | null;
-      postedAt: Date;
-      voterCount: number;
-      votesCast: number;
-    }>
-  > {
+  ): Promise<{
+    messageId: string;
+    question: string | null;
+    postedAt: Date;
+    voterCount: number;
+    votesCast: number;
+  } | null> {
     try {
       await this.ensureConnection();
 
-      const docs = await PollTurnout.find(
-        { guildId, lastVoteAt: { $gte: since } },
-        { messageId: 1, question: 1, postedAt: 1, voterIds: 1, votesCast: 1 },
-      )
-        .sort({ postedAt: -1 })
-        .limit(limit)
-        .lean<
-          Array<{
-            messageId: string;
-            question?: string | null;
-            postedAt: Date;
-            voterIds?: string[];
-            votesCast?: number;
-          }>
-        >();
+      const rows = await PollTurnout.aggregate<{
+        messageId: string;
+        question?: string | null;
+        postedAt: Date;
+        voterCount?: number;
+        votesCast?: number;
+      }>([
+        { $match: { guildId, lastVoteAt: { $gte: since } } },
+        {
+          $addFields: {
+            voterCount: { $size: { $ifNull: ["$voterIds", []] } },
+          },
+        },
+        { $sort: { voterCount: -1, postedAt: -1 } },
+        { $limit: 1 },
+        {
+          $project: {
+            _id: 0,
+            messageId: 1,
+            question: 1,
+            postedAt: 1,
+            voterCount: 1,
+            votesCast: 1,
+          },
+        },
+      ]);
 
-      return docs.map((doc) => ({
-        messageId: doc.messageId,
-        question: doc.question ?? null,
-        postedAt: doc.postedAt,
-        voterCount: doc.voterIds?.length ?? 0,
-        votesCast: doc.votesCast ?? 0,
-      }));
+      const top = rows?.[0];
+      if (!top) return null;
+
+      return {
+        messageId: top.messageId,
+        question: top.question ?? null,
+        postedAt: top.postedAt,
+        voterCount: top.voterCount ?? 0,
+        votesCast: top.votesCast ?? 0,
+      };
     } catch (error) {
-      logger.error("Error reading recent poll turnout:", error);
-      return [];
+      logger.error("Error reading top poll turnout:", error);
+      return null;
     }
   }
 
@@ -518,21 +549,45 @@ export class PollParticipationTracker {
     return result;
   }
 
-  /** Unset week buckets older than the retention window. */
+  /**
+   * Unset week buckets older than the retention window.
+   *
+   * The stale-key filtering runs inside Mongo — `$objectToArray` turns the
+   * bucket map into entries, and only documents that still hold a key below
+   * the cutoff come back, carrying just those keys. Combined with a cursor
+   * that means neither the read side nor the write side scales with the size
+   * of the participation collection: a steady-state sweep transfers nothing
+   * at all, rather than every member's full bucket map. Keys are compared as
+   * strings, which is valid because ISO week keys sort chronologically.
+   */
   private async pruneWeekBuckets(retentionWeeks: number): Promise<number> {
     const cutoffKey = getIsoWeekKey(
       new Date(Date.now() - retentionWeeks * 7 * 24 * 60 * 60 * 1000),
     );
 
-    const docs = await PollParticipationTracking.find(
-      {},
-      { weeklyVotes: 1 },
-    ).lean<
-      Array<{
-        _id: mongoose.Types.ObjectId;
-        weeklyVotes?: Map<string, number> | Record<string, number>;
-      }>
-    >();
+    const cursor = PollParticipationTracking.aggregate<{
+      _id: mongoose.Types.ObjectId;
+      staleKeys: string[];
+    }>([
+      {
+        $project: {
+          staleKeys: {
+            $map: {
+              input: {
+                $filter: {
+                  input: {
+                    $objectToArray: { $ifNull: ["$weeklyVotes", {}] },
+                  },
+                  cond: { $lt: ["$$this.k", cutoffKey] },
+                },
+              },
+              in: "$$this.k",
+            },
+          },
+        },
+      },
+      { $match: { "staleKeys.0": { $exists: true } } },
+    ]).cursor();
 
     // The `$unset` paths are dotted Map keys, which the typed UpdateFilter
     // can't express, so the ops are assembled as the bulkWrite element type.
@@ -549,13 +604,8 @@ export class PollParticipationTracker {
       batch = [];
     };
 
-    for (const doc of docs) {
-      const buckets = doc.weeklyVotes;
-      const keys =
-        buckets instanceof Map
-          ? Array.from(buckets.keys())
-          : Object.keys(buckets ?? {});
-      const stale = keys.filter((key) => key < cutoffKey);
+    for await (const doc of cursor) {
+      const stale: string[] = doc.staleKeys ?? [];
       if (stale.length === 0) continue;
 
       pruned += stale.length;

--- a/src/services/poll-participation-tracker.ts
+++ b/src/services/poll-participation-tracker.ts
@@ -1,27 +1,62 @@
 import { Client, PollAnswer, PartialPollAnswer, Snowflake } from "discord.js";
 import logger, { isDebugMode } from "../utils/logger.js";
 import { PollParticipationTracking } from "../models/poll-participation-tracking.js";
+import { PollTurnout } from "../models/poll-turnout.js";
 import mongoose from "mongoose";
 import { ConfigService } from "./config-service.js";
+import { getIsoWeekKey } from "../utils/time.js";
+import { sanitizeForLog } from "../utils/log-sanitize.js";
+
+/**
+ * Read one counter out of a `Map` field. A `.lean()` read hands back the Map
+ * as a plain object while a hydrated document keeps a real `Map`, so both
+ * shapes are handled; anything missing or non-numeric reads as 0.
+ */
+function readBucket(
+  bucket: Map<string, number> | Record<string, number> | undefined,
+  key: string,
+): number {
+  const raw =
+    bucket instanceof Map
+      ? bucket.get(key)
+      : (bucket as Record<string, number> | undefined)?.[key];
+  return typeof raw === "number" && Number.isFinite(raw) ? raw : 0;
+}
+
+// How often the retention pass runs. Both windows are measured in weeks/days,
+// so a daily sweep is ample; the first one runs at startup.
+const PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+// Cap on how many bulk `$unset` operations are sent to Mongo at once while
+// pruning week buckets.
+const PRUNE_BATCH_SIZE = 500;
 
 /**
  * Tracks poll participation: a `messagePollVoteAdd` listener bumps a
- * per-user "votes cast" counter (plus per-year buckets) in the
- * `PollParticipationTracking` collection. Discord does not let us query a
- * poll's per-user votes after the fact, so this capture is the only chance to
- * record participation for a future Rewind.
+ * per-user "votes cast" counter (lifetime, per-year and per-ISO-week buckets)
+ * in the `PollParticipationTracking` collection, and upserts a per-poll
+ * turnout row in `PollTurnout`. Discord does not let us query a poll's
+ * per-user votes after the fact, so this capture is the only chance to record
+ * participation.
  *
  * Writes are gated on `polls.participation.enabled`. A vote on any guild poll
  * counts — the tracking is independent of whether the bot's own poll feature
  * created the poll. The captured counts are surfaced (#655) via
  * `getParticipationSummary` (the `/me/` overview card), the Rewind
- * `pollVotesCast` stat, and the poll-participation accolades.
+ * `pollVotesCast` stat, the poll-participation accolades, and the weekly
+ * recap's "N members voted across M polls this week" line (#777, #816).
+ *
+ * Both time-scoped stores are bounded by a daily retention pass
+ * (`pruneExpiredData`): week buckets older than
+ * `polls.participation.weekly_retention_weeks` are unset, and turnout rows
+ * older than `polls.turnout.retention_days` are deleted.
  */
 export class PollParticipationTracker {
   private static instance: PollParticipationTracker;
   private client: Client;
   private isConnected: boolean = false;
   private configService: ConfigService;
+  private pruneInterval: ReturnType<typeof setInterval> | null = null;
 
   private constructor(client: Client) {
     this.client = client;
@@ -112,8 +147,10 @@ export class PollParticipationTracker {
         return;
       }
 
-      const year = String(new Date().getFullYear());
-      await this.recordVote(userId, guildId, user.username, year);
+      const now = new Date();
+      const year = String(now.getFullYear());
+      await this.recordVote(userId, guildId, user.username, year, now);
+      await this.recordTurnout(guildId, message, userId, now);
 
       if (isDebugMode()) {
         logger.info(
@@ -127,26 +164,138 @@ export class PollParticipationTracker {
 
   /**
    * Atomically upsert one user's vote counters. A Mongo `Map` field lets us
-   * `$inc` the per-year bucket on a dotted path, so a new user, a new year,
-   * and the steady state are all a single write.
+   * `$inc` the per-year and per-ISO-week buckets on dotted paths, so a new
+   * user, a new year, a new week, and the steady state are all a single
+   * write. The week key is UTC-anchored (`getIsoWeekKey`) while the year key
+   * stays host-timezone for backwards compatibility with rows written before
+   * #816 — they are read independently and never compared to each other.
    */
   private async recordVote(
     userId: string,
     guildId: string,
     username: string,
     year: string,
+    now: Date,
   ): Promise<void> {
     await this.ensureConnection();
 
+    const week = getIsoWeekKey(now);
     await PollParticipationTracking.updateOne(
       { userId, guildId },
       {
         $setOnInsert: { userId, guildId },
-        $set: { username, lastVoteAt: new Date() },
-        $inc: { totalVotes: 1, [`yearlyVotes.${year}`]: 1 },
+        $set: { username, lastVoteAt: now },
+        $inc: {
+          totalVotes: 1,
+          [`yearlyVotes.${year}`]: 1,
+          [`weeklyVotes.${week}`]: 1,
+        },
       },
       { upsert: true },
     );
+  }
+
+  /**
+   * Upsert the per-poll turnout row for the poll this vote belongs to (#816).
+   * Keyed by the poll's message id, so repeat votes (and multiselect votes,
+   * which fire one event per chosen answer) fold into one row: `votesCast`
+   * counts events while `voterIds` accumulates distinct members.
+   *
+   * `postedAt` falls back to the message's creation time, which discord.js
+   * derives from the snowflake and is therefore available even when the
+   * message is partial; the question text is only present on a fully cached
+   * poll, and stays null otherwise until/unless `recordPollPosted` fills it.
+   */
+  private async recordTurnout(
+    guildId: string,
+    message: {
+      id?: string | null;
+      channelId?: string | null;
+      createdAt?: Date | null;
+      poll?: unknown;
+    },
+    userId: string,
+    now: Date,
+  ): Promise<void> {
+    const messageId = message.id;
+    if (!messageId) return;
+
+    await this.ensureConnection();
+
+    const question = (
+      message.poll as { question?: { text?: string } } | null | undefined
+    )?.question?.text;
+
+    await PollTurnout.updateOne(
+      { guildId, messageId },
+      {
+        $setOnInsert: {
+          guildId,
+          messageId,
+          channelId: message.channelId ?? null,
+          question: question ?? null,
+          postedAt: message.createdAt ?? now,
+          firstVoteAt: now,
+        },
+        $set: { lastVoteAt: now },
+        $inc: { votesCast: 1 },
+        $addToSet: { voterIds: userId },
+      },
+      { upsert: true },
+    );
+  }
+
+  /**
+   * Record a poll the bot just posted (#816). This is the only moment the
+   * question text and an exact `postedAt` are known, so `PollService` calls
+   * it right after sending; a poll nobody votes on still gets a row this way.
+   * Gated on `polls.participation.enabled` here rather than at the call site
+   * so the poll feature stays oblivious to the capture toggle, and
+   * best-effort: a failure is logged, never propagated into poll posting.
+   */
+  public async recordPollPosted(params: {
+    guildId: string;
+    messageId: string;
+    channelId: string | null;
+    question: string | null;
+    postedAt: Date;
+  }): Promise<void> {
+    try {
+      const isEnabled = await this.configService.getBoolean(
+        "polls.participation.enabled",
+        false,
+      );
+      if (!isEnabled) return;
+
+      await this.ensureConnection();
+
+      await PollTurnout.updateOne(
+        { guildId: params.guildId, messageId: params.messageId },
+        {
+          $setOnInsert: {
+            guildId: params.guildId,
+            messageId: params.messageId,
+            firstVoteAt: null,
+            lastVoteAt: null,
+            votesCast: 0,
+            voterIds: [],
+          },
+          // Posting is the authoritative source for these three, so they
+          // overwrite anything a racing vote capture guessed.
+          $set: {
+            channelId: params.channelId,
+            question: params.question,
+            postedAt: params.postedAt,
+          },
+        },
+        { upsert: true },
+      );
+    } catch (error) {
+      logger.error(
+        `Error recording posted poll ${sanitizeForLog(params.messageId)}:`,
+        error,
+      );
+    }
   }
 
   /**
@@ -170,6 +319,7 @@ export class PollParticipationTracker {
   ): Promise<{
     totalVotes: number;
     thisYearVotes: number;
+    thisWeekVotes: number;
     lastVoteAt: Date | null;
   } | null> {
     try {
@@ -177,28 +327,27 @@ export class PollParticipationTracker {
 
       const doc = await PollParticipationTracking.findOne(
         { userId, guildId },
-        { totalVotes: 1, yearlyVotes: 1, lastVoteAt: 1 },
+        { totalVotes: 1, yearlyVotes: 1, weeklyVotes: 1, lastVoteAt: 1 },
       ).lean<{
         totalVotes?: number;
         yearlyVotes?: Map<string, number> | Record<string, number>;
+        weeklyVotes?: Map<string, number> | Record<string, number>;
         lastVoteAt?: Date | null;
       }>();
       if (!doc) return null;
 
-      const year = String(new Date().getFullYear());
-      const bucket = doc.yearlyVotes;
-      const rawThisYear =
-        bucket instanceof Map
-          ? bucket.get(year)
-          : (bucket as Record<string, number> | undefined)?.[year];
-      const thisYearVotes =
-        typeof rawThisYear === "number" && Number.isFinite(rawThisYear)
-          ? rawThisYear
-          : 0;
+      const now = new Date();
+      const thisYearVotes = readBucket(
+        doc.yearlyVotes,
+        String(now.getFullYear()),
+      );
+      // Zero for rows that predate #816 (no week buckets were written then).
+      const thisWeekVotes = readBucket(doc.weeklyVotes, getIsoWeekKey(now));
 
       return {
         totalVotes: typeof doc.totalVotes === "number" ? doc.totalVotes : 0,
         thisYearVotes,
+        thisWeekVotes,
         lastVoteAt: doc.lastVoteAt ?? null,
       };
     } catch (error) {
@@ -212,11 +361,9 @@ export class PollParticipationTracker {
    * the public weekly recap (#777). `lastVoteAt` is each member's most recent
    * vote, so `lastVoteAt >= since` is true for exactly the members who voted at
    * least once inside the window — this is an *exact* distinct-member count for
-   * captured votes, not an approximation. What this tracker cannot provide is
-   * how many polls ran or how many votes each member cast (there is no per-poll
-   * record and no weekly frequency bucket; see the follow-up tracking issue
-   * referenced from #777). Best-effort — returns 0 on any DB error so the recap
-   * never fails on this section.
+   * captured votes, not an approximation. The companion half of the recap
+   * sentence ("across M polls") comes from `getRecentPollCount`. Best-effort —
+   * returns 0 on any DB error so the recap never fails on this section.
    */
   public async getRecentVoterCount(
     guildId: string,
@@ -234,13 +381,230 @@ export class PollParticipationTracker {
     }
   }
 
+  /**
+   * Count polls that received at least one captured vote since `since` — the
+   * "M polls" in the recap's "N members voted across M polls this week"
+   * (#816). Counts turnout rows rather than poll *posts* so the figure lines
+   * up with `getRecentVoterCount`: both cover every guild poll people
+   * actually voted on, including ones the bot did not post, and a poll that
+   * drew no votes is not something members "voted across". Best-effort —
+   * returns 0 on any DB error so the recap never fails on this section.
+   */
+  public async getRecentPollCount(
+    guildId: string,
+    since: Date,
+  ): Promise<number> {
+    try {
+      await this.ensureConnection();
+      return await PollTurnout.countDocuments({
+        guildId,
+        lastVoteAt: { $gte: since },
+      });
+    } catch (error) {
+      logger.error("Error counting recent polls:", error);
+      return 0;
+    }
+  }
+
+  /**
+   * Per-poll turnout for a window, newest first — the aggregate view behind
+   * the recap line (how many members each poll drew). Distinct voters are
+   * computed from `voterIds` rather than stored, so the count can never drift
+   * from the set it summarises. Best-effort: returns [] on a DB error.
+   */
+  public async getRecentPollTurnout(
+    guildId: string,
+    since: Date,
+    limit = 25,
+  ): Promise<
+    Array<{
+      messageId: string;
+      question: string | null;
+      postedAt: Date;
+      voterCount: number;
+      votesCast: number;
+    }>
+  > {
+    try {
+      await this.ensureConnection();
+
+      const docs = await PollTurnout.find(
+        { guildId, lastVoteAt: { $gte: since } },
+        { messageId: 1, question: 1, postedAt: 1, voterIds: 1, votesCast: 1 },
+      )
+        .sort({ postedAt: -1 })
+        .limit(limit)
+        .lean<
+          Array<{
+            messageId: string;
+            question?: string | null;
+            postedAt: Date;
+            voterIds?: string[];
+            votesCast?: number;
+          }>
+        >();
+
+      return docs.map((doc) => ({
+        messageId: doc.messageId,
+        question: doc.question ?? null,
+        postedAt: doc.postedAt,
+        voterCount: doc.voterIds?.length ?? 0,
+        votesCast: doc.votesCast ?? 0,
+      }));
+    } catch (error) {
+      logger.error("Error reading recent poll turnout:", error);
+      return [];
+    }
+  }
+
+  /**
+   * Retention pass for the two time-scoped stores (#816). The lifetime and
+   * per-year counters are deliberately untouched — they are a fixed handful
+   * of numbers per member and feed all-time surfaces — but the week buckets
+   * and the per-poll rows (which carry voter ids) grow without bound, so both
+   * are trimmed here:
+   *
+   * - week buckets older than `polls.participation.weekly_retention_weeks`
+   *   are `$unset`. Because ISO week keys ("YYYY-Www") sort lexicographically
+   *   in chronological order, "older than the cutoff week" is a plain string
+   *   compare.
+   * - `PollTurnout` rows whose `postedAt` predates
+   *   `polls.turnout.retention_days` are deleted.
+   *
+   * Either window set to 0 means "keep forever", matching the other
+   * `*.retention_*` keys. Best-effort: errors are logged, never thrown, so a
+   * failed sweep can't take down the interval that drives it.
+   */
+  public async pruneExpiredData(): Promise<{
+    weekBucketsPruned: number;
+    turnoutRowsDeleted: number;
+  }> {
+    const result = { weekBucketsPruned: 0, turnoutRowsDeleted: 0 };
+
+    try {
+      await this.ensureConnection();
+
+      const retentionWeeks = await this.configService.getNumber(
+        "polls.participation.weekly_retention_weeks",
+        12,
+      );
+      if (retentionWeeks > 0) {
+        result.weekBucketsPruned = await this.pruneWeekBuckets(retentionWeeks);
+      }
+
+      const retentionDays = await this.configService.getNumber(
+        "polls.turnout.retention_days",
+        90,
+      );
+      if (retentionDays > 0) {
+        const cutoff = new Date(
+          Date.now() - retentionDays * 24 * 60 * 60 * 1000,
+        );
+        const deleted = await PollTurnout.deleteMany({
+          postedAt: { $lt: cutoff },
+        });
+        result.turnoutRowsDeleted = deleted?.deletedCount ?? 0;
+      }
+
+      if (result.weekBucketsPruned > 0 || result.turnoutRowsDeleted > 0) {
+        logger.info(
+          `Poll participation retention: pruned ${result.weekBucketsPruned} week bucket(s), deleted ${result.turnoutRowsDeleted} poll turnout row(s)`,
+        );
+      }
+    } catch (error) {
+      logger.error("Error pruning poll participation data:", error);
+    }
+
+    return result;
+  }
+
+  /** Unset week buckets older than the retention window. */
+  private async pruneWeekBuckets(retentionWeeks: number): Promise<number> {
+    const cutoffKey = getIsoWeekKey(
+      new Date(Date.now() - retentionWeeks * 7 * 24 * 60 * 60 * 1000),
+    );
+
+    const docs = await PollParticipationTracking.find(
+      {},
+      { weeklyVotes: 1 },
+    ).lean<
+      Array<{
+        _id: mongoose.Types.ObjectId;
+        weeklyVotes?: Map<string, number> | Record<string, number>;
+      }>
+    >();
+
+    // The `$unset` paths are dotted Map keys, which the typed UpdateFilter
+    // can't express, so the ops are assembled as the bulkWrite element type.
+    type PruneOp = Parameters<
+      typeof PollParticipationTracking.bulkWrite
+    >[0][number];
+
+    let pruned = 0;
+    let batch: PruneOp[] = [];
+
+    const flush = async (): Promise<void> => {
+      if (batch.length === 0) return;
+      await PollParticipationTracking.bulkWrite(batch);
+      batch = [];
+    };
+
+    for (const doc of docs) {
+      const buckets = doc.weeklyVotes;
+      const keys =
+        buckets instanceof Map
+          ? Array.from(buckets.keys())
+          : Object.keys(buckets ?? {});
+      const stale = keys.filter((key) => key < cutoffKey);
+      if (stale.length === 0) continue;
+
+      pruned += stale.length;
+      batch.push({
+        updateOne: {
+          filter: { _id: doc._id },
+          update: {
+            $unset: Object.fromEntries(
+              stale.map((key) => [`weeklyVotes.${key}`, ""]),
+            ),
+          },
+        },
+      } as PruneOp);
+
+      if (batch.length >= PRUNE_BATCH_SIZE) {
+        await flush();
+      }
+    }
+
+    await flush();
+    return pruned;
+  }
+
   public async initialize(): Promise<void> {
     try {
       await this.ensureConnection();
+
+      // Run the retention pass once at startup, then daily. The interval is
+      // unref'd so it never keeps the process alive on shutdown, and the
+      // pass swallows its own errors so a bad sweep can't kill the timer.
+      await this.pruneExpiredData();
+      if (!this.pruneInterval) {
+        this.pruneInterval = setInterval(() => {
+          void this.pruneExpiredData();
+        }, PRUNE_INTERVAL_MS);
+        this.pruneInterval.unref?.();
+      }
+
       logger.info("PollParticipationTracker initialized");
     } catch (error) {
       logger.error("Error initializing PollParticipationTracker:", error);
       throw error;
+    }
+  }
+
+  public destroy(): void {
+    if (this.pruneInterval) {
+      clearInterval(this.pruneInterval);
+      this.pruneInterval = null;
     }
   }
 }

--- a/src/services/poll-service.ts
+++ b/src/services/poll-service.ts
@@ -4,6 +4,7 @@ import { ConfigService } from "./config-service.js";
 import logger from "../utils/logger.js";
 import { PollSchedule, IPollSchedule } from "../models/poll-schedule.js";
 import { PollItem, IPollItem } from "../models/poll-item.js";
+import { PollParticipationTracker } from "./poll-participation-tracker.js";
 import { sanitizeForLog } from "../utils/log-sanitize.js";
 import yaml from "js-yaml";
 
@@ -243,10 +244,27 @@ export class PollService {
       }
 
       // Send the poll
-      await channel.send({
+      const sent = await channel.send({
         content: content || undefined,
         poll: pollData,
       });
+
+      // Log the poll run so the weekly recap can count how many polls ran and
+      // what turnout they drew (#816). Posting is the only moment we know the
+      // question text and the exact post time; the tracker no-ops when
+      // participation capture is off and swallows its own errors, but guard
+      // here too so nothing about turnout bookkeeping can break poll posting.
+      if (sent?.id) {
+        await PollParticipationTracker.getInstance(
+          this.client,
+        ).recordPollPosted({
+          guildId: schedule.guildId,
+          messageId: sent.id,
+          channelId: schedule.channelId,
+          question: pollItem.question,
+          postedAt: sent.createdAt ?? new Date(),
+        });
+      }
 
       // Update poll item usage statistics
       pollItem.usageCount += 1;

--- a/src/services/voice-channel-announcer.ts
+++ b/src/services/voice-channel-announcer.ts
@@ -465,29 +465,25 @@ export class VoiceChannelAnnouncer {
   }
 
   /**
-   * The most-voted poll of the window, or null when none of the rows carry a
-   * question (turnout captured from a vote event only knows the question when
-   * the poll was cached). Ties keep the first row, i.e. the most recent poll.
-   * Scans the accessor's page of most-recent rows rather than every poll ever
-   * run, which is the same set for any realistic week.
+   * The window's best-attended poll, ready to render, or null when there is
+   * nothing honest to show. The winner is picked by the tracker across every
+   * poll in the window; if that poll has no question text (turnout captured
+   * from a vote event only knows the question when the poll was cached) the
+   * highlight is dropped rather than handed to a runner-up — "Best turnout"
+   * naming the second-best poll would be wrong, not merely incomplete.
    */
   private async findTopPoll(
     tracker: PollParticipationTracker,
     guildId: string,
     since: Date,
   ): Promise<{ question: string; voterCount: number } | null> {
-    const rows = await tracker.getRecentPollTurnout(guildId, since);
-    let best: { question: string; voterCount: number } | null = null;
+    const top = await tracker.getTopPollTurnout(guildId, since);
+    if (!top?.question || top.voterCount <= 0) return null;
 
-    for (const row of rows) {
-      if (!row.question || row.voterCount <= 0) continue;
-      if (best && row.voterCount <= best.voterCount) continue;
-      const question = sanitizeRecapText(row.question);
-      if (!question) continue;
-      best = { question, voterCount: row.voterCount };
-    }
+    const question = sanitizeRecapText(top.question);
+    if (!question) return null;
 
-    return best;
+    return { question, voterCount: top.voterCount };
   }
 
   public destroy(): void {

--- a/src/services/voice-channel-announcer.ts
+++ b/src/services/voice-channel-announcer.ts
@@ -25,6 +25,26 @@ function resolveAuthorMentionId(authorId: string): string | null {
   return match[1] ?? match[2] ?? null;
 }
 
+/** Longest poll question the recap will quote before eliding it. */
+const MAX_RECAP_QUESTION_LENGTH = 120;
+
+/**
+ * Flatten a poll question for a single recap line. A question can come from a
+ * member-created poll, so it is collapsed to one line, capped in length, and
+ * stripped of the characters that would break out of the quoted text —
+ * backticks and the smart quotes used as delimiters. Mentions are neutralised
+ * separately by `allowedMentions`.
+ */
+function sanitizeRecapText(text: string): string {
+  const flattened = text
+    .replace(/[\r\n]+/g, " ")
+    .replace(/[`“”]/g, "'")
+    .trim();
+  return flattened.length > MAX_RECAP_QUESTION_LENGTH
+    ? `${flattened.slice(0, MAX_RECAP_QUESTION_LENGTH - 1)}…`
+    : flattened;
+}
+
 export class VoiceChannelAnnouncer {
   private static instance: VoiceChannelAnnouncer;
   private client: Client;
@@ -379,7 +399,14 @@ export class VoiceChannelAnnouncer {
     }
   }
 
-  /** Recap section: how many members voted in polls this week (#777). */
+  /**
+   * Recap section: how many members voted, across how many polls, this week
+   * (#777, #816). The poll count comes from the per-poll turnout rows, which
+   * only exist for polls voted on after #816 shipped — when there are none
+   * (an install that has been capturing votes for longer than it has been
+   * recording turnout) the line falls back to the original member-only
+   * wording rather than claiming "across 0 polls".
+   */
   private async announcePollTurnout(
     channel: TextChannel,
     guildId: string,
@@ -402,18 +429,65 @@ export class VoiceChannelAnnouncer {
       const voters = await tracker.getRecentVoterCount(guildId, since);
       if (voters <= 0) return;
 
+      const polls = await tracker.getRecentPollCount(guildId, since);
+
       const memberLabel = voters === 1 ? "member" : "members";
-      await channel.send(
-        [
-          "",
-          "🗳️ **Poll Participation** 🗳️",
-          "",
-          `${voters} ${memberLabel} voted in polls this week. Thanks for weighing in!`,
-        ].join("\n"),
-      );
+      const lines = [
+        "",
+        "🗳️ **Poll Participation** 🗳️",
+        "",
+        polls > 0
+          ? `${voters} ${memberLabel} voted across ${polls} ${polls === 1 ? "poll" : "polls"} this week. Thanks for weighing in!`
+          : `${voters} ${memberLabel} voted in polls this week. Thanks for weighing in!`,
+      ];
+
+      // Highlight the best-attended poll when there was more than one to
+      // choose between — the aggregate turnout is what makes "M polls" more
+      // than a bare number.
+      if (polls > 1) {
+        const top = await this.findTopPoll(tracker, guildId, since);
+        if (top) {
+          lines.push(
+            `🏆 Best turnout: “${top.question}” — ${top.voterCount} ${top.voterCount === 1 ? "member" : "members"}.`,
+          );
+        }
+      }
+
+      await channel.send({
+        content: lines.join("\n"),
+        // Poll questions can come from a member-created poll, so never let
+        // one resolve a mention.
+        allowedMentions: { parse: [] },
+      });
     } catch (error) {
       logger.error("Error announcing poll participation:", error);
     }
+  }
+
+  /**
+   * The most-voted poll of the window, or null when none of the rows carry a
+   * question (turnout captured from a vote event only knows the question when
+   * the poll was cached). Ties keep the first row, i.e. the most recent poll.
+   * Scans the accessor's page of most-recent rows rather than every poll ever
+   * run, which is the same set for any realistic week.
+   */
+  private async findTopPoll(
+    tracker: PollParticipationTracker,
+    guildId: string,
+    since: Date,
+  ): Promise<{ question: string; voterCount: number } | null> {
+    const rows = await tracker.getRecentPollTurnout(guildId, since);
+    let best: { question: string; voterCount: number } | null = null;
+
+    for (const row of rows) {
+      if (!row.question || row.voterCount <= 0) continue;
+      if (best && row.voterCount <= best.voterCount) continue;
+      const question = sanitizeRecapText(row.question);
+      if (!question) continue;
+      best = { question, voterCount: row.voterCount };
+    }
+
+    return best;
   }
 
   public destroy(): void {

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -45,6 +45,33 @@ export function formatTimeAgo(date: Date): string {
 }
 
 /**
+ * Build the ISO-8601 week key for a date (e.g. "2026-W05").
+ *
+ * The year component is the ISO *week-year*, not the calendar year — near
+ * year boundaries the two differ (Dec 30, 2024 is "2025-W01"), and using the
+ * calendar year would collide with an unrelated week. Buckets by the UTC
+ * calendar date so a key stays stable regardless of the host timezone, and
+ * the two-digit zero-padded week number makes the keys sort
+ * lexicographically in chronological order — which is what lets retention
+ * passes prune "everything before week X" with a plain string compare.
+ *
+ * @param date The date to bucket
+ * @returns The ISO week key, e.g. "2026-W05"
+ */
+export function getIsoWeekKey(date: Date): string {
+  const d = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const weekNumber = Math.ceil(
+    ((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7,
+  );
+  return `${d.getUTCFullYear()}-W${String(weekNumber).padStart(2, "0")}`;
+}
+
+/**
  * Formats a date to a specific timezone
  * @param date The date to format
  * @param timezone The timezone to use (e.g., "UTC", "America/New_York")

--- a/src/web/user-layout.ts
+++ b/src/web/user-layout.ts
@@ -410,6 +410,9 @@ export function renderUserIndexBody(opts: {
   pollParticipation?: {
     totalVotes: number;
     thisYearVotes: number;
+    // Votes cast in the current ISO week (#816). Optional so a caller that
+    // predates the weekly bucket can omit it; the stat is then hidden.
+    thisWeekVotes?: number;
     lastVoted: string | null;
   } | null;
 }): string {
@@ -460,6 +463,10 @@ export function renderUserIndexBody(opts: {
           `<div class="value">${poll.totalVotes}</div></div>`,
         '<div class="rw-stat"><div class="label">Votes cast this year</div>' +
           `<div class="value">${poll.thisYearVotes}</div></div>`,
+        typeof poll.thisWeekVotes === "number"
+          ? '<div class="rw-stat"><div class="label">Votes cast this week</div>' +
+            `<div class="value">${poll.thisWeekVotes}</div></div>`
+          : "",
         '<div class="rw-stat"><div class="label">Last voted</div>' +
           (poll.lastVoted
             ? `<div class="value">${escapeHtml(poll.lastVoted)}</div></div>`

--- a/src/web/user-routes.ts
+++ b/src/web/user-routes.ts
@@ -380,6 +380,7 @@ export function createUserRouter(
               ? {
                   totalVotes: pollParticipation.totalVotes,
                   thisYearVotes: pollParticipation.thisYearVotes,
+                  thisWeekVotes: pollParticipation.thisWeekVotes,
                   lastVoted: pollParticipation.lastVoteAt
                     ? pollParticipation.lastVoteAt.toISOString().slice(0, 10)
                     : null,


### PR DESCRIPTION
## Description

The weekly recap (#777) could only report how many members voted, because nothing recorded *which polls ran* or *how often each member voted*. `PollItem` is the question library (`usageCount`/`lastUsed`), not a log of polls actually posted, and `PollParticipationTracking` kept only lifetime + per-year counters plus a single `lastVoteAt`.

This adds both missing pieces of time-scoped data, then upgrades the recap line.

**Data**

- `weeklyVotes` on `PollParticipationTracking` — per-ISO-week buckets keyed `"YYYY-Www"`, `$inc`'d in the same atomic upsert as the yearly bucket. Gives per-member weekly frequency, surfaced as a "Votes cast this week" stat on the `/me/` Poll participation card.
- `PollTurnout` (new model) — one row per poll message: question, `postedAt`, first/last vote, `votesCast`, and the distinct `voterIds`. Written from two places: `PollService` when it posts a scheduled poll (the only moment the question text and exact post time are known), and `PollParticipationTracker` on every captured vote, so polls the bot did not post still count — matching how the recap's member count is computed. Because either writer can create the row, the vote path is an update *pipeline*: `$ifNull` stamps `firstVoteAt` on the first vote even when the row already existed, and fills a `question` that was unknown when the row was created.

**Recap**

`VoiceChannelAnnouncer` now renders "N members voted across M polls this week", plus a "🏆 Best turnout" highlight when more than one poll ran. The winner is ranked in Mongo across every poll in the window (`getTopPollTurnout`), and the highlight is dropped — not handed to a runner-up — when that poll has no question text, since naming the second-best poll "Best turnout" would be false. When no turnout rows exist yet (an install that has been capturing votes longer than it has been recording turnout) the line falls back to the previous member-only wording rather than claiming "across 0 polls". Poll questions can come from member-created polls, so the highlight is flattened to one line, length-capped, and sent with `allowedMentions: { parse: [] }`.

**Retention**

Both new stores grow over time, so the tracker runs a daily pass (`pruneExpiredData`, first run at startup, interval unref'd and cleared in `destroy()`):

- week buckets older than `polls.participation.weekly_retention_weeks` (default 12) are `$unset`. Stale keys are selected inside the aggregation (`$objectToArray` + `$filter`, comparing ISO week keys as strings because they sort chronologically) and streamed through a cursor, so only documents that actually hold an expired key are transferred;
- `PollTurnout` rows older than `polls.turnout.retention_days` (default 90) are deleted, which also bounds how long per-poll voter ids are kept.

`0` means keep forever for either window, matching the other `*.retention_*` keys. Lifetime and per-year counters are never pruned.

**Drive-by**: the ISO week-key helper was duplicated in `achievements-service.ts` and `seed-sample-data.ts`; both now use `getIsoWeekKey` in `utils/time.ts`.

Backfill remains impossible — Discord does not expose per-user votes after the fact — so both stores only cover polls from here on, as the issue notes.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Related Issues

Closes #816
Refs #777

## How Has This Been Tested?

- [x] Existing tests pass (`npm test`) — 139 suites, 1748 tests
- [x] Added new tests for new functionality
- [ ] Manually tested in development environment
- [ ] Tested in Docker environment

New/updated coverage:

- `poll-participation-tracker.test.ts` — weekly bucket `$inc`; the turnout pipeline (voter dedup, `firstVoteAt` preserved when already stored, `question` offered but not overwriting); skipping the row when the message id is unknown; `recordPollPosted` gating/authoritative fields/error swallowing; `getRecentPollCount`; `getTopPollTurnout` (ranking done in Mongo, voter count from `$size`, null winner, error path); and the retention pass (stale keys selected in the pipeline, cursor iteration, turnout cutoff, `0` = keep forever, error isolation).
- `voice-channel-announcer.test.ts` — "across M polls" wording, singular/plural, fallback with no turnout rows, best-turnout highlight, the highlight being dropped when the true winner is unnamed, no highlight for a single poll, and untrusted-question flattening/capping with mentions blocked.
- `poll-service.test.ts` — posting a poll hands off to `recordPollPosted`; no row when the send returns no message id.
- `user-routes.test.ts` — the `/me/` overview renders "Votes cast this week" and its value, including a zero week.
- `time.test.ts` — `getIsoWeekKey` week-year boundaries, zero-padding, UTC bucketing, lexicographic ordering.

Note: the global mongoose mock in `__tests__/setup.ts` returns the *same* stub object for every `mongoose.model()` call, so the tracker suite now mocks the two model modules directly to keep the counters and turnout rows distinguishable.

## Checklist

### Code Quality

- [x] My code follows the project's coding standards
- [x] I have run `npm run check:all` and all checks pass
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run format` to format my code
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Documentation

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary:
  - [x] `SETTINGS.md` (new keys + updated `polls.participation.enabled` and `include_poll_turnout` descriptions)
  - [x] `WEBUI.md` (the `/me/` Poll participation card now shows this-week votes)
  - [x] Inline code comments for complex logic
- [x] I have validated markdown with `npx markdownlint "**/*.md" --ignore node_modules --ignore dist`

No command changes, so `COMMANDS.md` is untouched; no dependency or build changes, so the Dockerfiles are untouched.

### Configuration (if applicable)

- [x] New behaviour stays behind the existing `polls.participation.enabled` gate (off by default)
- [x] I have added configuration schema entries in `config-schema.ts`
- [x] I have documented new configuration keys in `SETTINGS.md`

## Additional Notes

Two judgement calls worth a reviewer's attention:

1. **"M polls" counts polls with votes, not polls posted.** `getRecentPollCount` counts turnout rows with a vote in the window so both halves of the sentence cover the same set of polls; a poll that drew no votes isn't something members "voted across". Posted-but-unvoted polls still get a row (from `PollService`), they just don't count toward M.
2. **`voterIds` stores per-poll voter ids.** Exact distinct turnout needs the set; it is bounded by `polls.turnout.retention_days` and never surfaced per-member. Vote *removals* are not tracked, matching the existing "votes cast" semantics.

The turnout write needs MongoDB ≥ 4.2 for pipeline updates, which the pinned `mongo:latest` image comfortably satisfies.